### PR TITLE
script_test: Move helpers out

### DIFF
--- a/internal/termtest/with_term.go
+++ b/internal/termtest/with_term.go
@@ -1,0 +1,242 @@
+// Package termtest provides utilities for testing terminal-based programs.
+package termtest
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/creack/pty/v2"
+	"github.com/vito/midterm"
+)
+
+// WithTerm is an entry point for a command line program "with-term".
+// Its usage is as follows:
+//
+//	with-term script -- cmd [args ...]
+//
+// It runs cmd with the given arguments inside a terminal emulator,
+// using the script file to drive interactions with it.
+//
+// The file contains a series of newline delimited commands.
+//
+//	await Enter a name
+//	feed Foo\r
+//	snapshot
+//
+// The following commands are supported.
+//
+//   - await [txt]:
+//     Wait up to 1 second for the given text to become visible on the screen.
+//     If [txt] is absent, wait until contents of the screen change
+//     compared to the last captured snapshot.
+//   - snapshot [name]:
+//     Take a picture of the screen as it is right now, and print it to stdout.
+//     If name is provided, the output will include that as a header.
+//   - feed txt:
+//     Feed the given string into the terminal.
+//     Go string-style escape codes are permitted without quotes.
+//     Examples: \r, \x1b[B
+func WithTerm() (exitCode int) {
+	log.SetFlags(0)
+
+	args := os.Args[1:]
+	if len(args) < 2 {
+		log.Println("usage: with-term file -- cmd [args ...]")
+		return 1
+	}
+
+	instructions, args := args[0], args[1:]
+	instructionFile, err := os.Open(instructions)
+	if err != nil {
+		log.Printf("cannot open instructions: %v", err)
+		return 1
+	}
+	defer func() {
+		if err := instructionFile.Close(); err != nil {
+			log.Printf("cannot close instructions: %v", err)
+			exitCode = 1
+		}
+	}()
+
+	if args[0] == "--" {
+		args = args[1:]
+	}
+
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Env = append(os.Environ(), "TERM=screen")
+	cmd.Stderr = os.Stderr
+
+	size := &pty.Winsize{
+		Rows: 40,
+		Cols: 70,
+	}
+	f, err := pty.StartWithSize(cmd, size)
+	if err != nil {
+		log.Printf("cannot open pty: %v", err)
+		return 1
+	}
+
+	emu := newVT100Emulator(f, cmd, int(size.Rows), int(size.Cols), log.Printf)
+	defer func() {
+		if err := emu.Close(); err != nil {
+			log.Printf("%v: %v", cmd, err)
+			exitCode = 1
+		}
+	}()
+
+	var lastSnapshot []byte
+	scan := bufio.NewScanner(instructionFile)
+	for scan.Scan() {
+		line := bytes.TrimSpace(scan.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+
+		cmd, rest, _ := strings.Cut(string(line), " ")
+		switch cmd {
+		case "await":
+			timeout := time.Second
+			start := time.Now()
+
+			var match func([]byte) bool
+			switch {
+			case len(rest) > 0:
+				want := []byte(rest)
+				match = func(snap []byte) bool {
+					return bytes.Contains(snap, want)
+				}
+			case len(lastSnapshot) > 0:
+				want := lastSnapshot
+				lastSnapshot = nil
+				match = func(snap []byte) bool {
+					return !bytes.Equal(snap, want)
+				}
+
+			default:
+				log.Printf("await: argument is required if no snapshots were captured")
+				continue
+			}
+
+			for time.Since(start) < timeout {
+				if match(emu.Snapshot()) {
+					break
+				}
+				time.Sleep(50 * time.Millisecond)
+			}
+
+		case "snapshot":
+			lastSnapshot = emu.Snapshot()
+			if len(rest) > 0 {
+				fmt.Printf("### %s ###\n", rest)
+			}
+			if _, err := os.Stdout.Write(lastSnapshot); err != nil {
+				log.Printf("error writing to stdout: %v", err)
+			}
+
+		case "feed":
+			s := strings.ReplaceAll(rest, `"`, `\"`)
+			s = `"` + s + `"`
+			keys, err := strconv.Unquote(s)
+			if err != nil {
+				log.Printf("cannot unquote: %v", rest)
+				return 1
+			}
+
+			if err := emu.FeedKeys(keys); err != nil {
+				log.Printf("error feeding keys: %v", err)
+			}
+		}
+	}
+
+	return 0
+}
+
+type terminalEmulator struct {
+	mu   sync.Mutex
+	cmd  *exec.Cmd
+	pty  *os.File
+	logf func(string, ...any)
+
+	term *midterm.Terminal
+}
+
+func newVT100Emulator(
+	f *os.File,
+	cmd *exec.Cmd,
+	rows, cols int,
+	logf func(string, ...any),
+) *terminalEmulator {
+	if logf == nil {
+		logf = log.Printf
+	}
+	term := midterm.NewTerminal(rows, cols)
+	m := terminalEmulator{
+		pty:  f,
+		cmd:  cmd,
+		term: term,
+		logf: logf,
+	}
+	go m.Start()
+	return &m
+}
+
+func (m *terminalEmulator) Start() {
+	var buffer [1024]byte
+loop:
+	for {
+		n, err := m.pty.Read(buffer[0:])
+		if n > 0 {
+			m.mu.Lock()
+			_, writeErr := m.term.Write(buffer[:n])
+			m.mu.Unlock()
+			if writeErr != nil {
+				m.logf("decode error: %v", writeErr)
+			}
+		}
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				m.logf("read error: %v", err)
+			}
+			break loop
+		}
+	}
+}
+
+func (m *terminalEmulator) Close() error {
+	_, err := m.pty.Write([]byte{4}) // EOT
+	return errors.Join(
+		err,
+		m.cmd.Wait(),
+		m.pty.Close(),
+	)
+}
+
+func (m *terminalEmulator) FeedKeys(s string) error {
+	_, err := io.WriteString(m.pty, s)
+	_ = m.pty.Sync()
+	return err
+}
+
+func (m *terminalEmulator) Snapshot() []byte {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var buff bytes.Buffer
+	for _, row := range m.term.Content {
+		rowstr := strings.TrimRight(string(row), " \t\n")
+		buff.WriteString(rowstr)
+		buff.WriteRune('\n')
+	}
+
+	return append(bytes.TrimRight(buff.Bytes(), "\n"), '\n')
+}

