### PR TITLE
rebase continue: Recover from 'rebase --abort'

### DIFF
--- a/.changes/unreleased/Fixed-20240603-194754.yaml
+++ b/.changes/unreleased/Fixed-20240603-194754.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'rebase {continue, abort}: Heal from external `git rebase --continue` or `git rebase --abort` and avoid running old rebase continuation commands.'
+time: 2024-06-03T19:47:54.882529-07:00

--- a/internal/spice/service.go
+++ b/internal/spice/service.go
@@ -64,7 +64,8 @@ type BranchStore interface {
 	// Trunk returns the name of the trunk branch.
 	Trunk() string
 
-	AppendContinuation(context.Context, state.SetContinuationRequest) error
+	AppendContinuations(context.Context, string, ...state.Continuation) error
+	TakeContinuations(context.Context, string) ([]state.Continuation, error)
 }
 
 var _ BranchStore = (*state.Store)(nil)

--- a/internal/spice/state/continue.go
+++ b/internal/spice/state/continue.go
@@ -4,53 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
-	"go.abhg.dev/gs/internal/must"
 )
 
-// SetContinuationRequest is a request to set the operation
-// that should run after the current rebase finishes successfully.
-type SetContinuationRequest struct {
-	// Branch is the branch on which the operation should run.
-	Branch string // required
-
-	// Command specifies the gs command that will be run.
-	Command []string // required
-
-	// Message is a message for the gs state log.
-	Message string
-}
-
-// AppendContinuation records a command that should run
-// when an interrupted rebase operation is resumed.
-// If there are existing continuations, this will append to the list.
-func (s *Store) AppendContinuation(ctx context.Context, req SetContinuationRequest) error {
-	must.NotBeBlankf(req.Branch, "a branch name is required")
-	must.NotBeEmptyf(req.Command, "arguments for git-spice are required")
-	if req.Message == "" {
-		req.Message = "set rebase continuation"
-	}
-
-	state, err := s.getRebaseContinueState(ctx)
-	if err != nil {
-		return fmt.Errorf("get rebase continue state: %w", err)
-	}
-
-	state.Continuations = append(state.Continuations, rebaseContinuation{
-		Branch:  req.Branch,
-		Command: req.Command,
-	})
-
-	if err := s.setRebaseContinueState(ctx, *state, req.Message); err != nil {
-		return fmt.Errorf("set rebase continue state: %w", err)
-	}
-
-	return nil
-}
-
-// TakeContinuationResult includes the information needed to resume a
+// Continuation includes the information needed to resume a
 // rebase operation that was interrupted.
