### PR TITLE
repo sync: Check for merged branches even if no commits

### DIFF
--- a/.changes/unreleased/Fixed-20240522-212505.yaml
+++ b/.changes/unreleased/Fixed-20240522-212505.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'repo sync: Fix deleting merged branches after a manual ''git pull''.'
+time: 2024-05-22T21:25:05.527728-07:00

--- a/repo_sync.go
+++ b/repo_sync.go
@@ -175,10 +175,9 @@ func (*repoSyncCmd) Run(
 
 	if trunkStartHash == trunkEndHash {
 		log.Infof("%v: already up-to-date", trunk)
-		return nil
-	}
-
-	if repo.IsAncestor(ctx, trunkStartHash, trunkEndHash) {
+	} else if repo.IsAncestor(ctx, trunkStartHash, trunkEndHash) {
+		// CountCommits only if IsAncestor is true
+		// because there may have been a force push.
 		count, err := repo.CountCommits(ctx,
 			git.CommitRangeFrom(trunkEndHash).ExcludeFrom(trunkStartHash))
 		if err != nil {

--- a/testdata/script/repo_sync_manual_pull_merged_pr.txt
+++ b/testdata/script/repo_sync_manual_pull_merged_pr.txt
@@ -1,0 +1,33 @@
+# 'repo sync' deletes merged branches
+# even if we ran a 'git pull' manually.
+
+as 'Test <test@example.com>'
+at '2024-05-18T13:59:12Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+gh-init
+gh-add-remote origin alice/example.git
+git push origin main
+
+# submit a PR and merge it
+git add feature.txt
+gs bc -m 'Add feature' feature
+gs branch submit --fill
+stderr 'Created #'
+gh-merge alice/example 1
+
+# Pull the merged changes
+git checkout main
+git pull origin main
+gs repo sync
+stderr 'feature: #1 was merged'
+stderr 'feature: deleted \(was 8f14b6e\)'
+
+-- repo/feature.txt --
+Contents of feature
+


### PR DESCRIPTION
Returning early if there are no commits between start and end
leaves merged branches around locally if the user manually
ran 'git pull' before running 'gs repo sync'.

We should always check for merged branches.

Resolves #64