### PR TITLE
fix(state): make([]T, len) with append

### DIFF
--- a/.changes/unreleased/Fixed-20240608-172302.yaml
+++ b/.changes/unreleased/Fixed-20240608-172302.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fix bug in state management attempting to write files with empty names to state.
+time: 2024-06-08T17:23:02.05017-07:00

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,6 +32,9 @@ linters:
     # Require field tags for serialized structs.
     - musttag
 
+    # Catch make([]T, N) used with append
+    - makezero
+
 linters-settings:
   errcheck:
     exclude-functions:

--- a/internal/git/tree.go
+++ b/internal/git/tree.go
@@ -406,6 +406,7 @@ func (du *directoryUpdate) Empty() bool {
 
 func (du *directoryUpdate) Put(ent TreeEntry) {
 	must.NotBeBlankf(ent.Name, "name must not be blank")
+	must.NotBeEqualf(ent.Name, ".", "name must not be .")
 
 	idx, ok := slices.BinarySearchFunc(du.Writes, ent.Name, entryByName)
 	if ok {

--- a/internal/spice/state/backend.go
+++ b/internal/spice/state/backend.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/must"
 )
 
 const (
@@ -170,6 +171,8 @@ type updateRequest struct {
 func (g *gitStorageBackend) Update(ctx context.Context, req updateRequest) error {
 	setBlobs := make([]git.Hash, len(req.Sets))
 	for i, set := range req.Sets {
+		must.NotBeBlankf(set.Key, "key must not be blank")
+
 		var buf bytes.Buffer
 		enc := json.NewEncoder(&buf)
 		enc.SetIndent("", "  ")

--- a/internal/spice/state/branch.go
+++ b/internal/spice/state/branch.go
@@ -145,7 +145,7 @@ func (s *Store) UpdateBranch(ctx context.Context, req *UpdateRequest) error {
 		req.Message = fmt.Sprintf("update at %s", time.Now().Format(time.RFC3339))
 	}
 
-	sets := make([]setRequest, len(req.Upserts))
+	sets := make([]setRequest, 0, len(req.Upserts))
 	for i, req := range req.Upserts {
 		if req.Name == "" {
 			return fmt.Errorf("upsert [%d]: branch name is required", i)


### PR DESCRIPTION
Fixes a silly bug where state was using
`make([]T, len)` instead of `make([]T, 0, len)`
when appending to a slice.

This can cause state corruption.