### PR TITLE
branch submit: Support leaving draft status unchanged

### DIFF
--- a/.changes/unreleased/Changed-20240603-045756.yaml
+++ b/.changes/unreleased/Changed-20240603-045756.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'branch submit: Update an existing PR''s draft status only if `--draft` or `--no-draft` flags are provided.'
+time: 2024-06-03T04:57:56.435285-07:00

--- a/.changes/unreleased/Fixed-20240603-045713.yaml
+++ b/.changes/unreleased/Fixed-20240603-045713.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: '{downstack, stack} submit: Don''t change draft status of existing PRs. Use `branch submit --[no-]draft` to do that.'
+time: 2024-06-03T04:57:13.643413-07:00

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -461,14 +461,19 @@ gs branch (b) submit (s) [<name>] [flags]
 
 Submit a branch
 
-Creates or updates a Pull Request for the specified branch,
+Creates or updates a pull request for the specified branch,
 or the current branch if none is specified.
-The Pull Request will use the tracked base branch
+The pull request will use the branch's base branch
 as the merge base.
 
-For new Pull Requests, a prompt will allow filling metadata.
-Use the --title and --body flags to set the title and body,
+For new pull requests, a prompt will allow filling metadata.
+Use the --title and --body flags to skip the prompt,
 or the --fill flag to use the commit message to fill them in.
+The --draft flag marks the pull request as a draft.
+
+When updating an existing pull request,
+the --[no-]draft flag can be used to update the draft status.
+Without the flag, the draft status is not changed.
 
 **Arguments**
 
@@ -477,9 +482,9 @@ or the --fill flag to use the commit message to fill them in.
 **Flags**
 
 * `-n`, `--dry-run`: Don't actually submit the stack
-* `--title=STRING`: Title of the pull request (if creating one)
-* `--body=STRING`: Body of the pull request (if creating one)
-* `--draft`: Mark the pull request as a draft
+* `--title=STRING`: Title of the pull request
+* `--body=STRING`: Body of the pull request
+* `--[no-]draft`: Whether to mark the pull request as draft
 * `--fill`: Fill in the pull request title and body from the commit messages
 
 ## gs commit create

--- a/internal/cmputil/zero.go
+++ b/internal/cmputil/zero.go
@@ -1,0 +1,8 @@
+// Package cmputil provides utilities for comparing values.
+package cmputil
+
+// Zero reports whether v is the zero value for its type.
+func Zero[T comparable](v T) bool {
+	var zero T
+	return v == zero
+}

