### PR TITLE
fix(branch delete): don't report empty hash for untracked branches

### DIFF
--- a/.changes/unreleased/Fixed-20240528-053746.yaml
+++ b/.changes/unreleased/Fixed-20240528-053746.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'branch delete: Don''t report an empty hash for untracked branches.'
+time: 2024-05-28T05:37:46.288995-07:00

--- a/internal/spice/branch.go
+++ b/internal/spice/branch.go
@@ -135,13 +135,14 @@ func (s *Service) LookupBranch(ctx context.Context, name string) (*LookupBranchR
 
 // ForgetBranch stops tracking a branch,
 // updating the upstacks for it to point to its base.
-//
-// Returns an error matching [state.ErrNotExist] if the branch is not tracked.
 func (s *Service) ForgetBranch(ctx context.Context, name string) error {
 	// This does not use LookupBranch because we don't care if the branch
-	// doesn't exist, we just want to update the upstacks.
+	// doesn't actually exist, we just want to update the upstacks.
 	branch, err := s.store.Lookup(ctx, name)
 	if err != nil {
+		if errors.Is(err, state.ErrNotExist) {
+			return nil
+		}
 		return fmt.Errorf("lookup branch: %w", err)
 	}
 

--- a/testdata/script/branch_delete_unmerged_err.txt
+++ b/testdata/script/branch_delete_unmerged_err.txt
@@ -9,9 +9,8 @@ git init
 git commit --allow-empty -m 'initial commit'
 gs repo init
 
-git checkout -b foo
 git add foo.txt
-git commit -m 'add foo.txt'
+gs bc foo -m 'add foo.txt'
 
 git checkout main
 
@@ -25,6 +24,7 @@ git rev-parse --verify foo
 stdout 'd844dc8b311d27c74fee35f8501171610124ee7a'
 
 gs branch delete --force foo
+stderr 'foo: deleted \(was d844dc8'
 ! git rev-parse --verify foo
 
 -- repo/foo.txt --

--- a/testdata/script/branch_delete_untracked.txt
+++ b/testdata/script/branch_delete_untracked.txt
@@ -13,5 +13,6 @@ git branch foo
 gs branch delete foo
 stderr 'branch is not tracked'
 stderr 'deleting anyway'
+stderr 'foo: deleted \(was 3b9a56f\)'
 
 ! git rev-parse --verify foo


### PR DESCRIPTION
The head hash is never set for untracked branches,
so we report `(was: )`, which is obviously wrong.
Report the actual hash, make sure tests verify this.