### PR TITLE
branch submit: Fix PR title and body for multiple commits

### DIFF
--- a/.changes/unreleased/Fixed-20240522-182144.yaml
+++ b/.changes/unreleased/Fixed-20240522-182144.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'branch submit: Fix default PR title and body for branches with multiple commits.'
+time: 2024-05-22T18:21:44.647546-07:00

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -12,6 +12,9 @@ on:
       - "labeled"
       - "unlabeled"
 
+permissions:
+  pull-requests: write
+
 jobs:
   check-changelog:
     name: Check for changelog
@@ -24,6 +27,7 @@ jobs:
             .changes/unreleased/*.yaml
             CHANGELOG.md
           skip-label: "skip changelog"
+          token: ${{ secrets.GITHUB_TOKEN }}
           failure-message: >-
             Missing a changelog file in ${file-pattern};
             please add one or apply the ${skip-label} label to the pull request

--- a/branch_submit.go
+++ b/branch_submit.go
@@ -141,23 +141,28 @@ func (cmd *branchSubmitCmd) Run(
 			return errors.New("no commits to submit")
 		}
 
-		defaultTitle := msgs[0].Subject
-
-		// If there's only one commit,
-		// just the body will be the default body.
-		// Otherwise, we'll concatenate all the messages.
-		var defaultBody string
+		var defaultTitle, defaultBody string
 		if len(msgs) == 1 {
+			// If there's only one commit,
+			// just the body will be the default body.
+			defaultTitle = msgs[0].Subject
 			defaultBody = msgs[0].Body
 		} else {
+			// Otherwise, we'll concatenate all the messages.
+			// The revisions are in reverse order,
+			// so we'll want to iterate in reverse.
 			var body strings.Builder
-			for i, msg := range msgs {
-				if i > 0 {
+			defaultTitle = msgs[len(msgs)-1].Subject
+			for i := len(msgs) - 1; i >= 0; i-- {
+				msg := msgs[i]
+				if body.Len() > 0 {
 					body.WriteString("\n\n")
 				}
 				body.WriteString(msg.Subject)
-				body.WriteString("\n\n")
-				body.WriteString(msg.Body)
+				if msg.Body != "" {
+					body.WriteString("\n\n")
+					body.WriteString(msg.Body)
+				}
 			}
 			defaultBody = body.String()
 		}

--- a/testdata/script/branch_submit_multiple_commits.txt
+++ b/testdata/script/branch_submit_multiple_commits.txt
@@ -1,0 +1,55 @@
+# submitting a branch with multiple commits
+# uses the combined commit messages in the right order.
+#
+# Regression test for https://github.com/abhinav/git-spice/issues/69
+
+as 'Test <test@example.com>'
+at '2024-04-05T16:40:32Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+gh-init
+gh-add-remote origin alice/example.git
+git push origin main
+
+# create a branch and go back to main
+git add feature-part1.txt
+gs bc -m 'Add feature' feature
+
+git add feature-part2.txt
+gs cc -m 'Add feature part 2'
+
+gs branch submit --fill
+stderr 'Created #1'
+gh-dump-pull
+cmpenvJSON stdout $WORK/golden/pulls.json
+
+-- repo/feature-part1.txt --
+Part 1 of the feature
+
+-- repo/feature-part2.txt --
+Part 2 of the feature
+
+-- golden/pulls.json --
+[
+  {
+    "number": 1,
+    "state": "open",
+    "title": "Add feature",
+    "body": "Add feature\n\nAdd feature part 2",
+    "html_url": "$GITHUB_GIT_URL/alice/example/pull/1",
+    "head": {
+      "ref": "feature",
+      "sha": "c1a2497e4115fcbfc275d36b754a8ed4ca1169e4"
+    },
+    "base": {
+      "ref": "main",
+      "sha": "ece8ed7bb81d74cb6787309fa41b7deb2e0558a3"
+    }
+  }
+]
+


### PR DESCRIPTION
git rev-list returns the commit list in reverse order
(newest commit first).
This is right for most of our needs,
except when generating the default PR title and body,
we need to consider it in reverse:
earliest commit should be the PR title,
and the commit bodies should be in the PR description
in chronological order.

Resolves #69