### PR TITLE
restack/alias: rs => r

### DIFF
--- a/.changes/unreleased/Changed-20240523-191153.yaml
+++ b/.changes/unreleased/Changed-20240523-191153.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: '*Breaking*: Change restack alias to ''r'', allowing for ''br'', ''sr'', ''usr'', etc.'
+time: 2024-05-23T19:11:53.312055-07:00

--- a/branch.go
+++ b/branch.go
@@ -14,7 +14,7 @@ type branchCmd struct {
 	// Mutation
 	Edit    branchEditCmd    `cmd:"" aliases:"e" help:"Edit the commits in a branch"`
 	Rename  branchRenameCmd  `cmd:"" aliases:"mv" help:"Rename a branch"`
-	Restack branchRestackCmd `cmd:"" aliases:"rs" help:"Restack a branch"`
+	Restack branchRestackCmd `cmd:"" aliases:"r" help:"Restack a branch"`
 
 	// Pull request management
 	Submit branchSubmitCmd `cmd:"" aliases:"s" help:"Submit a branch"`

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -69,7 +69,7 @@ Submit the current stack
 ## gs stack restack
 
 ```
-gs stack (s) restack (rs)
+gs stack (s) restack (r)
 ```
 
 Restack the current stack
@@ -77,7 +77,7 @@ Restack the current stack
 ## gs upstack restack
 
 ```
-gs upstack (us) restack (rs)
+gs upstack (us) restack (r)
 ```
 
 Restack this branch those above it
@@ -321,7 +321,7 @@ and untrack the old name with 'gs branch untrack'.
 ## gs branch restack
 
 ```
-gs branch (b) restack (rs) [<name>]
+gs branch (b) restack (r) [<name>]
 ```
 
 Restack a branch

--- a/stack.go
+++ b/stack.go
@@ -2,5 +2,5 @@ package main
 
 type stackCmd struct {
 	Submit  stackSubmitCmd  `cmd:"" aliases:"s" help:"Submit the current stack"`
-	Restack stackRestackCmd `cmd:"" aliases:"rs" help:"Restack the current stack"`
+	Restack stackRestackCmd `cmd:"" aliases:"r" help:"Restack the current stack"`
 }

--- a/testdata/script/stack_submit.txt
+++ b/testdata/script/stack_submit.txt
@@ -34,7 +34,7 @@ cmpenvJSON stdout $WORK/golden/start.json
 gh-merge alice/example 1
 gs rs
 stderr '#1 was merged'
-gs srs  # stack restack
+gs sr   # stack restack
 gs ss   # stack submit
 stderr 'Updated #2'
 stderr 'Updated #3'

--- a/upstack.go
+++ b/upstack.go
@@ -1,5 +1,5 @@
 package main
 
 type upstackCmd struct {
-	Restack upstackRestackCmd `cmd:"" aliases:"rs" help:"Restack this branch those above it"`
+	Restack upstackRestackCmd `cmd:"" aliases:"r" help:"Restack this branch those above it"`
 }


### PR DESCRIPTION
Shorten the restack alias to just 'r' since 'r' is not used anywhere.
Restacking is now:

    gs br   # branch
    gs sr   # stack
    gs usr  # upstack