### PR TITLE
branch onto: Prompt for destination branch if not provided

### DIFF
--- a/.changes/unreleased/Added-20240526-164805.yaml
+++ b/.changes/unreleased/Added-20240526-164805.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'branch onto: Prompt for destination branch if a name isn''t provided.'
+time: 2024-05-26T16:48:05.095067-07:00

--- a/branch_checkout.go
+++ b/branch_checkout.go
@@ -46,7 +46,7 @@ func (cmd *branchCheckoutCmd) Run(ctx context.Context, log *log.Logger, opts *gl
 			Exclude:           []string{currentBranch},
 			ExcludeCheckedOut: true,
 			Title:             "Select a branch to checkout",
-		}).Run(ctx, repo)
+		}).Run(ctx, repo, store)
 		if err != nil {
 			return fmt.Errorf("select branch: %w", err)
 		}

--- a/branch_delete.go
+++ b/branch_delete.go
@@ -50,7 +50,7 @@ func (cmd *branchDeleteCmd) Run(ctx context.Context, log *log.Logger, opts *glob
 			Exclude:           []string{store.Trunk()},
 			ExcludeCheckedOut: true,
 			Title:             "Select a branch to delete",
-		}).Run(ctx, repo)
+		}).Run(ctx, repo, store)
 		if err != nil {
 			return fmt.Errorf("select branch: %w", err)
 		}


### PR DESCRIPTION
You can now run `gs branch onto` without any arguments
and it'll present a prompt to pick a destination branch.
