### PR TITLE
rebase continue: recover from rebase conflicts

### DIFF
--- a/.changes/unreleased/Added-20240527-202119.yaml
+++ b/.changes/unreleased/Added-20240527-202119.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add `gs rebase continue` (alias `gs rbc`) and `gs rebase abort` (alias `gs rba`) to continue git-spice operations interrupted by rebase conflicts.
+time: 2024-05-27T20:21:19.22906-07:00

--- a/.changes/unreleased/Changed-20240527-202155.yaml
+++ b/.changes/unreleased/Changed-20240527-202155.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'branch {edit, onto}: Support continuing the operation after resolving conflicts with `gs rebase continue`.'
+time: 2024-05-27T20:21:55.380558-07:00

--- a/.changes/unreleased/Changed-20240527-202308.yaml
+++ b/.changes/unreleased/Changed-20240527-202308.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: '{branch, upstack, stack} restack: Support continuing the operation after resolving conflicts with `gs rebase continue`.'
+time: 2024-05-27T20:23:08.650923-07:00

--- a/branch_onto.go
+++ b/branch_onto.go
@@ -102,10 +102,15 @@ func (cmd *branchOntoCmd) Run(ctx context.Context, log *log.Logger, opts *global
 		Autostash: true,
 		Quiet:     true,
 	}); err != nil {
-		return fmt.Errorf("rebase: %w", err)
+		// If the rebase is interrupted,
+		// we'll just re-run this command again later.
+		return svc.RebaseRescue(ctx, spice.RebaseRescueRequest{
+			Err:     err,
+			Command: []string{"branch", "onto", cmd.Onto},
+			Branch:  cmd.Branch,
+			Message: fmt.Sprintf("interrupted: branch %s onto %s", cmd.Branch, cmd.Onto),
+		})
 	}
