### PR TITLE
branch prompt: Better default selections

### DIFF
--- a/.changes/unreleased/Fixed-20240608-092227.yaml
+++ b/.changes/unreleased/Fixed-20240608-092227.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'branch delete: When prompting for branch selection, select current branch by default.'
+time: 2024-06-08T09:22:27.459938-07:00

--- a/.changes/unreleased/Fixed-20240608-092534.yaml
+++ b/.changes/unreleased/Fixed-20240608-092534.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: '{branch, upstack} onto: When prompting for a new base, default to current base.'
+time: 2024-06-08T09:25:34.554148-07:00

--- a/branch.go
+++ b/branch.go
@@ -46,6 +46,9 @@ type branchPrompt struct {
 	// should be included in the list.
 	TrackedOnly bool
 
+	// Default specifies the branch to select by default.
+	Default string
+
 	// Title specifies the prompt to display to the user.
 	Title string
 
@@ -110,13 +113,15 @@ nextBranch:
 		return "", errors.New("no branches available")
 	}
 
+	value := p.Default
 	prompt := ui.NewSelect().
 		WithOptions(branches...).
 		WithTitle(p.Title).
+		WithValue(&value).
 		WithDescription(p.Description)
 	if err := ui.Run(prompt); err != nil {
 		return "", fmt.Errorf("select branch: %w", err)
 	}
 
-	return prompt.Value(), nil
+	return value, nil
 }

--- a/branch_delete.go
+++ b/branch_delete.go
@@ -51,13 +51,13 @@ func (cmd *branchDeleteCmd) Run(ctx context.Context, log *log.Logger, opts *glob
 		}
 
 		currentBranch, err := repo.CurrentBranch(ctx)
-		if err == nil {
-			// Select current branch by default.
-			cmd.Name = currentBranch
+		if err != nil {
+			currentBranch = ""
 		}
 
 		cmd.Name, err = (&branchPrompt{
 			Exclude: []string{store.Trunk()},
+			Default: currentBranch,
 			Title:   "Select a branch to delete",
 		}).Run(ctx, repo, store)
 		if err != nil {


### PR DESCRIPTION
Right now, the branch selection prompt just defaults to whatever.
Add sane default for commands where it makes sense:

- branch delete: Default to current
- branch onto: Default to current base