### PR TITLE
Cache PR templates in data store

### DIFF
--- a/.changes/unreleased/Changed-20240608-155044.yaml
+++ b/.changes/unreleased/Changed-20240608-155044.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'branch submit: Make fewer requests to GitHub for PR templates by caching them locally.'
+time: 2024-06-08T15:50:44.768147-07:00

--- a/branch_submit.go
+++ b/branch_submit.go
@@ -188,7 +188,7 @@ func (cmd *branchSubmitCmd) Run(
 			ctx, cancel := context.WithTimeout(ctx, time.Second)
 			defer cancel()
 
-			templates, err := remoteRepo.ListChangeTemplates(ctx)
+			templates, err := svc.ListChangeTemplates(ctx, remoteRepo)
 			if err != nil {
 				log.Warn("Could not list change templates", "error", err)
 				return

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -88,10 +88,16 @@ type Forge interface {
 	//
 	// Returns [ErrUnsupportedURL] if the URL is not supported.
 	OpenURL(ctx context.Context, remoteURL string) (Repository, error)
+
+	// ChangeTemplatePaths reports the case-insensitive paths at which
+	// it's possible to define change templates in the repository.
+	ChangeTemplatePaths() []string
 }
 
 // Repository is a Git repository hosted on a forge.
 type Repository interface {
+	Forge() Forge
+
 	SubmitChange(ctx context.Context, req SubmitChangeRequest) (SubmitChangeResult, error)
 	EditChange(ctx context.Context, id ChangeID, opts EditChangeOptions) error
 	FindChangesByBranch(ctx context.Context, branch string, opts FindChangesOptions) ([]*FindChangeItem, error)

--- a/internal/forge/github/forge.go
+++ b/internal/forge/github/forge.go
@@ -66,7 +66,7 @@ func (f *Forge) OpenURL(ctx context.Context, remoteURL string) (forge.Repository
 		ghc = githubv4.NewClient(oauthClient)
 	}
 
-	return newRepository(ctx, owner, repo, f.Log, ghc, nil)
+	return newRepository(ctx, f, owner, repo, f.Log, ghc, nil)
 }
 
 func extractRepoInfo(githubURL, remoteURL string) (owner, repo string, err error) {

--- a/internal/forge/github/integration_test.go
+++ b/internal/forge/github/integration_test.go
@@ -123,7 +123,7 @@ func TestIntegration_Repository(t *testing.T) {
 	ctx := context.Background()
 	rec := newRecorder(t, t.Name())
 	ghc := githubv4.NewClient(rec.GetDefaultClient())
-	_, err := github.NewRepository(ctx, "abhinav", "git-spice", logtest.New(t), ghc, nil)
+	_, err := github.NewRepository(ctx, new(github.Forge), "abhinav", "git-spice", logtest.New(t), ghc, nil)
 	require.NoError(t, err)
 }
 
@@ -131,7 +131,7 @@ func TestIntegration_Repository_FindChangeByID(t *testing.T) {
 	ctx := context.Background()
 	rec := newRecorder(t, t.Name())
 	ghc := githubv4.NewClient(rec.GetDefaultClient())
-	repo, err := github.NewRepository(ctx, "abhinav", "git-spice", logtest.New(t), ghc, _gitSpiceRepoID)
+	repo, err := github.NewRepository(ctx, new(github.Forge), "abhinav", "git-spice", logtest.New(t), ghc, _gitSpiceRepoID)
 	require.NoError(t, err)
 
 	t.Run("found", func(t *testing.T) {
@@ -160,7 +160,7 @@ func TestIntegration_Repository_FindChangesByBranch(t *testing.T) {
 	ctx := context.Background()
 	rec := newRecorder(t, t.Name())
 	ghc := githubv4.NewClient(rec.GetDefaultClient())
-	repo, err := github.NewRepository(ctx, "abhinav", "git-spice", logtest.New(t), ghc, _gitSpiceRepoID)
+	repo, err := github.NewRepository(ctx, new(github.Forge), "abhinav", "git-spice", logtest.New(t), ghc, _gitSpiceRepoID)
 	require.NoError(t, err)
 
 	t.Run("found", func(t *testing.T) {
@@ -190,7 +190,7 @@ func TestIntegration_Repository_IsMerged(t *testing.T) {
 	ctx := context.Background()
 	rec := newRecorder(t, t.Name())
 	ghc := githubv4.NewClient(rec.GetDefaultClient())
-	repo, err := github.NewRepository(ctx, "abhinav", "git-spice", logtest.New(t), ghc, _gitSpiceRepoID)
+	repo, err := github.NewRepository(ctx, new(github.Forge), "abhinav", "git-spice", logtest.New(t), ghc, _gitSpiceRepoID)
 	require.NoError(t, err)
 
 	t.Run("false", func(t *testing.T) {
@@ -212,7 +212,7 @@ func TestIntegration_Repository_ListChangeTemplates(t *testing.T) {
 	t.Run("absent", func(t *testing.T) {
 		rec := newRecorder(t, t.Name())
 		ghc := githubv4.NewClient(rec.GetDefaultClient())
-		repo, err := github.NewRepository(ctx, "abhinav", "git-spice", logtest.New(t), ghc, _gitSpiceRepoID)
+		repo, err := github.NewRepository(ctx, new(github.Forge), "abhinav", "git-spice", logtest.New(t), ghc, _gitSpiceRepoID)
 		require.NoError(t, err)
 
 		templates, err := repo.ListChangeTemplates(ctx)
@@ -223,7 +223,7 @@ func TestIntegration_Repository_ListChangeTemplates(t *testing.T) {
 	t.Run("present", func(t *testing.T) {
 		rec := newRecorder(t, t.Name())
 		ghc := githubv4.NewClient(rec.GetDefaultClient())
-		repo, err := github.NewRepository(ctx, "golang", "go", logtest.New(t), ghc, nil)
+		repo, err := github.NewRepository(ctx, new(github.Forge), "golang", "go", logtest.New(t), ghc, nil)
 		require.NoError(t, err)
 
 		templates, err := repo.ListChangeTemplates(ctx)

--- a/internal/forge/github/repository.go
+++ b/internal/forge/github/repository.go
@@ -15,12 +15,14 @@ type Repository struct {
 	repoID      githubv4.ID
 	log         *log.Logger
 	client      *githubv4.Client
+	forge       *Forge
 }
 
 var _ forge.Repository = (*Repository)(nil)
 
 func newRepository(
 	ctx context.Context,
+	forge *Forge,
 	owner, repo string,
 	log *log.Logger,
 	client *githubv4.Client,
@@ -50,3 +52,6 @@ func newRepository(
 		repoID: repoID,
 	}, nil
 }
+
+// Forge returns the forge this repository belongs to.
+func (r *Repository) Forge() forge.Forge { return r.forge }

--- a/internal/forge/github/template.go
+++ b/internal/forge/github/template.go
@@ -7,6 +7,20 @@ import (
 	"go.abhg.dev/gs/internal/forge"
 )
 
+// ChangeTemplatePaths reports the allowed paths for possible PR templates.
+//
+// Ref https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository.
+func (f *Forge) ChangeTemplatePaths() []string {
+	return []string{
+		"PULL_REQUEST_TEMPLATE.md",
+		"PULL_REQUEST_TEMPLATE",
+		".github/PULL_REQUEST_TEMPLATE.md",
+		".github/PULL_REQUEST_TEMPLATE",
+		"docs/PULL_REQUEST_TEMPLATE.md",
+		"docs/PULL_REQUEST_TEMPLATE",
+	}
+}
+
 // ListChangeTemplates returns PR templates defined in the repository.
 func (r *Repository) ListChangeTemplates(ctx context.Context) ([]*forge.ChangeTemplate, error) {
 	var q struct {

--- a/internal/forge/shamhub/shamhub.go
+++ b/internal/forge/shamhub/shamhub.go
@@ -637,16 +637,18 @@ func (sh *ShamHub) handleChangeTemplate(w http.ResponseWriter, r *http.Request) 
 	logw, flush := ioutil.LogWriter(sh.log, log.DebugLevel)
 	defer flush()
 
-	cmd := exec.Command(sh.gitExe, "cat-file", "-p", "HEAD:.shamhub/CHANGE_TEMPLATE.md")
-	cmd.Dir = sh.repoDir(owner, repo)
-	cmd.Stderr = logw
-
 	var res changeTemplateResponse
-	if out, err := cmd.Output(); err == nil {
-		res = append(res, &changeTemplate{
-			Filename: "CHANGE_TEMPLATE.md",
-			Body:     strings.TrimSpace(string(out)) + "\n",
-		})
+	for _, path := range _changeTemplatePaths {
+		cmd := exec.Command(sh.gitExe, "cat-file", "-p", "HEAD:"+path)
+		cmd.Dir = sh.repoDir(owner, repo)
+		cmd.Stderr = logw
+
+		if out, err := cmd.Output(); err == nil {
+			res = append(res, &changeTemplate{
+				Filename: path,
+				Body:     strings.TrimSpace(string(out)) + "\n",
+			})
+		}
 	}
 
 	enc := json.NewEncoder(w)

--- a/internal/git/hash.go
+++ b/internal/git/hash.go
@@ -57,13 +57,9 @@ func (r *Repository) PeelToTree(ctx context.Context, ref string) (Hash, error) {
 	return r.revParse(ctx, ref+"^{tree}")
 }
 
-// TreeAt reports the hash of the tree object at the provided commit-ish and path.
-func (r *Repository) TreeAt(ctx context.Context, commitish, path string) (Hash, error) {
-	return r.revParse(ctx, commitish+":"+path)
-}
-
-// BlobAt reports the hash of the blob object at the provided tree-ish and path.
-func (r *Repository) BlobAt(ctx context.Context, treeish, path string) (Hash, error) {
+// HashAt reports the hash of the object at the provided path in the given
+// treeish.
+func (r *Repository) HashAt(ctx context.Context, treeish, path string) (Hash, error) {
 	return r.revParse(ctx, treeish+":"+path)
 }
 

--- a/internal/spice/service.go
+++ b/internal/spice/service.go
@@ -41,6 +41,7 @@ type GitRepository interface {
 	Rebase(context.Context, git.RebaseRequest) error
 	RenameBranch(context.Context, git.RenameBranchRequest) error
 	DeleteBranch(context.Context, string, git.BranchDeleteOptions) error
+	HashAt(context.Context, string, string) (git.Hash, error)
 }
 
 var _ GitRepository = (*git.Repository)(nil)
@@ -65,6 +66,9 @@ type Store interface {
 
 	AppendContinuations(context.Context, string, ...state.Continuation) error
 	TakeContinuations(context.Context, string) ([]state.Continuation, error)
+
+	LoadCachedTemplates(context.Context, string) ([]*state.CachedTemplate, error)
+	CacheTemplates(context.Context, string, []*state.CachedTemplate) error
 }
 
 var _ Store = (*state.Store)(nil)

--- a/internal/spice/state/backend.go
+++ b/internal/spice/state/backend.go
@@ -22,8 +22,7 @@ const (
 type GitRepository interface {
 	PeelToCommit(ctx context.Context, ref string) (git.Hash, error)
 	PeelToTree(ctx context.Context, ref string) (git.Hash, error)
-	BlobAt(ctx context.Context, treeish, path string) (git.Hash, error)
-	TreeAt(ctx context.Context, commitish, path string) (git.Hash, error)
+	HashAt(ctx context.Context, commitish, path string) (git.Hash, error)
 
 	ReadObject(ctx context.Context, typ git.Type, hash git.Hash, dst io.Writer) error
 	WriteObject(ctx context.Context, typ git.Type, src io.Reader) (git.Hash, error)
@@ -76,7 +75,7 @@ func (g *gitStorageBackend) Keys(ctx context.Context, dir string) ([]string, err
 	if dir == "" {
 		treeHash, err = g.repo.PeelToTree(ctx, g.ref)
 	} else {
-		treeHash, err = g.repo.TreeAt(ctx, g.ref, dir)
+		treeHash, err = g.repo.HashAt(ctx, g.ref, dir)
 	}
 	if err != nil {
 		if errors.Is(err, git.ErrNotExist) {
@@ -105,7 +104,7 @@ func (g *gitStorageBackend) Keys(ctx context.Context, dir string) ([]string, err
 }
 
 func (g *gitStorageBackend) Get(ctx context.Context, key string, v interface{}) error {
-	blobHash, err := g.repo.BlobAt(ctx, g.ref, key)
+	blobHash, err := g.repo.HashAt(ctx, g.ref, key)
 	if err != nil {
 		return ErrNotExist
 	}

--- a/internal/spice/state/template.go
+++ b/internal/spice/state/template.go
@@ -1,0 +1,84 @@
+package state
+
+import (
+	"context"
+	"fmt"
+)
+
+const _templatesJSON = "templates"
+
+type templateState struct {
+	CacheKey  string           `json:"key"`
+	Templates []changeTemplate `json:"templates"`
+}
+
+type changeTemplate struct {
+	Filename string `json:"filename"`
+	Body     string `json:"body"`
+}
+
+// CachedTemplate is a change template cached in the git spice store.
+type CachedTemplate struct {
+	// Filename is the name of the template file.
+	//
+	// This is NOT the path, and is not guaranteed
+	// to correspond to a file on disk.
+	Filename string
+
+	// Body is the content of the template file.
+	Body string
+}
+
+// LoadCachedTemplates returns the cached templates if the cache key matches.
+// Returns [ErrNotExist] if the cache key does not match,
+// or there are no cached templates.
+func (s *Store) LoadCachedTemplates(ctx context.Context, cacheKey string) ([]*CachedTemplate, error) {
+	var state templateState
+	if err := s.b.Get(ctx, _templatesJSON, &state); err != nil {
+		return nil, fmt.Errorf("load template state: %w", err)
+	}
+
+	if state.CacheKey != cacheKey {
+		return nil, fmt.Errorf("cache key mismatch: %w", ErrNotExist)
+	}
+
+	out := make([]*CachedTemplate, len(state.Templates))
+	for i, t := range state.Templates {
+		out[i] = &CachedTemplate{
+			Filename: t.Filename,
+			Body:     t.Body,
+		}
+	}
+
+	return out, nil
+}
+
+// CacheTemplates caches the given templates with the given cache key.
+// If there's existing cached data, it will be overwritten.
+func (s *Store) CacheTemplates(ctx context.Context, cacheKey string, ts []*CachedTemplate) error {
+	state := templateState{
+		CacheKey:  cacheKey,
+		Templates: make([]changeTemplate, len(ts)),
+	}
+	for i, t := range ts {
+		state.Templates[i] = changeTemplate{
+			Filename: t.Filename,
+			Body:     t.Body,
+		}
+	}
+
+	err := s.b.Update(ctx, updateRequest{
+		Sets: []setRequest{
+			{
+				Key: _templatesJSON,
+				Val: state,
+			},
+		},
+		Msg: "cache templates",
+	})
+	if err != nil {
+		return fmt.Errorf("cache templates: %w", err)
+	}
+
+	return nil
+}

--- a/internal/spice/template.go
+++ b/internal/spice/template.go
@@ -1,0 +1,70 @@
+package spice
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"sort"
+
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/spice/state"
+)
+
+// ListChangeTemplates returns the Change templates defined in the repository.
+// For GitHub, these are PR templates.
+func (s *Service) ListChangeTemplates(ctx context.Context, fr forge.Repository) ([]*forge.ChangeTemplate, error) {
+	// TODO: Should Repo be injected?
+	templatePaths := fr.Forge().ChangeTemplatePaths()
+	sort.Strings(templatePaths)
+
+	// Cache key is a SHA256 hash of the following, in order:
+	//   - Number of allowed template paths
+	//   - Git SHA of each template path on the trunk branch,
+	//     or "0" if the path does not exist on the trunk branch.
+	keyHash := sha256.New()
+	_, _ = fmt.Fprintf(keyHash, "%d\n", len(templatePaths))
+	for _, path := range templatePaths {
+		h, err := s.repo.HashAt(ctx, s.store.Trunk(), path)
+		if err != nil {
+			if errors.Is(err, git.ErrNotExist) {
+				_, _ = fmt.Fprintf(keyHash, "0\n")
+				continue
+			}
+			return nil, fmt.Errorf("lookup %q: %w", path, err)
+		}
+		_, _ = fmt.Fprintf(keyHash, "%s\n", h)
+	}
+
+	key := fmt.Sprintf("%x", keyHash.Sum(nil))
+	if ts, err := s.store.LoadCachedTemplates(ctx, key); err == nil {
+		result := make([]*forge.ChangeTemplate, len(ts))
+		for i, t := range ts {
+			result[i] = &forge.ChangeTemplate{
+				Filename: t.Filename,
+				Body:     t.Body,
+			}
+		}
+		return result, nil
+	}
+
+	// Fetch templates from the forge.
+	ts, err := fr.ListChangeTemplates(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list templates: %w", err)
+	}
+
+	cached := make([]*state.CachedTemplate, len(ts))
+	for i, t := range ts {
+		cached[i] = &state.CachedTemplate{
+			Filename: t.Filename,
+			Body:     t.Body,
+		}
+	}
+	if err := s.store.CacheTemplates(ctx, key, cached); err != nil {
+		s.log.Warn("Failed to cache templates", "err", err)
+	}
+
+	return ts, nil
+}

--- a/testdata/script/branch_submit_pr_template_cache_invalidation.txt
+++ b/testdata/script/branch_submit_pr_template_cache_invalidation.txt
@@ -1,0 +1,82 @@
+# 'branch submit' uses new templates if present on main.
+
+as 'Test <test@example.com>'
+at '2024-06-08T15:45:32Z'
+
+# setup
+cd repo
+git init
+git add .shamhub
+git commit -m 'Initial commit'
+
+# set up a fake remote
+gh-init
+gh-add-remote origin alice/example.git
+git push origin main
+
+# Submit a PR with the first template.
+git add feature1.txt
+gs bc -m feature1
+gs branch submit --fill
+
+# While that PR is open, push a new template.
+gs trunk
+mv $WORK/extra/CHANGE_TEMPLATE.md .shamhub/CHANGE_TEMPLATE.md
+git add .shamhub/CHANGE_TEMPLATE.md
+git commit -m 'Change the template'
+git push origin main
+
+# Create a new PR with the new template.
+git add feature2.txt
+gs bc -m feature2
+gs branch submit --fill
+
+gh-dump-pull
+cmpenvJSON stdout $WORK/golden/pulls.json
+
+-- repo/.shamhub/CHANGE_TEMPLATE.md --
+This is the first template.
+
+-- extra/CHANGE_TEMPLATE.md --
+This is the second template.
+
+-- repo/feature1.txt --
+feature 1
+
+-- repo/feature2.txt --
+feature 2
+
+-- golden/pulls.json --
+[
+  {
+    "number": 1,
+    "state": "open",
+    "title": "feature1",
+    "body": "\n\nThis is the first template.\n",
+    "html_url": "$SHAMHUB_URL/alice/example/change/1",
+    "head": {
+      "ref": "feature1",
+      "sha": "2cf8fafa7da354fa870d768c3aecb4999b876111"
+    },
+    "base": {
+      "ref": "main",
+      "sha": "ee2153c8901b20404f8bb610be7f6e60a6f39a0b"
+    }
+  },
+  {
+    "number": 2,
+    "state": "open",
+    "title": "feature2",
+    "body": "\n\nThis is the second template.\n",
+    "html_url": "$SHAMHUB_URL/alice/example/change/2",
+    "head": {
+      "ref": "feature2",
+      "sha": "6402d80c89e1b6d620d9059e426b3f1b4f232041"
+    },
+    "base": {
+      "ref": "main",
+      "sha": "ee2153c8901b20404f8bb610be7f6e60a6f39a0b"
+    }
+  }
+]
+


### PR DESCRIPTION
Instead of making a request to GitHub every time a PR is submitted
cache information about the templates in the data store.

The cache key is calculated from the list of possible template paths,
so the cache is invalidated when the templates change.

Resolves #163