### PR TITLE
git/rebase: Detect interrupts and provide a hook

### DIFF
--- a/internal/git/gittest/fixture.go
+++ b/internal/git/gittest/fixture.go
@@ -1,0 +1,147 @@
+package gittest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/rogpeppe/go-internal/testscript"
+	"go.abhg.dev/gs/internal/must"
+)
+
+// Fixture is a temporary directory that contains a Git repository
+// built from a testscript file.
+type Fixture struct {
+	dir string
+}
+
+// Cleanup removes the temporary directory created by the fixture.
+func (f *Fixture) Cleanup() {
+	_ = os.RemoveAll(f.dir)
+}
+
+// Dir returns the directory of the fixture.
+func (f *Fixture) Dir() string {
+	return f.dir
+}
+
+// LoadFixtureFile loads a fixture file from the given path.
+// The fixture file is expected to be testscript file
+// that runs a series of git commands to set up a Git repository.
+func LoadFixtureFile(path string) (_ *Fixture, err error) {
+	script, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read script: %w", err)
+	}
+
+	return LoadFixtureScript(script)
+}
+
+// LoadFixtureScript loads a fixture from the testscript.
+// It has access to the following commands in addition to testscript defaults:
+//
+//   - [CmdGit]
+//   - [CmdAt]
+//   - [CmdAs]
+func LoadFixtureScript(script []byte) (_ *Fixture, err error) {
+	// testscript.Params expects a directory with several test files in it.
+	tmpDir, err := os.MkdirTemp("", "gittest-fixture-")
+	if err != nil {
+		return nil, fmt.Errorf("create temp dir: %w", err)
+	}
+	tmpScript := filepath.Join(tmpDir, "test.txt")
+	if err := os.WriteFile(tmpScript, script, 0o644); err != nil {
+		return nil, fmt.Errorf("write script: %w", err)
+	}
+
+	defaultEnv := DefaultConfig().EnvMap()
+	defaultEnv["EDITOR"] = "false"
+	defaultEnv["GIT_AUTHOR_NAME"] = "Test"
+	defaultEnv["GIT_AUTHOR_EMAIL"] = "test@example.com"
+	defaultEnv["GIT_COMMITTER_NAME"] = "Test"
+	defaultEnv["GIT_COMMITTER_EMAIL"] = "test@example.com"
+
+	var (
+		t          fakeT
+		fixtureDir string
+	)
+
+	// Run in a separate goroutine so that FailNow and Skip
+	// can call runtime.Goexit.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		testscript.RunT(&t, testscript.Params{
+			Dir: tmpDir,
+			// Don't delete fixtureDir when this returns.
+			TestWork:           true,
+			RequireUniqueNames: true,
+			Setup: func(e *testscript.Env) error {
+				for k, v := range defaultEnv {
+					e.Setenv(k, v)
+				}
+
+				fixtureDir = e.WorkDir
+				return nil
+			},
+			Cmds: map[string]func(*testscript.TestScript, bool, []string){
+				"git": CmdGit,
+				"as":  CmdAs,
+				"at":  CmdAt,
+			},
+		})
+	}()
+	<-done
+
+	if t.skipped || t.failed || t.fatal {
+		return nil, fmt.Errorf("testscript failed or was skipped:\n%s", t.msgs.String())
+	}
+
+	must.NotBeBlankf(fixtureDir, "fixtureDir must not be blank")
+	if _, err := os.Stat(fixtureDir); err != nil {
+		must.Failf("fixtureDir must exist: %v", err)
+	}
+
+	return &Fixture{dir: fixtureDir}, nil
+}
+
+// fakeT implements testscript.T so that we can run a testscript
+// without affecting the test or creating subtests.
+type fakeT struct {
+	fatal   bool
+	failed  bool
+	skipped bool
+	msgs    strings.Builder
+}
+
+var _ testscript.T = (*fakeT)(nil)
+
+// Parallel and Run are no-ops so that testscript.Run is synchronous.
+func (*fakeT) Parallel()                              {}
+func (f *fakeT) Run(_ string, run func(testscript.T)) { run(f) }
+
+func (f *fakeT) FailNow() {
+	f.fatal = true
+	f.failed = true
+	runtime.Goexit()
+}
+
+func (f *fakeT) Fatal(args ...interface{}) {
+	fmt.Fprintln(&f.msgs, fmt.Sprint(args...))
+	f.FailNow()
+}
+
+func (f *fakeT) Log(args ...interface{}) {
+	fmt.Fprintln(&f.msgs, fmt.Sprint(args...))
+}
+
+func (f *fakeT) Skip(args ...interface{}) {
+	f.skipped = true
+	fmt.Fprintln(&f.msgs, fmt.Sprint(args...))
+	runtime.Goexit()
+}
+
+func (f *fakeT) Verbose() bool { return false }

