### PR TITLE
fix(branch edit): invoke the editor for interactive rebase

### DIFF
--- a/.changes/unreleased/Fixed-20240523-204443.yaml
+++ b/.changes/unreleased/Fixed-20240523-204443.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'branch edit: Fix not surfacing the editor to the user.'
+time: 2024-05-23T20:44:43.596952-07:00

--- a/internal/git/rebase.go
+++ b/internal/git/rebase.go
@@ -89,8 +89,12 @@ func (r *Repository) Rebase(ctx context.Context, req RebaseRequest) error {
 		args = append(args, req.Branch)
 	}
 
-	err := r.gitCmd(ctx, args...).Run(r.exec)
-	if err != nil {
+	cmd := r.gitCmd(ctx, args...)
+	if req.Interactive {
+		cmd.Stdin(os.Stdin).Stdout(os.Stdout).Stderr(os.Stderr)
+	}
+
+	if err := cmd.Run(r.exec); err != nil {
 		originalErr := err
 		if exitErr := new(exec.ExitError); !errors.As(err, &exitErr) {
 			return fmt.Errorf("rebase: %w", err)


### PR DESCRIPTION
Fixes a bug where the editor was being invoked,
but because stdout/stderr/etc. were not sharted,
it was not showing up.