### PR TITLE
fix(checkout): don't report untracked for absent

### DIFF
--- a/branch_checkout.go
+++ b/branch_checkout.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/state"
 )
 
 type branchCheckoutCmd struct {
@@ -39,11 +40,13 @@ func (cmd *branchCheckoutCmd) Run(ctx context.Context, log *log.Logger, opts *gl
 		switch {
 		case errors.As(err, &restackErr):
 			log.Warnf("%v: needs to be restacked: run 'gs branch restack %v'", cmd.Name, cmd.Name)
-		case errors.Is(err, spice.ErrNotExist):
+		case errors.Is(err, state.ErrNotExist):
 			// TODO: in interactive mode, prompt to track.
 			if store.Trunk() != cmd.Name {
 				log.Warnf("%v: branch not tracked: run 'gs branch track'", cmd.Name)
 			}
+		case errors.Is(err, git.ErrNotExist):
+			return fmt.Errorf("branch %q does not exist", cmd.Name)
 		default:
 			log.Warnf("error checking branch: %v", err)
 		}

--- a/branch_fold.go
+++ b/branch_fold.go
@@ -51,7 +51,7 @@ func (cmd *branchFoldCmd) Run(ctx context.Context, log *log.Logger, opts *global
 	if err := svc.VerifyRestacked(ctx, cmd.Name); err != nil {
 		var restackErr *spice.BranchNeedsRestackError
 		switch {
-		case errors.Is(err, spice.ErrNotExist):
+		case errors.Is(err, state.ErrNotExist):
 			return fmt.Errorf("branch %v not tracked", cmd.Name)
 		case errors.As(err, &restackErr):
 			return fmt.Errorf("branch %v needs to be restacked before it can be folded", cmd.Name)

--- a/branch_restack.go
+++ b/branch_restack.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/state"
 	"go.abhg.dev/gs/internal/text"
 )
 
@@ -47,7 +48,7 @@ func (cmd *branchRestackCmd) Run(ctx context.Context, log *log.Logger, opts *glo
 	res, err := svc.Restack(ctx, cmd.Name)
 	if err != nil {
 		switch {
-		case errors.Is(err, spice.ErrNotExist):
+		case errors.Is(err, state.ErrNotExist):
 			log.Errorf("%v: branch not tracked: run 'gs branch track'", cmd.Name)
 			return errors.New("untracked branch")
 		case errors.Is(err, spice.ErrAlreadyRestacked):

--- a/internal/git/hash.go
+++ b/internal/git/hash.go
@@ -2,12 +2,12 @@ package git
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"os"
 )
 
 // ErrNotExist is returned when a Git object does not exist.
-var ErrNotExist = os.ErrNotExist
+var ErrNotExist = errors.New("does not exist")
 
 // Hash is a 40-character Git object ID.
 type Hash string

--- a/internal/spice/restack.go
+++ b/internal/spice/restack.go
@@ -9,9 +9,6 @@ import (
 	"go.abhg.dev/gs/internal/state"
 )
 
-// ErrNotExist indicates that a branch is not tracked.
-var ErrNotExist = git.ErrNotExist
-
 // ErrAlreadyRestacked indicates that a branch is already restacked
 // on top of its base.
 var ErrAlreadyRestacked = errors.New("branch is already restacked")
@@ -119,7 +116,7 @@ func (e *BranchNeedsRestackError) Error() string {
 // but the branch is restacked properly.
 //
 // It returns [ErrNeedsRestack] if the branch needs to be restacked,
-// and [ErrNotExist] if the branch is not tracked.
+// [state.ErrNotExist] if the branch is not tracked.
 // Any other error indicates a problem with checking the branch.
 func (s *Service) VerifyRestacked(ctx context.Context, name string) error {
 	// A branch needs to be restacked if
@@ -129,7 +126,7 @@ func (s *Service) VerifyRestacked(ctx context.Context, name string) error {
 	// That is, the branch is not on top of its base branch's current head.
 	b, err := s.LookupBranch(ctx, name)
 	if err != nil {
-		return err // includes ErrNotExist
+		return err
 	}
 
 	baseHash, err := s.repo.PeelToCommit(ctx, b.Base)

--- a/internal/state/read.go
+++ b/internal/state/read.go
@@ -2,8 +2,8 @@ package state
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"os"
 	"sort"
 
 	"go.abhg.dev/gs/internal/git"
@@ -25,7 +25,7 @@ func (s *Store) Remote() (string, error) {
 }
 
 // ErrNotExist indicates that a key that was expected to exist does not exist.
-var ErrNotExist = os.ErrNotExist
+var ErrNotExist = errors.New("does not exist in store")
 
 // LookupResponse is the response to a Lookup request.
 type LookupResponse struct {

--- a/testdata/script/branch_checkout_does_not_exist.txt
+++ b/testdata/script/branch_checkout_does_not_exist.txt
@@ -1,0 +1,17 @@
+# 'branch checkout' does not print the incorrect message
+# when the branch does not exist.
+
+as 'Test <test@example.com>'
+at '2024-03-30T14:59:32Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+! gs branch checkout does-not-exist
+cmp stderr $WORK/golden/expected.txt
+
+-- golden/expected.txt --
+FTL git-spice: branch "does-not-exist" does not exist


### PR DESCRIPTION
If you run 'branch checkout foo' for a foo
that does not exist, branch checkout would report
that the branch is untracked
and that the user should run 'gs branch track foo',
before reporting that the branch does not exist.

The reason for this was that LookupBranch did care about non-existence
and returned all branches as untracked when they didn't exist.
The handling for this is a bit messy, but 