--- a/internal/forge/github/edit.go
+++ b/internal/forge/github/edit.go
@@ -5,11 +5,16 @@ import (
 	"fmt"
 
 	"github.com/shurcooL/githubv4"
+	"go.abhg.dev/gs/internal/cmputil"
 	"go.abhg.dev/gs/internal/forge"
 )
 
 // EditChange edits an existing change in a repository.
 func (r *Repository) EditChange(ctx context.Context, id forge.ChangeID, opts forge.EditChangeOptions) error {
+	if cmputil.Zero(opts) {
+		return nil // nothing to do
+	}
+
 	// We don't know the GraphQL ID for the PR, so find it.
 	var graphQLID githubv4.ID
 	{

--- a/testdata/script/stack_submit_update_leave_draft.txt
+++ b/testdata/script/stack_submit_update_leave_draft.txt
@@ -1,0 +1,169 @@
+# submit a stack of PRs with 'branch submit',
+# then submit the entire stack with 'stack submit',
+# but leave their draft status unchanged.
+
+as 'Test <test@example.com>'
+at '2024-06-03T04:56:32Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+gh-init
+gh-add-remote origin alice/example.git
+git push origin main
+
+# create a stack:
+# main -> feature1 -> feature2 -> feature3
+git add feature1.txt
+gs branch create feature1 -m 'Add feature 1'
+gs branch submit --fill --draft
+
+git add feature2.txt
+gs branch create feature2 -m 'Add feature 2'
+gs branch submit --fill --draft
+
+git add feature3.txt
+gs branch create feature3 -m 'Add feature 3'
+gs branch submit --fill --draft
+
+# middle of the stack
+git checkout feature2
+
+# Dry run
+gs stack submit --dry-run
+cmp stderr $WORK/golden/submit-dry-run.txt
+! stderr 'draft' # draft status should not be changed
+
+gh-dump-pull
+cmpenvJSON stdout $WORK/golden/start.json
+
+# Merge the bottom PR, sync, restack, and submit.
+gh-merge alice/example 1
+gs rs
+stderr '#1 was merged'
+gs sr   # stack restack
+gs ss   # stack submit
+stderr 'Updated #2'
+stderr 'Updated #3'
+
+gh-dump-pull
+cmpenvJSON stdout $WORK/golden/pr-1-merged.json
+
+-- repo/feature1.txt --
+This is feature 1
+-- repo/feature2.txt --
+This is feature 2
+-- repo/feature3.txt --
+This is feature 3
+
+-- golden/submit-dry-run.txt --
+INF Pull request #1 is up-to-date
+INF Pull request #2 is up-to-date
+INF Pull request #3 is up-to-date
+-- golden/start.json --
+[
+  {
+    "number": 1,
+    "state": "open",
+    "title": "Add feature 1",
+    "draft": true,
+    "body": "",
+    "html_url": "$SHAMHUB_URL/alice/example/change/1",
+    "head": {
+      "ref": "feature1",
+      "sha": "84f59e49b054bfd4e8d8a253fb9bd58de94be334"
+    },
+    "base": {
+      "ref": "main",
+      "sha": "2fdb9dfd9a5835e3604dafa788044409473ffffd"
+    }
+  },
+  {
+    "number": 2,
+    "state": "open",
+    "title": "Add feature 2",
+    "draft": true,
+    "body": "",
+    "html_url": "$SHAMHUB_URL/alice/example/change/2",
+    "head": {
+      "ref": "feature2",
+      "sha": "21283286a4dfbf7b8f4b0132ef3cf9a76704043e"
+    },
+    "base": {
+      "ref": "feature1",
+      "sha": "84f59e49b054bfd4e8d8a253fb9bd58de94be334"
+    }
+  },
+  {
+    "number": 3,
+    "state": "open",
+    "title": "Add feature 3",
+    "draft": true,
+    "body": "",
+    "html_url": "$SHAMHUB_URL/alice/example/change/3",
+    "head": {
+      "ref": "feature3",
+      "sha": "9d213feb71f5913a5bc20fab160efd973de93991"
+    },
+    "base": {
+      "ref": "feature2",
+      "sha": "21283286a4dfbf7b8f4b0132ef3cf9a76704043e"
+    }
+  }
+]
+
+-- golden/pr-1-merged.json --
+[
+  {
+    "number": 1,
+    "state": "closed",
+    "merged": true,
+    "title": "Add feature 1",
+    "draft": true,
+    "body": "",
+    "html_url": "$SHAMHUB_URL/alice/example/change/1",
+    "head": {
+      "ref": "feature1",
+      "sha": "84f59e49b054bfd4e8d8a253fb9bd58de94be334"
+    },
+    "base": {
+      "ref": "main",
+      "sha": "a6c91da75861301e73f0c8fd5585de39d27432b3"
+    }
+  },
+  {
+    "number": 2,
+    "state": "open",
+    "title": "Add feature 2",
+    "draft": true,
+    "body": "",
+    "html_url": "$SHAMHUB_URL/alice/example/change/2",
+    "head": {
+      "ref": "feature2",
+      "sha": "bac8cbd7c69c0a6d78d2ae4c1df7077f02d3577b"
+    },
+    "base": {
+      "ref": "main",
+      "sha": "a6c91da75861301e73f0c8fd5585de39d27432b3"
+    }
+  },
+  {
+    "number": 3,
+    "state": "open",
+    "title": "Add feature 3",
+    "draft": true,
+    "body": "",
+    "html_url": "$SHAMHUB_URL/alice/example/change/3",
+    "head": {
+      "ref": "feature3",
+      "sha": "2ee6f663a29ecdcdda29aeace47dede1db4f7a4d"
+    },
+    "base": {
+      "ref": "feature2",
+      "sha": "bac8cbd7c69c0a6d78d2ae4c1df7077f02d3577b"
+    }
+  }
+]


### PR DESCRIPTION
When submitting a pull request, differentiate between
`--draft`, `--no-draft`, and absent.
If the flag is absent, and the PR is being updated,
leave the current status unchanged.

This way, `{downstack, upstack} submit` won't mark all PRs as non-draft
just because you're submitting a stack.

Resolves #67