### PR TITLE
repo sync: Heal from PRs submitted without gs

### DIFF
--- a/.changes/unreleased/Added-20240605-082245.yaml
+++ b/.changes/unreleased/Added-20240605-082245.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'repo sync: Detect PRs for local branches created and merged externally.'
+time: 2024-06-05T08:22:45.051598-07:00

--- a/branch_submit.go
+++ b/branch_submit.go
@@ -122,7 +122,10 @@ func (cmd *branchSubmitCmd) Run(
 	// but verify that there isn't already one open.
 	var existingChange *forge.FindChangeItem
 	if branch.PR == 0 {
-		changes, err := remoteRepo.FindChangesByBranch(ctx, upstreamBranch)
+		changes, err := remoteRepo.FindChangesByBranch(ctx, upstreamBranch, forge.FindChangesOptions{
+			State: forge.ChangeOpen,
+			Limit: 3,
+		})
 		if err != nil {
 			return fmt.Errorf("list changes: %w", err)
 		}

--- a/internal/forge/github/find.go
+++ b/internal/forge/github/find.go
@@ -10,19 +10,21 @@ import (
 )
 
 type findPRNode struct {
-	ID          githubv4.ID          `graphql:"id"`
-	Number      githubv4.Int         `graphql:"number"`
-	URL         githubv4.URI         `graphql:"url"`
-	Title       githubv4.String      `graphql:"title"`
-	HeadRefOid  githubv4.GitObjectID `graphql:"headRefOid"`
-	BaseRefName githubv4.String      `graphql:"baseRefName"`
-	IsDraft     githubv4.Boolean     `graphql:"isDraft"`
+	ID          githubv4.ID               `graphql:"id"`
+	Number      githubv4.Int              `graphql:"number"`
+	URL         githubv4.URI              `graphql:"url"`
+	Title       githubv4.String           `graphql:"title"`
+	State       githubv4.PullRequestState `graphql:"state"`
+	HeadRefOid  githubv4.GitObjectID      `graphql:"headRefOid"`
+	BaseRefName githubv4.String           `graphql:"baseRefName"`
+	IsDraft     githubv4.Boolean          `graphql:"isDraft"`
 }
 
 func (n *findPRNode) toFindChangeItem() *forge.FindChangeItem {
 	return &forge.FindChangeItem{
 		ID:       forge.ChangeID(n.Number),
 		URL:      n.URL.String(),
+		State:    forgeChangeState(n.State),
 		Subject:  string(n.Title),
 		BaseName: string(n.BaseRefName),
 		HeadHash: git.Hash(n.HeadRefOid),
@@ -30,22 +32,65 @@ func (n *findPRNode) toFindChangeItem() *forge.FindChangeItem {
 	}
 }
 
-// FindChangesByBranch searches for open changes with the given branch name.
-// Returns [ErrNotFound] if no changes are found.
-func (r *Repository) FindChangesByBranch(ctx context.Context, branch string) ([]*forge.FindChangeItem, error) {
+func pullRequestState(s forge.ChangeState) githubv4.PullRequestState {
+	switch s {
+	case forge.ChangeOpen:
+		return githubv4.PullRequestStateOpen
+	case forge.ChangeClosed:
+		return githubv4.PullRequestStateClosed
+	case forge.ChangeMerged:
+		return githubv4.PullRequestStateMerged
+	default:
+		return ""
+	}
+}
+
+func forgeChangeState(s githubv4.PullRequestState) forge.ChangeState {
+	switch s {
+	case githubv4.PullRequestStateOpen:
+		return forge.ChangeOpen
+	case githubv4.PullRequestStateClosed:
+		return forge.ChangeClosed
+	case githubv4.PullRequestStateMerged:
+		return forge.ChangeMerged
+	default:
+		return 0
+	}
+}
+
+// FindChangesByBranch searches for changes with the given branch name.
+// It returns both, open and closed changes.
+// Only recent changes are returned, limited by the given limit.
+func (r *Repository) FindChangesByBranch(ctx context.Context, branch string, opts forge.FindChangesOptions) ([]*forge.FindChangeItem, error) {
+	if opts.Limit == 0 {
+		opts.Limit = 10
+	}
+
 	var q struct {
 		Repository struct {
 			PullRequests struct {
 				Nodes []findPRNode `graphql:"nodes"`
-			} `graphql:"pullRequests(first: 10, states: OPEN, headRefName: $branch)"`
+			} `graphql:"pullRequests(first: $limit, headRefName: $branch, states: $states, orderBy: {field: UPDATED_AT, direction: DESC})"`
 		} `graphql:"repository(owner: $owner, name: $repo)"`
 	}
 
-	if err := r.client.Query(ctx, &q, map[string]any{
+	vars := map[string]any{
 		"owner":  githubv4.String(r.owner),
 		"repo":   githubv4.String(r.repo),
 		"branch": githubv4.String(branch),
-	}); err != nil {
+		"limit":  githubv4.Int(opts.Limit),
+	}
+	if opts.State == 0 {
+		vars["states"] = []githubv4.PullRequestState{
+			githubv4.PullRequestStateOpen,
+			githubv4.PullRequestStateClosed,
+			githubv4.PullRequestStateMerged,
+		}
+	} else {
+		vars["states"] = []githubv4.PullRequestState{pullRequestState(opts.State)}
+	}
+
+	if err := r.client.Query(ctx, &q, vars); err != nil {
 		return nil, fmt.Errorf("find changes by branch: %w", err)
 	}
 

--- a/internal/forge/github/integration_test.go
+++ b/internal/forge/github/integration_test.go
@@ -142,6 +142,7 @@ func TestIntegration_Repository_FindChangeByID(t *testing.T) {
 			ID:       141,
 			URL:      "https://github.com/abhinav/git-spice/pull/141",
 			Subject:  "branch submit: Heal from external PR submissions",
+			State:    forge.ChangeMerged,
 			BaseName: "main",
 			HeadHash: "df0289d83ffae816105947875db01c992224913d",
 			Draft:    false,
@@ -163,22 +164,23 @@ func TestIntegration_Repository_FindChangesByBranch(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("found", func(t *testing.T) {
-		changes, err := repo.FindChangesByBranch(ctx, "gh-graphql")
+		changes, err := repo.FindChangesByBranch(ctx, "gh-graphql", forge.FindChangesOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, []*forge.FindChangeItem{
 			{
 				ID:       144,
 				URL:      "https://github.com/abhinav/git-spice/pull/144",
-				Subject:  "WIP: GitHub: Use GraphQL API",
+				State:    forge.ChangeMerged,
+				Subject:  "GitHub: Use GraphQL API",
 				BaseName: "main",
-				HeadHash: "02195c2a399642a5f66ac9c65f57c7c97b1a7a6c",
+				HeadHash: "5d74cecfe3cb066044d129232229e07f5d04e194",
 				Draft:    false,
 			},
 		}, changes)
 	})
 
 	t.Run("not-found", func(t *testing.T) {
-		changes, err := repo.FindChangesByBranch(ctx, "does-not-exist")
+		changes, err := repo.FindChangesByBranch(ctx, "does-not-exist", forge.FindChangesOptions{})
 		require.NoError(t, err)
 		assert.Empty(t, changes)
 	})
@@ -192,13 +194,13 @@ func TestIntegration_Repository_IsMerged(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("false", func(t *testing.T) {
-		ok, err := repo.IsMerged(ctx, 144)
+		ok, err := repo.ChangeIsMerged(ctx, 144)
 		require.NoError(t, err)
 		assert.False(t, ok)
 	})
 
 	t.Run("true", func(t *testing.T) {
-		ok, err := repo.IsMerged(ctx, 141)
+		ok, err := repo.ChangeIsMerged(ctx, 141)
 		require.NoError(t, err)
 		assert.True(t, ok)
 	})

--- a/internal/forge/github/merged.go
+++ b/internal/forge/github/merged.go
@@ -8,8 +8,8 @@ import (
 	"go.abhg.dev/gs/internal/forge"
 )
 
-// IsMerged reports whether a change has been merged.
-func (r *Repository) IsMerged(ctx context.Context, id forge.ChangeID) (bool, error) {
+// ChangeIsMerged reports whether a change has been merged.
+func (r *Repository) ChangeIsMerged(ctx context.Context, id forge.ChangeID) (bool, error) {
 	var q struct {
 		Repository struct {
 			PullRequest struct {

--- a/internal/forge/github/testdata/fixtures/TestIntegration_Repository_FindChangeByID.yaml
+++ b/internal/forge/github/testdata/fixtures/TestIntegration_Repository_FindChangeByID.yaml
@@ -6,14 +6,14 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 245
+        content_length: 251
         transfer_encoding: []
         trailer: {}
         host: api.github.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"query":"query($number:Int!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){pullRequest(number: $number){id,number,url,title,headRefOid,baseRefName,isDraft}}}","variables":{"number":141,"owner":"abhinav","repo":"git-spice"}}
+            {"query":"query($number:Int!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){pullRequest(number: $number){id,number,url,title,state,headRefOid,baseRefName,isDraft}}}","variables":{"number":141,"owner":"abhinav","repo":"git-spice"}}
         form: {}
         headers:
             Content-Type:
@@ -28,26 +28,26 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"data":{"repository":{"pullRequest":{"id":"PR_kwDOJ2BQKs5xNT-u","number":141,"url":"https://github.com/abhinav/git-spice/pull/141","title":"branch submit: Heal from external PR submissions","headRefOid":"df0289d83ffae816105947875db01c992224913d","baseRefName":"main","isDraft":false}}}}'
+        body: '{"data":{"repository":{"pullRequest":{"id":"PR_kwDOJ2BQKs5xNT-u","number":141,"url":"https://github.com/abhinav/git-spice/pull/141","title":"branch submit: Heal from external PR submissions","state":"MERGED","headRefOid":"df0289d83ffae816105947875db01c992224913d","baseRefName":"main","isDraft":false}}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 188.794916ms
+        duration: 291.343334ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 245
+        content_length: 251
         transfer_encoding: []
         trailer: {}
         host: api.github.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"query":"query($number:Int!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){pullRequest(number: $number){id,number,url,title,headRefOid,baseRefName,isDraft}}}","variables":{"number":999,"owner":"abhinav","repo":"git-spice"}}
+            {"query":"query($number:Int!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){pullRequest(number: $number){id,number,url,title,state,headRefOid,baseRefName,isDraft}}}","variables":{"number":999,"owner":"abhinav","repo":"git-spice"}}
         form: {}
         headers:
             Content-Type:
@@ -68,4 +68,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 166.253667ms
+        duration: 216.053833ms

--- a/internal/forge/github/testdata/fixtures/TestIntegration_Repository_FindChangesByBranch.yaml
+++ b/internal/forge/github/testdata/fixtures/TestIntegration_Repository_FindChangesByBranch.yaml
@@ -6,14 +6,14 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 295
+        content_length: 441
         transfer_encoding: []
         trailer: {}
         host: api.github.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"query":"query($branch:String!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){pullRequests(first: 10, states: OPEN, headRefName: $branch){nodes{id,number,url,title,headRefOid,baseRefName,isDraft}}}}","variables":{"branch":"gh-graphql","owner":"abhinav","repo":"git-spice"}}
+            {"query":"query($branch:String!$limit:Int!$owner:String!$repo:String!$states:[PullRequestState!]!){repository(owner: $owner, name: $repo){pullRequests(first: $limit, headRefName: $branch, states: $states, orderBy: {field: UPDATED_AT, direction: DESC}){nodes{id,number,url,title,state,headRefOid,baseRefName,isDraft}}}}","variables":{"branch":"gh-graphql","limit":10,"owner":"abhinav","repo":"git-spice","states":["OPEN","CLOSED","MERGED"]}}
         form: {}
         headers:
             Content-Type:
@@ -28,26 +28,26 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"data":{"repository":{"pullRequests":{"nodes":[{"id":"PR_kwDOJ2BQKs5xNeqO","number":144,"url":"https://github.com/abhinav/git-spice/pull/144","title":"WIP: GitHub: Use GraphQL API","headRefOid":"02195c2a399642a5f66ac9c65f57c7c97b1a7a6c","baseRefName":"main","isDraft":false}]}}}}'
+        body: '{"data":{"repository":{"pullRequests":{"nodes":[{"id":"PR_kwDOJ2BQKs5xNeqO","number":144,"url":"https://github.com/abhinav/git-spice/pull/144","title":"GitHub: Use GraphQL API","state":"MERGED","headRefOid":"5d74cecfe3cb066044d129232229e07f5d04e194","baseRefName":"main","isDraft":false}]}}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 220.78625ms
+        duration: 397.070541ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 299
+        content_length: 445
         transfer_encoding: []
         trailer: {}
         host: api.github.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"query":"query($branch:String!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){pullRequests(first: 10, states: OPEN, headRefName: $branch){nodes{id,number,url,title,headRefOid,baseRefName,isDraft}}}}","variables":{"branch":"does-not-exist","owner":"abhinav","repo":"git-spice"}}
+            {"query":"query($branch:String!$limit:Int!$owner:String!$repo:String!$states:[PullRequestState!]!){repository(owner: $owner, name: $repo){pullRequests(first: $limit, headRefName: $branch, states: $states, orderBy: {field: UPDATED_AT, direction: DESC}){nodes{id,number,url,title,state,headRefOid,baseRefName,isDraft}}}}","variables":{"branch":"does-not-exist","limit":10,"owner":"abhinav","repo":"git-spice","states":["OPEN","CLOSED","MERGED"]}}
         form: {}
         headers:
             Content-Type:
@@ -68,4 +68,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 176.129333ms
+        duration: 193.592459ms

--- a/testdata/script/repo_sync_detect_externally_created_prs.txt
+++ b/testdata/script/repo_sync_detect_externally_created_prs.txt
@@ -1,0 +1,108 @@
+# 'repo sync' detects and deletes branches for PRs
+# that were created externally and then merged.
+
+as 'Test <test@example.com>'
+at '2024-06-05T05:29:28Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+gh-init
+gh-add-remote origin alice/example.git
+git push origin main
+
+# Create a new branch and submit it
+git add feature1.txt
+gs bc -m 'Add feature1' feature1
+gs branch submit --fill
+stderr 'Created #'
+
+# Create another branch, submit it,
+# and create a local unpushed change.
+gs trunk
+git add feature2.txt
+gs bc -m 'Add feature2' feature2
+gs branch submit --fill
+mv $WORK/extra/modified-feature2.txt feature2.txt
+git add feature2.txt
+gs cc -m 'Modify feature2'
+
+# Forget all state.
+gs repo init --reset --trunk=main --remote=origin
+# At this point, gs has no knowledge of the PRs.
+# Merge them server-side.
+gh-merge alice/example 1
+gh-merge alice/example 2
+
+# Track the branches and sync.
+gs branch track --base=main feature1
+gs branch track --base=main feature2
+gs repo sync
+stderr 'feature1: #1 was merged'
+stderr 'feature2: #2 was merged but local SHA \(6b83ef3\) does not match remote SHA \(33f1653\). Skipping'
+
+git graph --branches
+cmp stdout $WORK/golden/merged-log.txt
+
+gh-dump-pull
+cmpenvJSON stdout $WORK/golden/pull.json
+
+-- repo/feature1.txt --
+Contents of feature
+
+-- repo/feature2.txt --
+Contents of feature2
+
+-- extra/modified-feature2.txt --
+New contents of feature2
+
+-- golden/merged-log.txt --
+* 6b83ef3 (HEAD -> feature2) Modify feature2
+| *   e9220e5 (origin/main, main) Merge change #2
+| |\  
+| |/  
+|/|   
+* | 33f1653 (origin/feature2) Add feature2
+| * b58492c Merge change #1
+|/| 
+| * 7bf98f4 Add feature1
+|/  
+* 13538da Initial commit
+-- golden/pull.json --
+[
+  {
+    "number": 1,
+    "state": "closed",
+    "title": "Add feature1",
+    "body": "",
+    "merged": true,
+    "html_url": "$SHAMHUB_URL/alice/example/change/1",
+    "head": {
+      "ref": "feature1",
+      "sha": "7bf98f4bf69e9ba74fdcfc42ac5b8b30dcccaf13"
+    },
+    "base": {
+      "ref": "main",
+      "sha": "e9220e54445ee9da6c56bbfddf2feabc9fc3d279"
+    }
+  },
+  {
+    "base": {
+      "ref": "main",
+      "sha": "e9220e54445ee9da6c56bbfddf2feabc9fc3d279"
+    },
+    "body": "",
+    "head": {
+      "ref": "feature2",
+      "sha": "33f16530f499eb13bbe639deeed206df958c5b5a"
+    },
+    "html_url": "$SHAMHUB_URL/alice/example/change/2",
+    "merged": true,
+    "number": 2,
+    "state": "closed",
+    "title": "Add feature2"
+  }
+]

--- a/testdata/script/repo_sync_external_pr_head_mismatch.txt
+++ b/testdata/script/repo_sync_external_pr_head_mismatch.txt
@@ -1,0 +1,62 @@
+# When 'repo sync' is deleting a branch for an externally created PR,
+# if the heads mismatch and we're in interactive mode,
+# prompt the user for deletion.
+
+as 'Test <test@example.com>'
+at '2024-06-05T05:29:28Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+gh-init
+gh-add-remote origin alice/example.git
+git push origin main
+
+# Create a branch, submit it.
+gs trunk
+git add feature.txt
+gs bc -m 'Add feature' feature
+gs branch submit --fill
+
+# Modify the branch, don't submit.
+mv $WORK/extra/modified-feature.txt feature.txt
+git add feature.txt
+gs cc -m 'Modify feature'
+
+# Forget all state and merge the branch server-side.
+gs repo init --reset --trunk=main --remote=origin
+gh-merge alice/example 1
+
+# Re-track the branch and sync in interactive mode.
+gs branch track --base=main feature
+with-term $WORK/input/prompt.txt -- gs rs
+cmp stdout $WORK/golden/prompt.txt
+stderr 'feature: deleted \(was 4513f9f\)'
+
+git graph --branches
+cmp stdout $WORK/golden/merged-log.txt
+
+-- repo/feature.txt --
+Contents of feature
+
+-- extra/modified-feature.txt --
+New contents of feature
+
+-- input/prompt.txt --
+await Delete feature
+snapshot
+feed y
+await
+
+-- golden/prompt.txt --
+Delete feature?: [y/N]
+#1 was merged but local SHA (4513f9f) does not match remote SHA (a1b54
+-- golden/merged-log.txt --
+*   f512e87 (HEAD -> main, origin/main) Merge change #1
+|\  
+| * a1b54a6 Add feature
+|/  
+* 13538da Initial commit


### PR DESCRIPTION
'repo sync' should detect merged PRs from tracked branches
that were submitted out of band (not through gs).

To do this, correlate merged PR branch names to tracked branches.
If they match AND the SHAs match, mark the branch for deletion.
Otherwise, prompt the user if we can, or skip the branch if we can't.

Resolves #153