--- a/script_test.go
+++ b/script_test.go
@@ -1,26 +1,15 @@
 package main
 
 import (
-	"bufio"
-	"bytes"
-	"errors"
 	"flag"
-	"fmt"
-	"io"
-	"log"
 	"net/mail"
-	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
-	"strings"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/creack/pty/v2"
 	"github.com/rogpeppe/go-internal/testscript"
-	"github.com/vito/midterm"
+	"go.abhg.dev/gs/internal/termtest"
 )
 
 var _update = flag.Bool("update", false, "update golden files")
@@ -35,138 +24,8 @@ func TestMain(m *testing.M) {
 		//
 		// Runs the given command inside a terminal emulator,
 		// using the file to drive interactions with it.
-		// The file contains a series of newline delimited commands.
-		//
-		//  - await [txt]:
-		//    Wait up to 1 second for the given text to become visible
-		//    on the screen.
-		//    If [txt] is absent, wait until contents of the screen
-		//    have changed since the last captured snapshot.
-		//  - feed txt:
-		//    Feed the given string into the terminal.
-		//    Go string-style escape codes are permitted.
-		//    Examples:
-		//      Enter	   \r
-		//      Down arrow \x1b[B
-		//  - snapshot [name]:
-		//    Take a picture of the screen as it is right now,
-		//    and print it to stdout.
-		//    If name is provided,
-		//    the output will include that as a header.
-		"with-term": func() (exitCode int) {
-			log.SetFlags(0)
-
-			args := os.Args[1:]
-			if len(args) < 2 {
-				log.Println("usage: with-term file -- cmd [args ...]")
-				return 1
-			}
-
-			instructions, args := args[0], args[1:]
-			instructionFile, err := os.Open(instructions)
-			if err != nil {
-				log.Printf("cannot open instructions: %v", err)
-				return 1
-			}
-			defer func() {
-				if err := instructionFile.Close(); err != nil {
-					log.Printf("cannot close instructions: %v", err)
-					exitCode = 1
-				}
-			}()
-
-			if args[0] == "--" {
-				args = args[1:]
-			}
-
-			cmd := exec.Command(args[0], args[1:]...)
-			cmd.Env = append(os.Environ(), "TERM=screen")
-			cmd.Stderr = os.Stderr
-
-			size := &pty.Winsize{
-				Rows: 40,
-				Cols: 70,
-			}
-			f, err := pty.StartWithSize(cmd, size)
-			if err != nil {
-				log.Printf("cannot open pty: %v", err)
-				return 1
-			}
-
-			emu := newVT100Emulator(f, cmd, int(size.Rows), int(size.Cols), log.Printf)
-			defer func() {
-				if err := emu.Close(); err != nil {
-					log.Printf("%v: %v", cmd, err)
-					exitCode = 1
-				}
-			}()
-
-			var lastSnapshot []byte
-			scan := bufio.NewScanner(instructionFile)
-			for scan.Scan() {
-				line := bytes.TrimSpace(scan.Bytes())
-				if len(line) == 0 {
-					continue
-				}
-
-				cmd, rest, _ := strings.Cut(string(line), " ")
-				switch cmd {
-				case "await":
-					timeout := time.Second
-					start := time.Now()
-
-					var match func([]byte) bool
-					switch {
-					case len(rest) > 0:
-						want := []byte(rest)
-						match = func(snap []byte) bool {
-							return bytes.Contains(snap, want)
-						}
-					case len(lastSnapshot) > 0:
-						want := lastSnapshot
-						lastSnapshot = nil
-						match = func(snap []byte) bool {
-							return !bytes.Equal(snap, want)
-						}
-
-					default:
-						log.Printf("await: argument is required if no snapshots were captured")
-						continue
-					}
-
-					for time.Since(start) < timeout {
-						if match(emu.Snapshot()) {
-							break
-						}
-						time.Sleep(50 * time.Millisecond)
-					}
-
-				case "snapshot":
-					lastSnapshot = emu.Snapshot()
-					if len(rest) > 0 {
-						fmt.Printf("### %s ###\n", rest)
-					}
-					if _, err := os.Stdout.Write(lastSnapshot); err != nil {
-						log.Printf("error writing to stdout: %v", err)
-					}
-
-				case "feed":
-					s := strings.ReplaceAll(rest, `"`, `\"`)
-					s = `"` + s + `"`
-					keys, err := strconv.Unquote(s)
-					if err != nil {
-						log.Printf("cannot unquote: %v", rest)
-						return 1
-					}
-
-					if err := emu.FeedKeys(keys); err != nil {
-						log.Printf("error feeding keys: %v", err)
-					}
-				}
-			}
-
-			return 0
-		},
+		// See [termtest.WithTerm] for supported commands.
+		"with-term": termtest.WithTerm,
 	})
 }
 