--- a/internal/git/rebase.go
+++ b/internal/git/rebase.go
@@ -2,9 +2,19 @@ package git
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"go.abhg.dev/gs/internal/must"
 )
+
+// ErrRebaseInterrupted is returned when a rebase operation is interrupted
+// because of a
+var ErrRebaseInterrupted = errors.New("rebase interrupted")
 
 // RebaseRequest is a request to rebase a branch.
 type RebaseRequest struct {
@@ -33,6 +43,14 @@ type RebaseRequest struct {
 	// with a list of rebase instructions to edit
 	// before starting the rebase operation.
 	Interactive bool
+
+	// InterruptFunc, if set, is called if a rebase operation
+	// is interrupted because of a conflict,
+	// or because the user an instruction to pause the rebase
+	// (e.g. 'edit' or 'break').
+	//
+	// The Rebase function will return the error returned by this function.
+	InterruptFunc func(context.Context, *RebaseState) error
 }
 
 // Rebase runs a git rebase operation with the specified parameters.
@@ -57,14 +75,150 @@ func (r *Repository) Rebase(ctx context.Context, req RebaseRequest) error {
 		args = append(args, req.Branch)
 	}
 
-	err := r.gitCmd(ctx, args...).
-		Stdin(os.Stdin).
-		Stdout(os.Stdout).
-		Stderr(os.Stderr).
-		Run(r.exec)
+	err := r.gitCmd(ctx, args...).Run(r.exec)
 	if err != nil {
-		return fmt.Errorf("rebase: %w", err)
+		originalErr := err
+		if exitErr := new(exec.ExitError); !errors.As(err, &exitErr) {
+			return fmt.Errorf("rebase: %w", err)
+		}
+
+		// If the rebase operation actually ran, but failed,
+		// we might be in the middle of a rebase operation.
+		state, err := r.loadRebaseState(false /* deliberate */)
+		if err != nil {
+			// Rebase probably failed for a different reason,
+			// so no need to log the state read failure verbosely.
+			r.log.Debug("Failed to read rebase state: %v", err)
+			return originalErr
+		}
+
+		if req.InterruptFunc == nil {
+			// The rebase failed, but we don't have a way to handle it.
+			// Return ErrRebaseInterrupted.
+			return errors.Join(ErrRebaseInterrupted, originalErr)
+		}
+
+		return req.InterruptFunc(ctx, state)
+	}
+
+	// If we have rebase state after a successful return,
+	// this was a deliberate break or edit.
+	if state, err := r.loadRebaseState(true /* deliberate */); err == nil {
+		if req.InterruptFunc == nil {
+			return ErrRebaseInterrupted
+		}
+		return req.InterruptFunc(ctx, state)
 	}
 
 	return nil
+}
+
+// RebaseAbort aborts an ongoing rebase operation.
+func (r *Repository) RebaseAbort(ctx context.Context) error {
+	if err := r.gitCmd(ctx, "rebase", "--abort").Run(r.exec); err != nil {
+		return fmt.Errorf("rebase abort: %w", err)
+	}
+	return nil
+}
+
+// RebaseBackend specifies the kind of rebase backend in use.
+//
+// See https://git-scm.com/docs/git-rebase#_behavioral_differences for details.
+type RebaseBackend int
+
+const (
+	// RebaseBackendMerge refers to the "merge" backend.
+	// It is the default backend used by Git,
+	// and handles more corner cases better.
+	RebaseBackendMerge RebaseBackend = iota
+
+	// RebaseBackendApply refers to the "apply" backend.
+	// It is rarely used and may be phased out in the future
+	// if the merge backend gains all of its features.
+	// It is enabled with the --apply flag.
+	RebaseBackendApply
+)
+
+func (b RebaseBackend) String() string {
+	switch b {
+	case RebaseBackendMerge:
+		return "merge"
+	case RebaseBackendApply:
+		return "apply"
+	default:
+		return "unknown"
+	}
+}
+
+// RebaseState holds information about the current state of a rebase operation.
+type RebaseState struct {
+	// Branch is the branch being rebased.
+	Branch string
+
+	// Backend specifies which merge backend is being used.
+	// Merge is the default.
+	// Apply is rarely used and may be phased out in the future.
+	Backend RebaseBackend
+
+	// Deliberate is true if the rebase was interrupted
+	// because of a deliberate user action (e.g. 'edit' or 'break').
+	Deliberate bool
+}
+
+// loadRebaseState loads information about an ongoing rebase.
+//
+// Rebase state is stored inside .git/rebase-merge or .git/rebase-apply
+// depending on the backend in use.
+// See https://github.com/git/git/blob/d8ab1d464d07baa30e5a180eb33b3f9aa5c93adf/wt-status.c#L1711.
+// Inside that directory, we care about the following files:
+//
+//   - head-name: full ref name of the branch being rebased (e.g. refs/heads/main)
+//
+// There's no Git porcelain command to directly get this information.
+func (r *Repository) loadRebaseState(deliberate bool) (*RebaseState, error) {
+	for _, backend := range []RebaseBackend{RebaseBackendApply, RebaseBackendMerge} {
+		stateDir := filepath.Join(r.gitDir, backend.stateDir())
+		if _, err := os.Stat(stateDir); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return nil, fmt.Errorf("check %v: %w", backend, err)
+		}
+
+		head, err := os.ReadFile(filepath.Join(stateDir, "head-name"))
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return nil, fmt.Errorf("read %v head: %w", backend, err)
+		}
+
+		branchRef := strings.TrimSpace(string(head))
+		state := &RebaseState{
+			Branch:     strings.TrimPrefix(branchRef, "refs/heads/"),
+			Backend:    backend,
+			Deliberate: deliberate,
+		}
+
+		return state, nil
+	}
+
+	return nil, errors.New("no rebase in progress")
+}
+
+// stateDir reports the directory inside the .git directory
+// where rebase state is stored.
+//
+// See
+// https://github.com/git/git/blob/d8ab1d464d07baa30e5a180eb33b3f9aa5c93adf/wt-status.c#L1711.
+func (b RebaseBackend) stateDir() string {
+	switch b {
+	case RebaseBackendMerge:
+		return "rebase-merge"
+	case RebaseBackendApply:
+		return "rebase-apply"
+	default:
+		must.Failf("unknown rebase backend: %v", b)
+		return ""
+	}
 }

