### PR TITLE
branch: Adjust 'branch delete' and 'branch rename' shorthands

### DIFF
--- a/.changes/unreleased/Changed-20240528-194221.yaml
+++ b/.changes/unreleased/Changed-20240528-194221.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: (*Breaking*) Change shorthand for 'branch delete' to 'bd'.
+time: 2024-05-28T19:42:21.606423-07:00

--- a/.changes/unreleased/Changed-20240528-194306.yaml
+++ b/.changes/unreleased/Changed-20240528-194306.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: (*Breaking*) Change shorthand for 'branch rename' to 'brn'.
+time: 2024-05-28T19:43:06.253854-07:00

--- a/branch.go
+++ b/branch.go
@@ -20,12 +20,12 @@ type branchCmd struct {
 
 	// Creation and destruction
 	Create branchCreateCmd `cmd:"" aliases:"c" help:"Create a new branch"`
-	Delete branchDeleteCmd `cmd:"" aliases:"rm" help:"Delete a branch"`
+	Delete branchDeleteCmd `cmd:"" aliases:"d,rm" help:"Delete a branch"`
 	Fold   branchFoldCmd   `cmd:"" aliases:"fo" help:"Merge a branch into its base"`
 
 	// Mutation
 	Edit    branchEditCmd    `cmd:"" aliases:"e" help:"Edit the commits in a branch"`
-	Rename  branchRenameCmd  `cmd:"" aliases:"mv" help:"Rename a branch"`
+	Rename  branchRenameCmd  `cmd:"" aliases:"rn,mv" help:"Rename a branch"`
 	Restack branchRestackCmd `cmd:"" aliases:"r" help:"Restack a branch"`
 
 	// Pull request management

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -355,7 +355,7 @@ and creating a new branch with --insert there.
 ## gs branch delete
 
 ```
-gs branch (b) delete (rm) [<name>] [flags]
+gs branch (b) delete (d,rm) [<name>] [flags]
 ```
 
 Delete a branch
@@ -409,7 +409,7 @@ will be restacked.
 ## gs branch rename
 
 ```
-gs branch (b) rename (mv) [<name>]
+gs branch (b) rename (rn,mv) [<name>]
 ```
 
 Rename a branch


### PR DESCRIPTION
With 'bd' freed up ('branch down' is just 'down', and alias is 'd')
we can use 'bd' for 'branch delete'.
'rm' is still an alias for the command.

'brn' is a better alias than 'bmv' for 'branch rename'.
'mv' is still an alias.