### PR TITLE
rebase: No merge conflict advice

### DIFF
--- a/.changes/unreleased/Fixed-20240527-203929.yaml
+++ b/.changes/unreleased/Fixed-20240527-203929.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Reduce boilerplate in rebase error messages.
+time: 2024-05-27T20:39:29.578484-07:00

--- a/internal/git/rebase.go
+++ b/internal/git/rebase.go
@@ -93,7 +93,12 @@ type RebaseRequest struct {
 // It returns [ErrRebaseInterrupted] or [ErrRebaseConflict] for known
 // rebase interruptions.
 func (r *Repository) Rebase(ctx context.Context, req RebaseRequest) error {
-	args := []string{"rebase"}
+	args := []string{
+		// Never include advice on how to resolve merge conflicts.
+		// We'll do that ourselves.
+		"-c", "advice.mergeConflict=false",
+		"rebase",
+	}
 	if req.Interactive {
 		args = append(args, "--interactive")
 	}


### PR DESCRIPTION
For rebase operations invoked by git spice,
we don't need to include advise in the output
about `git rebase --continue` or `--abort` because:

a) users of git-spice probably already know
b) we recommend use of gs rebase continue and abort,
   which supersedes that advice