### PR TITLE
fix(branch track): Don't auto-guess self, always reject cycles

### DIFF
--- a/testdata/script/branch_track_after_rebase.txt
+++ b/testdata/script/branch_track_after_rebase.txt
@@ -1,0 +1,38 @@
+# Creates two branches off main,
+# rebases one of them on top of the other,
+# and re-tracks it.
+#
+# Reproduces a bug report.
+
+as 'Test <test@example.com>'
+at '2024-03-30T14:59:32Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git add feature1.txt
+gs bc feature1 -m 'Add feature1'
+
+git checkout main
+git add feature2.txt
+gs bc feature2 -m 'Add feature2'
+
+git rebase feature1
+gs branch track
+stderr 'feature2: tracking with base feature1'
+
+git log --graph --oneline --decorate --branches
+cmp stdout $WORK/golden/log.txt
+
+-- repo/feature1.txt --
+Feature 1
+
+-- repo/feature2.txt --
+Feature 2
+
+-- golden/log.txt --
+* 6b07f21 (HEAD -> feature2) Add feature2
+* 32a777d (feature1) Add feature1
+* 9bad92b (main) Initial commit

--- a/testdata/script/branch_track_cycle_err.txt
+++ b/testdata/script/branch_track_cycle_err.txt
@@ -1,0 +1,32 @@
+# 'branch track' rejects attempts to create a cycle.
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git add feature1.txt
+gs bc feature1 -m 'Add feature 1'
+
+git add feature2.txt
+gs bc feature2 -m 'Add feature 2'
+
+git add feature3.txt
+gs bc feature3 -m 'Add feature 3'
+
+git checkout feature1
+! gs branch track --base feature3
+stderr 'feature1: base feature3 would create a cycle'
+stderr 'feature1 -> feature2 -> feature3 -> feature1'
+
+-- repo/feature1.txt --
+Feature 1
+
+-- repo/feature2.txt --
+Feature 2
+
+-- repo/feature3.txt --
+Feature 3
+
+
+


### PR DESCRIPTION
'gs branch create' had a bug where,
when auto-guessing a base branch for a branch,
if the target branch was already tracked,
it would use self as the base branch.
Fixing that is easy: leave self out of consideration,
but it also exposed the fact that it's possible to create tracking
cycles.

This fixes the prior bug, and adds a check to 'branch track',
ensuring that adding that connection would no