### PR TITLE
restack: Use --is-ancestor, share logic with VerifyRestacked

### DIFF
--- a/branch_checkout.go
+++ b/branch_checkout.go
@@ -35,8 +35,9 @@ func (cmd *branchCheckoutCmd) Run(ctx context.Context, log *log.Logger, opts *gl
 	}
 
 	if err := svc.VerifyRestacked(ctx, cmd.Name); err != nil {
+		var restackErr *spice.BranchNeedsRestackError
 		switch {
-		case errors.Is(err, spice.ErrNeedsRestack):
+		case errors.As(err, &restackErr):
 			log.Warnf("%v: needs to be restacked: run 'gs branch restack %v'", cmd.Name, cmd.Name)
 		case errors.Is(err, spice.ErrNotExist):
 			// TODO: in interactive mode, prompt to track.

--- a/branch_fold.go
+++ b/branch_fold.go
@@ -49,10 +49,11 @@ func (cmd *branchFoldCmd) Run(ctx context.Context, log *log.Logger, opts *global
 	}
 
 	if err := svc.VerifyRestacked(ctx, cmd.Name); err != nil {
+		var restackErr *spice.BranchNeedsRestackError
 		switch {
 		case errors.Is(err, spice.ErrNotExist):
 			return fmt.Errorf("branch %v not tracked", cmd.Name)
-		case errors.Is(err, spice.ErrNeedsRestack):
+		case errors.As(err, &restackErr):
 			return fmt.Errorf("branch %v needs to be restacked before it can be folded", cmd.Name)
 		default:
 			return fmt.Errorf("verify restacked: %w", err)

--- a/branch_track.go
+++ b/branch_track.go
@@ -177,7 +177,8 @@ func (cmd *branchTrackCmd) Run(ctx context.Context, log *log.Logger, opts *globa
 	log.Infof("%v: tracking with base %v", cmd.Name, cmd.Base)
 
 	if err := svc.VerifyRestacked(ctx, cmd.Name); err != nil {
-		if errors.Is(err, spice.ErrNeedsRestack) {
+		var restackErr *spice.BranchNeedsRestackError
+		if errors.As(err, &restackErr) {
 			log.Warnf("%v: needs to be restacked: run 'gs branch restack %v'", cmd.Name, cmd.Name)
 		}
 		log.Warnf("error checking branch: %v", err)

--- a/internal/spice/service.go
+++ b/internal/spice/service.go
@@ -16,6 +16,9 @@ type GitRepository interface {
 	// This is a commit that is an ancestor of both commits.
 	MergeBase(ctx context.Context, a, b string) (git.Hash, error)
 
+	// IsAncestor reports whether commit a is an ancestor of commit b.
+	IsAncestor(ctx context.Context, a, b git.Hash) bool
+
 	// ForkPoint reports the git hash at which branch b
 	// forked from branch a.
 	ForkPoint(ctx context.Context, a, b string) (git.Hash, error)


### PR DESCRIPTION
To check if a branch is already restacked, use --is-ancestor.
It's better than checking if the merge-base of the two branches
is the base branch.

Also, instead of duplicating the logic in Restack,
share it with VerifyRestacked.
For efficiency, pass information back from VerifyRestacked to Restack
through the BranchNeedsRestackError type.