### PR TITLE
branch init: Track remote

### DIFF
--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -1,0 +1,35 @@
+package git
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+)
+
+// ListRemotes returns a list of remotes for the repository.
+func (r *Repository) ListRemotes(ctx context.Context) ([]string, error) {
+	cmd := newGitCmd(ctx, r.log, "remote")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("pipe stdout: %w", err)
+	}
+
+	if err := cmd.Start(r.exec); err != nil {
+		return nil, fmt.Errorf("start: %w", err)
+	}
+
+	var remotes []string
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		remotes = append(remotes, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan: %w", err)
+	}
+
+	if err := cmd.Wait(r.exec); err != nil {
+		return nil, fmt.Errorf("git remote: %w", err)
+	}
+
+	return remotes, nil
+}

--- a/internal/state/read.go
+++ b/internal/state/read.go
@@ -14,6 +14,16 @@ func (s *Store) Trunk() string {
 	return s.trunk
 }
 
+// Remote returns the remote configured for the repository.
+// Returns [ErrNotExist] if no remote is configured.
+func (s *Store) Remote() (string, error) {
+	if s.remote == "" {
+		return "", ErrNotExist
+	}
+
+	return s.remote, nil
+}
+
 // ErrNotExist indicates that a key that was expected to exist does not exist.
 var ErrNotExist = os.ErrNotExist
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -8,7 +8,8 @@ const (
 )
 
 type repoInfo struct {
-	Trunk string `json:"trunk"`
+	Trunk  string `json:"trunk"`
+	Remote string `json:"remote"`
 }
 
 type branchStateBase struct {

--- a/testdata/script/repo_init_remote_default.txt
+++ b/testdata/script/repo_init_remote_default.txt
@@ -1,0 +1,14 @@
+# 'gs repo init' uses the default remote
+# if there's only one remote.
+
+as 'Test <test@example.com>'
+at '2024-03-30T14:59:32Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+git remote add origin https://example.com/foo.git
+
+gs repo init
+stderr 'Using remote: origin'

--- a/testdata/script/repo_init_remote_prompt.txt
+++ b/testdata/script/repo_init_remote_prompt.txt
@@ -1,0 +1,27 @@
+# 'gs repo init' prompts for a remote
+# if there are multiple remotes.
+
+as 'Test <test@example.com>'
+at '2024-03-30T14:59:32Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+git remote add origin https://example.com/foo-fork.git
+git remote add upstream https://example.com/foo.git
+
+with-term $WORK/input.txt -- gs repo init
+cmp stdout $WORK/golden/dialog.txt
+
+-- input.txt --
+await Pick a remote
+snapshot dialog
+feed \r
+
+-- golden/dialog.txt --
+### dialog ###
+┃ Pick a remote
+┃ > origin
+┃   upstream


### PR DESCRIPTION
Changes `gs repo init` to optionally track the Git remote
to which changes will be pushed.

This is optional so that users can still use branch stacking locally
if they've got nowhere to push to yet.