-
-	// TODO: handle conflicts/partial rebase
 
 	err = store.Update(ctx, &state.UpdateRequest{
 		Upserts: []state.UpsertRequest{

--- a/commit_amend.go
+++ b/commit_amend.go
@@ -39,7 +39,7 @@ func (cmd *commitAmendCmd) Run(ctx context.Context, log *log.Logger, opts *globa
 		return fmt.Errorf("commit: %w", err)
 	}
 
-	if _, err := repo.RebaseState(); err == nil {
+	if _, err := repo.RebaseState(ctx); err == nil {
 		// In the middle of a rebase.
 		// Don't restack upstack branches.
 		return nil

--- a/commit_create.go
+++ b/commit_create.go
@@ -38,7 +38,7 @@ func (cmd *commitCreateCmd) Run(ctx context.Context, log *log.Logger, opts *glob
 		return fmt.Errorf("commit: %w", err)
 	}
 
-	if _, err := repo.RebaseState(); err == nil {
+	if _, err := repo.RebaseState(ctx); err == nil {
 		// In the middle of a rebase.
 		// Don't restack upstack branches.
 		return nil

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -14,6 +14,32 @@ gs (git-spice) is a command line tool for stacking Git branches.
 * `-C`, `--dir=DIR`: Change to DIR before doing anything
 * `--[no-]prompt`: Whether to prompt for missing information
 
+## gs completion
+
+```
+gs completion <shell> [flags]
+```
+
+Generate shell completion script
+
+Generates shell completion scripts.
+To install the script, add the output of this command to your
+shell's rc file.
+For example:
+
+	# bash
+	gs completion bash >> ~/.bashrc
+
+	# zsh
+	gs completion zsh >> ~/.zshrc
+
+	# fish
+	gs completion fish >> ~/.config/fish/config.fish
+
+**Arguments**
+
+* `shell`: Shell to generate completions for.
+
 ## gs repo init
 
 ```
@@ -297,8 +323,11 @@ gs branch (b) edit (e)
 
 Edit the commits in a branch
 
-Allows editing the commits in the current branch
-with an interactive rebase.
+Begins an interactive rebase of a branch without affecting its
+base branch. This allows you to edit the commits in the branch,
+reword their messages, etc.
+After the rebase, the branches upstack from the edited branch
+will be restacked.
 
 ## gs branch rename
 
@@ -398,6 +427,40 @@ as you update a branch in the middle of the stack.
 * `-m`, `--message=STRING`: Use the given message as the commit message.
 * `-n`, `--no-edit`: Don't edit the commit message
 
+## gs rebase continue
+
+```
+gs rebase (rb) continue (c)
+```
+
+Continue an interrupted operation
+
+This command continues an ongoing git-spice operation that was
+interrupted by a Git rebase action.
+Without an ongoing git-spice operation,
+this is equivalent to 'git rebase --continue'.
+
+For example, if 'gs upstack restack' encounters a conflict,
+resolve the conflict and run 'gs rebase continue'
+(or its shorthand 'gs rbc') to continue the operation.
+
+## gs rebase abort
+
+```
+gs rebase (rb) abort (a)
+```
+
+Abort an operation
+
+This command cancels an ongoing git-spice operation that was
+interrupted by a Git rebase action.
+Without an ongoing git-spice operation,
+this is equivalent to 'git rebase --abort'.
+
+For example, if 'gs upstack restack' encounters a conflict,
+cancel the operation with 'gs rebase abort'
+(or its shorthand 'gs rba').
+
 ## gs up
 
 ```
@@ -461,30 +524,4 @@ gs trunk [flags]
 ```
 
 Move to the trunk branch
-
-## gs completion
-
-```
-gs completion <shell> [flags]
-```
-
-Generate shell completion script
-
-Generates shell completion scripts.
-To install the script, add the output of this command to your
-shell's rc file.
-For example:
-
-	# bash
-	gs completion bash >> ~/.bashrc
-
-	# zsh
-	gs completion zsh >> ~/.zshrc
-
-	# fish
-	gs completion fish >> ~/.config/fish/config.fish
-
-**Arguments**
-
-* `shell`: Shell to generate completions for.
 

--- a/internal/spice/rebase.go
+++ b/internal/spice/rebase.go
@@ -1,0 +1,107 @@
+package spice
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/must"
+	"go.abhg.dev/gs/internal/spice/state"
+)
+
+// ErrRebaseInterrupted indicates that a rebase operation was interrupted.
+var ErrRebaseInterrupted = errors.New("rebase interrupted")
+
+// RebaseRescueRequest is a request to rescue a rebase operation.
+type RebaseRescueRequest struct {
+	// Err is the error that caused the rebase operation to be interrupted.
+	Err error
+
+	// Command is the command that should be run
+	// after the rebase operation has been rescued.
+	//
+	// If this is unset, a continuation will NOT be recorded.
+	Command []string
+
+	// Branch is the branch on which the command should be run.
+	//
+	// If this is unset, the continuation will run on the interrupted
+	// branch.
+	Branch string
+
+	// Message is the message that should be recorded
+	// for debugging this continuation.
+	Message string // optional
+}
+
+// RebaseRescue attempts to recover a git-spice operation that was interrupted
+// by a rebase conflict or other interruption.
+// If it determines that the rebase can be recovered from and continued in the
+// future, it records the continuation command in the data store for later
+// resumption.
+//
+// This returns [ErrRebaseInterrupted] if the rebase was recovered from
+// so that the program can exit and the oepration can resume later.
+func (s *Service) RebaseRescue(ctx context.Context, req RebaseRescueRequest) error {
+	if req.Err == nil {
+		return nil
+	}
+
+	var rebaseErr *git.RebaseInterruptError
+	if !errors.As(req.Err, &rebaseErr) {
+		return req.Err
+	}
+
+	// TODO: This will also log git's standard advice for resolving conflicts.
+	// We could suppress that by setting advice.mergeConflict=false
+	// during the rebase operation.
+	s.log.Warn("rebase interrupted", "error", rebaseErr)
+
+	switch rebaseErr.Kind {
+	case git.RebaseInterruptConflict:
+		var msg strings.Builder
+		fmt.Fprintf(&msg, "There was a conflict while rebasing.\n")
+		fmt.Fprintf(&msg, "Resolve the conflict and run:\n")
+		fmt.Fprintf(&msg, "  gs rebase continue\n")
+		fmt.Fprintf(&msg, "Or abort the operation with:\n")
+		fmt.Fprintf(&msg, "  gs rebase abort\n")
+		s.log.Error(msg.String())
+	case git.RebaseInterruptDeliberate:
+		var msg strings.Builder
+		fmt.Fprintf(&msg, "The rebase operation was interrupted with an 'edit' or 'break' command.\n")
+		fmt.Fprintf(&msg, "When you're ready to continue, run:\n")
+		fmt.Fprintf(&msg, "  gs rebase continue\n")
+		fmt.Fprintf(&msg, "Or abort the operation with:\n")
+		fmt.Fprintf(&msg, "  gs rebase abort\n")
+		s.log.Info(msg.String())
+	default:
+		must.Failf("unexpected rebase interrupt kind: %v", rebaseErr.Kind)
+	}
+
+	// No continuation to record.
+	if len(req.Command) == 0 {
+		return ErrRebaseInterrupted
+	}
+
+	branch := req.Branch
+	if branch == "" {
+		branch = rebaseErr.State.Branch
+	}
+
+	msg := req.Message
+	if msg == "" {
+		msg = fmt.Sprintf("interrupted: branch %s", req.Branch)
+	}
+
+	if err := s.store.SetContinuation(ctx, state.SetContinuationRequest{
+		Command: req.Command,
+		Branch:  branch,
+		Message: msg,
+	}); err != nil {
+		return fmt.Errorf("edit state: %w", err)
+	}
+
+	return ErrRebaseInterrupted
+}

--- a/internal/spice/restack.go
+++ b/internal/spice/restack.go
@@ -87,7 +87,7 @@ func (s *Service) Restack(ctx context.Context, name string) (*RestackResponse, e
 	}); err != nil {
 		return nil, fmt.Errorf("rebase: %w", err)
 		// TODO: detect conflicts in rebase,
-		// print message about "gs continue"
+		// print message about "gs rebase continue"
 	}
 
 	err = s.store.Update(ctx, &state.UpdateRequest{

--- a/internal/spice/service.go
+++ b/internal/spice/service.go
@@ -63,6 +63,8 @@ type BranchStore interface {
 
 	// Trunk returns the name of the trunk branch.
 	Trunk() string
+
+	SetContinuation(context.Context, state.SetContinuationRequest) error
 }
 
 var _ BranchStore = (*state.Store)(nil)

--- a/internal/spice/state/continue.go
+++ b/internal/spice/state/continue.go
@@ -1,0 +1,98 @@
+package state
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.abhg.dev/gs/internal/must"
+)
+
+// SetContinuationRequest is a request to set the operation
+// that should run after the current rebase finishes successfully.
+type SetContinuationRequest struct {
+	// Branch is the branch on which the operation should run.
+	Branch string // required
+
+	// Command specifies the gs command that will be run.
+	Command []string // required
+
+	// Message is a message for the gs state log.
+	Message string
+}
+
+// SetContinuation records a command that should run
+// when an interrupted rebase operation is resumed.
+func (s *Store) SetContinuation(ctx context.Context, req SetContinuationRequest) error {
+	must.NotBeBlankf(req.Branch, "a branch name is required")
+	must.NotBeEmptyf(req.Command, "arguments for git-spice are required")
+	if req.Message == "" {
+		req.Message = "set rebase continuation"
+	}
+
+	// Sanity check:
+	// Must not have an existing continuation.
+	var cont rebaseContinuation
+	if err := s.b.Get(ctx, _rebaseContinueJSON, &cont); err == nil {
+		s.log.Errorf("Found an existing rebase continuation for %v: %q", cont.Branch, cont.Command)
+		return errors.New("an unfinished rebase continuation already exists")
+		// TODO: If we encounter this in practice from a normal workflow,
+		// we'll probably want a queue or stack for continuations.
+	}
+
+	cont = rebaseContinuation{
+		Branch:  req.Branch,
+		Command: req.Command,
+	}
+	if err := s.b.Update(ctx, updateRequest{
+		Sets: []setRequest{
+			{Key: _rebaseContinueJSON, Val: cont},
+		},
+		Msg: req.Message,
+	}); err != nil {
+		return fmt.Errorf("set rebase continuation: %w", err)
+	}
+
+	return nil
+}
+
+// TakeContinuationResult includes the information needed to resume a
+// rebase operation that was interrupted.
+type TakeContinuationResult struct {
+	// Command specifies the arguments for the gs operation
+	// that was interrupted.
+	Command []string
+
+	// Branch is the branch that the command should be run on.
+	Branch string
+}
+
+// TakeContinuation removes a recorded rebase continuation from the store
+// and returns it.
+//
+// If there is no continuation, it returns nil.
+func (s *Store) TakeContinuation(ctx context.Context, msg string) (*TakeContinuationResult, error) {
+	if msg == "" {
+		msg = "take rebase continuation"
+	}
+
+	var cont rebaseContinuation
+	if err := s.b.Get(ctx, _rebaseContinueJSON, &cont); err != nil {
+		if errors.Is(err, ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get rebase continuation: %w", err)
+	}
+
+	if err := s.b.Update(ctx, updateRequest{
+		Dels: []string{_rebaseContinueJSON},
+		Msg:  msg,
+	}); err != nil {
+		return nil, fmt.Errorf("delete rebase continuation: %w", err)
+	}
+
+	return &TakeContinuationResult{
+		Command: cont.Command,
+		Branch:  cont.Branch,
+	}, nil
+}

--- a/internal/spice/state/state.go
+++ b/internal/spice/state/state.go
@@ -6,8 +6,9 @@ import (
 )
 
 const (
-	_repoJSON    = "repo"
-	_branchesDir = "branches"
+	_repoJSON           = "repo"
+	_branchesDir        = "branches"
+	_rebaseContinueJSON = "rebase-continue"
 )
 
 type repoInfo struct {
@@ -20,6 +21,14 @@ func (i *repoInfo) Validate() error {
 		return errors.New("trunk branch name is empty")
 	}
 	return nil
+}
+
+type rebaseContinuation struct {
+	// Command is the gs command that will be run.
+	Command []string `json:"command"`
+
+	// Branch on which the command must be run.
+	Branch string `json:"branch"`
 }
 
 type branchStateBase struct {

--- a/main.go
+++ b/main.go
@@ -186,6 +186,8 @@ type globalOptions struct {
 type mainCmd struct {
 	globalOptions `group:"globals"`
 
+	Completion completionCmd `cmd:"" group:"Setup" help:"Generate shell completion script"`
+
 	Repo repoCmd `cmd:"" aliases:"r" group:"Repository"`
 
 	Stack     stackCmd     `cmd:"" aliases:"s" group:"Stack"`
@@ -195,15 +197,14 @@ type mainCmd struct {
 	Branch branchCmd `cmd:"" aliases:"b" group:"Branch"`
 	Commit commitCmd `cmd:"" aliases:"c" group:"Commit"`
 
+	Rebase rebaseCmd `cmd:"" aliases:"rb" group:"Rebase"`
+
 	// Navigation
 	Up     upCmd     `cmd:"" aliases:"u" group:"Navigation" help:"Move up one branch"`
 	Down   downCmd   `cmd:"" aliases:"d" group:"Navigation" help:"Move down one branch"`
 	Top    topCmd    `cmd:"" aliases:"U" group:"Navigation" help:"Move to the top of the stack"`
 	Bottom bottomCmd `cmd:"" aliases:"D" group:"Navigation" help:"Move to the bottom of the stack"`
 	Trunk  trunkCmd  `cmd:"" group:"Navigation" help:"Move to the trunk branch"`
-
-	// Other
-	Completion completionCmd `name:"completion" cmd:"" group:"System" help:"Generate shell completion script"`
 
 	// Hidden commands:
 	DumpMD dumpMarkdownCmd `name:"dump-md" hidden:"" cmd:"" help:"Dump a Markdown reference to stdout and quit"`

--- a/rebase.go
+++ b/rebase.go
@@ -1,0 +1,6 @@
+package main
+
+type rebaseCmd struct {
+	Continue rebaseContinueCmd `aliases:"c" cmd:"" help:"Continue an interrupted operation"`
+	Abort    rebaseAbortCmd    `aliases:"a" cmd:"" help:"Abort an operation"`
+}

--- a/rebase_abort.go
+++ b/rebase_abort.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/text"
+)
+
+type rebaseAbortCmd struct{}
+
+func (*rebaseAbortCmd) Help() string {
+	return text.Dedent(`
+		This command cancels an ongoing git-spice operation that was
+		interrupted by a Git rebase action.
+		Without an ongoing git-spice operation,
+		this is equivalent to 'git rebase --abort'.
+
+		For example, if 'gs upstack restack' encounters a conflict,
+		cancel the operation with 'gs rebase abort'
+		(or its shorthand 'gs rba').
+	`)
+}
+
+func (cmd *rebaseAbortCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
+	repo, err := git.Open(ctx, ".", git.OpenOptions{
+		Log: log,
+	})
+	if err != nil {
+		return fmt.Errorf("open repository: %w", err)
+	}
+
+	store, err := ensureStore(ctx, repo, log, opts)
+	if err != nil {
+		return err
+	}
+
+	var wasRebasing bool
+	if _, err := repo.RebaseState(ctx); err != nil {
+		if !errors.Is(err, git.ErrNoRebase) {
+			return fmt.Errorf("get rebase state: %w", err)
+		}
+		// If the user ran 'git rebase --abort' instead,
+		// we will not be in the middle of a rebase operation.
+		// That's okay -- assume that they still want to abort
+		// the gs operation they were running.
+	} else {
+		wasRebasing = true
+		if err := repo.RebaseAbort(ctx); err != nil {
+			return fmt.Errorf("abort rebase: %w", err)
+		}
+	}
+
+	cont, err := store.TakeContinuation(ctx, "gs rebase abort")
+	if err != nil {
+		return fmt.Errorf("take rebase continuation: %w", err)
+	}
+	if cont == nil && !wasRebasing {
+		return errors.New("no operation to abort")
+	}
+	if cont != nil {
+		log.Debugf("%v: dropping continuation: %q", cont.Branch, cont.Command)
+	}
+
+	return nil
+}

--- a/rebase_continue.go
+++ b/rebase_continue.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/alecthomas/kong"
+	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/text"
+)
+
+type rebaseContinueCmd struct{}
+
+func (*rebaseContinueCmd) Help() string {
+	return text.Dedent(`
+		This command continues an ongoing git-spice operation that was
+		interrupted by a Git rebase action.
+		Without an ongoing git-spice operation,
+		this is equivalent to 'git rebase --continue'.
+
+		For example, if 'gs upstack restack' encounters a conflict,
+		resolve the conflict and run 'gs rebase continue'
+		(or its shorthand 'gs rbc') to continue the operation.
+	`)
+}
+
+func (cmd *rebaseContinueCmd) Run(
+	ctx context.Context,
+	log *log.Logger,
+	opts *globalOptions,
+	parser *kong.Kong,
+) error {
+	repo, err := git.Open(ctx, ".", git.OpenOptions{
+		Log: log,
+	})
+	if err != nil {
+		return fmt.Errorf("open repository: %w", err)
+	}
+
+	store, err := ensureStore(ctx, repo, log, opts)
+	if err != nil {
+		return err
+	}
+
+	svc := spice.NewService(repo, store, log)
+
+	var wasRebasing bool
+	if _, err := repo.RebaseState(ctx); err != nil {
+		if !errors.Is(err, git.ErrNoRebase) {
+			return fmt.Errorf("get rebase state: %w", err)
+		}
+		// If the user ran 'git rebase --continue' instead,
+		// we will not be in the middle of a rebase operation.
+		// That's okay -- assume that they still want to continue
+		// with the gs operations they were running.
+	} else {
+		// If we're in the middle of a rebase, finish it.
+		wasRebasing = true
+		if err := repo.RebaseContinue(ctx); err != nil {
+			return svc.RebaseRescue(ctx, spice.RebaseRescueRequest{
+				Err: err,
+			})
+		}
+	}
+
+	cont, err := store.TakeContinuation(ctx, "gs rebase continue")
+	if err != nil {
+		return fmt.Errorf("take rebase continuation: %w", err)
+	}
+	if cont == nil && !wasRebasing {
+		return errors.New("no operation to continue")
+	}
+	for cont != nil {
+		log.Debugf("Got rebase continuation: %q", cont.Command)
+		if err := repo.Checkout(ctx, cont.Branch); err != nil {
+			return fmt.Errorf("checkout branch %q: %w", cont.Branch, err)
+		}
+
+		kctx, err := parser.Parse(cont.Command)
+		if err != nil {
+			log.Errorf("Corrupt rebase continuation: %q", cont.Command)
+			return fmt.Errorf("parse rebase continuation: %w", err)
+		}
+
+		if err := kctx.Run(ctx); err != nil {
+			return fmt.Errorf("continue operation %q: %w", cont.Command, err)
+		}
+
+		cont, err = store.TakeContinuation(ctx, "gs rebase continue")
+		if err != nil {
+			return fmt.Errorf("take rebase continuation: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/script_test.go
+++ b/script_test.go
@@ -31,6 +31,8 @@ func TestMain(m *testing.M) {
 			return 0
 		},
 		"mockedit": mockedit.Main,
+		// "true" is a no-op command that always succeeds.
+		"true": func() int { return 0 },
 		// with-term file -- cmd [args ...]
 		//
 		// Runs the given command inside a terminal emulator,

--- a/stack_restack.go
+++ b/stack_restack.go
@@ -45,7 +45,17 @@ loop:
 
 		res, err := svc.Restack(ctx, branch)
 		if err != nil {
+			var rebaseErr *git.RebaseInterruptError
 			switch {
+			case errors.As(err, &rebaseErr):
+				// If the rebase is interrupted by a conflict,
+				// we'll resume by re-running this command.
+				return svc.RebaseRescue(ctx, spice.RebaseRescueRequest{
+					Err:     rebaseErr,
+					Command: []string{"stack", "restack"},
+					Branch:  currentBranch,
+					Message: fmt.Sprintf("interrupted: restack stack for %s", branch),
+				})
 			case errors.Is(err, spice.ErrAlreadyRestacked):
 				// Log the "does not need to be restacked" message
 				// only for branches that are not the current branch.

--- a/testdata/script/branch_edit_interrupt.txt
+++ b/testdata/script/branch_edit_interrupt.txt
@@ -1,0 +1,66 @@
+# 'branch edit' with a 'break' instruction
+# can continue work afterwards with a 'rebase continue'.
+
+as 'Test <test@example.com>'
+at '2024-05-27T13:57:09Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git add feature1.txt
+gs bc -m 'Add feature 1' feature1
+
+git add feature2.txt
+gs bc -m 'Add feature 2' feature2
+
+git add feature3.txt
+gs bc -m 'Add feature 3' feature3
+
+gs bottom
+
+# Run a 'gs branch edit', and add a 'break' instruction
+# at the top of the rebase TODO.
+env EDITOR=mockedit MOCKEDIT_GIVE=$WORK/input/rebase-todo.txt
+! gs branch edit
+stderr 'The rebase operation was interrupted'
+stderr '  gs rebase continue'
+stderr '  gs rebase abort'
+
+# Add a new commit.
+git add feature1-part2.txt
+gs cc -m 'Add part 2 of feature 1'
+
+gs rebase continue
+stderr 'feature2: restacked'
+stderr 'feature3: restacked'
+
+# current branch should be back to feature1
+git branch --show-current
+stdout 'feature1'
+
+git graph --branches
+cmp stdout $WORK/golden/branches.txt
+
+-- repo/feature1.txt --
+Contents of feature 1.
+
+-- repo/feature2.txt --
+Contents of feature 2.
+
+-- repo/feature3.txt --
+Contents of feature 3.
+
+-- repo/feature1-part2.txt --
+Part 2 of feature 1.
+
+-- input/rebase-todo.txt --
+edit 3972713 Add feature 1
+
+-- golden/branches.txt --
+* c7c7547 (feature3) Add feature 3
+* f5c4ede (feature2) Add feature 2
+* aaf0fbd (HEAD -> feature1) Add part 2 of feature 1
+* 3972713 Add feature 1
+* a798a87 (main) Initial commit

--- a/testdata/script/branch_onto_conflict.txt
+++ b/testdata/script/branch_onto_conflict.txt
@@ -1,0 +1,71 @@
+# Changing the base for a branch with 'branch onto'
+# while resolving a conflict.
+
+as 'Test <test@example.com>'
+at '2024-05-27T16:58:12Z'
+
+# set up
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+cp $WORK/extra/feature.1.txt feature.txt
+git add feature.txt
+gs bc A -m 'Add a feature'
+
+cp $WORK/extra/feature.2.txt feature.txt
+git add feature.txt
+gs bc B -m 'Make a change'
+
+cp $WORK/extra/feature.3.txt feature.txt
+git add feature.txt
+gs bc C -m 'Make a dependent change'
+
+# At this point, we have:
+#   A --> B --> C --> D
+# We'll attempt to move C onto A to get:
+#   A --> {B, C --> D}
+# But that'll conflict and we'll have to resolve it.
+! gs branch onto A
+stderr 'There was a conflict while rebasing'
+stderr '  gs rebase continue'
+stderr '  gs rebase abort'
+
+# Resolve the conflict
+cp $WORK/extra/feature.3-resolved.txt feature.txt
+git add feature.txt
+
+# Continue the rebase without editing the commit message
+env EDITOR=true
+gs rebase continue
+
+# Verify state
+git graph --branches
+cmp stdout $WORK/golden/graph.txt
+
+cmp feature.txt $WORK/extra/feature.3-resolved.txt
+
+-- extra/feature.1.txt --
+Add a feature
+
+-- extra/feature.2.txt --
+Add a feature
+Make a change
+
+-- extra/feature.3.txt --
+Add a feature
+Make a dependent change
+Make a change
+
+-- extra/feature.3-resolved.txt --
+Add a feature
+Make a dependent change
+
+-- golden/graph.txt --
+* 7321210 (B) Make a change
+| * 814d06b (HEAD -> C) Make a dependent change
+|/  
+* 5ada401 (A) Add a feature
+* 3cc7bfc (main) Initial commit

--- a/testdata/script/branch_restack_conflict.txt
+++ b/testdata/script/branch_restack_conflict.txt
@@ -1,0 +1,60 @@
+# 'branch restack' can continue from a conflict with 'gs rebase continue'
+
+as 'Test <test@example.com>'
+at '2024-05-27T18:24:42Z'
+
+mkdir repo
+cd repo
+git init
+git add init.txt
+git commit -m 'Initial commit'
+gs repo init
+
+# create a feature branch that modifies init.
+cp $WORK/extra/init.feature.txt init.txt
+git add init.txt
+gs bc -m feature
+
+# go back to main and modify init
+gs trunk
+cp $WORK/extra/init.new.txt init.txt
+git add init.txt
+git commit -m 'Change init'
+
+gs up
+stderr 'feature: needs to be restacked'
+
+# restack the feature branch
+! gs branch restack
+stderr 'There was a conflict while rebasing'
+
+# resolve the conflict
+cp $WORK/extra/init.resolved.txt init.txt
+git add init.txt
+env EDITOR=true
+gs rebase continue
+
+# verify state
+cmp init.txt $WORK/extra/init.resolved.txt
+git graph --branches
+cmp stdout $WORK/golden/graph.txt
+
+gs trunk
+cmp init.txt $WORK/extra/init.new.txt
+
+-- repo/init.txt --
+initial init
+
+-- extra/init.new.txt --
+changed init
+
+-- extra/init.feature.txt --
+feature's init
+
+-- extra/init.resolved.txt --
+updated init
+
+-- golden/graph.txt --
+* bd2299a (HEAD -> feature) feature
+* 57ab3b0 (main) Change init
+* d692027 Initial commit

--- a/testdata/script/branch_restack_conflict_abort.txt
+++ b/testdata/script/branch_restack_conflict_abort.txt
@@ -1,0 +1,51 @@
+# 'branch restack' can cancel the restack with 'gs rebase abort'.
+
+as 'Test <test@example.com>'
+at '2024-05-27T18:24:42Z'
+
+mkdir repo
+cd repo
+git init
+git add init.txt
+git commit -m 'Initial commit'
+gs repo init
+
+# create a feature branch that modifies init.
+cp $WORK/extra/init.feature.txt init.txt
+git add init.txt
+gs bc -m feature
+
+# go back to main and modify init
+gs trunk
+cp $WORK/extra/init.new.txt init.txt
+git add init.txt
+git commit -m 'Change init'
+
+gs up
+stderr 'feature: needs to be restacked'
+
+# restack the feature branch
+! gs branch restack
+stderr 'There was a conflict while rebasing'
+
+gs rebase abort
+
+# verify state
+git graph --branches
+cmp stdout $WORK/golden/graph.txt
+cmp init.txt $WORK/extra/init.feature.txt
+
+-- repo/init.txt --
+initial init
+
+-- extra/init.new.txt --
+changed init
+
+-- extra/init.feature.txt --
+feature's init
+
+-- golden/graph.txt --
+* 10ab8d9 (HEAD -> feature) feature
+| * 57ab3b0 (main) Change init
+|/  
+* d692027 Initial commit

--- a/testdata/script/stack_restack_conflict.txt
+++ b/testdata/script/stack_restack_conflict.txt
@@ -1,0 +1,99 @@
+# A 'stack restack' where a downstack and an upstack branch have conflicts.
+
+as 'Test <test@example.com>'
+at '2024-05-27T18:39:40Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+cp $WORK/extra/feature1.txt feature1.txt
+git add feature1.txt
+gs bc -m feature1
+
+cp $WORK/extra/feature2.txt feature2.txt
+git add feature2.txt
+gs bc -m feature2
+
+cp $WORK/extra/feature3.txt feature3.txt
+git add feature3.txt
+gs bc -m feature3
+
+# go to main, add a file conflicting with feature1 and 3.
+gs trunk
+cp $WORK/extra/feature1.conflict.txt feature1.txt
+cp $WORK/extra/feature3.conflict.txt feature3.txt
+git add feature1.txt feature3.txt
+git commit -m 'Ad feature 1 and 3 here for some reason'
+
+env EDITOR=true
+
+# go back to feature2 and try to restack
+gs branch checkout feature2
+! gs stack restack
+stderr 'There was a conflict while rebasing'
+stderr '  gs rebase continue'
+stderr '  gs rebase abort'
+
+# only feature1.txt should be conflicting right now
+git status --porcelain
+cmp stdout $WORK/golden/conflict-status-feature1.txt
+
+# resolve the conflict and continue
+cp $WORK/extra/feature1.resolved.txt feature1.txt
+git add feature1.txt
+! gs rebase continue
+stderr 'There was a conflict while rebasing'
+
+# only feature3.txt should be conflicting right now
+git status --porcelain
+cmp stdout $WORK/golden/conflict-status-feature3.txt
+
+# resolve the conflict and continue
+cp $WORK/extra/feature3.resolved.txt feature3.txt
+git add feature3.txt
+gs rebase continue
+
+# the rebase should have succeeded
+git graph --branches
+cmp stdout $WORK/golden/graph.txt
+
+# verify files
+gs branch checkout feature3
+cmp feature1.txt $WORK/extra/feature1.resolved.txt
+cmp feature2.txt $WORK/extra/feature2.txt
+cmp feature3.txt $WORK/extra/feature3.resolved.txt
+
+-- extra/feature1.txt --
+foo
+-- extra/feature2.txt --
+bar
+-- extra/feature3.txt --
+baz
+
+-- extra/feature1.conflict.txt --
+not foo
+
+-- extra/feature3.conflict.txt --
+not baz
+
+-- extra/feature1.resolved.txt --
+foo
+not foo
+
+-- extra/feature3.resolved.txt --
+baz
+not baz
+
+-- golden/conflict-status-feature1.txt --
+AA feature1.txt
+-- golden/conflict-status-feature3.txt --
+AA feature3.txt
+-- golden/graph.txt --
+* 00e57c1 (feature3) feature3
+* f433bb9 (HEAD -> feature2) feature2
+* d231589 (feature1) feature1
+* e2b76d8 (main) Ad feature 1 and 3 here for some reason
+* a545001 Initial commit

--- a/testdata/script/upstack_restack_repeated_conflicts.txt
+++ b/testdata/script/upstack_restack_repeated_conflicts.txt
@@ -1,0 +1,99 @@
+# An 'upstack restack' where the upstack branches have mutliple conflicts
+# with the updated changes.
+
+as 'Test <test@example.com>'
+at '2024-05-27T18:39:40Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+cp $WORK/extra/feature1.txt feature1.txt
+git add feature1.txt
+gs bc -m feature1
+
+cp $WORK/extra/feature2.txt feature2.txt
+git add feature2.txt
+gs bc -m feature2
+
+cp $WORK/extra/feature3.txt feature3.txt
+git add feature3.txt
+gs bc -m feature3
+
+# go back to feature1
+# and add conflicting feature2 and feature3 files.
+gs bottom
+cp $WORK/extra/feature2.conflict.txt feature2.txt
+cp $WORK/extra/feature3.conflict.txt feature3.txt
+git add feature2.txt feature3.txt
+! gs cc -m 'Add feature 2 and 3 here for some reason'
+stderr 'There was a conflict while rebasing'
+stderr '  gs rebase continue'
+stderr '  gs rebase abort'
+
+# only feature2.txt should be conflicting right now
+git status --porcelain
+cmp stdout $WORK/golden/conflict-status-feature2.txt
+
+env EDITOR=true
+
+# resolve the conflict and continue
+cp $WORK/extra/feature2.resolved.txt feature2.txt
+git add feature2.txt
+! gs rebase continue
+stderr 'There was a conflict while rebasing'
+stderr '  gs rebase continue'
+stderr '  gs rebase abort'
+
+# only feature3.txt should be conflicting right now
+git status --porcelain
+cmp stdout $WORK/golden/conflict-status-feature3.txt
+
+# resolve the conflict and continue
+cp $WORK/extra/feature3.resolved.txt feature3.txt
+git add feature3.txt
+gs rebase continue
+
+# the rebase should be complete now
+git graph --branches
+cmp stdout $WORK/golden/graph.txt
+
+# verify files
+gs branch checkout feature3
+cmp feature1.txt $WORK/extra/feature1.txt
+cmp feature2.txt $WORK/extra/feature2.resolved.txt
+cmp feature3.txt $WORK/extra/feature3.resolved.txt
+
+-- extra/feature1.txt --
+foo
+-- extra/feature2.txt --
+bar
+-- extra/feature3.txt --
+baz
+
+-- extra/feature2.conflict.txt --
+not bar
+
+-- extra/feature3.conflict.txt --
+not baz
+
+-- extra/feature2.resolved.txt --
+bar
+not bar
+
+-- extra/feature3.resolved.txt --
+baz
+not baz
+
+-- golden/conflict-status-feature2.txt --
+AA feature2.txt
+-- golden/conflict-status-feature3.txt --
+AA feature3.txt
+-- golden/graph.txt --
+* 572dca3 (feature3) feature3
+* 5de761e (feature2) feature2
+* cbe5048 (HEAD -> feature1) Add feature 2 and 3 here for some reason
+* d0f66a5 feature1
+* a545001 (main) Initial commit


### PR DESCRIPTION
This adds support for continuing or aborting an interrupted rebase-ish
operation with two new commands:

    gs rebase continue  # alias: gs rbc
    gs rebase abort     # alias: gs rba

The general idea is that when a rebase-ish operation is interrupted,
we'll record the command that should run after the rebase is resolved,
and the user can run 'gs rebase continue' to continue the operation.

This works for all commands that call `git rebase` under the hood,
including convenience commands like `gs commit create`.

Resolves #42
