### PR TITLE
branch checkout: If new branch is untracked, allow tracking

### DIFF
--- a/.changes/unreleased/Changed-20240526-214550.yaml
+++ b/.changes/unreleased/Changed-20240526-214550.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'branch checkout: Allow opting into tracking after checking out a branch.'
+time: 2024-05-26T21:45:50.553608-07:00

--- a/branch_onto.go
+++ b/branch_onto.go
@@ -97,7 +97,7 @@ func (cmd *branchOntoCmd) Run(ctx context.Context, log *log.Logger, opts *global
 
 	if err := repo.Rebase(ctx, git.RebaseRequest{
 		Branch:    cmd.Branch,
-		Upstream:  branch.Base, // TODO: use fork point?
+		Upstream:  branch.Base,
 		Onto:      cmd.Onto,
 		Autostash: true,
 		Quiet:     true,

--- a/branch_rename.go
+++ b/branch_rename.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/git"
@@ -44,8 +45,13 @@ func (cmd *branchRenameCmd) Run(ctx context.Context, log *log.Logger, opts *glob
 	if cmd.Name == "" {
 		prompt := ui.NewInput(&cmd.Name).
 			WithTitle("New branch name").
-			WithDescription(fmt.Sprintf("Renaming branch: %v", oldName))
-			// TODO: validate func
+			WithDescription(fmt.Sprintf("Renaming branch: %v", oldName)).
+			WithValidate(func(s string) error {
+				if strings.TrimSpace(s) == "" {
+					return fmt.Errorf("branch name cannot be empty")
+				}
+				return nil
+			})
 
 		if err := ui.Run(prompt); err != nil {
 			return fmt.Errorf("prompt: %w", err)

--- a/testdata/script/branch_checkout_prompt.txt
+++ b/testdata/script/branch_checkout_prompt.txt
@@ -29,7 +29,7 @@ git commit -m 'Add qux'
 git checkout -b quux main
 git merge -m 'Merge many' foo bar baz qux
 
-with-term -rows 8 -cols 40 $WORK/input.txt -- gs branch checkout
+with-term -rows 8 -cols 50 $WORK/input.txt -- gs branch checkout
 cmp stdout $WORK/golden/prompt.txt
 
 git branch --show-current
@@ -55,7 +55,10 @@ await
 snapshot after-ba
 feed \x1b[B
 await
-snapshot end
+snapshot select
+feed \r
+await Do you want to track
+snapshot track
 feed \r
 
 -- golden/prompt.txt --
@@ -71,8 +74,15 @@ Select a branch to checkout:
 
 ▶ bar
   baz
-### end ###
+### select ###
 Select a branch to checkout:
 
   bar
 ▶ baz
+### track ###
+Select a branch to checkout:
+
+  bar
+▶ baz
+
+Do you want to track this branch now?: [Y/n]

--- a/testdata/script/branch_checkout_track_prompt.txt
+++ b/testdata/script/branch_checkout_track_prompt.txt
@@ -1,0 +1,36 @@
+# branch checkout of an untracked branch
+# prompts to check it out.
+
+as 'Test <test@example.com>'
+at '2024-03-30T14:59:32Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# A couple tracked branches, and a couple untracked.
+git checkout -b feature
+git add foo.txt
+git commit -m 'Add foo.txt'
+
+git checkout main
+
+with-term $WORK/input.txt -- gs branch checkout feature
+stderr 'feature: branch not tracked'
+cmp stdout $WORK/golden/prompt.txt
+
+# TODO: when we have 'gs list',
+# verify branch is tracked.
+
+-- repo/foo.txt --
+whatever
+
+-- input.txt --
+await Do you want to track
+snapshot
+feed y
+await
+
+-- golden/prompt.txt --
+Do you want to track this branch now?: [Y/n]


### PR DESCRIPTION
When checking out a branch that was previously untracked,
allow the user to opt into tracking the branch.