### PR TITLE
lint/errcheck: Ignore Fprint*

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,6 +32,13 @@ linters:
     - musttag
 
 linters-settings:
+  errcheck:
+    exclude-functions:
+      # Usually used in the same capacity as fmt.Print*.
+      - fmt.Fprint
+      - fmt.Fprintf
+      - fmt.Fprintln
+
   govet:
     enable:
       - niliness


### PR DESCRIPTION
These functions are used in the same capacity as Printf and friends,
and those are already excldued by default.