### PR TITLE
[breaking] Adjust import path, move command to cmd/gs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ stitchmd-lint: $(STITCHMD) generate-lint
 	fi \
 
 $(GS): $(GO_SRC_FILES)
-	go install go.abhg.dev/gs
+	go install go.abhg.dev/git-spice/cmd/gs
 
 $(MOCKGEN): go.mod
 	go install go.uber.org/mock/mockgen

--- a/bottom.go
+++ b/bottom.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 import (
 	"context"
@@ -6,9 +6,9 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/spice"
-	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/spice"
+	"go.abhg.dev/git-spice/internal/text"
 )
 
 type bottomCmd struct{}

--- a/branch.go
+++ b/branch.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 type branchCmd struct {
 	Track    branchTrackCmd    `cmd:"" aliases:"tr" help:"Track a branch with git-spice"`

--- a/branch_checkout.go
+++ b/branch_checkout.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 import (
 	"context"
@@ -6,9 +6,9 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/spice"
-	"go.abhg.dev/gs/internal/state"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/spice"
+	"go.abhg.dev/git-spice/internal/state"
 )
 
 type branchCheckoutCmd struct {

--- a/branch_create.go
+++ b/branch_create.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 import (
 	"context"
@@ -6,10 +6,10 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/spice"
-	"go.abhg.dev/gs/internal/state"
-	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/spice"
+	"go.abhg.dev/git-spice/internal/state"
+	"go.abhg.dev/git-spice/internal/text"
 )
 
 type branchCreateCmd struct {

--- a/branch_delete.go
+++ b/branch_delete.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 import (
 	"context"
@@ -6,10 +6,10 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/spice"
-	"go.abhg.dev/gs/internal/state"
-	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/spice"
+	"go.abhg.dev/git-spice/internal/state"
+	"go.abhg.dev/git-spice/internal/text"
 )
 
 type branchDeleteCmd struct {

--- a/branch_edit.go
+++ b/branch_edit.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 import (
 	"context"
@@ -6,10 +6,10 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/spice"
-	"go.abhg.dev/gs/internal/state"
-	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/spice"
+	"go.abhg.dev/git-spice/internal/state"
+	"go.abhg.dev/git-spice/internal/text"
 )
 
 type branchEditCmd struct{}

--- a/branch_fold.go
+++ b/branch_fold.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 import (
 	"context"
@@ -6,10 +6,10 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/spice"
-	"go.abhg.dev/gs/internal/state"
-	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/spice"
+	"go.abhg.dev/git-spice/internal/state"
+	"go.abhg.dev/git-spice/internal/text"
 )
 
 type branchFoldCmd struct {

--- a/branch_onto.go
+++ b/branch_onto.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 import (
 	"context"
@@ -6,10 +6,10 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/spice"
-	"go.abhg.dev/gs/internal/state"
-	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/spice"
+	"go.abhg.dev/git-spice/internal/state"
+	"go.abhg.dev/git-spice/internal/text"
 )
 
 type branchOntoCmd struct {

--- a/branch_rename.go
+++ b/branch_rename.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 import (
 	"context"
@@ -6,9 +6,9 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/spice"
-	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/spice"
+	"go.abhg.dev/git-spice/internal/text"
 )
 
 type branchRenameCmd struct {

--- a/branch_restack.go
+++ b/branch_restack.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 import (
 	"context"
@@ -6,10 +6,10 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/spice"
-	"go.abhg.dev/gs/internal/state"
-	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/spice"
+	"go.abhg.dev/git-spice/internal/state"
+	"go.abhg.dev/git-spice/internal/text"
 )
 
 type branchRestackCmd struct {

--- a/branch_submit.go
+++ b/branch_submit.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 import (
 	"context"
@@ -9,11 +9,11 @@ import (
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/log"
 	"github.com/google/go-github/v61/github"
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/must"
-	"go.abhg.dev/gs/internal/spice"
-	"go.abhg.dev/gs/internal/state"
-	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/must"
+	"go.abhg.dev/git-spice/internal/spice"
+	"go.abhg.dev/git-spice/internal/state"
+	"go.abhg.dev/git-spice/internal/text"
 	"golang.org/x/oauth2"
 )
 

--- a/branch_track.go
+++ b/branch_track.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 import (
 	"context"
@@ -8,10 +8,10 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/spice"
-	"go.abhg.dev/gs/internal/state"
-	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/spice"
+	"go.abhg.dev/git-spice/internal/state"
+	"go.abhg.dev/git-spice/internal/text"
 )
 
 type branchTrackCmd struct {

--- a/branch_untrack.go
+++ b/branch_untrack.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 import (
 	"context"
@@ -6,10 +6,10 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/spice"
-	"go.abhg.dev/gs/internal/state"
-	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/spice"
+	"go.abhg.dev/git-spice/internal/state"
+	"go.abhg.dev/git-spice/internal/text"
 )
 
 type branchUntrackCmd struct {

--- a/cmd/gs/main.go
+++ b/cmd/gs/main.go
@@ -1,0 +1,8 @@
+// gs, short for git-stack, is a command-line tool for stacking Git branches.
+package main
+
+import gitspice "go.abhg.dev/git-spice"
+
+func main() {
+	gitspice.Main()
+}

--- a/commit.go
+++ b/commit.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 type commitCmd struct {
 	Create commitCreateCmd `cmd:"" aliases:"c" help:"Create a new commit"`

--- a/commit_amend.go
+++ b/commit_amend.go
@@ -1,12 +1,12 @@
-package main
+package gitspice
 
 import (
 	"context"
 	"fmt"
 
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/text"
 )
 
 type commitAmendCmd struct {

--- a/commit_create.go
+++ b/commit_create.go
@@ -1,12 +1,12 @@
-package main
+package gitspice
 
 import (
 	"context"
 	"fmt"
 
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/text"
 )
 
 type commitCreateCmd struct {

--- a/complete.go
+++ b/complete.go
@@ -1,14 +1,14 @@
-package main
+package gitspice
 
 import (
 	"context"
 	"time"
 
 	"github.com/posener/complete"
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/komplete"
-	"go.abhg.dev/gs/internal/state"
-	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/komplete"
+	"go.abhg.dev/git-spice/internal/state"
+	"go.abhg.dev/git-spice/internal/text"
 )
 
 type completeCmd struct {

--- a/down.go
+++ b/down.go
@@ -1,13 +1,13 @@
-package main
+package gitspice
 
 import (
 	"context"
 	"fmt"
 
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/spice"
-	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/spice"
+	"go.abhg.dev/git-spice/internal/text"
 )
 
 type downCmd struct {

--- a/downstack.go
+++ b/downstack.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 type downstackCmd struct {
 	Submit downstackSubmitCmd `cmd:"" aliases:"s" help:"Submit the current branch and those below it"`

--- a/downstack_edit.go
+++ b/downstack_edit.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 import (
 	"bufio"
@@ -12,10 +12,10 @@ import (
 	"slices"
 
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/must"
-	"go.abhg.dev/gs/internal/spice"
-	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/must"
+	"go.abhg.dev/git-spice/internal/spice"
+	"go.abhg.dev/git-spice/internal/text"
 )
 
 type downstackEditCmd struct {

--- a/downstack_submit.go
+++ b/downstack_submit.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 import (
 	"context"
@@ -7,10 +7,10 @@ import (
 	"slices"
 
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/must"
-	"go.abhg.dev/gs/internal/spice"
-	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/must"
+	"go.abhg.dev/git-spice/internal/spice"
+	"go.abhg.dev/git-spice/internal/text"
 	"golang.org/x/oauth2"
 )
 

--- a/dumpmd.go
+++ b/dumpmd.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 import (
 	"bufio"

--- a/gh.go
+++ b/gh.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 import (
 	"context"
@@ -6,8 +6,8 @@ import (
 
 	"github.com/charmbracelet/log"
 	"github.com/google/go-github/v61/github"
-	"go.abhg.dev/gs/internal/gh"
-	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/git-spice/internal/gh"
+	"go.abhg.dev/git-spice/internal/git"
 	"golang.org/x/oauth2"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go.abhg.dev/gs
+module go.abhg.dev/git-spice
 
 go 1.22.1
 

--- a/internal/gh/ghtest/shamhub.go
+++ b/internal/gh/ghtest/shamhub.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/charmbracelet/log"
 	"github.com/google/go-github/v61/github"
-	"go.abhg.dev/gs/internal/ioutil"
+	"go.abhg.dev/git-spice/internal/ioutil"
 )
 
 // ShamHub is a fake GitHub server.

--- a/internal/git/cmd.go
+++ b/internal/git/cmd.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/ioutil"
+	"go.abhg.dev/git-spice/internal/ioutil"
 )
 
 // execer controls actual execution of Git commands.

--- a/internal/git/gittest/fixture.go
+++ b/internal/git/gittest/fixture.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/rogpeppe/go-internal/testscript"
-	"go.abhg.dev/gs/internal/must"
+	"go.abhg.dev/git-spice/internal/must"
 )
 
 // Fixture is a temporary directory that contains a Git repository

--- a/internal/git/object.go
+++ b/internal/git/object.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"go.abhg.dev/gs/internal/must"
+	"go.abhg.dev/git-spice/internal/must"
 )
 
 // Type specifies the type of a Git object.

--- a/internal/git/rebase.go
+++ b/internal/git/rebase.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"go.abhg.dev/gs/internal/must"
+	"go.abhg.dev/git-spice/internal/must"
 )
 
 // ErrRebaseInterrupted is returned when a rebase operation is interrupted

--- a/internal/git/rebase_test.go
+++ b/internal/git/rebase_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/rogpeppe/go-internal/testscript"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/git/gittest"
-	"go.abhg.dev/gs/internal/logtest"
-	"go.abhg.dev/gs/internal/mockedit"
-	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/git/gittest"
+	"go.abhg.dev/git-spice/internal/logtest"
+	"go.abhg.dev/git-spice/internal/mockedit"
+	"go.abhg.dev/git-spice/internal/text"
 )
 
 func TestMain(m *testing.M) {

--- a/internal/git/repo_test.go
+++ b/internal/git/repo_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"go.abhg.dev/gs/internal/logtest"
+	"go.abhg.dev/git-spice/internal/logtest"
 )
 
 func NewTestRepository(t testing.TB, dir string, execer execer) *Repository {

--- a/internal/git/tree.go
+++ b/internal/git/tree.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	"go.abhg.dev/gs/internal/osutil"
+	"go.abhg.dev/git-spice/internal/osutil"
 )
 
 // Mode is the octal file mode of a Git tree entry.

--- a/internal/komplete/komplete.go
+++ b/internal/komplete/komplete.go
@@ -74,7 +74,7 @@ import (
 
 	"github.com/alecthomas/kong"
 	"github.com/posener/complete"
-	"go.abhg.dev/gs/internal/must"
+	"go.abhg.dev/git-spice/internal/must"
 )
 
 // Implementation notes:

--- a/internal/logtest/logger.go
+++ b/internal/logtest/logger.go
@@ -3,7 +3,7 @@ package logtest
 
 import (
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/ioutil"
+	"go.abhg.dev/git-spice/internal/ioutil"
 )
 
 // New builds a logger that writes messages

--- a/internal/mockedit/main.go
+++ b/internal/mockedit/main.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.abhg.dev/gs/internal/osutil"
+	"go.abhg.dev/git-spice/internal/osutil"
 )
 
 // Main runs the mock editor and exits the process.

--- a/internal/spice/branch.go
+++ b/internal/spice/branch.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"unicode"
 
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/must"
-	"go.abhg.dev/gs/internal/state"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/must"
+	"go.abhg.dev/git-spice/internal/state"
 )
 
 const _generatedBranchNameLimit = 32

--- a/internal/spice/guess.go
+++ b/internal/spice/guess.go
@@ -6,7 +6,7 @@ import (
 	"slices"
 	"strings"
 
-	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/git-spice/internal/git"
 )
 
 // GuessOp specifies the kind of guess operation

--- a/internal/spice/restack.go
+++ b/internal/spice/restack.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"fmt"
 
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/state"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/state"
 )
 
 // ErrAlreadyRestacked indicates that a branch is already restacked

--- a/internal/spice/service.go
+++ b/internal/spice/service.go
@@ -5,8 +5,8 @@ import (
 	"context"
 
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/state"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/state"
 )
 
 // GitRepository provides read/write access to the conents of a git repository.

--- a/internal/state/backend.go
+++ b/internal/state/backend.go
@@ -9,11 +9,11 @@ import (
 	"io"
 
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/git-spice/internal/git"
 )
 
 const (
-	_dataRef     = "refs/gs/data"
+	_dataRef     = "refs/spice/data"
 	_authorName  = "git-spice"
 	_authorEmail = "git-spice@localhost"
 )

--- a/internal/state/read.go
+++ b/internal/state/read.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"sort"
 
-	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/git-spice/internal/git"
 )
 
 // Trunk reports the trunk branch configured for the repository.

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/logtest"
-	"go.abhg.dev/gs/internal/state"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/logtest"
+	"go.abhg.dev/git-spice/internal/state"
 )
 
 func TestIntegrationStore(t *testing.T) {

--- a/internal/state/write.go
+++ b/internal/state/write.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/git-spice/internal/git"
 )
 
 // SetRemote changes teh remote name configured for the repository.

--- a/main.go
+++ b/main.go
@@ -1,5 +1,7 @@
-// git-spice is a command line tool for stacking Git branches.
-package main
+// Package gitspice implements the entry point for the git-spice CLI.
+// This package is not intended to be used as a library.
+// See cmd/gs for details about the CLI.
+package gitspice
 
 import (
 	"context"
@@ -15,8 +17,8 @@ import (
 	"github.com/charmbracelet/log"
 	"github.com/mattn/go-isatty"
 	"github.com/posener/complete"
-	"go.abhg.dev/gs/internal/gh"
-	"go.abhg.dev/gs/internal/komplete"
+	"go.abhg.dev/git-spice/internal/gh"
+	"go.abhg.dev/git-spice/internal/komplete"
 	"golang.org/x/oauth2"
 )
 
@@ -24,7 +26,8 @@ var _version = "dev"
 
 var errNoPrompt = fmt.Errorf("not allowed to prompt for input")
 
-func main() {
+// Main runs the git-spice CLI and exits the program.
+func Main() {
 	logger := log.NewWithOptions(os.Stderr, log.Options{
 		Level: log.InfoLevel,
 	})

--- a/repo.go
+++ b/repo.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 type repoCmd struct {
 	Init repoInitCmd `cmd:"" aliases:"i" help:"Initialize a repository"`

--- a/repo_init.go
+++ b/repo_init.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 import (
 	"context"
@@ -7,11 +7,11 @@ import (
 
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/must"
-	"go.abhg.dev/gs/internal/spice"
-	"go.abhg.dev/gs/internal/state"
-	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/must"
+	"go.abhg.dev/git-spice/internal/spice"
+	"go.abhg.dev/git-spice/internal/state"
+	"go.abhg.dev/git-spice/internal/text"
 )
 
 type repoInitCmd struct {

--- a/repo_sync.go
+++ b/repo_sync.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 import (
 	"context"
@@ -9,9 +9,9 @@ import (
 	"sync"
 
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/spice"
-	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/spice"
+	"go.abhg.dev/git-spice/internal/text"
 	"golang.org/x/oauth2"
 )
 

--- a/script_test.go
+++ b/script_test.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 import (
 	"encoding/json"
@@ -15,11 +15,11 @@ import (
 	"github.com/google/go-github/v61/github"
 	"github.com/rogpeppe/go-internal/diff"
 	"github.com/rogpeppe/go-internal/testscript"
-	"go.abhg.dev/gs/internal/gh/ghtest"
-	"go.abhg.dev/gs/internal/git/gittest"
-	"go.abhg.dev/gs/internal/logtest"
-	"go.abhg.dev/gs/internal/mockedit"
-	"go.abhg.dev/gs/internal/termtest"
+	"go.abhg.dev/git-spice/internal/gh/ghtest"
+	"go.abhg.dev/git-spice/internal/git/gittest"
+	"go.abhg.dev/git-spice/internal/logtest"
+	"go.abhg.dev/git-spice/internal/mockedit"
+	"go.abhg.dev/git-spice/internal/termtest"
 )
 
 var _update = flag.Bool("update", false, "update golden files")
@@ -27,7 +27,7 @@ var _update = flag.Bool("update", false, "update golden files")
 func TestMain(m *testing.M) {
 	testscript.RunMain(m, map[string]func() int{
 		"gs": func() int {
-			main()
+			Main()
 			return 0
 		},
 		"mockedit": mockedit.Main,

--- a/stack.go
+++ b/stack.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 type stackCmd struct {
 	Submit  stackSubmitCmd  `cmd:"" aliases:"s" help:"Submit the current stack"`

--- a/stack_restack.go
+++ b/stack_restack.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 import (
 	"context"
@@ -6,8 +6,8 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/spice"
 )
 
 type stackRestackCmd struct{}

--- a/stack_submit.go
+++ b/stack_submit.go
@@ -1,12 +1,12 @@
-package main
+package gitspice
 
 import (
 	"context"
 	"fmt"
 
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/spice"
 	"golang.org/x/oauth2"
 )
 

--- a/testdata/script/issue41_up_delete_heal.txt
+++ b/testdata/script/issue41_up_delete_heal.txt
@@ -1,4 +1,4 @@
-# Reproduces https://github.com/abhinav/gs/issues/41
+# Reproduces https://github.com/abhinav/git-spice/issues/41
 
 as 'Test <test@example.com>'
 at '2024-05-19T09:05:12Z'

--- a/tools.go
+++ b/tools.go
@@ -1,6 +1,6 @@
 //go:build tools
 
-package main
+package gitspice
 
 import (
 	_ "go.abhg.dev/stitchmd"

--- a/top.go
+++ b/top.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 import (
 	"context"
@@ -6,10 +6,10 @@ import (
 
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/must"
-	"go.abhg.dev/gs/internal/spice"
-	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/must"
+	"go.abhg.dev/git-spice/internal/spice"
+	"go.abhg.dev/git-spice/internal/text"
 )
 
 type topCmd struct{}

--- a/trunk.go
+++ b/trunk.go
@@ -1,11 +1,11 @@
-package main
+package gitspice
 
 import (
 	"context"
 	"fmt"
 
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/git-spice/internal/git"
 )
 
 type trunkCmd struct{}

--- a/up.go
+++ b/up.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 import (
 	"context"
@@ -6,9 +6,9 @@ import (
 
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/spice"
-	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/spice"
+	"go.abhg.dev/git-spice/internal/text"
 )
 
 type upCmd struct {

--- a/upstack.go
+++ b/upstack.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 type upstackCmd struct {
 	Restack upstackRestackCmd `cmd:"" aliases:"rs" help:"Restack this branch those above it"`

--- a/upstack_restack.go
+++ b/upstack_restack.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 import (
 	"context"
@@ -6,9 +6,9 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/spice"
-	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/git-spice/internal/git"
+	"go.abhg.dev/git-spice/internal/spice"
+	"go.abhg.dev/git-spice/internal/text"
 )
 
 type upstackRestackCmd struct{}

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
-package main
+package gitspice
 
 import (
 	"fmt"
@@ -18,7 +18,7 @@ func (v versionFlag) BeforeReset(app *kong.Kong) error {
 
 	fmt.Fprintln(app.Stdout)
 	fmt.Fprintln(app.Stdout, "Copyright (C) 2024 Abhinav Gupta")
-	fmt.Fprintln(app.Stdout, "  <https://github.com/abhinav/gs>")
+	fmt.Fprintln(app.Stdout, "  <https://github.com/abhinav/git-spice>")
 	fmt.Fprintln(app.Stdout, "This program comes with ABSOLUTELY NO WARRANTY")
 	fmt.Fprintln(app.Stdout, "This is free software, and you are welcome to redistribute it")
 	fmt.Fprintln(app.Stdout, "under certain conditions; see source for details.")


### PR DESCRIPTION
Change the import path of the project to use "git-stack",
same as the repository name.
We still want to use the command name "gs", so move the actual CLI
to a cmd/gs subdirectory.

So installation from source will now be

    go install go.abhg.dev/git-spice/cmd/gs

# BREAKING

This also adjusts the ref name under which data is stored
from refs/gs/data to refs/spice/data.

Migration steps for alpha users:
Run the following command when you pull the new binary.

	git update-ref refs/spice/data $(git rev-parse refs/gs/data)
	git update-ref -d refs/gs/data

