### PR TITLE
commit {create, amend}: Don't restack if rebasing

### DIFF
--- a/.changes/unreleased/Fixed-20240523-193544.yaml
+++ b/.changes/unreleased/Fixed-20240523-193544.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'commit create, commit amend: Fix usage during an ongoing rebase. If used during a rebase, these commands will not rebase the upstack.'
+time: 2024-05-23T19:35:44.704921-07:00

--- a/commit_amend.go
+++ b/commit_amend.go
@@ -39,6 +39,12 @@ func (cmd *commitAmendCmd) Run(ctx context.Context, log *log.Logger, opts *globa
 		return fmt.Errorf("commit: %w", err)
 	}
 
+	if _, err := repo.RebaseState(); err == nil {
+		// In the middle of a rebase.
+		// Don't restack upstack branches.
+		return nil
+	}
+
 	// TODO: handle not tracked
 	return (&upstackRestackCmd{}).Run(ctx, log, opts)
 }

--- a/commit_create.go
+++ b/commit_create.go
@@ -38,6 +38,12 @@ func (cmd *commitCreateCmd) Run(ctx context.Context, log *log.Logger, opts *glob
 		return fmt.Errorf("commit: %w", err)
 	}
 
+	if _, err := repo.RebaseState(); err == nil {
+		// In the middle of a rebase.
+		// Don't restack upstack branches.
+		return nil
+	}
+
 	// TODO: handle not tracked
 	return (&upstackRestackCmd{}).Run(ctx, log, opts)
 }

--- a/internal/git/rebase_test.go
+++ b/internal/git/rebase_test.go
@@ -121,13 +121,11 @@ func TestRebase_deliberateInterrupt(t *testing.T) {
 			Branch:      "feature",
 			Upstream:    "main",
 			Interactive: true,
-			InterruptFunc: func(_ context.Context, state *git.RebaseState) error {
+			InterruptFunc: func(_ context.Context, state *git.RebaseState, kind git.RebaseInterruptKind) error {
 				calledInterrupt = true
 
-				assert.Equal(t, &git.RebaseState{
-					Branch:     "feature",
-					Deliberate: true,
-				}, state)
+				assert.Equal(t, &git.RebaseState{Branch: "feature"}, state)
+				assert.Equal(t, git.RebaseInterruptDeliberate, kind)
 				return nil
 			},
 		})
@@ -199,12 +197,11 @@ func TestRebase_unexpectedInterrupt(t *testing.T) {
 		err = repo.Rebase(ctx, git.RebaseRequest{
 			Branch:   "feature",
 			Upstream: "main",
-			InterruptFunc: func(_ context.Context, state *git.RebaseState) error {
+			InterruptFunc: func(_ context.Context, state *git.RebaseState, kind git.RebaseInterruptKind) error {
 				calledInterrupt = true
 
-				assert.Equal(t, &git.RebaseState{
-					Branch: "feature",
-				}, state)
+				assert.Equal(t, &git.RebaseState{Branch: "feature"}, state)
+				assert.Equal(t, git.RebaseInterruptConflict, kind)
 				return nil
 			},
 		})

--- a/testdata/script/commit_amend_rebase.txt
+++ b/testdata/script/commit_amend_rebase.txt
@@ -1,0 +1,70 @@
+# commit amend in the middle of a rebase
+# works like a plain git commit --amend.
+
+as 'Test <test@example.com>'
+at '2024-05-23T19:23:24Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git add feature1.txt
+gs bc -m 'Add feature 1' feature1
+
+git add feature2.txt
+gs bc -m 'Add feature 2' feature2
+
+git add feature3.txt
+gs bc -m 'Add feature 3' feature3
+
+git graph --branches
+cmp stdout $WORK/golden/graph-before.txt
+
+env EDITOR=mockedit MOCKEDIT_GIVE=$WORK/input/rebase-todo.txt
+git rebase -i HEAD~3
+
+# should be in detached head state on feature1
+git rev-parse HEAD
+stdout 94ce19e
+
+# add a commit with 'commit create'
+mv $WORK/extra/feature1-part2.txt feature1-part2.txt
+git add feature1-part2.txt
+gs commit amend -n
+
+git rev-parse HEAD
+stdout 95044b5
+git rebase --continue
+
+git graph HEAD
+cmp stdout $WORK/golden/graph-after.txt
+
+-- repo/feature1.txt --
+Contents of feature 1.
+
+-- repo/feature2.txt --
+Contents of feature 2.
+
+-- repo/feature3.txt --
+Contents of feature 3.
+
+-- golden/graph-before.txt --
+* 4041fd7 (HEAD -> feature3) Add feature 3
+* 556ae49 (feature2) Add feature 2
+* 94ce19e (feature1) Add feature 1
+* 63c927d (main) Initial commit
+-- input/rebase-todo.txt --
+pick 94ce19e Add feature 1
+break
+pick 556ae49 Add feature 2
+pick 4041fd7 Add feature 3
+
+-- extra/feature1-part2.txt --
+Part 2 of feature 1.
+-- golden/graph-after.txt --
+* 20cdfa1 (HEAD -> feature3) Add feature 3
+* bfd39aa Add feature 2
+* 95044b5 Add feature 1
+* 63c927d (main) Initial commit

--- a/testdata/script/commit_create_rebase.txt
+++ b/testdata/script/commit_create_rebase.txt
@@ -1,0 +1,71 @@
+# commit create in the middle of a rebase
+# works like a plain git commit.
+
+as 'Test <test@example.com>'
+at '2024-05-23T19:23:24Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git add feature1.txt
+gs bc -m 'Add feature 1' feature1
+
+git add feature2.txt
+gs bc -m 'Add feature 2' feature2
+
+git add feature3.txt
+gs bc -m 'Add feature 3' feature3
+
+git graph --branches
+cmp stdout $WORK/golden/graph-before.txt
+
+env EDITOR=mockedit MOCKEDIT_GIVE=$WORK/input/rebase-todo.txt
+git rebase -i HEAD~3
+
+# should be in detached head state on feature1
+git rev-parse HEAD
+stdout 94ce19e
+
+# add a commit with 'commit create'
+mv $WORK/extra/feature1-part2.txt feature1-part2.txt
+git add feature1-part2.txt
+gs cc -m 'Add part 2 of feature 1'
+
+git rev-parse HEAD
+stdout 914573f
+git rebase --continue
+
+git graph HEAD
+cmp stdout $WORK/golden/graph-after.txt
+
+-- repo/feature1.txt --
+Contents of feature 1.
+
+-- repo/feature2.txt --
+Contents of feature 2.
+
+-- repo/feature3.txt --
+Contents of feature 3.
+
+-- golden/graph-before.txt --
+* 4041fd7 (HEAD -> feature3) Add feature 3
+* 556ae49 (feature2) Add feature 2
+* 94ce19e (feature1) Add feature 1
+* 63c927d (main) Initial commit
+-- input/rebase-todo.txt --
+pick 94ce19e Add feature 1
+break
+pick 556ae49 Add feature 2
+pick 4041fd7 Add feature 3
+
+-- extra/feature1-part2.txt --
+Part 2 of feature 1.
+-- golden/graph-after.txt --
+* be60379 (HEAD -> feature3) Add feature 3
+* 092561c Add feature 2
+* 914573f Add part 2 of feature 1
+* 94ce19e (feature1) Add feature 1
+* 63c927d (main) Initial commit


### PR DESCRIPTION
If 'gs cc' or 'gs ca' are used in the middle of a rebase,
we should not restack the upstack branches.