### PR TITLE
refactor: Auto-heal from deleted branches

### DIFF
--- a/branch_create.go
+++ b/branch_create.go
@@ -93,7 +93,7 @@ func (cmd *branchCreateCmd) Run(ctx context.Context, log *log.Logger, opts *glob
 			return fmt.Errorf("--below cannot be used from  %v", trunk)
 		}
 
-		b, err := store.Lookup(ctx, currentBranch)
+		b, err := svc.LookupBranch(ctx, currentBranch)
 		if err != nil {
 			return fmt.Errorf("branch not tracked: %v", currentBranch)
 		}

--- a/branch_delete.go
+++ b/branch_delete.go
@@ -8,7 +8,6 @@ import (
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/gs"
-	"go.abhg.dev/gs/internal/must"
 	"go.abhg.dev/gs/internal/state"
 	"go.abhg.dev/gs/internal/text"
 )
@@ -50,78 +49,53 @@ func (cmd *branchDeleteCmd) Run(ctx context.Context, log *log.Logger, opts *glob
 		return fmt.Errorf("get current branch: %w", err)
 	}
 
-	var (
-		aboves  []string
-		base    string
-		tracked bool
-	)
-	if b, err := store.Lookup(ctx, cmd.Name); err == nil {
-		tracked = true
-		// If we know this branch, we'll want to update the upstacks
-		// after deletion.
-		base = b.Base
-
-		aboves, err = svc.ListAbove(ctx, cmd.Name)
-		if err != nil {
-			log.Warn("failed to list branches above", "branch", cmd.Name, "err", err)
-			aboves = nil
+	tracked, exists := true, true
+	base := store.Trunk()
+	if b, err := svc.LookupBranch(ctx, cmd.Name); err != nil {
+		if delErr := new(gs.DeletedBranchError); errors.As(err, &delErr) {
+			exists = false
+			log.Info("branch has already been deleted", "branch", cmd.Name)
+		} else if errors.Is(err, state.ErrNotExist) {
+			tracked = false
+			log.Info("branch is not tracked: deleting anyway", "branch", cmd.Name)
+		} else {
+			return fmt.Errorf("lookup branch %v: %w", cmd.Name, err)
 		}
 	} else {
-		log.Warn("branch is not tracked by gs; deleting anyway", "branch", cmd.Name)
+		base = b.Base
 	}
 
 	// Move to the base of the branch
 	// if we're on the branch we're deleting.
 	if cmd.Name == currentBranch {
-		next := base
-		if next == "" {
-			next = store.Trunk()
-		}
-
-		if err := repo.Checkout(ctx, next); err != nil {
-			return fmt.Errorf("checkout %v: %w", next, err)
+		if err := repo.Checkout(ctx, base); err != nil {
+			return fmt.Errorf("checkout %v: %w", base, err)
 		}
 	}
 
-	if err := repo.DeleteBranch(ctx, cmd.Name, git.BranchDeleteOptions{
-		Force: cmd.Force,
-	}); err != nil {
-		// If the branch still exists,
-		// it's likely because it's not merged.
-		if _, peelErr := repo.PeelToCommit(ctx, cmd.Name); peelErr == nil {
-			log.Error("git refused to delete the branch", "err", err)
-			log.Error("try re-running with --force")
-			return errors.New("branch not deleted")
+	if exists {
+		opts := git.BranchDeleteOptions{Force: cmd.Force}
+		if err := repo.DeleteBranch(ctx, cmd.Name, opts); err != nil {
+			// If the branch still exists,
+			// it's likely because it's not merged.
+			if _, peelErr := repo.PeelToCommit(ctx, cmd.Name); peelErr == nil {
+				log.Error("git refused to delete the branch", "err", err)
+				log.Error("try re-running with --force")
+				return errors.New("branch not deleted")
+			}
+
+			// If the branch doesn't exist,
+			// it may already have been deleted.
+			log.Warn("branch may already have been deleted", "err", err)
 		}
-
-		// If the branch doesn't exist,
-		// it may already have been deleted.
-		log.Warn("branch may already have been deleted", "err", err)
 	}
 
-	if !tracked {
-		return nil
+	if tracked {
+		if err := svc.ForgetBranch(ctx, cmd.Name); err != nil {
+			return fmt.Errorf("forget branch %v: %w", cmd.Name, err)
+		}
 	}
 
-	update := state.UpdateRequest{
-		Message: fmt.Sprintf("delete branch %v", cmd.Name),
-		Deletes: []string{cmd.Name},
-	}
-
-	if len(aboves) > 0 {
-		must.NotBeBlankf(base, "base must be set if branches were found above")
-	}
-	for _, above := range aboves {
-		update.Upserts = append(update.Upserts, state.UpsertRequest{
-			Name: above,
-			Base: base,
-		})
-	}
-
-	if err := store.Update(ctx, &update); err != nil {
-		return fmt.Errorf("update branches: %w", err)
-	}
-
-	// TODO: auto-restack with opt-out flag
+	// TODO: flag to auto-restack upstack branches?
 	return nil
 }

--- a/branch_edit.go
+++ b/branch_edit.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/gs"
 	"go.abhg.dev/gs/internal/state"
 	"go.abhg.dev/gs/internal/text"
 )
@@ -33,12 +34,14 @@ func (*branchEditCmd) Run(ctx context.Context, log *log.Logger, opts *globalOpti
 		return err
 	}
 
+	svc := gs.NewService(repo, store, log)
+
 	currentBranch, err := repo.CurrentBranch(ctx)
 	if err != nil {
 		return fmt.Errorf("get current branch: %w", err)
 	}
 
-	b, err := store.Lookup(ctx, currentBranch)
+	b, err := svc.LookupBranch(ctx, currentBranch)
 	if err != nil {
 		if errors.Is(err, state.ErrNotExist) {
 			return fmt.Errorf("branch not tracked: %s", currentBranch)

--- a/branch_fold.go
+++ b/branch_fold.go
@@ -59,7 +59,7 @@ func (cmd *branchFoldCmd) Run(ctx context.Context, log *log.Logger, opts *global
 		}
 	}
 
-	b, err := store.Lookup(ctx, cmd.Name)
+	b, err := svc.LookupBranch(ctx, cmd.Name)
 	if err != nil {
 		return fmt.Errorf("get branch: %w", err)
 	}

--- a/branch_submit.go
+++ b/branch_submit.go
@@ -76,7 +76,7 @@ func (cmd *branchSubmitCmd) Run(
 		cmd.Name = currentBranch
 	}
 
-	branch, err := store.Lookup(ctx, cmd.Name)
+	branch, err := svc.LookupBranch(ctx, cmd.Name)
 	if err != nil {
 		return fmt.Errorf("lookup branch: %w", err)
 	}

--- a/internal/gs/restack.go
+++ b/internal/gs/restack.go
@@ -32,7 +32,7 @@ type RestackResponse struct {
 //
 // Returns [ErrAlreadyRestacked] if the branch does not need to be restacked.
 func (s *Service) Restack(ctx context.Context, name string) (*RestackResponse, error) {
-	b, err := s.store.Lookup(ctx, name)
+	b, err := s.LookupBranch(ctx, name)
 	if err != nil {
 		return nil, err // includes ErrNotExist
 	}
@@ -139,7 +139,7 @@ func (s *Service) VerifyRestacked(ctx context.Context, name string) error {
 	// is not its base branch's head.
 	//
 	// That is, the branch is not on top of its base branch's current head.
-	b, err := s.store.Lookup(ctx, name)
+	b, err := s.LookupBranch(ctx, name)
 	if err != nil {
 		return err // includes ErrNotExist
 	}

--- a/internal/gs/service.go
+++ b/internal/gs/service.go
@@ -35,7 +35,9 @@ type GitRepository interface {
 	// ListRemotes returns the names of all known remotes.
 	ListRemotes(ctx context.Context) ([]string, error)
 
-	Rebase(ctx context.Context, req git.RebaseRequest) error
+	Rebase(context.Context, git.RebaseRequest) error
+	RenameBranch(context.Context, git.RenameBranchRequest) error
+	DeleteBranch(context.Context, string, git.BranchDeleteOptions) error
 }
 
 var _ GitRepository = (*git.Repository)(nil)

--- a/testdata/script/branch_delete_heal.txt
+++ b/testdata/script/branch_delete_heal.txt
@@ -1,0 +1,67 @@
+# Deleting a tracked branch out-of-band,
+# and then running 'gs branch delete'
+# auto-heals the upstack of the deleted branch.
+
+as 'Test <test@example.com>'
+at '2024-05-19T14:30:12Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# Create a stack with:
+#   main -> feature1 -> {feature2, feature3}
+
+git add feature1.txt
+gs bc -m feature1
+
+git add feature2.txt
+gs bc -m feature2
+
+gs down
+git add feature3.txt
+gs bc -m feature3
+
+# sanity check
+git graph --branches
+cmp stdout $WORK/golden/before.txt
+
+# Delete feature1 branch out-of-band
+# and then run gs branch delete.
+git branch -D feature1
+
+gs branch delete feature1
+stderr 'branch has already been deleted'
+
+# state should have auto-healed.
+# feature3 should now have main as its base.
+gs down
+git branch --show-current
+stdout 'main'
+
+git graph --branches
+cmp stdout $WORK/golden/after.txt
+
+# TODO:
+# when 'gs ls' exists, check that feature1 is not listed.
+
+-- repo/feature1.txt --
+feature 1
+-- repo/feature2.txt --
+feature 2
+-- repo/feature3.txt --
+feature 3
+
+-- golden/before.txt --
+* 762f63b (feature2) feature2
+| * 36a1e69 (HEAD -> feature3) feature3
+|/  
+* aa78494 (feature1) feature1
+* 102a190 (main) Initial commit
+-- golden/after.txt --
+* 762f63b (feature2) feature2
+| * 36a1e69 (feature3) feature3
+|/  
+* aa78494 feature1
+* 102a190 (HEAD -> main) Initial commit

--- a/testdata/script/branch_delete_untracked.txt
+++ b/testdata/script/branch_delete_untracked.txt
@@ -11,7 +11,7 @@ gs repo init
 
 git branch foo
 gs branch delete foo
-stderr 'not tracked by gs'
+stderr 'branch is not tracked'
 stderr 'deleting anyway'
 
 ! git rev-parse --verify foo

--- a/testdata/script/branch_delete_upstack_restack.txt
+++ b/testdata/script/branch_delete_upstack_restack.txt
@@ -1,3 +1,0 @@
-# TODO
-# deleting a branch rebases its upstack on top of the deleted branch's base
-# *without* the deleted commit.

--- a/testdata/script/down_delete_heal.txt
+++ b/testdata/script/down_delete_heal.txt
@@ -1,4 +1,4 @@
-# Reproduces https://github.com/abhinav/gs/issues/41
+# 'gs down' recovers from manually deleted downstack branches.
 
 as 'Test <test@example.com>'
 at '2024-05-19T09:05:12Z'
@@ -14,17 +14,17 @@ gs branch create feature1 -m 'Add feature1'
 git add feature2.txt
 gs branch create feature2 -m 'Add feature2'
 
-# Delete feature1 out of band.
-git checkout main
-git branch -D feature1
-
-# gs up should gracefully handle the missing branch,
-# and we should end up on feature2.
-gs up
-stderr 'feature1: branch deleted outside gs'
-
 git branch --show-current
 stdout 'feature2'
+
+# delete downstack without using 'gs branch delete'
+git branch -D feature1
+
+gs down
+stderr 'branch feature1 deleted outside gs'
+
+git branch --show-current
+stdout 'main'
 
 git graph --branches
 cmp stdout $WORK/golden/branches.txt
@@ -36,6 +36,6 @@ feature1
 feature2
 
 -- golden/branches.txt --
-* a4db0a4 (HEAD -> feature2) Add feature2
+* a4db0a4 (feature2) Add feature2
 * 3a8c0b8 Add feature1
-* aaa8bab (main) Initial commit
+* aaa8bab (HEAD -> main) Initial commit

--- a/testdata/script/issue41_up_delete_heal.txt
+++ b/testdata/script/issue41_up_delete_heal.txt
@@ -1,0 +1,41 @@
+# Reproduces https://github.com/abhinav/gs/issues/41
+
+as 'Test <test@example.com>'
+at '2024-05-19T09:05:12Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git add feature1.txt
+gs branch create feature1 -m 'Add feature1'
+
+git add feature2.txt
+gs branch create feature2 -m 'Add feature2'
+
+# Delete feature1 out of band.
+git checkout main
+git branch -D feature1
+
+# gs up should gracefully handle the missing branch,
+# and we should end up on feature2.
+gs up
+stderr 'branch feature1 deleted outside gs'
+
+git branch --show-current
+stdout 'feature2'
+
+git graph --branches
+cmp stdout $WORK/golden/branches.txt
+
+-- repo/feature1.txt --
+feature1
+
+-- repo/feature2.txt --
+feature2
+
+-- golden/branches.txt --
+* a4db0a4 (HEAD -> feature2) Add feature2
+* 3a8c0b8 Add feature1
+* aaa8bab (main) Initial commit

--- a/testdata/script/up_down_top_bottom.txt
+++ b/testdata/script/up_down_top_bottom.txt
@@ -30,7 +30,7 @@ git branch
 cmp stdout $WORK/golden/git_branch_feature1.output
 
 gs down
-stderr 'exiting stack: moving to trunk'
+stderr 'moving to trunk'
 git branch
 cmp stdout $WORK/golden/git_branch_main.output
 


### PR DESCRIPTION
All branch lookups now take place via the service,
which verifies that all branches exist before returning them.
For each place where the lookup fails,
if it's possible to heal from the deleted branch, do so.

All navigation will not auto-heal from intermediate branches
deleted out of band.
Other commands will more gracefully handle similar deletions.

'gs branch delete' itself will untrack and up

Resolves #8