### PR TITLE
add 'downstack edit'

### DIFF
--- a/downstack.go
+++ b/downstack.go
@@ -1,0 +1,5 @@
+package main
+
+type downstackCmd struct {
+	Edit downstackEditCmd `cmd:"" aliases:"e" help:"Edit the order of branches below the current branch"`
+}

--- a/downstack_edit.go
+++ b/downstack_edit.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"slices"
+
+	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/gs"
+	"go.abhg.dev/gs/internal/must"
+)
+
+type downstackEditCmd struct {
+	Editor string `env:"EDITOR" help:"Editor to use for editing the downstack."`
+
+	Name string `arg:"" optional:"" help:"Name of the branch to start editing from."`
+}
+
+func (cmd *downstackEditCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
+	if cmd.Editor == "" {
+		return errors.New("an editor is required: use --editor or set $EDITOR")
+	}
+
+	repo, err := git.Open(ctx, ".", git.OpenOptions{
+		Log: log,
+	})
+	if err != nil {
+		return fmt.Errorf("open repository: %w", err)
+	}
+
+	store, err := ensureStore(ctx, repo, log, opts)
+	if err != nil {
+		return err
+	}
+
+	if cmd.Name == "" {
+		currentBranch, err := repo.CurrentBranch(ctx)
+		if err != nil {
+			return fmt.Errorf("get current branch: %w", err)
+		}
+		cmd.Name = currentBranch
+	}
+
+	if cmd.Name == store.Trunk() {
+		return errors.New("cannot edit below trunk")
+	}
+
+	svc := gs.NewService(repo, store, log)
+
+	downstacks, err := svc.ListDownstack(ctx, cmd.Name)
+	if err != nil {
+		return fmt.Errorf("list downstack: %w", err)
+	}
+	must.NotBeEmptyf(downstacks, "downstack cannot be empty")
+	must.BeEqualf(downstacks[0], cmd.Name,
+		"downstack must start with the original branch")
+
+	if len(downstacks) == 1 {
+		log.Infof("nothing to edit below %s", cmd.Name)
+		return nil
+	}
+
+	originalBranches := make(map[string]struct{}, len(downstacks))
+	for _, branch := range downstacks {
+		originalBranches[branch] = struct{}{}
+	}
+
+	instructionFile, err := createEditFile(downstacks)
+	if err != nil {
+		return err
+	}
+
+	editCmd := exec.CommandContext(ctx, cmd.Editor, instructionFile)
+	editCmd.Stdin = os.Stdin
+	editCmd.Stdout = os.Stdout
+	editCmd.Stderr = os.Stderr
+	if err := editCmd.Run(); err != nil {
+		return fmt.Errorf("run editor: %w", err)
+	}
+
+	f, err := os.Open(instructionFile)
+	if err != nil {
+		return fmt.Errorf("open edited file: %w", err)
+	}
+
+	newOrder := make([]string, 0, len(downstacks))
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		bs := bytes.TrimSpace(scanner.Bytes())
+		if len(bs) == 0 || bs[0] == '#' {
+			continue
+		}
+
+		name := string(bs)
+		if _, ok := originalBranches[name]; !ok {
+			// TODO: better error
+			return fmt.Errorf("branch %q not in original downstack, or is duplicated", name)
+		}
+		delete(originalBranches, name)
+
+		newOrder = append(newOrder, name)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("read edited file: %w", err)
+	}
+
+	if len(newOrder) == 0 {
+		log.Infof("downstack edit aborted or nothing to do")
+		return nil
+	}
+	newTop := newOrder[0]
+	slices.Reverse(newOrder)
+
+	base := store.Trunk()
+	for _, branch := range newOrder {
+		err := (&branchOntoCmd{
+			Branch: branch,
+			Onto:   base,
+		}).Run(ctx, log, opts)
+		if err != nil {
+			return fmt.Errorf("branch onto %s: %w", branch, err)
+		}
+		base = branch
+	}
+
+	return (&branchCheckoutCmd{
+		Name: newTop,
+	}).Run(ctx, log, opts)
+}
+
+var _editFooter = `
+# Edit the order of branches by modifying the list above.
+# The branch at the bottom of the list will be merged into trunk first.
+# Branches above that will be stacked on top of it in the order they appear.
+# Branches deleted from the list will not be modified.
+#
+# Save and quit the editor to apply the changes.
+# Delete all lines in the editor to abort the operation.
+`
+
+func createEditFile(branches []string) (_ string, err error) {
+	file, err := os.CreateTemp("", "gs-edit-*.txt")
+	if err != nil {
+		return "", fmt.Errorf("create temporary file: %w", err)
+	}
+	defer func() { err = errors.Join(err, file.Close()) }()
+
+	for _, branch := range branches {
+		if _, err := fmt.Fprintln(file, branch); err != nil {
+			return "", fmt.Errorf("write branc: %w", err)
+		}
+	}
+
+	if _, err := io.WriteString(file, _editFooter); err != nil {
+		return "", fmt.Errorf("write footer: %w", err)
+	}
+
+	return file.Name(), nil
+}

