### PR TITLE
Add gittest package

### DIFF
--- a/internal/git/gittest/config.go
+++ b/internal/git/gittest/config.go
@@ -1,0 +1,49 @@
+package gittest
+
+import (
+	"sort"
+	"strconv"
+)
+
+// DefaultConfig is the default Git configuration
+// for all test repositories.
+func DefaultConfig() Config {
+	return Config{
+		"init.defaultBranch": "main",
+		"alias.graph":        "log --graph --decorate --oneline",
+	}
+}
+
+// Config is a set of Git configuration values.
+type Config map[string]string
+
+// Env generates a list of environment variable assignments that will have
+// the same effect as setting these configuration values in a Git repository.
+// This is suitable for passing to exec.Cmd.Env.
+func (c Config) Env() []string {
+	m := c.EnvMap()
+	env := make([]string, 0, len(m))
+	for k, v := range m {
+		env = append(env, k+"="+v)
+	}
+	sort.Strings(env)
+	return env
+}
+
+// EnvMap generates a map of environment variable assignments that will have
+// the same effect as setting these configuration values in a Git repository.
+func (c Config) EnvMap() map[string]string {
+	env := make(map[string]string, len(c))
+
+	// We can set Git configuration values by setting
+	// GIT_CONFIG_KEY_<n>, GIT_CONFIG_VALUE_<n> and GIT_CONFIG_COUNT.
+	var numCfg int
+	for k, v := range c {
+		n := strconv.Itoa(numCfg)
+		env["GIT_CONFIG_KEY_"+n] = k
+		env["GIT_CONFIG_VALUE_"+n] = v
+		numCfg++
+	}
+	env["GIT_CONFIG_COUNT"] = strconv.Itoa(numCfg)
+	return env
+}

--- a/internal/git/gittest/script.go
+++ b/internal/git/gittest/script.go
@@ -1,0 +1,60 @@
+// Package gittest provides utilities for testing git repositories.
+package gittest
+
+import (
+	"net/mail"
+	"time"
+
+	"github.com/rogpeppe/go-internal/testscript"
+)
+
+// CmdGit runs a git command in the repository.
+//
+//	[!] git [args ...]
+func CmdGit(ts *testscript.TestScript, neg bool, args []string) {
+	err := ts.Exec("git", args...)
+	if neg {
+		if err == nil {
+			ts.Fatalf("unexpected success, expected failure")
+		}
+	} else {
+		ts.Check(err)
+	}
+}
+
+// CmdAs sets the author and committer of the commits that follow.
+//
+//	as 'User Name <user@example.com>'
+func CmdAs(ts *testscript.TestScript, neg bool, args []string) {
+	if neg || len(args) != 1 {
+		ts.Fatalf("usage: as 'User Name <user@example.com>'")
+	}
+
+	addr, err := mail.ParseAddress(args[0])
+	if err != nil {
+		ts.Fatalf("invalid email address: %s", err)
+	}
+
+	ts.Setenv("GIT_AUTHOR_NAME", addr.Name)
+	ts.Setenv("GIT_AUTHOR_EMAIL", addr.Address)
+	ts.Setenv("GIT_COMMITTER_NAME", addr.Name)
+	ts.Setenv("GIT_COMMITTER_EMAIL", addr.Address)
+}
+
+// CmdAt sets the author and commit time of the commits that follow.
+//
+//	at <YYYY-MM-DDTHH:MM:SS>
+func CmdAt(ts *testscript.TestScript, neg bool, args []string) {
+	if neg || len(args) != 1 {
+		ts.Fatalf("usage: at <YYYY-MM-DDTHH:MM:SS>")
+	}
+
+	t, err := time.Parse(time.RFC3339, args[0])
+	if err != nil {
+		ts.Fatalf("invalid time: %s", err)
+	}
+
+	gitTime := t.Format(time.RFC3339)
+	ts.Setenv("GIT_AUTHOR_DATE", gitTime)
+	ts.Setenv("GIT_COMMITTER_DATE", gitTime)
+}


### PR DESCRIPTION
Adds a gittest package, moving some of the
script test setup components into it.
These may be reused for git package tests.