### PR TITLE
repo sync: Delete remote tracking branches

### DIFF
--- a/.changes/unreleased/Fixed-20240522-183448.yaml
+++ b/.changes/unreleased/Fixed-20240522-183448.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'repo sync: Delete remote tracking branches for merged PRs.'
+time: 2024-05-22T18:34:48.086778-07:00

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -143,6 +143,10 @@ type BranchDeleteOptions struct {
 	// Force specifies that a branch should be deleted
 	// even if it has unmerged changes.
 	Force bool
+
+	// Remote indicates that the branch being deleted
+	// is a remote tracking branch.
+	Remote bool
 }
 
 // DeleteBranch deletes a branch from the repository.
@@ -156,6 +160,9 @@ func (r *Repository) DeleteBranch(
 	args := []string{"branch", "--delete"}
 	if opts.Force {
 		args = append(args, "--force")
+	}
+	if opts.Remote {
+		args = append(args, "--remotes")
 	}
 	args = append(args, branch)
 

--- a/repo_sync.go
+++ b/repo_sync.go
@@ -282,6 +282,14 @@ func (*repoSyncCmd) Run(
 		if err != nil {
 			return fmt.Errorf("delete branch %v: %w", branch, err)
 		}
+
+		// Also delete the remote tracking branch for this branch.
+		remoteBranch := remote + "/" + branch
+		if err := repo.DeleteBranch(ctx, remoteBranch, git.BranchDeleteOptions{
+			Remote: true,
+		}); err != nil {
+			log.Warn("Unable to delete remote tracking branch", "branch", remoteBranch, "error", err)
+		}
 	}
 
 	// TODO:

--- a/testdata/script/repo_sync_merged_pr.txt
+++ b/testdata/script/repo_sync_merged_pr.txt
@@ -57,6 +57,6 @@ Contents of feature1
 -- golden/merged-log.txt --
 *   7bfac22 (HEAD -> main, origin/main) Merge pull request #1
 |\  
-| * 9f1c9af (origin/feature1) Add feature1
+| * 9f1c9af Add feature1
 |/  
 * d90607e Initial commit

--- a/testdata/script/repo_sync_unpushed_commits.txt
+++ b/testdata/script/repo_sync_unpushed_commits.txt
@@ -66,6 +66,6 @@ Contents of feature2
 * e40a703 (HEAD -> main) Add feature2
 *   7bfac22 (origin/main) Merge pull request #1
 |\  
-| * 9f1c9af (origin/feature1) Add feature1
+| * 9f1c9af Add feature1
 |/  
 * d90607e Initial commit


### PR DESCRIPTION
When a PR is merged, we delete that branch locally.
With this change, we'll also delete the rmeote tracking branch
it leaves behind, which is otherwise only deleted
if the remote deletes the branch (which doesn't always happen)
and the user runs 'git fetch' afterwards.

Resolves #73