### PR TITLE
Add CLI completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 ```
 
 See LICENSE for details.
+
+As an exception to the above, the following files are distributed
+under a different license. See the file headers for details:
+
+    internal/komplete/komplete.go

--- a/branch_checkout.go
+++ b/branch_checkout.go
@@ -11,7 +11,7 @@ import (
 )
 
 type branchCheckoutCmd struct {
-	Name string `arg:"" optional:"" help:"Name of the branch to delete"`
+	Name string `arg:"" optional:"" help:"Name of the branch to delete" predictor:"branches"`
 }
 
 func (cmd *branchCheckoutCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {

--- a/branch_delete.go
+++ b/branch_delete.go
@@ -14,7 +14,7 @@ import (
 )
 
 type branchDeleteCmd struct {
-	Name  string `arg:"" optional:"" help:"Name of the branch to delete"`
+	Name  string `arg:"" optional:"" help:"Name of the branch to delete" predictor:"branches"`
 	Force bool   `short:"f" help:"Force deletion of the branch"`
 }
 

--- a/branch_fold.go
+++ b/branch_fold.go
@@ -13,7 +13,7 @@ import (
 )
 
 type branchFoldCmd struct {
-	Name string `arg:"" optional:"" help:"Name of the branch"`
+	Name string `arg:"" optional:"" help:"Name of the branch" predictor:"trackedBranches"`
 }
 
 func (*branchFoldCmd) Help() string {

--- a/branch_onto.go
+++ b/branch_onto.go
@@ -12,8 +12,8 @@ import (
 )
 
 type branchOntoCmd struct {
-	Branch string `help:"Branch to move" placeholder:"NAME"`
-	Onto   string `arg:"" optional:"" help:"Destination branch"`
+	Branch string `help:"Branch to move" placeholder:"NAME" predictor:"trackedBranches"`
+	Onto   string `arg:"" optional:"" help:"Destination branch" predictor:"trackedBranches"`
 }
 
 func (*branchOntoCmd) Help() string {

--- a/branch_restack.go
+++ b/branch_restack.go
@@ -12,7 +12,7 @@ import (
 )
 
 type branchRestackCmd struct {
-	Name string `arg:"" optional:"" help:"Branch to restack"`
+	Name string `arg:"" optional:"" help:"Branch to restack" predictor:"trackedBranches"`
 }
 
 func (*branchRestackCmd) Help() string {

--- a/branch_submit.go
+++ b/branch_submit.go
@@ -32,7 +32,7 @@ type branchSubmitCmd struct {
 	// - milestone
 	// - reviewers
 
-	Name string `arg:"" optional:"" placeholder:"BRANCH" help:"Branch to submit"`
+	Name string `arg:"" optional:"" placeholder:"BRANCH" help:"Branch to submit" predictor:"trackedBranches"`
 }
 
 func (*branchSubmitCmd) Help() string {

--- a/branch_track.go
+++ b/branch_track.go
@@ -15,8 +15,8 @@ import (
 )
 
 type branchTrackCmd struct {
-	Base string `short:"b" help:"Base branch this merges into"`
-	Name string `arg:"" optional:"" help:"Name of the branch to track"`
+	Base string `short:"b" help:"Base branch this merges into" predictor:"branches"`
+	Name string `arg:"" optional:"" help:"Name of the branch to track" predictor:"branches"`
 
 	// TODO:
 	// PR   int    `help:"Pull request number to associate with this branch"`

--- a/branch_untrack.go
+++ b/branch_untrack.go
@@ -11,7 +11,7 @@ import (
 )
 
 type branchUntrackCmd struct {
-	Name string `arg:"" optional:"" help:"Name of the branch to untrack"`
+	Name string `arg:"" optional:"" help:"Name of the branch to untrack" predictor:"branches"`
 }
 
 func (*branchUntrackCmd) Help() string {

--- a/complete.go
+++ b/complete.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/posener/complete"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/komplete"
+	"go.abhg.dev/gs/internal/state"
+	"go.abhg.dev/gs/internal/text"
+)
+
+type completeCmd struct {
+	*komplete.Command `embed:""`
+}
+
+func (c *completeCmd) Help() string {
+	return text.Dedent(`
+		Generates shell completion scripts for gs. To install the
+		script, add the generated script to your shell's rc file.
+		For example:
+
+			# bash
+			gs complete bash >> ~/.bashrc
+
+			# zsh
+			gs complete zsh >> ~/.zshrc
+
+			# fish
+			gs complete fish >> ~/.config/fish/config.fish
+	`)
+}
+
+func predictBranches(args complete.Args) (predictions []string) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	repo, err := git.Open(ctx, ".", git.OpenOptions{})
+	if err != nil {
+		return nil
+	}
+
+	branches, err := repo.LocalBranches(ctx)
+	if err != nil {
+		return nil
+	}
+
+	for _, branch := range branches {
+		predictions = append(predictions, branch.Name)
+	}
+
+	return predictions
+}
+
+func predictTrackedBranches(args complete.Args) (predictions []string) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	repo, err := git.Open(ctx, ".", git.OpenOptions{})
+	if err != nil {
+		return nil
+	}
+
+	store, err := state.OpenStore(ctx, repo, nil /* log */)
+	if err != nil {
+		return nil // not initialized
+	}
+
+	branches, err := store.List(ctx)
+	if err != nil {
+		return nil
+	}
+
+	return branches
+}
+
+func predictRemotes(args complete.Args) (predictions []string) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	repo, err := git.Open(ctx, ".", git.OpenOptions{})
+	if err != nil {
+		return nil
+	}
+
+	remotes, err := repo.ListRemotes(ctx)
+	if err != nil {
+		return nil
+	}
+
+	return remotes
+}

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -455,3 +455,28 @@ gs trunk (gg) [flags]
 
 Move to the trunk branch
 
+## gs complete
+
+```
+gs complete <shell> [flags]
+```
+
+Generate shell completion script
+
+Generates shell completion scripts for gs. To install the
+script, add the generated script to your shell's rc file.
+For example:
+
+	# bash
+	gs complete bash >> ~/.bashrc
+
+	# zsh
+	gs complete zsh >> ~/.zshrc
+
+	# fish
+	gs complete fish >> ~/.config/fish/config.fish
+
+**Arguments**
+
+* `shell`: Shell to generate completions for.
+

--- a/downstack_edit.go
+++ b/downstack_edit.go
@@ -21,7 +21,7 @@ import (
 type downstackEditCmd struct {
 	Editor string `env:"EDITOR" help:"Editor to use for editing the downstack."`
 
-	Name string `arg:"" optional:"" help:"Name of the branch to start editing from."`
+	Name string `arg:"" optional:"" help:"Name of the branch to start editing from." predictor:"trackedBranches"`
 }
 
 func (*downstackEditCmd) Help() string {

--- a/downstack_submit.go
+++ b/downstack_submit.go
@@ -18,7 +18,7 @@ type downstackSubmitCmd struct {
 	DryRun bool `short:"n" help:"Don't actually submit the stack"`
 	Fill   bool `help:"Fill in the pull request title and body from the commit messages"`
 
-	Name string `arg:"" optional:"" placeholder:"BRANCH" help:"Branch to start at"`
+	Name string `arg:"" optional:"" placeholder:"BRANCH" help:"Branch to start at" predictor:"trackedBranches"`
 }
 
 func (*downstackSubmitCmd) Help() string {

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/creack/pty/v2 v2.0.1
 	github.com/google/go-github/v61 v61.0.0
 	github.com/mattn/go-isatty v0.0.20
+	github.com/posener/complete v1.2.3
 	github.com/rogpeppe/go-internal v1.12.0
 	github.com/stretchr/testify v1.9.0
 	github.com/vito/midterm v0.1.5-0.20240307214207-d0271a7ca452
@@ -28,6 +29,8 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,7 @@ github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 h1:q2hJAaP1k2
 github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
 github.com/creack/pty/v2 v2.0.1 h1:RDY1VY5b+7m2mfPsugucOYPIxMp+xal5ZheSyVzUA+k=
 github.com/creack/pty/v2 v2.0.1/go.mod h1:2dSssKp3b86qYEMwA/FPwc3ff+kYpDdQI8osU8J7gxQ=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logfmt/logfmt v0.6.0 h1:wGYYu3uicYdqXVgoYbvnkrPVXkuLM1p1ifugDMEdRi4=
@@ -35,6 +36,12 @@ github.com/google/go-github/v61 v61.0.0 h1:VwQCBwhyE9JclCI+22/7mLB1PuU9eowCXKY5p
 github.com/google/go-github/v61 v61.0.0/go.mod h1:0WR+KmsWX75G2EbpyGsGmradjo3IiciuI4BmdVCobQY=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
+github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
@@ -56,6 +63,8 @@ github.com/muesli/termenv v0.15.2 h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo
 github.com/muesli/termenv v0.15.2/go.mod h1:Epx+iuz8sNs7mNKhxzH4fWXGNpZwUaJKRS1noLXviQ8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
+github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
@@ -66,6 +75,8 @@ github.com/sebdah/goldie/v2 v2.5.3 h1:9ES/mNN+HNUbNWpVAlrzuZ7jE+Nrczbj8uFRjM7624
 github.com/sebdah/goldie/v2 v2.5.3/go.mod h1:oZ9fp0+se1eapSRjfYbsV/0Hqhbuu3bJVvKI/NNtssI=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/vito/midterm v0.1.5-0.20240307214207-d0271a7ca452 h1:I5FdiUvkD++87hOiZYuDu0BqsaJXAnpOCed3kqkjCEE=
@@ -93,6 +104,7 @@ golang.org/x/tools v0.14.0/go.mod h1:uYBEerGOWcJyEORxN+Ek8+TT266gXkNlHdJBwexUsBg
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 pgregory.net/rapid v1.1.0 h1:CMa0sjHSru3puNx+J0MIAuiiEV4N0qj8/cMWGBBCsjw=

--- a/internal/komplete/komplete.go
+++ b/internal/komplete/komplete.go
@@ -1,0 +1,514 @@
+/*
+Unlike the rest of the code in this repository,
+this file is made available under the BSD 3-Clause License
+so that it can be copied into other projects.
+License text follows.
+------------------------------------------------------------------------------
+BSD 3-Clause License
+
+Copyright (c) 2024, Abhinav Gupta (https://abhinavg.net/)
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// Package komplete is a package for generating completions for Kong CLIs.
+//
+// To use it, build a Kong parser from your CLI grammar,
+// and then call [Run] with it to run the completion logic.
+// This will automatically determine if the CLI is being invoked
+// as a completion script or as a regular command.
+//
+//	parser, err := kong.New(cli)
+//	// ...
+//	komplete.Run(parser)
+//
+// [Command] is provided as a convenient subcommand for generating
+// completion scripts for various shells.
+//
+// Custom logic to predict values for flags and arguments can be provided
+// through [WithPredictor]. Install a predictor with a name,
+// and refer to it in your CLI grammar with the `predictor:"name"` tag.
+//
+//	type CLI struct {
+//		Name string `help:"Name of the branch" predictor:"branches"`
+//		// ...
+//	}
+//
+//	// ...
+//	komplete.Run(parser,
+//		komplete.WithPredictor("branches", branchesPredictor),
+//		// ...
+//	)
+package komplete
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/alecthomas/kong"
+	"github.com/posener/complete"
+	"go.abhg.dev/gs/internal/must"
+)
+
+// Implementation notes:
+//
+// - This package is inspired by https://github.com/WillAbides/kongplete,
+//   but it is a from-scratch implementation that more-or-less reimplements
+//   Kong's CLI parsing logic.
+// - We're not using complete/v2 because it does not expose
+//   the full argument list to predictors.
+
+// Command is the command to run to generate the completion script.
+// It is intended to be used as a subcommand of the main CLI.
+type Command struct {
+	Shell string ` enum:"bash,zsh,fish" arg:"" required:"" help:"Shell to generate completions for."`
+}
+
+// Run runs the completion script generator.
+// It will print the completion script to stdout and exit.
+func (cmd *Command) Run(kctx *kong.Context) (err error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("find executable: %w", err)
+	}
+
+	out := bufio.NewWriter(kctx.Stdout)
+	defer func() {
+		err = errors.Join(err, out.Flush())
+	}()
+
+	name := kctx.Model.Name
+	switch cmd.Shell {
+	case "bash":
+		fmt.Fprintf(out, "complete -C %s %s\n", exe, name)
+
+	case "zsh":
+		fmt.Fprintln(out, `autoload -U +X bashcompinit && bashcompinit`)
+		fmt.Fprintf(out, "complete -C %s %s\n", exe, name)
+
+	case "fish":
+		fmt.Fprintf(out, "function __complete_%s\n", name)
+		fmt.Fprintln(out, "    set -lx COMP_LINE (commandline -cp)")
+		fmt.Fprintln(out, "    test -z (commandline -ct)")
+		fmt.Fprintln(out, `    and set COMP_LINE "$COMP_LINE "`)
+		fmt.Fprintf(out, "    %s\n", exe)
+		fmt.Fprintln(out, "end")
+		fmt.Fprintf(out, `complete -f -c %s -a "(__complete_%s)"`+"\n", name, name)
+
+	default:
+		return fmt.Errorf("unsupported shell: %s", cmd.Shell)
+	}
+
+	return nil
+}
+
+// Run runs the CLI argument completer if the user has requested completions.
+// Otherwise, this is a no-op.
+func Run(parser *kong.Kong, opts ...Option) {
+	options := options{
+		named: make(map[string]complete.Predictor),
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	completer := complete.New(
+		parser.Model.Name,
+		complete.Command{
+			Args: newKongPredictor(parser.Model, options),
+		},
+	)
+	completer.Out = parser.Stdout
+	if done := completer.Complete(); done {
+		parser.Exit(0)
+	}
+}
+
+// Option customizes completion logic.
+type Option func(*options)
+
+type options struct {
+	named              map[string]complete.Predictor
+	transformCompleted func([]string) []string
+}
+
+// WithPredictor adds a named predictor to the completion logic.
+//
+// Flags and arguments can request a predictor for their values
+// by adding a `predictor:"name"` tag to the field.
+//
+//	type CLI struct {
+//		Name string `help:"Name of the branch" predictor:"branches"`
+//		// ...
+//	}
+//
+//	komplete.Run(parser,
+//		komplete.WithPredictor("branches", branchesPredictor),
+//	)
+func WithPredictor(name string, predictor complete.Predictor) Option {
+	return func(opts *options) {
+		opts.named[name] = predictor
+	}
+}
+
+// WithTransformCompleted allows modifying the list of completed arguments,
+// allowing replication of any os.Args transformations.
+func WithTransformCompleted(fn func([]string) []string) Option {
+	// TODO: better name for this
+	return func(opts *options) {
+		opts.transformCompleted = fn
+	}
+}
+
+// kongPredictor is a [complete.Predictor] that interprets flags
+// using Kong's CLI behaviors.
+//
+// It is intended to entirely replace complete.Command's flag and subcommand
+// behavior by being used as an Args predictor.
+type kongPredictor struct {
+	model *kong.Application
+
+	named              map[string]complete.Predictor // name => predictor
+	transformCompleted func([]string) []string
+}
+
+var _ complete.Predictor = (*kongPredictor)(nil)
+
+func newKongPredictor(model *kong.Application, opts options) *kongPredictor {
+	return &kongPredictor{
+		model:              model,
+		named:              opts.named,
+		transformCompleted: opts.transformCompleted,
+	}
+}
+
+func (k *kongPredictor) Predict(cargs complete.Args) (predictions []string) {
+	completed := cargs.Completed
+	if k.transformCompleted != nil {
+		completed = k.transformCompleted(completed)
+	}
+
+	p := k.findPredictor(k.model.Node, kong.Scan(completed...))
+	if p == nil {
+		return nil
+	}
+	return p.Predict(cargs)
+}
+
+func (k *kongPredictor) findPredictor(node *kong.Node, scan *kong.Scanner) complete.Predictor {
+	// Logic based on
+	// https://github.com/alecthomas/kong/blob/master/context.go#L370.
+
+	var positional int // current position in positional arguments
+	allFlags := slices.Clone(node.Flags)
+	usedFlags := make(map[string]struct{})
+
+parser:
+	for !scan.Peek().IsEOL() {
+		token := scan.Peek()
+		switch token.Type {
+		case kong.UntypedToken:
+			if v, ok := token.Value.(string); ok {
+				switch {
+				case v == "-":
+					// Bare "-" is a positional argument.
+					scan.Pop()
+					scan.PushTyped(token.Value, kong.PositionalArgumentToken)
+
+				case v == "--": // end of flags
+					scan.Pop()
+					return nil
+
+				case strings.HasPrefix(v, "--"): // long flag
+					scan.Pop()
+					v = v[2:]
+					flag, value, ok := strings.Cut(v, "=")
+					if ok {
+						scan.PushTyped(value, kong.FlagValueToken)
+					}
+					scan.PushTyped(flag, kong.FlagToken)
+
+				case strings.HasPrefix(v, "-"): // short flag
+					scan.Pop()
+					if tail := v[2:]; tail != "" {
+						scan.PushTyped(tail, kong.ShortFlagTailToken)
+					}
+					scan.PushTyped(v[1:2], kong.ShortFlagToken)
+
+				default:
+					// Anything that doesn't match the rest
+					// is a positional argument.
+					scan.Pop()
+					scan.PushTyped(token.Value, kong.PositionalArgumentToken)
+				}
+			} else {
+				scan.Pop()
+				scan.PushTyped(token.Value, kong.PositionalArgumentToken)
+			}
+
+		case kong.ShortFlagTailToken:
+			scan.Pop()
+			if tail := token.String()[1:]; tail != "" {
+				scan.PushTyped(tail, kong.ShortFlagTailToken)
+			}
+			scan.PushTyped(token.String()[0:1], kong.ShortFlagToken)
+
+		case kong.FlagToken, kong.ShortFlagToken:
+			f, status := k.matchFlag(allFlags, scan, token.String())
+			switch status {
+			case flagExpectingValue:
+				return &valuePredictor{
+					value: f.Value,
+					named: k.named,
+				}
+
+			case flagConsumed:
+				// Used flags will not be predicted,
+				// but they're allowed to be repeated.
+				usedFlags[f.Name] = struct{}{}
+
+			case flagNotMatched:
+				complete.Log("unexpected flag: %v", token)
+				return nil
+
+			default:
+				must.Failf("unexpected flag status: %v", status)
+			}
+
+		case kong.FlagValueToken:
+			// Flag values are consumed in matchFlag.
+			complete.Log("unexpected flag value: %v", token)
+			return nil
+
+		case kong.PositionalArgumentToken:
+			if positional < len(node.Positional) {
+				scan.Pop()
+				positional++
+				continue parser // move to next token
+			}
+
+			// We're at the end of expected positional arguments.
+			// Try commands next.
+			arg := token.String()
+			for _, child := range node.Children {
+				if child.Type != kong.CommandNode {
+					continue
+				}
+
+				match := child.Name == arg
+				if !match && len(child.Aliases) > 0 {
+					for _, alias := range child.Aliases {
+						if alias == arg {
+							match = true
+							break
+						}
+					}
+				}
+
+				if match {
+					scan.Pop() // consume the command
+					node = child
+					allFlags = append(allFlags, child.Flags...)
+					positional = 0
+					continue parser
+				}
+			}
+
+			// None of the command matched. Check argument nodes.
+			// These are positional arguments with fixed values.
+			// Just skip over them.
+			for _, child := range node.Children {
+				if child.Type == kong.ArgumentNode {
+					_ = child.Argument.Parse(scan, child.Target) // consume the value
+				}
+			}
+
+			if !scan.Peek().IsEOL() {
+				// We have extra arguments. Stop predicting.
+				complete.Log("unexpected argument: %v (%v)", token, token.Type)
+				return nil
+			}
+
+		default:
+			complete.Log("unexpected token: %v (%v)", token, token.Type)
+			return nil
+		}
+	}
+
+	var predictors []complete.Predictor
+	if positional < len(node.Positional) {
+		// If we haven't yet consumed all positional arguments of the
+		// current node, we can predict the next positional argument.
+		predictors = append(predictors, &valuePredictor{
+			value: node.Positional[positional],
+			named: k.named,
+		})
+	}
+
+	var subcommands []string
+	for _, child := range node.Children {
+		if child.Hidden {
+			continue
+		}
+		if child.Type == kong.CommandNode {
+			subcommands = append(subcommands, child.Name)
+		}
+	}
+	if len(subcommands) > 0 {
+		predictors = append(predictors, complete.PredictSet(subcommands...))
+	}
+
+	// Only predict the current node's flags.
+	predictors = append(predictors, &flagsPredictor{
+		allFlags: allFlags,
+		flags:    node.Flags,
+		used:     usedFlags,
+	})
+	return complete.PredictOr(predictors...)
+}
+
+type flagStatus int
+
+const (
+	flagConsumed       flagStatus = iota // consumed flag and value
+	flagExpectingValue                   // consumed flag, expecting value
+	flagNotMatched                       // flag not matched
+)
+
+// matchFlag attempts to match a flag in the current command node.
+// It returns flagStatus to indicate the outcome.
+// The returned flag is nil if a flag was not matched.
+func (k *kongPredictor) matchFlag(flags []*kong.Flag, scan *kong.Scanner, arg string) (*kong.Flag, flagStatus) {
+	// TODO: we can maybe combine the traverse and predict logic.
+	for _, flag := range flags {
+		matched := "--"+flag.Name == arg
+
+		if !matched && len(flag.Aliases) > 0 {
+			for _, alias := range flag.Aliases {
+				if "--"+alias == arg {
+					matched = true
+					break
+				}
+			}
+		}
+
+		if !matched && flag.Short != 0 {
+			matched = "-"+string(flag.Short) == arg
+		}
+
+		if !matched && flag.Tag.Negatable {
+			matched = "--no-"+flag.Name == arg
+		}
+
+		if !matched {
+			continue
+		}
+
+		scan.Pop() // consume the flag
+
+		if scan.Peek().IsEOL() && !flag.IsBool() {
+			// Missing value for the flag.
+			// Let the caller predict the value.
+			return flag, flagExpectingValue
+		}
+
+		_ = flag.Parse(scan, flag.Target) // consume the value
+		return flag, flagConsumed
+	}
+
+	return nil, flagNotMatched
+}
+
+type valuePredictor struct {
+	value *kong.Value
+	named map[string]complete.Predictor
+}
+
+var _ complete.Predictor = (*valuePredictor)(nil)
+
+func (p *valuePredictor) Predict(cargs complete.Args) []string {
+	if name := p.value.Tag.Get("predictor"); name != "" {
+		if p, ok := p.named[name]; ok {
+			return p.Predict(cargs)
+		}
+		complete.Log("predictor not found: %s", name)
+	}
+
+	if p.value.Enum != "" {
+		return p.value.EnumSlice()
+	}
+
+	return nil
+}
+
+// flagsPredictor attempts to be a bit smart:
+//
+//   - If there's no input, predict only flags for the current node.
+//   - If there's input, also include matching aliases, and flags from parent nodes.
+//   - Don't predict flags that have already been filled.
+type flagsPredictor struct {
+	allFlags []*kong.Flag
+	flags    []*kong.Flag
+	used     map[string]struct{}
+}
+
+var _ complete.Predictor = (*flagsPredictor)(nil)
+
+func (p *flagsPredictor) Predict(cargs complete.Args) (predictions []string) {
+	flagPrefix, _ := strings.CutPrefix(cargs.Last, "--")
+
+	flags := p.flags
+	if flagPrefix != "" {
+		flags = p.allFlags
+	}
+
+	for _, flag := range flags {
+		if _, ok := p.used[flag.Name]; ok || flag.Hidden {
+			continue
+		}
+
+		predictions = append(predictions, "--"+flag.Name)
+		if flag.Tag.Negatable {
+			predictions = append(predictions, "--no-"+flag.Name)
+		}
+
+		// Include aliases only if the user has typed a prefix.
+		// Otherwise they'll just clutter the completions.
+		if flagPrefix != "" {
+			for _, alias := range flag.Aliases {
+				if strings.HasPrefix(alias, flagPrefix) {
+					predictions = append(predictions, "--"+alias)
+				}
+			}
+		}
+	}
+
+	return predictions
+}

--- a/repo_init.go
+++ b/repo_init.go
@@ -15,8 +15,8 @@ import (
 )
 
 type repoInitCmd struct {
-	Trunk  string `placeholder:"BRANCH" help:"Name of the trunk branch"`
-	Remote string `placeholder:"NAME" help:"Name of the remote to push changes to"`
+	Trunk  string `placeholder:"BRANCH" predictor:"branches" help:"Name of the trunk branch"`
+	Remote string `placeholder:"NAME" predictor:"remotes" help:"Name of the remote to push changes to"`
 
 	Reset bool `help:"Reset the store if it's already initialized"`
 }


### PR DESCRIPTION
This adds bash, zsh, and fish completion for the CLI.
The logic for this is basically a copy of how Kong's CLI parsre works.
There may be some edge cases (it needs unit tests)
but manual testing indicates that this works reasonably well.

This does not use kongplete largely because:

- it appears to be unmaintained
- it does not expose the completed argument list
  (which is necessary for handling shorthand commands)
- I'm not entirely sure it implements the same parsing logic as Kong

We should consider upstreaming this logic into Kong in the future;
perhaps the duplication can be avoided.

Resolve #32