### PR TITLE
branch delete: Don't break on detached HEAD

### DIFF
--- a/.changes/unreleased/Fixed-20240531-203441.yaml
+++ b/.changes/unreleased/Fixed-20240531-203441.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'branch delete: Don''t fail if the repository is in detached HEAD state.'
+time: 2024-05-31T20:34:41.301336-07:00

--- a/testdata/script/branch_delete_detached_head.txt
+++ b/testdata/script/branch_delete_detached_head.txt
@@ -1,0 +1,20 @@
+# 'branch delete' should be able to delete branches if it's in detached head.
+# https://github.com/abhinav/git-spice/issues/131
+
+as 'Test <test@example.com>'
+at '2024-03-30T14:59:32Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'initial commit'
+gs repo init
+
+git add feature.txt
+gs bc -m feature
+
+git checkout --detach
+gs branch delete feature
+
+-- repo/feature.txt --
+stuff


### PR DESCRIPTION
Don't fail to delete a random branch
just because the repository is in detached HEAD.

Resolves #131