### PR TITLE
rebase continue: Don't run if no rebase in progress

### DIFF
--- a/.changes/unreleased/Changed-20240528-195746.yaml
+++ b/.changes/unreleased/Changed-20240528-195746.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'rebase continue: Don''t run continuations if a rebase wasn''t in progress. This avoids unexpected behavior from lefotver state.'
+time: 2024-05-28T19:57:46.263424-07:00

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -512,14 +512,15 @@ gs rebase (rb) continue (c)
 
 Continue an interrupted operation
 
-This command continues an ongoing git-spice operation that was
-interrupted by a Git rebase action.
-Without an ongoing git-spice operation,
-this is equivalent to 'git rebase --continue'.
-
-For example, if 'gs upstack restack' encounters a conflict,
-resolve the conflict and run 'gs rebase continue'
+Continues an ongoing git-spice operation interrupted by
+a git rebase after all conflicts have been resolved.
+For example, if 'gs upstack restack' gets interrupted
+because a conflict arises during the rebase,
+you can resolve the conflict and run 'gs rebase continue'
 (or its shorthand 'gs rbc') to continue the operation.
+
+The command can be used in place of 'git rebase --continue'
+even if a git-spice operation is not currently in progress.
 
 ## gs rebase abort
 
@@ -529,14 +530,15 @@ gs rebase (rb) abort (a)
 
 Abort an operation
 
-This command cancels an ongoing git-spice operation that was
-interrupted by a Git rebase action.
-Without an ongoing git-spice operation,
-this is equivalent to 'git rebase --abort'.
-
+Cancels an ongoing git-spice operation that was interrupted by
+a git rebase.
 For example, if 'gs upstack restack' encounters a conflict,
 cancel the operation with 'gs rebase abort'
-(or its shorthand 'gs rba').
+(or its shorthand 'gs rba'),
+going back to the state before the rebase.
+
+The command can be used in place of 'git rebase --abort'
+even if a git-spice operation is not currently in progress.
 
 ## gs up
 

--- a/rebase_continue.go
+++ b/rebase_continue.go
@@ -16,14 +16,15 @@ type rebaseContinueCmd struct{}
 
 func (*rebaseContinueCmd) Help() string {
 	return text.Dedent(`
-		This command continues an ongoing git-spice operation that was
-		interrupted by a Git rebase action.
-		Without an ongoing git-spice operation,
-		this is equivalent to 'git rebase --continue'.
-
-		For example, if 'gs upstack restack' encounters a conflict,
-		resolve the conflict and run 'gs rebase continue'
+		Continues an ongoing git-spice operation interrupted by
+		a git rebase after all conflicts have been resolved.
+		For example, if 'gs upstack restack' gets interrupted
+		because a conflict arises during the rebase,
+		you can resolve the conflict and run 'gs rebase continue'
 		(or its shorthand 'gs rbc') to continue the operation.
+
+		The command can be used in place of 'git rebase --continue'
+		even if a git-spice operation is not currently in progress.
 	`)
 }
 
@@ -47,31 +48,23 @@ func (cmd *rebaseContinueCmd) Run(
 
 	svc := spice.NewService(repo, store, log)
 
-	var wasRebasing bool
 	if _, err := repo.RebaseState(ctx); err != nil {
 		if !errors.Is(err, git.ErrNoRebase) {
 			return fmt.Errorf("get rebase state: %w", err)
 		}
-		// If the user ran 'git rebase --continue' instead,
-		// we will not be in the middle of a rebase operation.
-		// That's okay -- assume that they still want to continue
-		// with the gs operations they were running.
-	} else {
-		// If we're in the middle of a rebase, finish it.
-		wasRebasing = true
-		if err := repo.RebaseContinue(ctx); err != nil {
-			return svc.RebaseRescue(ctx, spice.RebaseRescueRequest{
-				Err: err,
-			})
-		}
+		return errors.New("no rebase in progress")
+	}
+
+	// Finish the ongoing rebase.
+	if err := repo.RebaseContinue(ctx); err != nil {
+		return svc.RebaseRescue(ctx, spice.RebaseRescueRequest{
+			Err: err,
+		})
 	}
 
 	cont, err := store.TakeContinuation(ctx, "gs rebase continue")
 	if err != nil {
 		return fmt.Errorf("take rebase continuation: %w", err)
-	}
-	if cont == nil && !wasRebasing {
-		return errors.New("no operation to continue")
 	}
 	for cont != nil {
 		log.Debugf("Got rebase continuation: %q (branch: %s)", cont.Command, cont.Branch)


### PR DESCRIPTION
Right now, we support a user running `git rebase --continue`
instead of `gs rebase continue` and *then* running `gs rebase continue`
to continue the gs operations.

This isn't right and will lead to unexpected behavior
as a user may have run `git rebase --continue`, moved on,
and then run a `gs rebase continue` for a different command.