--- a/internal/git/rebase_test.go
+++ b/internal/git/rebase_test.go
@@ -1,0 +1,229 @@
+package git_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rogpeppe/go-internal/testscript"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/git/gittest"
+	"go.abhg.dev/gs/internal/logtest"
+	"go.abhg.dev/gs/internal/mockedit"
+	"go.abhg.dev/gs/internal/text"
+)
+
+func TestMain(m *testing.M) {
+	testscript.RunMain(m, map[string]func() int{
+		// mockedit <input>:
+		"mockedit": mockedit.Main,
+	})
+}
+
+func TestRebase_deliberateInterrupt(t *testing.T) {
+	fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+		as 'Test <test@example.com>'
+		at '2024-05-21T20:30:40Z'
+
+		git init
+		git commit --allow-empty -m 'Initial commit'
+
+		git add foo.txt
+		git commit -m 'Add foo'
+
+		git checkout -b feature
+
+		git add bar.txt
+		git commit -m 'Add bar'
+
+		git add baz.txt
+		git commit -m 'Add baz'
+
+		-- foo.txt --
+		Contents of foo
+
+		-- bar.txt --
+		Contents of bar
+
+		-- baz.txt --
+		Contents of baz
+	`)))
+	require.NoError(t, err)
+	t.Cleanup(fixture.Cleanup)
+
+	ctx := context.Background()
+	repo, err := git.Open(ctx, fixture.Dir(), git.OpenOptions{
+		Log: logtest.New(t),
+	})
+	require.NoError(t, err)
+
+	login(t, "foo")
+
+	// Test cases with no InterruptFunc.
+	// All must see ErrRebaseInterrupted.
+	noFuncTests := []struct {
+		name  string
+		lines []string
+	}{
+		{
+			name: "break",
+			lines: []string{
+				"pick cc51432 Add bar",
+				"break",
+				"pick 7dd9ddf Add baz",
+			},
+		},
+		{
+			name: "edit",
+			lines: []string{
+				"pick cc51432 Add bar",
+				"edit 7dd9ddf Add baz",
+			},
+		},
+	}
+
+	for _, tt := range noFuncTests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				assert.NoError(t, repo.RebaseAbort(ctx))
+			}()
+			mockedit.Expect(t).
+				GiveLines(tt.lines...)
+
+			err = repo.Rebase(ctx, git.RebaseRequest{
+				Branch:      "feature",
+				Upstream:    "main",
+				Interactive: true,
+			})
+			require.Error(t, err)
+			assert.ErrorIs(t, err, git.ErrRebaseInterrupted)
+		})
+	}
+
+	t.Run("InterruptFunc", func(t *testing.T) {
+		defer func() {
+			assert.NoError(t, repo.RebaseAbort(ctx))
+		}()
+
+		// Either test case will do.
+		mockedit.Expect(t).
+			GiveLines(noFuncTests[0].lines...)
+
+		var calledInterrupt bool
+		defer func() {
+			assert.True(t, calledInterrupt, "InterruptFunc was not called")
+		}()
+
+		err = repo.Rebase(ctx, git.RebaseRequest{
+			Branch:      "feature",
+			Upstream:    "main",
+			Interactive: true,
+			InterruptFunc: func(_ context.Context, state *git.RebaseState) error {
+				calledInterrupt = true
+
+				assert.Equal(t, &git.RebaseState{
+					Branch:     "feature",
+					Deliberate: true,
+				}, state)
+				return nil
+			},
+		})
+	})
+}
+
+func TestRebase_unexpectedInterrupt(t *testing.T) {
+	fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+		as 'Test <test@example.com>'
+		at '2024-05-21T20:30:40Z'
+
+		git init
+		git commit --allow-empty -m 'Initial commit'
+
+		git add foo.txt
+		git commit -m 'Add foo'
+
+		git checkout -b feature
+		git add bar.txt
+		git commit -m 'Add bar'
+
+		git checkout main
+		mv conflicting-bar.txt bar.txt
+		git add bar.txt
+		git commit -m 'Conflicting bar'
+
+		-- foo.txt --
+		Contents of foo
+
+		-- bar.txt --
+		Contents of bar
+
+		-- conflicting-bar.txt --
+		Different contents of foo
+	`)))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	repo, err := git.Open(ctx, fixture.Dir(), git.OpenOptions{
+		Log: logtest.New(t),
+	})
+	require.NoError(t, err)
+
+	login(t, "user")
+
+	t.Run("noInterruptFunc", func(t *testing.T) {
+		defer func() {
+			assert.NoError(t, repo.RebaseAbort(ctx))
+		}()
+
+		err = repo.Rebase(ctx, git.RebaseRequest{
+			Branch:   "feature",
+			Upstream: "main",
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, git.ErrRebaseInterrupted)
+	})
+
+	t.Run("InterruptFunc", func(t *testing.T) {
+		defer func() {
+			assert.NoError(t, repo.RebaseAbort(ctx))
+		}()
+
+		var calledInterrupt bool
+		defer func() {
+			assert.True(t, calledInterrupt, "InterruptFunc was not called")
+		}()
+
+		err = repo.Rebase(ctx, git.RebaseRequest{
+			Branch:   "feature",
+			Upstream: "main",
+			InterruptFunc: func(_ context.Context, state *git.RebaseState) error {
+				calledInterrupt = true
+
+				assert.Equal(t, &git.RebaseState{
+					Branch: "feature",
+				}, state)
+				return nil
+			},
+		})
+		require.NoError(t, err)
+	})
+}
+
+func login(t testing.TB, username string) (home string) {
+	require.NotEmpty(t, username, "username must not be empty")
+	require.NotContains(t, username, " ", "username must not contain spaces")
+
+	home = filepath.Join(t.TempDir(), username)
+	require.NoError(t, os.MkdirAll(home, 0o700))
+
+	t.Setenv("HOME", home)
+	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(home, ".gitconfig"))
+	t.Setenv("GIT_AUTHOR_NAME", username)
+	t.Setenv("GIT_AUTHOR_EMAIL", username+"@example.com")
+	t.Setenv("GIT_COMMITTER_NAME", username)
+	t.Setenv("GIT_COMMITTER_EMAIL", username+"@example.com")
+	return home
+}

