### PR TITLE
submit: Handle renames, state: track upstream and PR

### DIFF
--- a/branch_rename.go
+++ b/branch_rename.go
@@ -62,17 +62,16 @@ func (cmd *branchRenameCmd) Run(ctx context.Context, log *log.Logger, opts *glob
 		return fmt.Errorf("rename branch: %w", err)
 	}
 
-	// TODO:
-	// If branch has a PR, we'll want to retain the upstream branch name.
-	// Maybe 'branch submit' should track the upstream branch name.
 	update := state.UpdateRequest{
 		Message: fmt.Sprintf("rename %q to %q", oldName, cmd.Name),
 	}
 	if b, err := store.Lookup(ctx, oldName); err == nil {
 		req := state.UpsertRequest{
-			Name:     cmd.Name,
-			Base:     b.Base,
-			BaseHash: b.BaseHash,
+			Name:           cmd.Name,
+			Base:           b.Base,
+			BaseHash:       b.BaseHash,
+			PR:             b.PR,
+			UpstreamBranch: b.UpstreamBranch,
 		}
 
 		update.Upserts = append(update.Upserts, req)

--- a/branch_track.go
+++ b/branch_track.go
@@ -17,6 +17,9 @@ import (
 type branchTrackCmd struct {
 	Base string `short:"b" help:"Base branch this merges into"`
 	Name string `arg:"" optional:"" help:"Name of the branch to track"`
+
+	// TODO:
+	// PR   int    `help:"Pull request number to associate with this branch"`
 }
 
 func (*branchTrackCmd) Help() string {
@@ -143,6 +146,10 @@ func (cmd *branchTrackCmd) Run(ctx context.Context, log *log.Logger, opts *globa
 	if err != nil {
 		return fmt.Errorf("peel to commit: %w", err)
 	}
+
+	// TODO:
+	// if GitHub information is available, check if branch has an
+	// open PR and associate it with the branch.
 
 	err = store.Update(ctx, &state.UpdateRequest{
 		Upserts: []state.UpsertRequest{

--- a/gh.go
+++ b/gh.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/charmbracelet/log"
+	"github.com/google/go-github/v61/github"
+	"go.abhg.dev/gs/internal/gh"
+	"go.abhg.dev/gs/internal/git"
+	"golang.org/x/oauth2"
+)
+
+func ensureGitHubRepo(
+	ctx context.Context,
+	log *log.Logger,
+	repo *git.Repository,
+	remote string,
+) (gh.RepoInfo, error) {
+	remoteURL, err := repo.RemoteURL(ctx, remote)
+	if err != nil {
+		return gh.RepoInfo{}, fmt.Errorf("get remote URL: %w", err)
+	}
+
+	// TODO: Take GITHUB_GIT_URL into account for ParseRepoInfo.
+	ghrepo, err := gh.ParseRepoInfo(remoteURL)
+	if err != nil {
+		log.Error("Could not guess GitHub repository from remote URL", "url", remoteURL)
+		log.Error("Are you sure the remote is a GitHub repository?")
+		return gh.RepoInfo{}, err
+	}
+
+	return ghrepo, nil
+}
+
+// TODO: move this into gh package
+func newGitHubClient(ctx context.Context, tokenSource oauth2.TokenSource, opts *globalOptions) (*github.Client, error) {
+	gh := github.NewClient(oauth2.NewClient(ctx, tokenSource))
+	if opts.GithubAPIURL != "" {
+		var err error
+		gh, err = gh.WithEnterpriseURLs(opts.GithubAPIURL, gh.UploadURL.String())
+		if err != nil {
+			return nil, fmt.Errorf("set GitHub API URL: %w", err)
+		}
+	}
+
+	return gh, nil
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -27,8 +27,18 @@ type branchStateBase struct {
 	Hash string `json:"hash"`
 }
 
+type branchGitHubState struct {
+	PR int `json:"pr,omitempty"`
+}
+
+type branchUpstreamState struct {
+	Branch string `json:"branch,omitempty"`
+}
+
 type branchState struct {
-	Base branchStateBase `json:"base"`
+	Base     branchStateBase      `json:"base"`
+	Upstream *branchUpstreamState `json:"upstream,omitempty"`
+	GitHub   *branchGitHubState   `json:"github,omitempty"`
 }
 
 // branchJSON returns the path to the JSON file for the given branch

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -41,6 +41,7 @@ func TestIntegrationStore(t *testing.T) {
 			Name:     "foo",
 			Base:     "main",
 			BaseHash: "123456",
+			PR:       42,
 		}},
 	})
 	require.NoError(t, err)
@@ -52,6 +53,7 @@ func TestIntegrationStore(t *testing.T) {
 		assert.Equal(t, &state.LookupResponse{
 			Base:     "main",
 			BaseHash: "123456",
+			PR:       42,
 		}, res)
 	})
 
@@ -61,6 +63,7 @@ func TestIntegrationStore(t *testing.T) {
 				Name:     "foo",
 				Base:     "bar",
 				BaseHash: "54321",
+				PR:       43,
 			}},
 		})
 		require.NoError(t, err)
