### PR TITLE
komplete: Add tests

### DIFF
--- a/.changes/unreleased/Fixed-20240609-122710.yaml
+++ b/.changes/unreleased/Fixed-20240609-122710.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'shell completion: Command aliases can now be completed.'
+time: 2024-06-09T12:27:10.309545-07:00

--- a/README.md
+++ b/README.md
@@ -48,4 +48,5 @@ under a different license. See the file headers for details:
 
 ```
 internal/komplete/komplete.go
+internal/komplete/komplete_test.go
 ```

--- a/doc/license.md
+++ b/doc/license.md
@@ -26,3 +26,4 @@ As an exception to the above, the following files are distributed
 under a different license. See the file headers for details:
 
     internal/komplete/komplete.go
+    internal/komplete/komplete_test.go

--- a/internal/komplete/LICENSE
+++ b/internal/komplete/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2024, Abhinav Gupta (https://abhinavg.net/)
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/internal/komplete/README.md
+++ b/internal/komplete/README.md
@@ -1,0 +1,3 @@
+This directory provides komplete, a command-line completion engine for Kong.
+The source code in this directory is made available under the BSD3 license.
+See LICENSE for the full license text.

--- a/internal/komplete/komplete_test.go
+++ b/internal/komplete/komplete_test.go
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+package komplete
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/posener/complete"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/ioutil"
+)
+
+func TestCommandRun(t *testing.T) {
+	shells := []string{"bash", "zsh", "fish"}
+	for _, shell := range shells {
+		t.Run(shell, func(t *testing.T) {
+			var stdout bytes.Buffer
+
+			parser, err := kong.New(
+				&struct{}{},
+				kong.Name("test"),
+				kong.Writers(&stdout, ioutil.TestOutputWriter(t, "")),
+			)
+			require.NoError(t, err)
+
+			err = (&Command{Shell: shell}).Run(&kong.Context{Kong: parser})
+			require.NoError(t, err)
+			assert.NotEmpty(t, stdout.String())
+		})
+	}
+
+	t.Run("unknown", func(t *testing.T) {
+		var stdout bytes.Buffer
+
+		parser, err := kong.New(
+			&struct{}{},
+			kong.Name("test"),
+			kong.Writers(&stdout, ioutil.TestOutputWriter(t, "")),
+		)
+		require.NoError(t, err)
+
+		err = (&Command{Shell: "unknown"}).Run(&kong.Context{Kong: parser})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "unsupported shell")
+
+		assert.Empty(t, stdout.String())
+	})
+}
+
+func TestKongPredictor(t *testing.T) {
+	// Helper to construct a complete.Args from a list of arguments.
+	// The last argument is what's being typed right now.
+	compLine := func(args ...string) complete.Args {
+		if len(args) == 0 {
+			return complete.Args{}
+		}
+
+		completed := args[:len(args)-1]
+		last := args[len(args)-1]
+		return complete.Args{
+			Completed: completed,
+			Last:      last,
+		}
+	}
+
+	type completeCase struct {
+		give complete.Args
+		want []string
+	}
+
+	type namedPredictor func(completed []string, last string) []string
+
+	tests := []struct {
+		name string
+
+		// Grammar of the CLI parser.
+		grammar any
+
+		// Set of named predictors available to the grammar.
+		named map[string]namedPredictor
+
+		cases []completeCase
+	}{
+		{
+			name: "simple options",
+			grammar: &struct {
+				Output string `short:"o"`
+			}{},
+			cases: []completeCase{
+				{
+					want: []string{"--help", "--output"},
+				},
+				{
+					give: compLine("--o"),
+					want: []string{"--output"},
+				},
+				{
+					give: compLine("--h"),
+					want: []string{"--help"},
+				},
+				{
+					give: compLine("-o", "file", ""),
+					want: []string{"--help"},
+				},
+				{
+					give: compLine("-o", "-", ""),
+					want: []string{"--help"},
+				},
+				// No predictions expected for the following:
+				{give: compLine("--", "")},
+				{give: compLine("-o", "")},
+				{give: compLine("-o", "-")},
+				{give: compLine("--output", "")},
+				{give: compLine("--unkn")},
+				{give: compLine("--unknown", "")},
+			},
+		},
+
+		{
+			name: "subcommands",
+			grammar: &struct {
+				Commit struct {
+					Message string
+				} `cmd:""`
+				Worktree struct {
+					Add    struct{} `cmd:"add"`
+					Delete struct{} `cmd:"delete"`
+				} `cmd:""`
+
+				// Global options
+				Verbose bool `short:"v"`
+			}{},
+			cases: []completeCase{
+				{
+					give: compLine(""),
+					want: []string{
+						"commit",
+						"worktree",
+						"--help", "--verbose",
+					},
+				},
+				{
+					give: compLine("co"),
+					want: []string{"commit"},
+				},
+				{
+					give: compLine("worktree", ""),
+					want: []string{"add", "delete"},
+				},
+				{
+					give: compLine("worktree", "a"),
+					want: []string{"add"},
+				},
+				{
+					give: compLine("commit", ""),
+					want: []string{"--message"},
+				},
+				{
+					give: compLine("commit", "--message", ""),
+				},
+			},
+		},
+
+		{
+			// https://github.com/alecthomas/kong/blob/d315006dcaba7a02249e1ad151962365410b601e/kong_test.go#L50
+			name: "branching positional arguments",
+			// user create <id> <first> <last>
+			// user        <id> delete
+			// user        <id> rename <to>
+			grammar: &struct {
+				User struct {
+					Create struct {
+						ID    string `arg:""`
+						First string `arg:""`
+						Last  string `arg:""`
+					} `cmd:""`
+
+					// Branching argument.
+					ID struct {
+						ID   int `arg:""`
+						Flag int
+
+						Delete struct{} `cmd:""`
+						Rename struct {
+							To string
+						} `cmd:""`
+					} `arg:""`
+				} `cmd:""`
+			}{},
+			cases: []completeCase{
+				{
+					want: []string{"user", "--help"},
+				},
+				{
+					give: compLine("user", ""),
+					want: []string{"create"},
+				},
+				{
+					give: compLine("user", "42", ""),
+					want: []string{"delete", "rename", "--flag"},
+				},
+				{
+					give: compLine("user", "42", "d"),
+					want: []string{"delete"},
+				},
+				{
+					give: compLine("user", "42", "rename", ""),
+					want: []string{"--to"},
+				},
+			},
+		},
+
+		{
+			name: "command aliases",
+			grammar: &struct {
+				Commit struct {
+					Message string `short:"m"`
+				} `cmd:"" aliases:"ci"`
+			}{},
+			cases: []completeCase{
+				{
+					give: compLine(""),
+					want: []string{"commit", "--help"},
+				},
+				{
+					give: compLine("ci"),
+					want: []string{"ci"},
+				},
+				{
+					give: compLine("ci", ""),
+					want: []string{"--message"},
+				},
+			},
+		},
+
+		{
+			name: "flag/enum",
+			grammar: &struct {
+				LogLevel string `enum:"debug,info,warning,error" default:"info"`
+			}{},
+			cases: []completeCase{
+				{
+					want: []string{"--help", "--log-level"},
+				},
+				{
+					give: compLine("--l"),
+					want: []string{"--log-level"},
+				},
+				{
+					give: compLine("--log-level", ""),
+					want: []string{"debug", "info", "warning", "error"},
+				},
+				{
+					give: compLine("--log-level", "d"),
+					want: []string{"debug"},
+				},
+			},
+		},
+
+		{
+			name: "predictor",
+			grammar: &struct {
+				Host string `arg:"" predictor:"host"`
+			}{},
+			named: map[string]namedPredictor{
+				"host": func([]string, string) []string {
+					return []string{"localhost", "example.com"}
+				},
+			},
+			cases: []completeCase{
+				{
+					give: compLine(""),
+					want: []string{"localhost", "example.com", "--help"},
+				},
+				{
+					give: compLine("l"),
+					want: []string{"localhost"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser, err := kong.New(tt.grammar)
+			require.NoError(t, err)
+
+			parser.Exit = func(code int) {
+				t.Fatalf("exit(%d)", code)
+			}
+
+			named := make(map[string]complete.Predictor)
+			for name, predictor := range tt.named {
+				named[name] = complete.PredictFunc(func(args complete.Args) []string {
+					return predictor(args.Completed, args.Last)
+				})
+			}
+
+			pred := newKongPredictor(parser.Model, options{
+				named: named,
+			})
+			for idx, c := range tt.cases {
+				name := strings.Join(c.give.Completed, " ")
+				if c.give.Last != "" {
+					if name != "" {
+						name += " "
+					}
+					name += c.give.Last
+				}
+				if name == "" {
+					name = fmt.Sprintf("%d", idx)
+				}
+
+				t.Run(name, func(t *testing.T) {
+					got := pred.Predict(c.give)
+					if len(c.want) == 0 {
+						assert.Empty(t, got)
+					} else {
+						assert.Equal(t, c.want, got)
+					}
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add some unit tests for Komplete and the various cases it handles.
In doing this, a couple subtle bugs were found and fixed:

- Aliases weren't completed, so, say `gs branch rm|` wouldn't
  complete to itself (`gs branch rm |`) allowing the user to
  type the next thing.
- Parsing of branching positional arguments was just broken.
  While we don't use this right now, it's conceivable that we may.