### PR TITLE
rebase recovery: Don't print a duplicate message

### DIFF
--- a/.changes/unreleased/Fixed-20240603-075856.yaml
+++ b/.changes/unreleased/Fixed-20240603-075856.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fix issue where some operations printed rebase conflict message two or more times.
+time: 2024-06-03T07:58:56.061696-07:00

--- a/testdata/script/branch_delete_rebase_conflict.txt
+++ b/testdata/script/branch_delete_rebase_conflict.txt
@@ -21,7 +21,7 @@ gs trunk
 ! gs branch delete --force feature1
 
 # feature2 conflict
-stderr 'There was a conflict while rebasing'
+stderr -count=1 'There was a conflict while rebasing'
 git status --porcelain
 cmp stdout $WORK/golden/conflict.txt
 


### PR DESCRIPTION
Because we go back to the rescuer for every entry in the stack,
we'd end up printing the message multiple times.
The fix is easy: tag the error with whether it's already been printed.