### PR TITLE
branch checkout/prompt: Show only tracked branches

### DIFF
--- a/.changes/unreleased/Changed-20240531-200838.yaml
+++ b/.changes/unreleased/Changed-20240531-200838.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'branch checkout: Prompt for picking a branch only shows tracked branches by default. Use -u/--untracked to also see untracked branches.'
+time: 2024-05-31T20:08:38.408083-07:00

--- a/branch_checkout.go
+++ b/branch_checkout.go
@@ -13,7 +13,8 @@ import (
 )
 
 type branchCheckoutCmd struct {
-	Name string `arg:"" optional:"" help:"Name of the branch to delete" predictor:"branches"`
+	Untracked bool   `short:"u" help:"Show untracked branches if one isn't supplied"`
+	Name      string `arg:"" optional:"" help:"Name of the branch to delete" predictor:"branches"`
 }
 
 func (cmd *branchCheckoutCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
@@ -46,6 +47,7 @@ func (cmd *branchCheckoutCmd) Run(ctx context.Context, log *log.Logger, opts *gl
 		cmd.Name, err = (&branchPrompt{
 			Exclude:           []string{currentBranch},
 			ExcludeCheckedOut: true,
+			TrackedOnly:       !cmd.Untracked,
 			Title:             "Select a branch to checkout",
 		}).Run(ctx, repo, store)
 		if err != nil {

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -241,7 +241,7 @@ they will be updated to point to its base branch.
 ## gs branch checkout
 
 ```
-gs branch (b) checkout (co) [<name>]
+gs branch (b) checkout (co) [<name>] [flags]
 ```
 
 Switch to a branch
@@ -249,6 +249,10 @@ Switch to a branch
 **Arguments**
 
 * `name`: Name of the branch to delete
+
+**Flags**
+
+* `-u`, `--untracked`: Show untracked branches if one isn't supplied
 
 ## gs branch onto
 

--- a/testdata/script/branch_checkout_prompt.txt
+++ b/testdata/script/branch_checkout_prompt.txt
@@ -29,9 +29,17 @@ git commit -m 'Add qux'
 git checkout -b quux main
 git merge -m 'Merge many' foo bar baz qux
 
-with-term -rows 8 -cols 50 $WORK/input.txt -- gs branch checkout
-cmp stdout $WORK/golden/prompt.txt
+# showing only tracked branches
+gs trunk
+with-term -rows 8 -cols 50 $WORK/input/tracked.txt -- gs branch checkout
+cmp stdout $WORK/golden/prompt-tracked.txt
+git branch --show-current
+stdout 'bar'
 
+# showing all branches
+gs trunk
+with-term -rows 8 -cols 50 $WORK/input/all.txt -- gs branch checkout -u
+cmp stdout $WORK/golden/prompt-all.txt
 git branch --show-current
 stdout 'baz'
 
@@ -47,7 +55,15 @@ whatever
 -- repo/qux.txt --
 whatever
 
--- input.txt --
+-- input/tracked.txt --
+await Select a branch
+snapshot init
+feed ba
+await
+snapshot after
+feed \r
+
+-- input/all.txt --
 await Select a branch
 snapshot init
 feed ba
@@ -61,7 +77,17 @@ await Do you want to track
 snapshot track
 feed \r
 
--- golden/prompt.txt --
+-- golden/prompt-tracked.txt --
+### init ###
+Select a branch to checkout:
+
+▶ bar
+  foo
+### after ###
+Select a branch to checkout:
+
+▶ bar
+-- golden/prompt-all.txt --
 ### init ###
 Select a branch to checkout:
 


### PR DESCRIPTION
The branch selection prompt for `gs branch checkout`
will now only show tracked branches by default.
The -u flag will include untracked branches.

Resolves #133