### PR TITLE
restack: Don't use fork point if base hash is up to date

### DIFF
--- a/.changes/unreleased/Fixed-20240523-195844.yaml
+++ b/.changes/unreleased/Fixed-20240523-195844.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Adjust restacking commit selection to avoid picking up extraneous commits.
+time: 2024-05-23T19:58:44.423236-07:00

--- a/internal/spice/restack.go
+++ b/internal/spice/restack.go
@@ -44,26 +44,38 @@ func (s *Service) Restack(ctx context.Context, name string) (*RestackResponse, e
 
 	baseHash := restackErr.BaseHash
 	upstream := b.BaseHash
+
 	// Case:
-	// Current branch has diverged from what the target branch
-	// was forked from. That is:
+	// Recorded base hash is super out of date,
+	// and is not an ancestor of the current branch.
+	// In that case, use fork point as a hail mary
+	// to guess the upstream start point.
 	//
-	//  ---X---A'---o current
+	// For context, fork point attempts to find the point
+	// where the current branch diverged from the branch it
+	// was originally forked from.
+	// For example, given:
+	//
+	//  ---X---A'---o foo
 	//      \
 	//       A
 	//        \
-	//         B---o---o target
+	//         B---o---o bar
 	//
-	// Upstack was forked from our branch when the child of X was A.
-	// Since then, we have amended A to get A',
-	// but the target branch still points to A.
+	// If bar branched from foo, when foo was at A,
+	// and then we amended foo to get A',
+	// bar will still refer to A.
 	//
 	// In this case, merge-base --fork-point will give us A,
-	// and that should be the base of the target branch.
-	forkPoint, err := s.repo.ForkPoint(ctx, b.Base, name)
-	if err == nil {
-		upstream = forkPoint
-		s.log.Debugf("Using fork point %v as rebase base", upstream)
+	// and that should be the upstream (commit to start rebasing from)
+	// if the recorded base hash is out of date
+	// because the user changed something externally.
+	if !s.repo.IsAncestor(ctx, baseHash, b.Head) {
+		forkPoint, err := s.repo.ForkPoint(ctx, b.Base, name)
+		if err == nil {
+			upstream = forkPoint
+			s.log.Debugf("Using fork point %v as rebase base", upstream)
+		}
 	}
 
 	if err := s.repo.Rebase(ctx, git.RebaseRequest{


### PR DESCRIPTION
When restacking, we run the equivalent of the following command:

    git rebase --onto [base] [upstream] [current]

Where,

- [base]: name of the base branch we're stacking on top of
- [upstream]: commit to start rebasing from
- [current]: branch we're rebasing

Commits that match `git rev-list [current] --not [upstream]`
are included in the rebase.

We track the hash of the base branch as the user uses git-spice
so that we know the best value of [upstream] to use when restacking.

However, our restacking logic was always overriding that
with the fork point between [base] and [current] if available.
This seems unnecessary and possibly faulty
given that our base branch information is more specific.

In this change, we'll only use the fork point as a fallback
if the recorded base hash is not an ancestor of the current branch.