--- a/internal/git/repo_test.go
+++ b/internal/git/repo_test.go
@@ -1,6 +1,9 @@
 package git
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"go.abhg.dev/gs/internal/logtest"
@@ -10,5 +13,12 @@ func NewTestRepository(t testing.TB, dir string, execer execer) *Repository {
 	if dir == "" {
 		dir = t.TempDir()
 	}
-	return newRepository(dir, logtest.New(t), execer)
+	gitDir := filepath.Join(dir, ".git")
+	if err := os.Mkdir(gitDir, 0o755); err != nil {
+		if !errors.Is(err, os.ErrExist) {
+			t.Fatalf("failed to create .git directory: %v", err)
+		}
+	}
+
+	return newRepository(dir, gitDir, logtest.New(t), execer)
 }

--- a/script_test.go
+++ b/script_test.go
@@ -30,20 +30,7 @@ func TestMain(m *testing.M) {
 			main()
 			return 0
 		},
-
-		// mockedit <input>:
-		//
-		// An EDITOR that writes the contents of MOCKEDIT_GIVE
-		// into <input>.
-		// If MOCKEDIT_GIVE is not set, returns an error.
-		//
-		// If MOCKEDIT_RECORD is set, it will also copy the contents
-		// of <input> into that file.
-		"mockedit": func() int {
-			mockedit.Run()
-			return 0
-		},
-
+		"mockedit": mockedit.Main,
 		// with-term file -- cmd [args ...]
 		//
 		// Runs the given command inside a terminal emulator,


### PR DESCRIPTION
If a rebase operation fails because it was interrupted,
whether due to conflict or because of a user instruction,
we don't want to fail the entire git-spice operation.

To fix this, we need a means to handle the rebase failure
with custom logic.

This adds support for a function to be run when a rebase is interrupted.
The function gets information about the state of the rebase,
extracted from rebase's internal state.

This isn't used yet by git-spice commands that perform rebases.

Refs #42