### PR TITLE
rebase {continue, abort}: Support multiple continuations

### DIFF
--- a/branch_onto.go
+++ b/branch_onto.go
@@ -143,13 +143,16 @@ func (cmd *branchOntoCmd) Run(ctx context.Context, log *log.Logger, opts *global
 		return fmt.Errorf("list branches above %s: %w", cmd.Branch, err)
 	}
 	for _, above := range aboves {
-		// TODO: if the 'upstack onto' has a conflict,
-		// the continuation command may end up wrong.
 		if err := (&upstackOntoCmd{
 			Branch: above,
 			Onto:   branch.Base,
 		}).Run(ctx, log, opts); err != nil {
-			return fmt.Errorf("move %s onto %s: %w", above, branch.Base, err)
+			return svc.RebaseRescue(ctx, spice.RebaseRescueRequest{
+				Err:     err,
+				Command: []string{"branch", "onto", cmd.Onto},
+				Branch:  cmd.Branch,
+				Message: fmt.Sprintf("interrupted: %s: branch onto %s", cmd.Branch, cmd.Onto),
+			})
 		}
 	}
 

--- a/internal/spice/service.go
+++ b/internal/spice/service.go
@@ -64,7 +64,7 @@ type BranchStore interface {
 	// Trunk returns the name of the trunk branch.
 	Trunk() string
 
-	SetContinuation(context.Context, state.SetContinuationRequest) error
+	AppendContinuation(context.Context, state.SetContinuationRequest) error
 }
 
 var _ BranchStore = (*state.Store)(nil)

--- a/internal/spice/state/state.go
+++ b/internal/spice/state/state.go
@@ -23,6 +23,10 @@ func (i *repoInfo) Validate() error {
 	return nil
 }
 