@@ -71,6 +74,7 @@ func TestIntegrationStore(t *testing.T) {
 		assert.Equal(t, &state.LookupResponse{
 			Base:     "bar",
 			BaseHash: "54321",
+			PR:       43,
 		}, res)
 	})
 
@@ -79,6 +83,7 @@ func TestIntegrationStore(t *testing.T) {
 			Upserts: []state.UpsertRequest{{
 				Name:     "bar/baz",
 				Base:     "main",
+				PR:       44,
 				BaseHash: "abcdef",
 			}},
 		})
@@ -89,6 +94,7 @@ func TestIntegrationStore(t *testing.T) {
 		assert.Equal(t, &state.LookupResponse{
 			Base:     "main",
 			BaseHash: "abcdef",
+			PR:       44,
 		}, res)
 	})
 }

--- a/testdata/script/branch_submit_rename.txt
+++ b/testdata/script/branch_submit_rename.txt
@@ -1,0 +1,84 @@
+# create a PR with 'branch submit',
+# rename the branch with 'branch rename',
+# and update the original PR with 'branch submit'.
+
+as 'Test <test@example.com>'
+at '2024-05-18T13:57:12Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+gh-init
+gh-add-remote origin alice/example.git
+git push origin main
+
+# create a new branch and submit it
+git add feature1.txt
+gs bc -m 'Add feature1' feature1
+gs branch submit --fill
+stderr 'Created #'
+
+gh-dump-pull
+cmpenvJSON stdout $WORK/golden/create.json
+
+# rename the branch
+gs branch rename feature1-new-name
+
+# update the file, commit, and update the PR
+cp $WORK/extra/feature1-update.txt feature1.txt
+git add feature1.txt
+git commit -m 'update feature1'
+
+gs bs
+stderr 'Updated #'
+gh-dump-pull
+cmpenvJSON stdout $WORK/golden/update.json
+
+-- repo/feature1.txt --
+Contents of feature1
+
+-- extra/feature1-update.txt --
+New contents of feature1
+
+-- golden/create.json --
+[
+  {
+    "number": 1,
+    "state": "open",
+    "title": "Add feature1",
+    "body": "",
+    "draft": false,
+    "html_url": "$GITHUB_GIT_URL/alice/example/pull/1",
+    "head": {
+      "ref": "feature1",
+      "sha": "854f3268c794eb5ec30439658dfb43ac494d9074"
+    },
+    "base": {
+      "ref": "main",
+      "sha": "9df31764fb4252f719c92d53fae05a766f019a17"
+    }
+  }
+]
+
+-- golden/update.json --
+[
+  {
+    "number": 1,
+    "state": "open",
+    "title": "Add feature1",
+    "body": "",
+    "draft": false,
+    "html_url": "$GITHUB_GIT_URL/alice/example/pull/1",
+    "head": {
+      "ref": "feature1",
+      "sha": "b805a8b9545d71929cc128fc81b0d86bb2def9ed"
+    },
+    "base": {
+      "ref": "main",
+      "sha": "9df31764fb4252f719c92d53fae05a766f019a17"
+    }
+  }
+]


### PR DESCRIPTION
When submitting a branch, track the PR, and the upstream branch.
This way, if the branch is renamed after submission,
we can still continue submitting to the original upstream.

The PR number is needed after all for `repo sync`.