--- a/main.go
+++ b/main.go
@@ -151,10 +151,13 @@ type mainCmd struct {
 
 	globalOptions
 
-	Repo    repoCmd    `cmd:"" aliases:"r" group:"Repository"`
-	Upstack upstackCmd `cmd:"" aliases:"us" group:"Stack"`
-	Branch  branchCmd  `cmd:"" aliases:"b" group:"Branch"`
-	Commit  commitCmd  `cmd:"" aliases:"c" group:"Commit"`
+	Repo repoCmd `cmd:"" aliases:"r" group:"Repository"`
+
+	Upstack   upstackCmd   `cmd:"" aliases:"us" group:"Stack"`
+	Downstack downstackCmd `cmd:"" aliases:"ds" group:"Stack"`
+
+	Branch branchCmd `cmd:"" aliases:"b" group:"Branch"`
+	Commit commitCmd `cmd:"" aliases:"c" group:"Commit"`
 
 	// Navigation
 	Up     upCmd     `cmd:"" aliases:"gu" group:"Navigation" help:"Move up one branch"`

--- a/testdata/script/branch_onto.txt
+++ b/testdata/script/branch_onto.txt
@@ -19,10 +19,8 @@ git add feature3.txt
 gs branch create feature3 -m 'Add feature 3'
 
 # Now we have:
-#   master -> feature1 -> feature2 -> feature3
-exists feature1.txt
-exists feature2.txt
-exists feature3.txt
+#   main -> feature1 -> feature2 -> feature3
+exists feature1.txt feature2.txt feature3.txt
 
 # Move feature3 to be based on feature1
 gs branch onto feature1

--- a/testdata/script/downstack_edit.txt
+++ b/testdata/script/downstack_edit.txt
@@ -1,0 +1,74 @@
+# Editing the order of a stack with 'downstack edit'.
+
+as 'Test <test@example.com>'
+at '2024-05-11T11:02:34Z'
+
+# set up
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git add feature1.txt
+gs branch create feature1 -m 'Add feature 1'
+
+git add feature2.txt
+gs branch create feature2 -m 'Add feature 2'
+
+git add feature3.txt
+gs branch create feature3 -m 'Add feature 3'
+
+# Now we have:
+#   main -> feature1 -> feature2 -> feature3
+exists feature1.txt feature2.txt feature3.txt
+
+# cannot edit downstack from main
+git checkout main
+! gs downstack edit
+stderr 'cannot edit below trunk'
+
+env MOCKEDIT_GIVE=$WORK/edit/give.txt MOCKEDIT_RECORD=$WORK/edit/got.txt
+git checkout feature3
+gs downstack edit
+cmp $WORK/edit/got.txt $WORK/edit/want.txt
+
+git log --oneline --graph --decorate --branches
+cmp stdout $WORK/golden/log.txt
+
+# edit at bottom branch is meaningless
+git checkout feature3
+env MOCKEDIT_GIVE=
+gs downstack edit
+stderr 'nothing to edit'
+
+-- repo/feature1.txt --
+Feature 1
+-- repo/feature2.txt --
+Feature 2
+-- repo/feature3.txt --
+Feature 3
+
+-- edit/want.txt --
+feature3
+feature2
+feature1
+
+# Edit the order of branches by modifying the list above.
+# The branch at the bottom of the list will be merged into trunk first.
+# Branches above that will be stacked on top of it in the order they appear.
+# Branches deleted from the list will not be modified.
+#
+# Save and quit the editor to apply the changes.
+# Delete all lines in the editor to abort the operation.
+-- edit/give.txt --
+# Invert the order completely.
+
+feature1
+feature2
+feature3
+
+-- golden/log.txt --
+* ed4680e (HEAD -> feature1) Add feature 1
+* c5b835f (feature2) Add feature 2
+* 8039b1d (feature3) Add feature 3
+* b91c6c5 (main) Initial commit


### PR DESCRIPTION
Adds a new command 'gs downstack edit'
which will provide a 'git rebase -i'-style interface
to edit the order of branches.

Branches will be reparented and restacked using the new order,
relying on the 'branch onto' command for the bulk of the work.