### PR TITLE
repo sync: Don't leave on the wrong branch

### DIFF
--- a/.changes/unreleased/Fixed-20240531-210710.yaml
+++ b/.changes/unreleased/Fixed-20240531-210710.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'branch delete: Fix repository left on the wrong branch if upstacks were restacked.'
+time: 2024-05-31T21:07:10.655054-07:00

--- a/testdata/script/repo_sync_merged_pr.txt
+++ b/testdata/script/repo_sync_merged_pr.txt
@@ -13,9 +13,15 @@ gh-init
 gh-add-remote origin alice/example.git
 git push origin main
 
-# create a new branch and submit it
+# create a stack
 git add feature1.txt
 gs bc -m 'Add feature1' feature1
+
+git add feature2.txt
+gs bc -m 'Add feature2' feature2
+
+# submit feature1
+gs bco feature1
 gs branch submit --fill
 stderr 'Created #'
 
@@ -24,8 +30,9 @@ gh-merge alice/example 1
 gs repo sync
 stderr 'feature1: #1 was merged'
 
-# we should now be on main
-# and feature1 branch should be gone.
+# we should now be on main,
+# feature1 branch should be gone,
+# and feature2 should be restacked.
 exists feature1.txt
 git graph --branches
 cmp stdout $WORK/golden/merged-log.txt
@@ -35,6 +42,9 @@ cmpenvJSON stdout $WORK/golden/pull.json
 
 -- repo/feature1.txt --
 Contents of feature1
+
+-- repo/feature2.txt --
+Contents of feature2
 
 -- golden/pull.json --
 {
@@ -55,6 +65,7 @@ Contents of feature1
 }
 
 -- golden/merged-log.txt --
+* e40a703 (feature2) Add feature2
 *   7bfac22 (HEAD -> main, origin/main) Merge pull request #1
 |\  
 | * 9f1c9af Add feature1


### PR DESCRIPTION
'repo sync' deletes merged branches and restacks the upstacks.
Previously, there was a bug in `branch delete` that left us
on the wrong branch afterwards (the upstack).
This was fixed in #137, but the issue was discovered in #130.

Adds a test case to verify the test case for the bug in #130.

Resolves #130