### PR TITLE
tests: Fix terminal tests passing despite failures

### DIFF
--- a/internal/termtest/with_term.go
+++ b/internal/termtest/with_term.go
@@ -47,6 +47,12 @@ import (
 //     Go string-style escape codes are permitted without quotes.
 //     Examples: \r, \x1b[B
 func WithTerm() (exitCode int) {
+	defer func() {
+		// testscript.RunMain does not seem to respect
+		// the returned exit code.
+		os.Exit(exitCode)
+	}()
+
 	log.SetFlags(0)
 
 	args := os.Args[1:]
@@ -143,8 +149,10 @@ func WithTerm() (exitCode int) {
 			if !matched {
 				if len(rest) > 0 {
 					log.Printf("await: %q not found", rest)
+					exitCode = 1
 				} else {
 					log.Printf("await: screen did not change")
+					exitCode = 1
 				}
 
 				log.Printf("###\n%s\n###", last)
@@ -180,7 +188,7 @@ func WithTerm() (exitCode int) {
 		}
 	}
 
-	return 0
+	return exitCode
 }
 
 type terminalEmulator struct {

--- a/testdata/script/branch_submit_long_body.txt
+++ b/testdata/script/branch_submit_long_body.txt
@@ -54,12 +54,12 @@ no sea takimata sanctus est Lorem ipsum dolor sit amet.
 End of message.
 
 -- input/prompt.txt --
-await Detailed description
+await Title:
 snapshot initial
 feed \t
-await
+await Body:
 feed \t
-await
+await Draft:
 snapshot last
 feed \r
 

--- a/testdata/script/branch_submit_remote_prompt.txt
+++ b/testdata/script/branch_submit_remote_prompt.txt
@@ -29,7 +29,7 @@ cmpenvJSON stdout $WORK/golden/pulls.json
 Contents of feature1
 
 -- input.txt --
-await Please select the remote
+await Please select a remote
 snapshot dialog
 feed \r
 

--- a/testdata/script/repo_init_prompt_multiple_local.txt
+++ b/testdata/script/repo_init_prompt_multiple_local.txt
@@ -15,7 +15,7 @@ with-term $WORK/input.txt -- gs repo init
 cmp stdout $WORK/golden/dialog.txt
 
 -- input.txt --
-await Pick a trunk
+await Please select the trunk branch
 snapshot dialog
 feed \r
 

--- a/testdata/script/repo_init_prompt_upstream.txt
+++ b/testdata/script/repo_init_prompt_upstream.txt
@@ -20,7 +20,7 @@ with-term $WORK/input.txt -- gs repo init
 cmp stdout $WORK/golden/dialog.txt
 
 -- input.txt --
-await Pick a trunk
+await Please select the trunk branch
 snapshot dialog
 feed \r
 

--- a/testdata/script/repo_init_remote_prompt.txt
+++ b/testdata/script/repo_init_remote_prompt.txt
@@ -16,7 +16,7 @@ with-term $WORK/input.txt -- gs repo init
 cmp stdout $WORK/golden/dialog.txt
 
 -- input.txt --
-await Pick a remote
+await Please select a remote:
 snapshot dialog
 feed \r
 

--- a/testdata/script/top_multiple_prompt.txt
+++ b/testdata/script/top_multiple_prompt.txt
@@ -45,7 +45,6 @@ stderr 'not allowed to prompt for input'
 # from main, we should be prompted to pick between
 # f2, f1-s1, and f1-s2-s
 with-term $WORK/input/main-prompt.txt -- gs top
-stderr 'There are multiple top-level branches'
 cmp stdout $WORK/golden/main-prompt.txt
 
 # from f1, we should wee f1-s1 and f1-s2-s
@@ -78,7 +77,7 @@ feature 1 sub feature 2 sub feature
 |/  
 * 9bad92b (HEAD -> main) Initial commit
 -- input/main-prompt.txt --
-await 'Pick a branch'
+await Pick a branch
 snapshot
 feed \r
 -- golden/main-prompt.txt --
@@ -90,7 +89,7 @@ Pick a branch:
 
 There are multiple top-level branches reachable from the current branc
 -- input/f1-prompt.txt --
-await 'Pick a branch'
+await Pick a branch
 snapshot
 feed \r
 -- golden/f1-prompt.txt --


### PR DESCRIPTION
termtest was not returning a non-zero exit code when 'await failed,
so the tests that use it were passing anyway.

This change fixes that and the tests that rightly started failing.
