### PR TITLE
repo init: Support updating configuration

### DIFF
--- a/repo_init.go
+++ b/repo_init.go
@@ -16,7 +16,8 @@ import (
 type repoInitCmd struct {
 	Trunk  string `help:"The name of the trunk branch"`
 	Remote string `help:"The name of the remote to use for the trunk branch"`
-	Force  bool   `help:"Overwrite storage for an initialized repository"`
+
+	Reset bool `help:"Reset the store if it's already initialized"`
 }
 
 func (cmd *repoInitCmd) Run(ctx context.Context, log *log.Logger) error {
@@ -110,13 +111,9 @@ func (cmd *repoInitCmd) Run(ctx context.Context, log *log.Logger) error {
 		Repository: repo,
 		Trunk:      cmd.Trunk,
 		Remote:     cmd.Remote,
-		Force:      cmd.Force,
+		Reset:      cmd.Reset,
 	})
 	if err != nil {
-		if errors.Is(err, state.ErrAlreadyInitialized) {
-			log.Error("use --force to overwrite existing storage.")
-			return errors.New("repository is already initialized")
-		}
 		return fmt.Errorf("initialize storage: %w", err)
 	}
 

--- a/testdata/script/repo_init_change_trunk.txt
+++ b/testdata/script/repo_init_change_trunk.txt
@@ -1,0 +1,31 @@
+# 'repo init' after an existing init allows changing the trunk.
+
+as 'Test <test@example.com>'
+at '2024-03-30T14:59:32Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+gs bc feature1 -m 'feature1'
+gs bc feature2 -m 'feature2'
+gs bc feature3 -m 'feature3'
+git checkout main
+
+git branch trunk
+gs repo init --trunk trunk
+
+# should be on feature3
+gs top
+
+git branch
+cmp stdout $WORK/golden/git-branch.txt
+
+-- golden/git-branch.txt --
+  feature1
+  feature2
+* feature3
+  main
+  trunk

--- a/testdata/script/repo_init_reset.txt
+++ b/testdata/script/repo_init_reset.txt
@@ -1,4 +1,4 @@
-# 'gs repo init' force forgets prior state.
+# 'gs repo init --reset' forgets prior state.
 
 as 'Test <test@example.com>'
 at '2024-03-30T14:59:32Z'
@@ -15,24 +15,18 @@ gs bc feature2 -m 'feature2'
 gs bc feature3 -m 'feature3'
 gs down
 
-# attempt to re-init without --force fails
+# attempt to re-init without --reset fails
 ! gs repo init --trunk feature2
-stderr 'repository is already initialized'
-stderr 'use --force to overwrite'
+stderr 'trunk branch "feature2" is tracked'
+stderr 'use --reset to clear'
 
 # init with feature2 as trunk,
 # and make feature2 base of feature1
 # (which is the opposite of before).
-gs repo init --force --trunk feature2
+gs repo init --reset --trunk feature2
 
 ! gs up
 stderr 'feature2: no branches found upstack'
 
 ! gs down
 stderr 'feature2: no branches found downstack'
-
--- golden/git-branch.txt --
-  feature1
-* feature2
-  feature3
-  main


### PR DESCRIPTION
Instead of requiring `--force`, which forgets all prior state,
we now support running `repo init` again to update the trunk branch
or specify a different remote.

The `--force` flag is replaced with `--reset` to force clearing known branches.