@@ -175,151 +34,82 @@ func TestScript(t *testing.T) {
 		"init.defaultBranch": "main",
 	}
 
+	defaultEnv := make(map[string]string)
+	// We can set Git configuration values by setting
+	// GIT_CONFIG_KEY_<n>, GIT_CONFIG_VALUE_<n> and GIT_CONFIG_COUNT.
+	var numCfg int
+	for k, v := range defaultGitConfig {
+		n := strconv.Itoa(numCfg)
+		defaultEnv["GIT_CONFIG_KEY_"+n] = k
+		defaultEnv["GIT_CONFIG_VALUE_"+n] = v
+		numCfg++
+	}
+	defaultEnv["GIT_CONFIG_COUNT"] = strconv.Itoa(numCfg)
+
+	// Add a default author to all commits.
+	// Tests can override with 'as' and 'at'.
+	defaultEnv["GIT_AUTHOR_NAME"] = "Test"
+	defaultEnv["GIT_AUTHOR_EMAIL"] = "test@example.com"
+	defaultEnv["GIT_COMMITTER_NAME"] = "Test"
+	defaultEnv["GIT_COMMITTER_EMAIL"] = "test@example.com"
+
 	testscript.Run(t, testscript.Params{
 		Dir:                filepath.Join("testdata", "script"),
 		UpdateScripts:      *_update,
 		RequireUniqueNames: true,
 		Setup: func(e *testscript.Env) error {
-			// We can set Git configuration values by setting
-			// GIT_CONFIG_KEY_<n>, GIT_CONFIG_VALUE_<n> and GIT_CONFIG_COUNT.
-			var numCfg int
-			for k, v := range defaultGitConfig {
-				n := strconv.Itoa(numCfg)
-				e.Setenv("GIT_CONFIG_KEY_"+n, k)
-				e.Setenv("GIT_CONFIG_VALUE_"+n, v)
-				numCfg++
+			for k, v := range defaultEnv {
+				e.Setenv(k, v)
 			}
-			e.Setenv("GIT_CONFIG_COUNT", strconv.Itoa(numCfg))
-
-			// Add a default author to all commits.
-			// Tests can override with 'as' and 'at'.
-			e.Setenv("GIT_AUTHOR_NAME", "Test")
-			e.Setenv("GIT_AUTHOR_EMAIL", "test@example.com")
-			e.Setenv("GIT_COMMITTER_NAME", "Test")
-			e.Setenv("GIT_COMMITTER_EMAIL", "test@example.com")
 
 			return nil
 		},
-		Cmds: map[string]func(ts *testscript.TestScript, neg bool, args []string){
-			"git": func(ts *testscript.TestScript, neg bool, args []string) {
-				err := ts.Exec("git", args...)
-				if neg {
-					if err == nil {
-						ts.Fatalf("unexpected success, expected failure")
-					}
-				} else {
-					ts.Check(err)
-				}
-			},
-			"as": func(ts *testscript.TestScript, neg bool, args []string) {
-				if neg || len(args) != 1 {
-					ts.Fatalf("usage: as 'User Name <user@example.com>'")
-				}
-
-				addr, err := mail.ParseAddress(args[0])
-				if err != nil {
-					ts.Fatalf("invalid email address: %s", err)
-				}
-
-				ts.Setenv("GIT_AUTHOR_NAME", addr.Name)
-				ts.Setenv("GIT_AUTHOR_EMAIL", addr.Address)
-				ts.Setenv("GIT_COMMITTER_NAME", addr.Name)
-				ts.Setenv("GIT_COMMITTER_EMAIL", addr.Address)
-			},
-			"at": func(ts *testscript.TestScript, neg bool, args []string) {
-				if neg || len(args) != 1 {
-					ts.Fatalf("usage: at <YYYY-MM-DDTHH:MM:SS>")
-				}
-
-				t, err := time.Parse(time.RFC3339, args[0])
-				if err != nil {
-					ts.Fatalf("invalid time: %s", err)
-				}
-
-				gitTime := t.Format(time.RFC3339)
-				ts.Setenv("GIT_AUTHOR_DATE", gitTime)
-				ts.Setenv("GIT_COMMITTER_DATE", gitTime)
-			},
+		Cmds: map[string]func(*testscript.TestScript, bool, []string){
+			"git": cmdGit,
+			"as":  cmdAs,
+			"at":  cmdAt,
 		},
 	})
 }
 
-type terminalEmulator struct {
-	mu   sync.Mutex
-	cmd  *exec.Cmd
-	pty  *os.File
-	logf func(string, ...any)
-
-	term *midterm.Terminal
-}
-
-func newVT100Emulator(
-	f *os.File,
-	cmd *exec.Cmd,
-	rows, cols int,
-	logf func(string, ...any),
-) *terminalEmulator {
-	if logf == nil {
-		logf = log.Printf
-	}
-	term := midterm.NewTerminal(rows, cols)
-	m := terminalEmulator{
-		pty:  f,
-		cmd:  cmd,
-		term: term,
-		logf: logf,
-	}
-	go m.Start()
-	return &m
-}
-
-func (m *terminalEmulator) Start() {
-	var buffer [1024]byte
-loop:
-	for {
-		n, err := m.pty.Read(buffer[0:])
-		if n > 0 {
-			m.mu.Lock()
-			_, writeErr := m.term.Write(buffer[:n])
-			m.mu.Unlock()
-			if writeErr != nil {
-				m.logf("decode error: %v", writeErr)
-			}
+func cmdGit(ts *testscript.TestScript, neg bool, args []string) {
+	err := ts.Exec("git", args...)
+	if neg {
+		if err == nil {
+			ts.Fatalf("unexpected success, expected failure")
 		}
-		if err != nil {
-			if !errors.Is(err, io.EOF) {
-				m.logf("read error: %v", err)
-			}
-			break loop
-		}
+	} else {
+		ts.Check(err)
 	}
 }
 
-func (m *terminalEmulator) Close() error {
-	_, err := m.pty.Write([]byte{4}) // EOT
-	return errors.Join(
-		err,
-		m.cmd.Wait(),
-		m.pty.Close(),
-	)
-}
-
-func (m *terminalEmulator) FeedKeys(s string) error {
-	_, err := io.WriteString(m.pty, s)
-	_ = m.pty.Sync()
-	return err
-}
-
-func (m *terminalEmulator) Snapshot() []byte {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	var buff bytes.Buffer
-	for _, row := range m.term.Content {
-		rowstr := strings.TrimRight(string(row), " \t\n")
-		buff.WriteString(rowstr)
-		buff.WriteRune('\n')
+func cmdAs(ts *testscript.TestScript, neg bool, args []string) {
+	if neg || len(args) != 1 {
+		ts.Fatalf("usage: as 'User Name <user@example.com>'")
 	}
 
-	return append(bytes.TrimRight(buff.Bytes(), "\n"), '\n')
+	addr, err := mail.ParseAddress(args[0])
+	if err != nil {
+		ts.Fatalf("invalid email address: %s", err)
+	}
+
+	ts.Setenv("GIT_AUTHOR_NAME", addr.Name)
+	ts.Setenv("GIT_AUTHOR_EMAIL", addr.Address)
+	ts.Setenv("GIT_COMMITTER_NAME", addr.Name)
+	ts.Setenv("GIT_COMMITTER_EMAIL", addr.Address)
+}
+
+func cmdAt(ts *testscript.TestScript, neg bool, args []string) {
+	if neg || len(args) != 1 {
+		ts.Fatalf("usage: at <YYYY-MM-DDTHH:MM:SS>")
+	}
+
+	t, err := time.Parse(time.RFC3339, args[0])
+	if err != nil {
+		ts.Fatalf("invalid time: %s", err)
+	}
+
+	gitTime := t.Format(time.RFC3339)
+	ts.Setenv("GIT_AUTHOR_DATE", gitTime)
+	ts.Setenv("GIT_COMMITTER_DATE", gitTime)
 }


### PR DESCRIPTION
Make script_test smaller and more readable.
Move the terminal emulator helper out into a separate package,
and move the custom commands out into their own functions.

Also, compute the default environment in advance insteda of in setup.