-type TakeContinuationResult struct {
+type Continuation struct {
 	// Command specifies the arguments for the gs operation
 	// that was interrupted.
 	Command []string
@@ -59,13 +17,37 @@ type TakeContinuationResult struct {
 	Branch string
 }
 
-// TakeContinuation removes a recorded rebase continuation from the store
-// and returns it.
-//
-// If there is no continuation, it returns nil.
-func (s *Store) TakeContinuation(ctx context.Context, msg string) (*TakeContinuationResult, error) {
+// AppendContinuations records one or more commands to run
+// when an interrupted rebase operation is resumed.
+// If there are existing continuations, this will append to the list.
+func (s *Store) AppendContinuations(ctx context.Context, msg string, conts ...Continuation) error {
 	if msg == "" {
-		msg = "take rebase continuation"
+		msg = "set rebase continuation"
+	}
+
+	state, err := s.getRebaseContinueState(ctx)
+	if err != nil {
+		return fmt.Errorf("get rebase continue state: %w", err)
+	}
+
+	for _, cont := range conts {
+		state.Continuations = append(state.Continuations, rebaseContinuation(cont))
+	}
+
+	if err := s.setRebaseContinueState(ctx, state, msg); err != nil {
+		return fmt.Errorf("set rebase continue state: %w", err)
+	}
+
+	return nil
+}
+
+// TakeContinuations removes all recorded rebase continuations from the store
+// and returns them.
+//
+// If there are no continuations, it returns an empty slice.
+func (s *Store) TakeContinuations(ctx context.Context, msg string) ([]Continuation, error) {
+	if msg == "" {
+		msg = "take all rebase continuations"
 	}
 
 	state, err := s.getRebaseContinueState(ctx)
@@ -77,17 +59,17 @@ func (s *Store) TakeContinuation(ctx context.Context, msg string) (*TakeContinua
 		return nil, nil
 	}
 
-	cont := state.Continuations[0]
-	state.Continuations = state.Continuations[1:]
+	conts := make([]Continuation, len(state.Continuations))
+	for i, cont := range state.Continuations {
+		conts[i] = Continuation(cont)
+	}
 
-	if err := s.setRebaseContinueState(ctx, *state, msg); err != nil {
+	state.Continuations = nil
+	if err := s.setRebaseContinueState(ctx, state, msg); err != nil {
 		return nil, fmt.Errorf("set rebase continue state: %w", err)
 	}
 
-	return &TakeContinuationResult{
-		Command: cont.Command,
-		Branch:  cont.Branch,
-	}, nil
+	return conts, nil
 }
 
 func (s *Store) getRebaseContinueState(ctx context.Context) (*rebaseContinueState, error) {
@@ -101,7 +83,7 @@ func (s *Store) getRebaseContinueState(ctx context.Context) (*rebaseContinueStat
 	return &state, nil
 }
 
-func (s *Store) setRebaseContinueState(ctx context.Context, state rebaseContinueState, msg string) error {
+func (s *Store) setRebaseContinueState(ctx context.Context, state *rebaseContinueState, msg string) error {
 	if msg == "" {
 		msg = "set rebase continue state"
 	}

--- a/rebase_abort.go
+++ b/rebase_abort.go
@@ -55,19 +55,16 @@ func (cmd *rebaseAbortCmd) Run(ctx context.Context, log *log.Logger, opts *globa
 		}
 	}
 
-	cont, err := store.TakeContinuation(ctx, "gs rebase abort")
+	conts, err := store.TakeContinuations(ctx, "gs rebase abort")
 	if err != nil {
-		return fmt.Errorf("take rebase continuation: %w", err)
+		return fmt.Errorf("take rebase continuations: %w", err)
 	}
-	if cont == nil && !wasRebasing {
+
+	// Make sure that *something* happened from the user's perspective.
+	// If we didn't abort a rebase, and we didn't delete a continuation,
+	// then this was a no-op, which this command should not be.
+	if len(conts) == 0 && !wasRebasing {
 		return errors.New("no operation to abort")
-	}
-	for cont != nil {
-		log.Debugf("%v: dropping continuation: %q", cont.Branch, cont.Command)
-		cont, err = store.TakeContinuation(ctx, "gs rebase abort")
-		if err != nil {
-			return fmt.Errorf("take rebase continuation: %w", err)
-		}
 	}
 
 	return nil

--- a/testdata/script/branch_restack_conflict_git_abort.txt
+++ b/testdata/script/branch_restack_conflict_git_abort.txt
@@ -1,0 +1,68 @@
+# 'branch restack' can recover from a manual 'git abort'.
+
+as 'Test <test@example.com>'
+at '2024-05-27T18:24:42Z'
+
+mkdir repo
+cd repo
+git init
+git add init.txt
+git commit -m 'Initial commit'
+gs repo init
+
+# create a feature branch that modifies init.
+cp $WORK/extra/init.feature.txt init.txt
+git add init.txt
+gs bc -m feature
+
+# go back to main and modify init
+gs trunk
+cp $WORK/extra/init.new.txt init.txt
+git add init.txt
+git commit -m 'Change init'
+
+gs up
+stderr 'feature: needs to be restacked'
+
+# restack the feature branch
+! gs branch restack
+stderr 'There was a conflict while rebasing'
+
+# abort the rebase, and try again.
+git rebase --abort
+! gs branch restack
+stderr 'There was a conflict while rebasing'
+
+# resolve the conflict
+cp $WORK/extra/init.resolved.txt init.txt
+git add init.txt
+env EDITOR=true
+gs rebase continue
+cmp stderr $WORK/golden/rebase-continue-stderr.txt
+
+# verify state
+cmp init.txt $WORK/extra/init.resolved.txt
+git graph --branches
+cmp stdout $WORK/golden/graph.txt
+
+gs trunk
+cmp init.txt $WORK/extra/init.new.txt
+
+-- repo/init.txt --
+initial init
+
+-- extra/init.new.txt --
+changed init
+
+-- extra/init.feature.txt --
+feature's init
+
+-- extra/init.resolved.txt --
+updated init
+
+-- golden/rebase-continue-stderr.txt --
+INF feature: branch does not need to be restacked.
+-- golden/graph.txt --
+* bd2299a (HEAD -> feature) feature
+* 57ab3b0 (main) Change init
+* d692027 Initial commit


### PR DESCRIPTION
If a user runs into a conflict with a `gs` operation,
and then they run `git rebase --abort` instead of a `gs rebase` command,
we'll leave behind a rebase continuation in the data store
which will then be called by the next `gs rebase continue` command.
This is undesirable and can lead to unexpected behavior.

Fix this by clearing the rebase state at the start of a rescue.

For this to work correctly with `gs rebase continue`,
the continue command has to restore the remaining continuations
if a prior continuation fails
because otherwise the continuation will clear the other ones.