+type rebaseContinueState struct {
+	Continuations []rebaseContinuation `json:"continuations"`
+}
+
 type rebaseContinuation struct {
 	// Command is the gs command that will be run.
 	Command []string `json:"command"`

--- a/rebase_abort.go
+++ b/rebase_abort.go
@@ -61,8 +61,12 @@ func (cmd *rebaseAbortCmd) Run(ctx context.Context, log *log.Logger, opts *globa
 	if cont == nil && !wasRebasing {
 		return errors.New("no operation to abort")
 	}
-	if cont != nil {
+	for cont != nil {
 		log.Debugf("%v: dropping continuation: %q", cont.Branch, cont.Command)
+		cont, err = store.TakeContinuation(ctx, "gs rebase abort")
+		if err != nil {
+			return fmt.Errorf("take rebase continuation: %w", err)
+		}
 	}
 
 	return nil

--- a/rebase_continue.go
+++ b/rebase_continue.go
@@ -74,7 +74,7 @@ func (cmd *rebaseContinueCmd) Run(
 		return errors.New("no operation to continue")
 	}
 	for cont != nil {
-		log.Debugf("Got rebase continuation: %q", cont.Command)
+		log.Debugf("Got rebase continuation: %q (branch: %s)", cont.Command, cont.Branch)
 		if err := repo.Checkout(ctx, cont.Branch); err != nil {
 			return fmt.Errorf("checkout branch %q: %w", cont.Branch, err)
 		}

--- a/testdata/script/branch_onto_conflict_hell.txt
+++ b/testdata/script/branch_onto_conflict_hell.txt
@@ -1,5 +1,6 @@
 # 'branch onto' is able to handle conflicts in the upstack.
 
+
 as 'Test <test@example.com>'
 at '2024-05-27T21:12:34Z'
 
@@ -17,63 +18,86 @@ gs bc -m feature1
 cp $WORK/extra/feature2.txt feature.txt
 git add feature.txt
 gs bc -m feature2
+gs bco feature1
 
 cp $WORK/extra/feature3.txt feature.txt
 git add feature.txt
 gs bc -m feature3
 
-# We now have: trunk -> feature1 -> feature2 -> feature3
-# where feature2 and feature3 have a hard-dependency on feature1.
-# Create a new branch off trunk with a conflict against feature1,
-# and move feature1 onto it.
-# feature2 and 3 will have conflicts rebasing onto trunk.
+# We now have:
+#
+#   trunk
+#    └─feature1
+#       ├─feature2  # hard-dependency on feature1
+#       └─feature3  # hard-dependency on feature1
+#
+# Create a new sibling to feature1,
+# and attempt to move feature1 onto it.
+#
+#   trunk                 trunk
+#    ├─feature0            ├─feature0
+#    └─feature1      ->    |  └─feature1
+#       ├─feature2         ├─feature2
+#       └─feature3         └─feature3
+#
+# All branches will have conflicts to deal with.
 
 gs trunk
 cp $WORK/extra/feature0.txt feature.txt
 git add feature.txt
 gs bc -m feature0
 
-env EDITOR=true
+env EDITOR=true GIT_SPICE_VERBOSE=1
 
 gs bco feature1
 ! gs branch onto feature0
-stderr 'There was a conflict while rebasing'
-stderr '  gs rebase continue'
-stderr '  gs rebase abort'
 
-# There should be a conflict on the file.
+# feature1 conflict
+stderr 'There was a conflict while rebasing'
 git status --porcelain
 cmp stdout $WORK/golden/conflict-status-feature1.txt
 
-# Fix it
+# fix feature1 conflict
 cp $WORK/extra/feature1-resolved.txt feature.txt
 git add feature.txt
 ! gs rebase continue
-stderr 'There was a conflict while rebasing'
 
-# There should be a conflict on the file.
+# feature2 conflict
+stderr 'There was a conflict while rebasing'
 git status --porcelain
 cmp stdout $WORK/golden/conflict-status-feature2.txt
 
-# Fix it.
+# fix feature2 conflict
 cp $WORK/extra/feature2-resolved.txt feature.txt
 git add feature.txt
 ! gs rebase continue
-stderr 'There was a conflict while rebasing'
 
-# There's a conflict rebasing feature3.
+# feature3 conflict
+stderr 'There was a conflict while rebasing'
 git status --porcelain
 cmp stdout $WORK/golden/conflict-status-feature3.txt
 
-# Fix it.
+# fix feature3 conflict
 cp $WORK/extra/feature3-resolved.txt feature.txt
 git add feature.txt
 gs rebase continue
 
-# feature1 should be on feature0,
-# feature2 and feature3 should be on main.
+# verify final state
 git graph --branches
 cmp stdout $WORK/golden/final-graph.txt
+
+# verify contents
+gs bco feature0
+cmp feature.txt $WORK/extra/feature0.txt
+
+gs bco feature1
+cmp feature.txt $WORK/extra/feature1-resolved.txt
+
+gs bco feature2
+cmp feature.txt $WORK/extra/feature2-resolved.txt
+
+gs bco feature3
+cmp feature.txt $WORK/extra/feature3-resolved.txt
 
 # TODO: when gs list exists,
 # verify branch stack
@@ -86,27 +110,27 @@ bar
 -- extra/feature3.txt --
 baz
 foo
-bar
 -- extra/feature0.txt --
-bad feature 0 version
+quux
 
 -- extra/feature1-resolved.txt --
 foo
+quux
 -- extra/feature2-resolved.txt --
 bar
 -- extra/feature3-resolved.txt --
 baz
-bar
 -- golden/conflict-status-feature1.txt --
 AA feature.txt
 -- golden/conflict-status-feature2.txt --
 DU feature.txt
 -- golden/conflict-status-feature3.txt --
-UU feature.txt
+DU feature.txt
 -- golden/final-graph.txt --
-* 30733f4 (feature1) feature1
-* 8dd8426 (feature0) feature0
-| * 743a4d1 (feature3) feature3
-| * a3e3d08 (HEAD -> feature2) feature2
+* 7b78153 (HEAD -> feature1) feature1
+* 2e43a0c (feature0) feature0
+| * a3e3d08 (feature2) feature2
+|/  
+| * 2ceb0a3 (feature3) feature3
 |/  
 * 53ec458 (main) Initial commit


### PR DESCRIPTION
It's possible to have multiple divergent rebase operatons
step from the same re-entrant command.
In particular, having a single continuation breaks for `branch onto`,
which needs to run `upstack onto` on the entire upstack
before updating the branch's own state.

To fix this, we need to use a queue of continuation commands.