### PR TITLE
repo sync: Support detached head

### DIFF
--- a/.changes/unreleased/Added-20240523-193544.yaml
+++ b/.changes/unreleased/Added-20240523-193544.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'commit create, commit amend: Allow using during an ongoing rebase. During a rebase, these commands will not restack the upstack.'
+time: 2024-05-23T19:35:44.704921-07:00

--- a/.changes/unreleased/Added-20240523-194314.yaml
+++ b/.changes/unreleased/Added-20240523-194314.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'repo sync: Support running in detached head state.'
+time: 2024-05-23T19:43:14.615612-07:00

--- a/.changes/unreleased/Fixed-20240523-193544.yaml
+++ b/.changes/unreleased/Fixed-20240523-193544.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: 'commit create, commit amend: Fix usage during an ongoing rebase. If used during a rebase, these commands will not rebase the upstack.'
-time: 2024-05-23T19:35:44.704921-07:00

--- a/repo_sync.go
+++ b/repo_sync.go
@@ -56,7 +56,10 @@ func (*repoSyncCmd) Run(
 
 	currentBranch, err := repo.CurrentBranch(ctx)
 	if err != nil {
-		return fmt.Errorf("get current branch: %w", err)
+		if !errors.Is(err, git.ErrDetachedHead) {
+			return fmt.Errorf("get current branch: %w", err)
+		}
+		currentBranch = "" // detached head
 	}
 
 	trunk := store.Trunk()
@@ -157,8 +160,8 @@ func (*repoSyncCmd) Run(
 				return fmt.Errorf("pull: %w", err)
 			}
 
-			if err := repo.Checkout(ctx, currentBranch); err != nil {
-				return fmt.Errorf("checkout current branch: %w", err)
+			if err := repo.Checkout(ctx, "-"); err != nil {
+				return fmt.Errorf("checkout old branch: %w", err)
 			}
 
 			// TODO: With a recent enough git,

--- a/testdata/script/repo_sync_detached_head.txt
+++ b/testdata/script/repo_sync_detached_head.txt
@@ -1,0 +1,40 @@
+# repo sync should update trunk even in detached head state.
+# https://github.com/abhinav/git-spice/issues/85
+
+as 'Test <test@example.com>'
+at '2024-05-18T13:59:12Z'
+
+# setup
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+gh-init
+gh-add-remote origin alice/example.git
+git push origin main
+gs repo init
+
+# update the remote out of band
+cd ..
+gh-clone alice/example.git fork
+cd fork
+cp $WORK/extra/feature1.txt .
+git add feature1.txt
+git commit -m 'Add feature1'
+git push origin main
+
+# put the original repo in detached head state
+cd ../repo
+git checkout --detach
+
+gs repo sync
+stderr 'pulled 1 new commit'
+
+# should still be in detached head state
+git branch --show-current
+stdout '^$'
+
+-- extra/feature1.txt --
+Contents of feature1


### PR DESCRIPTION
If a repository is in detached head state,
treat that the same as trunk not being the current branch,
and update the trunk branch as usual.

Resolves #85