### PR TITLE
git/UpdateTree: Don't create throwaway indexes

### DIFF
--- a/internal/git/tree.go
+++ b/internal/git/tree.go
@@ -7,11 +7,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
+	"path"
+	"slices"
 	"strconv"
 	"strings"
 
-	"go.abhg.dev/gs/internal/osutil"
+	"go.abhg.dev/gs/internal/maputil"
+	"go.abhg.dev/gs/internal/must"
 )
 
 // Mode is the octal file mode of a Git tree entry.
@@ -228,86 +230,204 @@ type BlobInfo struct {
 	Path string
 }
 
-// UpdateTree updates the given tree with the given writes and deletes,
-// returning the new tree hash.
+// UpdateTree updates an existing Git tree with differential changes to blobs
+// and returns the hash of the new tree.
 func (r *Repository) UpdateTree(ctx context.Context, req UpdateTreeRequest) (_ Hash, err error) {
-	// Use a temporary index file to update the tree.
-	indexFile, err := osutil.TempFilePath("", "spice-index-*")
-	if err != nil {
-		return ZeroHash, fmt.Errorf("create index: %w", err)
+	if len(req.Writes) == 0 && len(req.Deletes) == 0 {
+		return req.Tree, nil
 	}
-	defer func() {
-		err = errors.Join(err, os.Remove(indexFile))
-	}()
+	// We have a list of path updates. We need to take the following steps:
+	// 1. Group updates by directory.
+	// 2. Enumerate all intermediate directories for each update.
+	// 3. Starting with the deepest directory:
+	//     a. Read the current tree for that directory
+	//     b. Apply updates to the tree
+	//     c. Write the updated tree
+	//     d. Add the new hash of the tree to updates
+	//        for the parent directory
+	// 4. Return the hash of the root directory.
 
-	readTreeArgs := []string{"read-tree", "--index-output", indexFile}
-	if req.Tree == ZeroHash || req.Tree == "" {
-		readTreeArgs = append(readTreeArgs, "--empty")
-	} else {
-		readTreeArgs = append(readTreeArgs, req.Tree.String())
-	}
+	// Tracks all directories that are affected by updates
+	// up to the root directory.
+	affectedDirs := make(map[string]struct{})
+	affectDir := func(p string) {
+		must.NotBeBlankf(p, "path must not be blank")
 
-	if err := r.gitCmd(ctx, readTreeArgs...).Run(r.exec); err != nil {
-		return ZeroHash, fmt.Errorf("read-tree: %w", err)
-	}
-
-	updateCmd := r.gitCmd(ctx, "update-index", "--index-info").
-		AppendEnv("GIT_INDEX_FILE=" + indexFile)
-	stdin, err := updateCmd.StdinPipe()
-	if err != nil {
-		return ZeroHash, fmt.Errorf("create pipe: %w", err)
-	}
-	if err := updateCmd.Start(r.exec); err != nil {
-		return ZeroHash, fmt.Errorf("start: %w", err)
-	}
-
-	if req.Writes != nil {
-		for _, blob := range req.Writes {
-			// update-index accepts input in the form:
-			//   <mode> SP <sha1> TAB <path> NL
-			if blob.Mode == ZeroMode {
-				blob.Mode = RegularMode
-			}
-
-			if _, err := fmt.Fprintf(stdin, "%s %s\t%s\n", blob.Mode, blob.Hash, blob.Path); err != nil {
-				return ZeroHash, fmt.Errorf("write: %w", err)
-			}
+		for p != "." {
+			affectedDirs[p] = struct{}{}
+			p = path.Dir(p)
 		}
 	}
 
-	if req.Deletes != nil {
-		for _, path := range req.Deletes {
-			// For deletes, we need to use 000000 as the mode,
-			// and hash does not matter.
-			if _, err := fmt.Fprintf(stdin, "000000 %s\t%s\n", ZeroHash, path); err != nil {
-				return ZeroHash, fmt.Errorf("delete: %w", err)
+	updates := make(map[string]*directoryUpdate)
+	ensureUpdate := func(dir string) *directoryUpdate {
+		dir = strings.TrimSuffix(dir, "/")
+		if dir == "" {
+			dir = "."
+		}
+
+		affectDir(dir)
+		u, ok := updates[dir]
+		if !ok {
+			u = new(directoryUpdate)
+			updates[dir] = u
+		}
+		return u
+	}
+
+	for _, blob := range req.Writes {
+		dir, name := pathSplit(blob.Path)
+		ensureUpdate(dir).Put(TreeEntry{
+			Mode: blob.Mode,
+			Type: BlobType,
+			Hash: blob.Hash,
+			Name: name,
+		})
+	}
+
+	for _, p := range req.Deletes {
+		dir, name := pathSplit(p)
+		ensureUpdate(dir).Delete(name)
+	}
+
+	// Sort the directories by depth, so we can process them in order.
+	dirs := maputil.Keys(affectedDirs)
+	slices.SortFunc(dirs, func(a, b string) int {
+		diff := strings.Count(b, "/") - strings.Count(a, "/")
+		if diff == 0 {
+			diff = strings.Compare(a, b)
+		}
+		return diff
+	})
+
+	for _, dir := range dirs {
+		update := updates[dir]
+		delete(updates, dir)
+		if update.Empty() {
+			// This directory has no updates.
+			continue
+		}
+
+		oldHash, err := r.HashAt(ctx, req.Tree.String(), dir)
+		if err != nil {
+			if !errors.Is(err, ErrNotExist) {
+				return ZeroHash, fmt.Errorf("hash %v:%q: %w", req.Tree, dir, err)
 			}
+			oldHash = ZeroHash
+		}
+
+		var entries []TreeEntry
+		if oldHash != ZeroHash {
+			entries, err = r.ListTree(ctx, oldHash, ListTreeOptions{})
+			if err != nil {
+				return ZeroHash, fmt.Errorf("list %v (%v): %w", dir, oldHash, err)
+			}
+		}
+
+		newHash, err := r.MakeTree(ctx, update.Apply(entries))
+		if err != nil {
+			return ZeroHash, fmt.Errorf("make tree: %w", err)
+		}
+
+		// Update the parent directory with the new hash.
+		parent, base := pathSplit(dir)
+		ensureUpdate(parent).Put(TreeEntry{
+			Mode: DirMode,
+			Type: TreeType,
+			Hash: newHash,
+			Name: base,
+		})
+	}
+
+	// Process root directory separately.
+	var entries []TreeEntry
+	if req.Tree != ZeroHash && req.Tree != "" {
+		entries, err = r.ListTree(ctx, req.Tree, ListTreeOptions{})
+		if err != nil {
+			return ZeroHash, fmt.Errorf("list root (%v): %w", req.Tree, err)
 		}
 	}
 
-	if err := stdin.Close(); err != nil {
-		return ZeroHash, fmt.Errorf("close: %w", err)
+	rootHash, err := r.MakeTree(ctx, updates["."].Apply(entries))
+	if err != nil {
+		return ZeroHash, fmt.Errorf("make root tree: %w", err)
+	}
+	delete(updates, ".")
+
+	// If there are any updates that we didn't look at,
+	// we have a bug in our code and we should fail loudly.
+	if len(updates) > 0 {
+		var msg strings.Builder
+		msg.WriteString("unapplied updates:")
+		for dir := range updates {
+			msg.WriteString(" ")
+			msg.WriteString(dir)
+		}
+		must.Failf(msg.String())
 	}
 
-	if err := updateCmd.Wait(r.exec); err != nil {
-		return ZeroHash, fmt.Errorf("wait: %w", err)
-	}
-
-	// Write the updated index to a new tree.
-	return r.writeIndexToTree(ctx, indexFile)
+	return rootHash, nil
 }
 
-// writeIndexToTree writes the given Git index file into a new tree object.
-func (r *Repository) writeIndexToTree(ctx context.Context, index string) (_ Hash, err error) {
-	cmd := r.gitCmd(ctx, "write-tree")
-	if index != "" {
-		cmd = cmd.AppendEnv("GIT_INDEX_FILE=" + index)
+type directoryUpdate struct {
+	Writes  []TreeEntry // sorted by name
+	Deletes []string    // sorted
+}
+
+func (du *directoryUpdate) Apply(entries []TreeEntry) []TreeEntry {
+	if du == nil {
+		return entries
 	}
 
-	treeHash, err := cmd.OutputString(r.exec)
-	if err != nil {
-		return ZeroHash, fmt.Errorf("write-tree: %w", err)
+	newEntries := entries[:0]
+	for _, ent := range entries {
+		if idx, ok := slices.BinarySearch(du.Deletes, ent.Name); ok {
+			du.Deletes = slices.Delete(du.Deletes, idx, idx+1)
+			continue
+		}
+
+		if idx, ok := slices.BinarySearchFunc(du.Writes, ent.Name, entryByName); ok {
+			ent = du.Writes[idx]
+			du.Writes = slices.Delete(du.Writes, idx, idx+1)
+		}
+
+		newEntries = append(newEntries, ent)
 	}
 
-	return Hash(treeHash), nil
+	// If there are any more writes remaining,
+	// they are new entries.
+	newEntries = append(newEntries, du.Writes...)
+	return newEntries
+}
+
+func (du *directoryUpdate) Empty() bool {
+	return du == nil || len(du.Writes) == 0 && len(du.Deletes) == 0
+}
+
+func (du *directoryUpdate) Put(ent TreeEntry) {
+	must.NotBeBlankf(ent.Name, "name must not be blank")
+
+	idx, ok := slices.BinarySearchFunc(du.Writes, ent.Name, entryByName)
+	if ok {
+		du.Writes[idx] = ent
+	} else {
+		du.Writes = slices.Insert(du.Writes, idx, ent)
+	}
+}
+
+func (du *directoryUpdate) Delete(name string) {
+	must.NotBeBlankf(name, "name must not be blank")
+
+	idx, ok := slices.BinarySearch(du.Deletes, name)
+	if !ok {
+		du.Deletes = slices.Insert(du.Deletes, idx, name)
+	}
+}
+
+func entryByName(ent TreeEntry, name string) int {
+	return strings.Compare(ent.Name, name)
+}
+
+func pathSplit(p string) (dir, name string) {
+	return path.Dir(p), path.Base(p)
 }

--- a/internal/maputil/keys.go
+++ b/internal/maputil/keys.go
@@ -1,0 +1,13 @@
+// Package maputil provides utilities for working with maps.
+// It should be considered an extension to the std maps package.
+package maputil
+
+// Keys returns a slice of all keys in the given map.
+// The order of the keys is unspecified.
+func Keys[K comparable, V any](m map[K]V) []K {
+	keys := make([]K, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/internal/spice/state/store_test.go
+++ b/internal/spice/state/store_test.go
@@ -20,13 +20,11 @@ func TestIntegrationStore(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	t.Run("init", func(t *testing.T) {
-		_, err := state.InitStore(ctx, state.InitStoreRequest{
-			Repository: repo,
-			Trunk:      "main",
-		})
-		require.NoError(t, err)
+	_, err = state.InitStore(ctx, state.InitStoreRequest{
+		Repository: repo,
+		Trunk:      "main",
 	})
+	require.NoError(t, err)
 
 	store, err := state.OpenStore(ctx, repo, logtest.New(t))
 	require.NoError(t, err)


### PR DESCRIPTION
This replaces the implementation of UpdateTree
to stop creating throwaway Git indexes.
Use of update-index was semi-convenient,
but it hurts to have to create temporary files
for literally every state update.

This makes state updates significantly cheaper,
with the number of operations bounded by the deepest path.