### PR TITLE
refactor(state): Rename Branch state methods

### DIFF
--- a/branch.go
+++ b/branch.go
@@ -72,7 +72,7 @@ func (p *branchPrompt) Run(ctx context.Context, repo *git.Repository, store *sta
 
 	trunk := store.Trunk()
 	if p.TrackedOnly {
-		tracked, err := store.List(ctx)
+		tracked, err := store.ListBranches(ctx)
 		if err != nil {
 			return "", fmt.Errorf("list tracked branches: %w", err)
 		}

--- a/branch_create.go
+++ b/branch_create.go
@@ -203,7 +203,7 @@ func (cmd *branchCreateCmd) Run(ctx context.Context, log *log.Logger, opts *glob
 		msg = fmt.Sprintf("create branch %s", cmd.Name)
 	}
 
-	if err := store.Update(ctx, &state.UpdateRequest{
+	if err := store.UpdateBranch(ctx, &state.UpdateRequest{
 		Upserts: upserts,
 		Message: msg,
 	}); err != nil {

--- a/branch_fold.go
+++ b/branch_fold.go
@@ -98,7 +98,7 @@ func (cmd *branchFoldCmd) Run(ctx context.Context, log *log.Logger, opts *global
 		}
 	}
 
-	err = store.Update(ctx, &state.UpdateRequest{
+	err = store.UpdateBranch(ctx, &state.UpdateRequest{
 		Upserts: upserts,
 		Deletes: []string{cmd.Name},
 		Message: fmt.Sprintf("folding %v into %v", cmd.Name, b.Base),

--- a/branch_onto.go
+++ b/branch_onto.go
@@ -158,7 +158,7 @@ func (cmd *branchOntoCmd) Run(ctx context.Context, log *log.Logger, opts *global
 
 	// Once all the upstack branches have been grafted onto the original base,
 	// we can update the branch state to point to the new base.
-	err = store.Update(ctx, &state.UpdateRequest{
+	err = store.UpdateBranch(ctx, &state.UpdateRequest{
 		Upserts: []state.UpsertRequest{
 			{
 				Name:     cmd.Branch,

--- a/branch_submit.go
+++ b/branch_submit.go
@@ -136,7 +136,7 @@ func (cmd *branchSubmitCmd) Run(
 			// It was probably created manually.
 			// We'll heal the state while we're at it.
 			log.Infof("%v: Found existing PR %v", cmd.Name, existingChange.ID)
-			err := store.Update(ctx, &state.UpdateRequest{
+			err := store.UpdateBranch(ctx, &state.UpdateRequest{
 				Upserts: []state.UpsertRequest{
 					{
 						Name: cmd.Name,
@@ -280,7 +280,7 @@ func (cmd *branchSubmitCmd) Run(
 		// we need to save to the state that we pushed the branch
 		// with the recorded name.
 		defer func() {
-			err := store.Update(ctx, &state.UpdateRequest{
+			err := store.UpdateBranch(ctx, &state.UpdateRequest{
 				Upserts: []state.UpsertRequest{upsert},
 				Message: fmt.Sprintf("branch submit %s", cmd.Name),
 			})

--- a/branch_track.go
+++ b/branch_track.go
@@ -78,7 +78,7 @@ func (cmd *branchTrackCmd) Run(ctx context.Context, log *log.Logger, opts *globa
 			return fmt.Errorf("list commits: %w", err)
 		}
 
-		trackedBranches, err := store.List(ctx)
+		trackedBranches, err := store.ListBranches(ctx)
 		if err != nil {
 			return fmt.Errorf("list tracked branches: %w", err)
 		}
@@ -159,7 +159,7 @@ func (cmd *branchTrackCmd) Run(ctx context.Context, log *log.Logger, opts *globa
 	// if GitHub information is available, check if branch has an
 	// open PR and associate it with the branch.
 
-	err = store.Update(ctx, &state.UpdateRequest{
+	err = store.UpdateBranch(ctx, &state.UpdateRequest{
 		Upserts: []state.UpsertRequest{
 			{
 				Name:     cmd.Name,

--- a/completion.go
+++ b/completion.go
@@ -68,7 +68,7 @@ func predictTrackedBranches(args complete.Args) (predictions []string) {
 		return nil // not initialized
 	}
 
-	branches, err := store.List(ctx)
+	branches, err := store.ListBranches(ctx)
 	if err != nil {
 		return nil
 	}

--- a/internal/spice/restack.go
+++ b/internal/spice/restack.go
@@ -90,7 +90,7 @@ func (s *Service) Restack(ctx context.Context, name string) (*RestackResponse, e
 		// print message about "gs rebase continue"
 	}
 
-	err = s.store.Update(ctx, &state.UpdateRequest{
+	err = s.store.UpdateBranch(ctx, &state.UpdateRequest{
 		Upserts: []state.UpsertRequest{
 			{
 				Name:     name,
@@ -165,7 +165,7 @@ func (s *Service) VerifyRestacked(ctx context.Context, name string) error {
 			},
 			Message: fmt.Sprintf("branch %v was restacked externally", name),
 		}
-		if err := s.store.Update(ctx, &req); err != nil {
+		if err := s.store.UpdateBranch(ctx, &req); err != nil {
 			// This isn't a critical error. Just log it.
 			s.log.Warnf("failed to update state with new base hash: %v", err)
 		}

--- a/internal/spice/service.go
+++ b/internal/spice/service.go
@@ -51,19 +51,17 @@ type Store interface {
 	// Trunk returns the name of the trunk branch.
 	Trunk() string
 
-	// TODO: suffix "Branch(es)" to Lookup, Update, List
-
-	// Lookup returns the branch state for the given branch,
+	// LookupBranch returns the branch state for the given branch,
 	// or [state.ErrNotExist] if the branch does not exist.
-	Lookup(ctx context.Context, name string) (*state.LookupResponse, error)
+	LookupBranch(ctx context.Context, name string) (*state.LookupResponse, error)
 
-	// Update adds, updates, or removes state information
+	// UpdateBranch adds, updates, or removes state information
 	// for zero or more branches.
-	Update(ctx context.Context, req *state.UpdateRequest) error
+	UpdateBranch(ctx context.Context, req *state.UpdateRequest) error
 
-	// List returns a list of all tracked branch names.
+	// ListBranches returns a list of all tracked branch names.
 	// This list never includes the trunk branch.
-	List(ctx context.Context) ([]string, error)
+	ListBranches(ctx context.Context) ([]string, error)
 
 	AppendContinuations(context.Context, string, ...state.Continuation) error
 	TakeContinuations(context.Context, string) ([]state.Continuation, error)

--- a/internal/spice/state/read.go
+++ b/internal/spice/state/read.go
@@ -46,9 +46,9 @@ type LookupResponse struct {
 	UpstreamBranch string
 }
 
-// Lookup returns information about a tracked branch.
+// LookupBranch returns information about a tracked branch.
 // If the branch is not found, [ErrNotExist] will be returned.
-func (s *Store) Lookup(ctx context.Context, name string) (*LookupResponse, error) {
+func (s *Store) LookupBranch(ctx context.Context, name string) (*LookupResponse, error) {
 	state, err := s.lookupBranchState(ctx, name)
 	if err != nil {
 		return nil, err
@@ -76,9 +76,9 @@ func (s *Store) lookupBranchState(ctx context.Context, name string) (*branchStat
 	return &state, nil
 }
 
-// List reports the names of all tracked branches.
+// ListBranches reports the names of all tracked branches.
 // The list is sorted in lexicographic order.
-func (s *Store) List(ctx context.Context) ([]string, error) {
+func (s *Store) ListBranches(ctx context.Context) ([]string, error) {
 	branches, err := s.b.Keys(ctx, _branchesDir)
 	if err != nil {
 		return nil, fmt.Errorf("list branches: %w", err)

--- a/internal/spice/state/store.go
+++ b/internal/spice/state/store.go
@@ -74,7 +74,7 @@ func InitStore(ctx context.Context, req InitStoreRequest) (*Store, error) {
 		} else {
 			// If we're not resetting,
 			// ensure that the trunk branch is not tracked.
-			_, err := store.Lookup(ctx, req.Trunk)
+			_, err := store.LookupBranch(ctx, req.Trunk)
 			if err == nil {
 				// TODO: this should all be in 'repo init' implementation.
 				return nil, fmt.Errorf("trunk branch (%q) is tracked by gs; use --reset to clear", req.Trunk)

--- a/internal/spice/state/store_test.go
+++ b/internal/spice/state/store_test.go
@@ -32,11 +32,11 @@ func TestIntegrationStore(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("empty", func(t *testing.T) {
-		_, err := store.Lookup(ctx, "main")
+		_, err := store.LookupBranch(ctx, "main")
 		assert.ErrorIs(t, err, state.ErrNotExist)
 	})
 
-	err = store.Update(ctx, &state.UpdateRequest{
+	err = store.UpdateBranch(ctx, &state.UpdateRequest{
 		Upserts: []state.UpsertRequest{{
 			Name:     "foo",
 			Base:     "main",
@@ -47,7 +47,7 @@ func TestIntegrationStore(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("get", func(t *testing.T) {
-		res, err := store.Lookup(ctx, "foo")
+		res, err := store.LookupBranch(ctx, "foo")
 		require.NoError(t, err)
 
 		assert.Equal(t, &state.LookupResponse{
@@ -58,7 +58,7 @@ func TestIntegrationStore(t *testing.T) {
 	})
 
 	t.Run("overwrite", func(t *testing.T) {
-		err := store.Update(ctx, &state.UpdateRequest{
+		err := store.UpdateBranch(ctx, &state.UpdateRequest{
 			Upserts: []state.UpsertRequest{{
 				Name:     "foo",
 				Base:     "bar",
@@ -68,7 +68,7 @@ func TestIntegrationStore(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		res, err := store.Lookup(ctx, "foo")
+		res, err := store.LookupBranch(ctx, "foo")
 		require.NoError(t, err)
 
 		assert.Equal(t, &state.LookupResponse{
@@ -79,7 +79,7 @@ func TestIntegrationStore(t *testing.T) {
 	})
 
 	t.Run("name with slash", func(t *testing.T) {
-		err := store.Update(ctx, &state.UpdateRequest{
+		err := store.UpdateBranch(ctx, &state.UpdateRequest{
 			Upserts: []state.UpsertRequest{{
 				Name:     "bar/baz",
 				Base:     "main",
@@ -89,7 +89,7 @@ func TestIntegrationStore(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		res, err := store.Lookup(ctx, "bar/baz")
+		res, err := store.LookupBranch(ctx, "bar/baz")
 		require.NoError(t, err)
 		assert.Equal(t, &state.LookupResponse{
 			Base:     "main",

--- a/internal/spice/state/write.go
+++ b/internal/spice/state/write.go
@@ -77,8 +77,8 @@ type UpsertRequest struct {
 	UpstreamBranch string
 }
 
-// Update upates the store with the parameters in the request.
-func (s *Store) Update(ctx context.Context, req *UpdateRequest) error {
+// UpdateBranch upates the store with the parameters in the request.
+func (s *Store) UpdateBranch(ctx context.Context, req *UpdateRequest) error {
 	if req.Message == "" {
 		req.Message = fmt.Sprintf("update at %s", time.Now().Format(time.RFC3339))
 	}

--- a/upstack_onto.go
+++ b/upstack_onto.go
@@ -134,7 +134,7 @@ func (cmd *upstackOntoCmd) Run(ctx context.Context, log *log.Logger, opts *globa
 		})
 	}
 
-	err = store.Update(ctx, &state.UpdateRequest{
+	err = store.UpdateBranch(ctx, &state.UpdateRequest{
 		Upserts: []state.UpsertRequest{
 			{
 				Name:     cmd.Branch,


### PR DESCRIPTION
This is no longer just for branch storage.
Rename the methods to have a Branch or Branches suffix,
and rename the interface used in internal/spice for the store.