### PR TITLE
ui: Add Field initialization hook

### DIFF
--- a/internal/ui/confirm.go
+++ b/internal/ui/confirm.go
@@ -101,6 +101,11 @@ func (c *Confirm) Description() string {
 	return c.desc
 }
 
+// Init initializes the field.
+func (c *Confirm) Init() tea.Cmd {
+	return nil
+}
+
 // Update handles a bubbletea event.
 func (c *Confirm) Update(msg tea.Msg) tea.Cmd {
 	var cmds []tea.Cmd

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -65,6 +65,10 @@ type Writer interface {
 
 // Field is a single field in a form.
 type Field interface {
+	// Init initializes the field.
+	// This is called right before the field is first rendered,
+	// not when the form is initialized.
+	Init() tea.Cmd
 	Update(msg tea.Msg) tea.Cmd
 	Render(Writer)
 
@@ -145,7 +149,11 @@ func (f *Form) Err() error {
 // Init initializes the form.
 func (f *Form) Init() tea.Cmd {
 	f.focused = 0
-	return nil
+	if len(f.fields) == 0 {
+		return tea.Quit
+	}
+
+	return f.fields[f.focused].Init()
 }
 
 // Update implements tea.Model.
@@ -166,6 +174,8 @@ func (f *Form) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// never be out of bounds.
 			return f, tea.Quit
 		}
+
+		return f, f.fields[f.focused].Init()
 
 	case tea.KeyMsg:
 		if key.Matches(msg, f.KeyMap.Cancel) {

--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -44,7 +44,6 @@ var _ Field = (*Input)(nil)
 func NewInput() *Input {
 	m := textinput.New()
 	m.Prompt = "" // we have our own prompt
-	m.Focus()
 	return &Input{
 		KeyMap: DefaultInputKeyMap,
 		Style:  DefaultInputStyle,
@@ -96,6 +95,11 @@ func (i *Input) Err() error {
 func (i *Input) WithValidate(f func(string) error) *Input {
 	i.model.Validate = f
 	return i
+}
+
+// Init initializes the field.
+func (i *Input) Init() tea.Cmd {
+	return i.model.Focus()
 }
 
 // Update handles a bubbletea event.

--- a/internal/ui/open_editor.go
+++ b/internal/ui/open_editor.go
@@ -137,6 +137,11 @@ func (a *OpenEditor) Description() string {
 	return a.desc
 }
 
+// Init initializes the field.
+func (a *OpenEditor) Init() tea.Cmd {
+	return nil
+}
+
 type updateEditorValueMsg []byte
 
 // Update receives a new event from bubbletea

--- a/internal/ui/select.go
+++ b/internal/ui/select.go
@@ -96,7 +96,6 @@ func NewSelect() *Select {
 // The existing value, if any, will be selected by default.
 func (s *Select) WithValue(value *string) *Select {
 	s.value = value
-	s.initSelected()
 	return s
 }
 
@@ -120,17 +119,7 @@ func (s *Select) WithOptions(opts ...string) *Select {
 
 	s.options = options
 	s.matched = matched
-	s.initSelected()
 	return s
-}
-
-func (s *Select) initSelected() {
-	idx := slices.IndexFunc(s.matched, func(optIdx int) bool {
-		return s.options[optIdx].Value == *s.value
-	})
-	if idx != -1 {
-		s.selected = idx
-	}
 }
 
 // Title returns the title of the select field.
@@ -165,6 +154,17 @@ func (s *Select) WithVisible(visible int) *Select {
 // Err reports any errors in the select field.
 func (s *Select) Err() error {
 	return s.err
+}
+
+// Init initializes the field.
+func (s *Select) Init() tea.Cmd {
+	idx := slices.IndexFunc(s.matched, func(optIdx int) bool {
+		return s.options[optIdx].Value == *s.value
+	})
+	if idx != -1 {
+		s.selected = idx
+	}
+	return nil
 }
 
 // Update receives messages from bubbletea.


### PR DESCRIPTION
Add a hook that's called right before a field is first rendered.
This allows pulling some of the post `With*` initialization logic
into a more explicit place without duplication.
