### PR TITLE
Add 'repo sync'

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -41,6 +41,18 @@ However, any commands that require a remote will fail.
 * `--remote=NAME`: Name of the remote to push changes to
 * `--reset`: Reset the store if it's already initialized
 
+## gs repo sync
+
+```
+gs repo (r) sync (s)
+```
+
+Pull latest changes from the remote
+
+Pulls the latest changes from the remote repository.
+Deletes branches that have were merged into trunk,
+and updates the base branches of branches upstack from those.
+
 ## gs upstack restack
 
 ```

--- a/gen.go
+++ b/gen.go
@@ -1,3 +1,0 @@
-package main
-
-//go:generate go run . dump-md --out doc/reference.md

--- a/internal/git/hash.go
+++ b/internal/git/hash.go
@@ -78,6 +78,13 @@ func (r *Repository) MergeBase(ctx context.Context, a, b string) (Hash, error) {
 	return Hash(s), nil
 }
 
+// IsAncestor reports whether a is an ancestor of b.
+func (r *Repository) IsAncestor(ctx context.Context, a, b Hash) bool {
+	return r.gitCmd(ctx,
+		"merge-base", "--is-ancestor", string(a), string(b),
+	).Run(r.exec) == nil
+}
+
 func (r *Repository) revParse(ctx context.Context, ref string) (Hash, error) {
 	s, err := r.gitCmd(ctx, "rev-parse",
 		"--verify",         // fail if the object does not exist

--- a/internal/git/rev_list.go
+++ b/internal/git/rev_list.go
@@ -40,6 +40,27 @@ func (r *Repository) ListCommits(ctx context.Context, commits CommitRange) ([]Ha
 	return revs, nil
 }
 
+// CountCommits reports the number of commits matched by the given range.
+func (r *Repository) CountCommits(ctx context.Context, commits CommitRange) (int, error) {
+	args := make([]string, 0, len(commits)+1)
+	args = append(args, "rev-list")
+	args = append(args, []string(commits)...)
+	args = append(args, "--count")
+
+	cmd := r.gitCmd(ctx, args...)
+	out, err := cmd.OutputString(r.exec)
+	if err != nil {
+		return 0, fmt.Errorf("rev-list: %w", err)
+	}
+
+	count, err := strconv.Atoi(out)
+	if err != nil {
+		return 0, fmt.Errorf("rev-list --count: bad output %q: %w", out, err)
+	}
+
+	return count, nil
+}
+
 // CommitRange builds up arguments for a ListCommits command.
 type CommitRange []string
 

--- a/internal/gs/restack.go
+++ b/internal/gs/restack.go
@@ -25,6 +25,8 @@ type RestackResponse struct {
 	Base string
 }
 
+// TODO: Should we be using --is-ancestor to check if a branch is on top of another?
+
 // Restack restacks the given branch on top of its base branch,
 // handling movement of the base branch if necessary.
 //

--- a/repo.go
+++ b/repo.go
@@ -2,4 +2,5 @@ package main
 
 type repoCmd struct {
 	Init repoInitCmd `cmd:"" aliases:"i" help:"Initialize a repository"`
+	Sync repoSyncCmd `cmd:"" aliases:"s" help:"Pull latest changes from the remote"`
 }

--- a/repo_sync.go
+++ b/repo_sync.go
@@ -1,0 +1,295 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime"
+	"slices"
+	"sync"
+
+	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/text"
+	"golang.org/x/oauth2"
+)
+
+type repoSyncCmd struct {
+	// TODO: flag to not delete merged branches?
+	// TODO: flag to auto-restack current stack
+}
+
+func (*repoSyncCmd) Help() string {
+	return text.Dedent(`
+		Pulls the latest changes from the remote repository.
+		Deletes branches that have were merged into trunk,
+		and updates the base branches of branches upstack from those.
+	`)
+}
+
+func (*repoSyncCmd) Run(
+	ctx context.Context,
+	log *log.Logger,
+	opts *globalOptions,
+	tokenSource oauth2.TokenSource,
+) error {
+	repo, err := git.Open(ctx, ".", git.OpenOptions{
+		Log: log,
+	})
+	if err != nil {
+		return fmt.Errorf("open repository: %w", err)
+	}
+
+	store, err := ensureStore(ctx, repo, log, opts)
+	if err != nil {
+		return err
+	}
+
+	remote, err := ensureRemote(ctx, repo, store, log, opts)
+	if err != nil {
+		return err
+	}
+
+	currentBranch, err := repo.CurrentBranch(ctx)
+	if err != nil {
+		return fmt.Errorf("get current branch: %w", err)
+	}
+
+	trunk := store.Trunk()
+	trunkStartHash, err := repo.PeelToCommit(ctx, trunk)
+	if err != nil {
+		return fmt.Errorf("peel to trunk: %w", err)
+	}
+
+	// TODO: This is pretty messy. Refactor.
+
+	// There's a mix of scenarios here:
+	//
+	// 1. Check out status:
+	//    a. trunk is the current branch; or
+	//    b. trunk is not the current branch; or
+	//    c. trunk is not the current branch,
+	//       but is checked out in another worktree
+	// 2. Sync status:
+	//    a. trunk is at or behind the remote; or
+	//    b. trunk has unpushed local commits
+	if currentBranch == trunk {
+		// (1a): Trunk is the current branch.
+		// Sync status doesn't matter,
+		// git pull --rebase will handle everything.
+		log.Debug("trunk is checked out: pulling changes")
+		opts := git.PullOptions{
+			Remote:  remote,
+			Rebase:  true,
+			Refspec: git.Refspec(trunk),
+		}
+		if err := repo.Pull(ctx, opts); err != nil {
+			return fmt.Errorf("pull: %w", err)
+		}
+	} else {
+		localBranches, err := repo.LocalBranches(ctx)
+		if err != nil {
+			return fmt.Errorf("list branches: %w", err)
+		}
+
+		// (1c): Trunk is not the current branch,
+		// but it is checked out in another worktree.
+		// Reject sync because we don't want to update the ref
+		// and mess up the other worktree.
+		trunkCheckedOut := slices.ContainsFunc(localBranches,
+			func(b git.LocalBranch) bool {
+				return b.Name == trunk && b.CheckedOut
+			})
+		if trunkCheckedOut {
+			// TODO:
+			// restack should support working off $remote/$trunk
+			// so we can still git fetch
+			// and continue working on the branch
+			// without updating the local trunk ref.
+			return errors.New("trunk cannot be updated: " +
+				"it is checked out in another worktree")
+		}
+		// Rest of this block is (1b): Trunk is not the current branch.
+
+		trunkHash, err := repo.PeelToCommit(ctx, trunk)
+		if err != nil {
+			return fmt.Errorf("peel to trunk: %w", err)
+		}
+
+		remoteHash, err := repo.PeelToCommit(ctx, remote+"/"+trunk)
+		if err != nil {
+			return fmt.Errorf("resolve remote trunk: %w", err)
+		}
+
+		if repo.IsAncestor(ctx, trunkHash, remoteHash) {
+			// (2a): Trunk is at or behind the remote.
+			// Fetch and upate the local trunk ref.
+			log.Debug("trunk is at or behind remote: fetching changes")
+			opts := git.FetchOptions{
+				Remote: remote,
+				Refspecs: []git.Refspec{
+					git.Refspec(trunk + ":" + trunk),
+				},
+			}
+			if err := repo.Fetch(ctx, opts); err != nil {
+				return fmt.Errorf("fetch: %w", err)
+			}
+		} else {
+			// (2b): Trunk has unpushed local commits
+			// but also (1b) trunk is not checked out anywhere,
+			// so we can check out trunk and rebase.
+			log.Debug("trunk has unpushed commits: pulling from remote")
+
+			if err := repo.Checkout(ctx, trunk); err != nil {
+				return fmt.Errorf("checkout trunk: %w", err)
+			}
+
+			opts := git.PullOptions{
+				Remote:  remote,
+				Rebase:  true,
+				Refspec: git.Refspec(trunk),
+			}
+			if err := repo.Pull(ctx, opts); err != nil {
+				return fmt.Errorf("pull: %w", err)
+			}
+
+			if err := repo.Checkout(ctx, currentBranch); err != nil {
+				return fmt.Errorf("checkout current branch: %w", err)
+			}
+
+			// TODO: With a recent enough git,
+			// we can attempt to replay those commits
+			// without checking out trunk.
+			// https://git-scm.com/docs/git-replay/2.44.0
+		}
+	}
+
+	trunkEndHash, err := repo.PeelToCommit(ctx, trunk)
+	if err != nil {
+		return fmt.Errorf("peel to trunk: %w", err)
+	}
+
+	if trunkStartHash == trunkEndHash {
+		log.Infof("%v: already up-to-date", trunk)
+		return nil
+	}
+
+	if repo.IsAncestor(ctx, trunkStartHash, trunkEndHash) {
+		count, err := repo.CountCommits(ctx,
+			git.CommitRangeFrom(trunkEndHash).ExcludeFrom(trunkStartHash))
+		if err != nil {
+			log.Warn("Failed to count commits", "error", err)
+		} else {
+			log.Infof("%v: pulled %v new commit(s)", trunk, count)
+		}
+	}
+
+	ghrepo, err := ensureGitHubRepo(ctx, log, repo, remote)
+	if err != nil {
+		return err
+	}
+
+	gh, err := newGitHubClient(ctx, tokenSource, opts)
+	if err != nil {
+		return fmt.Errorf("create GitHub client: %w", err)
+	}
+
+	// There are two options for detecting merged branches:
+	//
+	// 1. Query the PR status for each submitted branch.
+	//    This is more accurate, but requires a lot of API calls.
+	// 2. List recently merged PRs and match against tracked branches.
+	//    The number of API calls here is smaller,
+	//    but the matching is less accurate because the PR may have been
+	//    submitted by someone else.
+	//
+	// For now, we'll go for (1) with the assumption that the number of
+	// submitted branches is small enough that we can afford the API calls.
+	// In the future, we may need a hybrid approach that switches to (2).
+
+	var (
+		branches []string
+		prs      []int // prs[i] = PR for branches[i]
+	)
+	{
+		tracked, err := store.List(ctx)
+		if err != nil {
+			return fmt.Errorf("list tracked branches: %w", err)
+		}
+
+		for _, branch := range tracked {
+			b, err := store.Lookup(ctx, branch)
+			if err != nil {
+				return fmt.Errorf("lookup branch %v: %w", branch, err)
+			}
+
+			if b.PR != 0 {
+				branches = append(branches, branch)
+				prs = append(prs, b.PR)
+			}
+		}
+	}
+
+	if len(branches) == 0 {
+		log.Debug("No PRs submitted from tracked branches")
+		return nil
+	}
+
+	prMerged := make([]bool, len(branches)) // whether prs[i] is merged
+	{
+		idxc := make(chan int) // PRs to query
+
+		// Spawn up to GOMAXPROCS workers to query PR status.
+		var wg sync.WaitGroup
+		for range min(runtime.GOMAXPROCS(0), len(branches)) {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				for idx := range idxc {
+					merged, _, err := gh.PullRequests.IsMerged(ctx, ghrepo.Owner, ghrepo.Name, prs[idx])
+					if err != nil {
+						log.Error("Failed to query PR status", "pr", prs[idx], "error", err)
+						continue
+					}
+
+					prMerged[idx] = merged
+				}
+			}()
+		}
+
+		// Feed PRs to workers.
+		for i := range branches {
+			idxc <- i
+		}
+		close(idxc) // signal workers to exit
+
+		wg.Wait()
+	}
+
+	// TODO:
+	// Should the branches be deleted in any particular order?
+	// (e.g. from the bottom of the stack up)
+	for i, branch := range branches {
+		if !prMerged[i] {
+			continue
+		}
+
+		log.Infof("%v: #%v was merged: deleting...", branch, prs[i])
+		err := (&branchDeleteCmd{
+			Name:  branch,
+			Force: true,
+		}).Run(ctx, log, opts)
+		if err != nil {
+			return fmt.Errorf("delete branch %v: %w", branch, err)
+		}
+	}
+
+	// TODO:
+	// If --restack is set, restack the affected branches
+	// (or restack just the branches in this stack?)
+	// For this, we need the Delete operation to report the affected
+	// branches, which means it has to be refactored into a gs-level
+	// operation first.
+	return nil
+}

--- a/testdata/script/branch_submit_by_name.txt
+++ b/testdata/script/branch_submit_by_name.txt
@@ -36,7 +36,6 @@ Contents of feature1
     "state": "open",
     "title": "Add feature1",
     "body": "",
-    "draft": false,
     "html_url": "$GITHUB_GIT_URL/alice/example/pull/1",
     "head": {
       "ref": "feature1",

--- a/testdata/script/branch_submit_create_update.txt
+++ b/testdata/script/branch_submit_create_update.txt
@@ -46,7 +46,6 @@ New contents of feature1
     "state": "open",
     "title": "Add feature1",
     "body": "",
-    "draft": false,
     "html_url": "$GITHUB_GIT_URL/alice/example/pull/1",
     "head": {
       "ref": "feature1",
@@ -66,7 +65,6 @@ New contents of feature1
     "state": "open",
     "title": "Add feature1",
     "body": "",
-    "draft": false,
     "html_url": "$GITHUB_GIT_URL/alice/example/pull/1",
     "head": {
       "ref": "feature1",

--- a/testdata/script/branch_submit_remote_prompt.txt
+++ b/testdata/script/branch_submit_remote_prompt.txt
@@ -45,7 +45,6 @@ feed \r
     "state": "open",
     "title": "Add feature1",
     "body": "",
-    "draft": false,
     "html_url": "$GITHUB_GIT_URL/bob/example-fork/pull/1",
     "head": {
       "ref": "feature1",

--- a/testdata/script/branch_submit_rename.txt
+++ b/testdata/script/branch_submit_rename.txt
@@ -50,7 +50,6 @@ New contents of feature1
     "state": "open",
     "title": "Add feature1",
     "body": "",
-    "draft": false,
     "html_url": "$GITHUB_GIT_URL/alice/example/pull/1",
     "head": {
       "ref": "feature1",
@@ -70,7 +69,6 @@ New contents of feature1
     "state": "open",
     "title": "Add feature1",
     "body": "",
-    "draft": false,
     "html_url": "$GITHUB_GIT_URL/alice/example/pull/1",
     "head": {
       "ref": "feature1",

--- a/testdata/script/downstack_submit.txt
+++ b/testdata/script/downstack_submit.txt
@@ -46,7 +46,6 @@ INF Created #3: $GITHUB_GIT_URL/alice/example/pull/3
     "state": "open",
     "title": "Add feature 1",
     "body": "",
-    "draft": false,
     "html_url": "$GITHUB_GIT_URL/alice/example/pull/1",
     "head": {
       "ref": "feature1",
@@ -62,7 +61,6 @@ INF Created #3: $GITHUB_GIT_URL/alice/example/pull/3
     "state": "open",
     "title": "Add feature 2",
     "body": "",
-    "draft": false,
     "html_url": "$GITHUB_GIT_URL/alice/example/pull/2",
     "head": {
       "ref": "feature2",
@@ -78,7 +76,6 @@ INF Created #3: $GITHUB_GIT_URL/alice/example/pull/3
     "state": "open",
     "title": "Add feature 3",
     "body": "",
-    "draft": false,
     "html_url": "$GITHUB_GIT_URL/alice/example/pull/3",
     "head": {
       "ref": "feature3",

--- a/testdata/script/repo_sync_merged_pr.txt
+++ b/testdata/script/repo_sync_merged_pr.txt
@@ -1,0 +1,62 @@
+# 'repo sync' from trunk, PR merged server-side with a merge commit.
+
+as 'Test <test@example.com>'
+at '2024-05-18T13:59:12Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+gh-init
+gh-add-remote origin alice/example.git
+git push origin main
+
+# create a new branch and submit it
+git add feature1.txt
+gs bc -m 'Add feature1' feature1
+gs branch submit --fill
+stderr 'Created #'
+
+# merge the PR server side and sync.
+gh-merge alice/example 1
+gs repo sync
+stderr 'feature1: #1 was merged'
+
+# we should now be on main
+# and feature1 branch should be gone.
+exists feature1.txt
+git log --branches --oneline --decorate --graph
+cmp stdout $WORK/golden/merged-log.txt
+
+gh-dump-pull 1
+cmpenvJSON stdout $WORK/golden/pull.json
+
+-- repo/feature1.txt --
+Contents of feature1
+
+-- golden/pull.json --
+{
+  "number": 1,
+  "state": "closed",
+  "title": "Add feature1",
+  "body": "",
+  "merged": true,
+  "html_url": "$GITHUB_GIT_URL/alice/example/pull/1",
+  "head": {
+    "ref": "feature1",
+    "sha": "9f1c9af063d2363d6a1381581bfab2a25d12be4c"
+  },
+  "base": {
+    "ref": "main",
+    "sha": "7bfac22ffbcf563e3434adf877eb3cda0fef3d48"
+  }
+}
+
+-- golden/merged-log.txt --
+*   7bfac22 (HEAD -> main, origin/main) Merge pull request #1
+|\  
+| * 9f1c9af (origin/feature1) Add feature1
+|/  
+* d90607e Initial commit

--- a/testdata/script/repo_sync_trunk_no_prs.txt
+++ b/testdata/script/repo_sync_trunk_no_prs.txt
@@ -1,0 +1,38 @@
+# 'repo sync' from trunk, no PRs submitted.
+
+as 'Test <test@example.com>'
+at '2024-05-18T13:59:12Z'
+
+# setup
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+gh-init
+gh-add-remote origin alice/example.git
+git push origin main
+gs repo init
+
+# update the remote out of band
+cd ..
+gh-clone alice/example.git fork
+cd fork
+cp $WORK/extra/feature1.txt .
+git add feature1.txt
+git commit -m 'Add feature1'
+git push origin main
+
+# sync the original repo
+cd ../repo
+gs repo sync
+stderr 'pulled 1 new commit'
+cmp feature1.txt $WORK/extra/feature1.txt
+
+# sync again
+gs repo sync
+stderr 'already up-to-date'
+
+-- extra/feature1.txt --
+Contents of feature1

--- a/testdata/script/repo_sync_unpushed_commits.txt
+++ b/testdata/script/repo_sync_unpushed_commits.txt
@@ -1,0 +1,71 @@
+# 'repo sync' to get a merged PR while having unpushed changes on trunk.
+
+as 'Test <test@example.com>'
+at '2024-05-18T13:59:12Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+gh-init
+gh-add-remote origin alice/example.git
+git push origin main
+
+# create a new branch and submit it
+git add feature1.txt
+gs bc -m 'Add feature1' feature1
+gs branch submit --fill
+stderr 'Created #'
+
+# add an unpublished change to main
+git checkout main
+git add feature2.txt
+git commit -m 'Add feature2'
+
+# merge the PR and sync from non-trunk branch.
+git checkout feature1
+gh-merge alice/example 1
+gs repo sync
+stderr 'feature1: #1 was merged'
+
+# now on main
+exists feature1.txt feature2.txt
+git log --branches --oneline --decorate --graph
+cmp stdout $WORK/golden/merged-log.txt
+
+gh-dump-pull 1
+cmpenvJSON stdout $WORK/golden/pull.json
+
+-- repo/feature1.txt --
+Contents of feature1
+
+-- repo/feature2.txt --
+Contents of feature2
+
+-- golden/pull.json --
+{
+  "number": 1,
+  "state": "closed",
+  "title": "Add feature1",
+  "body": "",
+  "merged": true,
+  "html_url": "$GITHUB_GIT_URL/alice/example/pull/1",
+  "head": {
+    "ref": "feature1",
+    "sha": "9f1c9af063d2363d6a1381581bfab2a25d12be4c"
+  },
+  "base": {
+    "ref": "main",
+    "sha": "7bfac22ffbcf563e3434adf877eb3cda0fef3d48"
+  }
+}
+
+-- golden/merged-log.txt --
+* e40a703 (HEAD -> main) Add feature2
+*   7bfac22 (origin/main) Merge pull request #1
+|\  
+| * 9f1c9af (origin/feature1) Add feature1
+|/  
+* d90607e Initial commit


### PR DESCRIPTION
This is a bit complicated, but it implements the 'gs repo sync' command.
This pulls the latest main, and deletes merged branches,
updating the upstacks of merged branches to point to their new bases.

It DOES NOT yet restack anything on merge.