### PR TITLE
ci: Add Prepare a release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,47 @@
+name: Prepare a release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release (e.g. v1.2.3)
+        required: false
+        default: 'auto'
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  generate-pr:
+    runs-on: ubuntu-latest
+    name: Generate release PR
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Batch changes
+      uses: miniscruff/changie-action@v2
+      with:
+        args: batch ${{ inputs.version }}
+
+    - name: Merge changes
+      uses: miniscruff/changie-action@v2
+      with:
+        args: merge
+
+    - name: Get the latest version
+      id: latest
+      uses: miniscruff/changie-action@v2
+      with:
+        args: latest
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v6
+      with:
+        title: Release ${{ steps.latest.outputs.output }}
+        branch: release/${{ steps.latest.outputs.output }}
+        commit-message: Release ${{ steps.latest.outputs.output }}
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,48 +80,8 @@ Read more about the test script format in the documentation of the package.
 
 To release a new version, take the following steps:
 
-1. Create a new branch for the release. For example:
-
-    ```sh
-    VERSION=$(changie next minor)
-    gs branch create release-$VERSION -m "Release $VERSION"
-    ```
-
-2. Combine unreleased changes into a single Markdown document.
-
-    ```sh
-    changie batch $VERSION
-    ```
-
-3. Open up this file and verify everything looks good.
-
-    ```sh
-    $EDITOR .changes/$(changie latest).md
-    ```
-
-4. Merge these changes into CHANGELOG.md.
-
-    ```sh
-    changie merge
-    ```
-
-5. Commit the changes.
-
-    ```sh
-    git add CHANGELOG.md .changes
-    gs commit amend --no-edit
-    ```
-
-6. Create a pull request for the release.
-
-    ```sh
-    gs branch submit
-    ```
-
-7. Once the pull request is merged, tag the release
-   either with the GitHub UI or with the following command:
-
-    ```sh
-    git tag $(changie latest)
-    git push origin $(changie latest)
-    ```
+1. Trigger the [Prepare release workflow](https://github.com/abhinav/git-spice/actions/workflows/prepare-release.yml).
+   This will create a pull request with the changelog entries for the release.
+2. Merge the pull request created by the workflow.
+3. Once the pull request has merged, [publish a release](https://github.com/abhinav/git-spice/releases/new)
+   for that tag.


### PR DESCRIPTION
Add a workflow that merges the changelog and posts a PR to the repository.
With this and GitHub UI, releases can be done entirely from the browser.