### PR TITLE
repo sync: auto-stash dirty trunk

### DIFF
--- a/.changes/unreleased/Fixed-20240531-202707.yaml
+++ b/.changes/unreleased/Fixed-20240531-202707.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'repo sync: Fix failure if the worktree has uncommitted changes.'
+time: 2024-05-31T20:27:07.299184-07:00

--- a/internal/git/pull.go
+++ b/internal/git/pull.go
@@ -8,9 +8,10 @@ import (
 
 // PullOptions specifies options for the Pull operation.
 type PullOptions struct {
-	Remote  string
-	Rebase  bool
-	Refspec Refspec
+	Remote    string
+	Rebase    bool
+	Autostash bool
+	Refspec   Refspec
 }
 
 // Pull fetches objects and refs from a remote repository
@@ -23,6 +24,9 @@ func (r *Repository) Pull(ctx context.Context, opts PullOptions) error {
 	args := []string{"pull"}
 	if opts.Rebase {
 		args = append(args, "--rebase")
+	}
+	if opts.Autostash {
+		args = append(args, "--autostash")
 	}
 	if opts.Remote != "" {
 		args = append(args, opts.Remote)

--- a/internal/git/pull_test.go
+++ b/internal/git/pull_test.go
@@ -33,6 +33,11 @@ func TestPullArgs(t *testing.T) {
 			want: []string{"pull", "origin"},
 		},
 		{
+			name: "autostash",
+			give: PullOptions{Autostash: true},
+			want: []string{"pull", "--autostash"},
+		},
+		{
 			name: "refspec",
 			give: PullOptions{
 				Remote:  "origin",

--- a/repo_sync.go
+++ b/repo_sync.go
@@ -86,9 +86,10 @@ func (*repoSyncCmd) Run(
 		// git pull --rebase will handle everything.
 		log.Debug("trunk is checked out: pulling changes")
 		opts := git.PullOptions{
-			Remote:  remote,
-			Rebase:  true,
-			Refspec: git.Refspec(trunk),
+			Remote:    remote,
+			Rebase:    true,
+			Autostash: true,
+			Refspec:   git.Refspec(trunk),
 		}
 		if err := repo.Pull(ctx, opts); err != nil {
 			return fmt.Errorf("pull: %w", err)

--- a/testdata/script/repo_sync_trunk_dirty_tree.txt
+++ b/testdata/script/repo_sync_trunk_dirty_tree.txt
@@ -1,0 +1,43 @@
+# 'repo sync' on trunk with a dirty worktree.
+# https://github.com/abhinav/git-spice/issues/132
+
+as 'Test <test@example.com>'
+at '2024-05-18T13:59:12Z'
+
+# setup
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+gh-init
+gh-add-remote origin alice/example.git
+git push origin main
+gs repo init
+
+# dirty the worktree
+cp $WORK/extra/feature1.txt .
+git add feature1.txt
+
+# update the remote out of band
+cd ..
+gh-clone alice/example.git fork
+cd fork
+cp $WORK/extra/feature2.txt .
+git add feature2.txt
+git commit -m 'Add feature2'
+git push origin main
+
+# sync the original repo
+cd ../repo
+gs repo sync
+stderr 'pulled 1 new commit'
+cmp feature1.txt $WORK/extra/feature1.txt
+cmp feature2.txt $WORK/extra/feature2.txt
+
+-- extra/feature1.txt --
+Contents of feature1
+
+-- extra/feature2.txt --
+Contents of feature2


### PR DESCRIPTION
For `repo sync`, if we're on trunk (and running `git pull`),
it'll fail if the worktree is dirty.
It makes sense to use `--autostash` to save those changes,
pull and unstash.

Resolves #132