### PR TITLE
branch delete: Nuke deleted branch from stack

### DIFF
--- a/.changes/unreleased/Changed-20240527-220542.yaml
+++ b/.changes/unreleased/Changed-20240527-220542.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: '(*Breaking*) branch delete: Remove commits of the deleted branch from the stack. If you want to keep them around, untrack the branch instead.'
+time: 2024-05-27T22:05:42.385352-07:00

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -360,8 +360,12 @@ gs branch (b) delete (rm) [<name>] [flags]
 
 Delete a branch
 
-Deletes the specified branch and updates upstack branches to
-point to the next branch down.
+Deletes the specified branch and removes its changes from the
+stack. Branches above the deleted branch are rebased onto the
+branch's base.
+
+If a branch name is not provided, an interactive prompt will be
+shown to pick one.
 
 **Arguments**
 

--- a/testdata/script/branch_delete_removes_changes.txt
+++ b/testdata/script/branch_delete_removes_changes.txt
@@ -1,0 +1,39 @@
+# 'gs branch delete' removes the changes that were made on the branch.
+
+as 'Test <test@example.com>'
+at '2024-03-30T14:59:32Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'initial commit'
+gs repo init
+
+git add feature1.txt
+gs bc -m feature1
+
+git add feature2.txt
+gs bc -m feature2
+
+git add feature3.txt
+gs bc -m feature3
+
+gs branch delete feature2 --force
+gs branch checkout feature3
+
+exists feature1.txt feature3.txt
+! exists feature2.txt
+
+git graph --branches
+cmp stdout $WORK/golden/branches.txt
+
+-- repo/feature1.txt --
+feature 1
+-- repo/feature2.txt --
+feature 2
+-- repo/feature3.txt --
+feature 3
+
+-- golden/branches.txt --
+* 7ed7e4b (HEAD -> feature3) feature3
+* 0ad3bcf (feature1) feature1
+* 3b9a56f (main) initial commit

--- a/testdata/script/branch_track_trunk_err.txt
+++ b/testdata/script/branch_track_trunk_err.txt
@@ -9,6 +9,5 @@ stderr 'cannot track trunk branch'
 
 git checkout -b feature
 git commit --allow-empty -m 'feature 1'
-gs branch track --base main
-# TODO: auto-discover base
+gs branch track
 stderr 'feature: tracking with base main'


### PR DESCRIPTION
Previously, when a branch was deleted, we stopped tracking it,
but its changes were still present in the stack.

This fixes this incorrect behavior:
now, the deleted branch's upstack will be rebased onto its base,
deleting its changes from the stack.

The old behavior is still available with `branch untrack`.