### PR TITLE
branch create: Add --target flag

### DIFF
--- a/.changes/unreleased/Added-20240610-175842.yaml
+++ b/.changes/unreleased/Added-20240610-175842.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'branch create: Add -b/--base flag to specify a different base branch for the new branch.'
+time: 2024-06-10T17:58:42.214976-07:00

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -324,52 +324,63 @@ gs branch (b) create (c) [<name>] [flags]
 Create a new branch
 
 Creates a new branch containing the staged changes
-on top of the current branch.
+on top of the current branch, or --target if specified.
 If there are no staged changes, creates an empty commit.
 
-By default, the new branch is created on top of the current branch,
+By default, the new branch is created on top of the target,
 but it does not affect the rest of the stack.
-Use the --insert flag to restack all existing upstack branches
-on top of the new branch.
-For example,
+Use the --insert flag to move the upstack branches of the
+target onto the new branch.
+Alternatively, use the --below flag to place the new branch
+below the target branch, making the new branch the base of the
+rest of the stack.
 
-	# Given:
-	#
-	#  trunk
-	#   └─A
-	#     └─B
-	#       └─C
-	git checkout A
-	gs branch create --insert X
-	# Result:
-	#
-	#  trunk
-	#   └─A
-	#     └─X
-	#       └─B
-	#         └─C
+For example, given the following stack, with A checked out:
 
-Instead of --insert,
-you can use --below to place the new branch
-below the current branch.
-This is equivalent to checking out the base branch
-and creating a new branch with --insert there.
+	    ┌── C
+	  ┌─┴ B
+	┌─┴ A ◀
+	trunk
 
-	# Given:
-	#
-	#  trunk
-	#   └─A
-	#     └─B
-	#       └─C
-	git checkout A
-	gs branch create --below X
-	# Result:
-	#
-	#  trunk
-	#   └─X
-	#     └─A
-	#       └─B
-	#         └─C
+'gs branch create X' will create a new branch X on top of A
+and leave B and C unchanged:
+
+	# gs branch create X
+	  ┌── X
+	  │ ┌── C
+	  ├─┴ B
+	┌─┴ A
+	trunk
+
+'gs branch create --insert X' will create a new branch X on top
+of A, and move B and C on top of X:
+
+	# gs branch create --insert X
+	      ┌── C
+	    ┌─┴ B
+	  ┌─┴ X
+	┌─┴ A
+	trunk
+
+'gs branch create --below X' will create a new branch X below A,
+and move A, B, and C on top of X:
+
+	# gs branch create --below X
+	      ┌── C
+	    ┌─┴ B
+	  ┌─┴ A
+	┌─┴ X
+	trunk
+
+In all cases above, use of -t/--target flag will change the
+target (A) to the specified branch:
+
+	# gs branch create --target B X
+	      ┌── C
+	    ┌─┴ B
+	  ┌─┴ X
+	┌─┴ A
+	trunk
 
 **Arguments**
 
@@ -379,6 +390,7 @@ and creating a new branch with --insert there.
 
 * `--insert`: Restack the upstack of the current branch on top of the new branch
 * `--below`: Place the branch below the current branch. Implies --insert.
+* `-t`, `--target=STRING`: Branch to create the new branch above/below
 * `-m`, `--message=STRING`: Commit message
 
 ### gs branch delete

--- a/testdata/script/branch_create_target.txt
+++ b/testdata/script/branch_create_target.txt
@@ -1,0 +1,80 @@
+# branch create with --target allows changing the target branch.
+
+as 'Test <test@example.com>'
+at '2024-06-10T20:05:32Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# set up a simple stack: main -> feature1 -> feature2
+git add feature1.txt
+gs bc feature1 -m 'Add feature 1'
+git add feature2.txt
+gs bc feature2 -m 'Add feature 2'
+
+# add feature3 above feature1, no --insert/--below.
+git checkout --detach
+git add feature3.txt
+gs bc feature3 -m 'Add feature 3' --target feature1
+gs ls -a
+cmp stderr $WORK/golden/add-feature3.txt
+
+# add feature4 above feature1 with --insert.
+git add feature4.txt
+gs bc feature4 -m 'Add feature 4' --target feature1 --insert
+gs ls -a
+cmp stderr $WORK/golden/add-feature4.txt
+
+# add feature5 below feature1 with --below.
+git add feature5.txt
+gs bc feature5 -m 'Add feature 5' --target feature1 --below
+gs ls -a
+cmp stderr $WORK/golden/add-feature5.txt
+
+# verify final state
+git graph --branches
+cmp stdout $WORK/golden/graph.txt
+
+-- repo/feature1.txt --
+feature 1
+
+-- repo/feature2.txt --
+feature 2
+
+-- repo/feature3.txt --
+feature 3
+
+-- repo/feature4.txt --
+feature 4
+
+-- repo/feature5.txt --
+feature 5
+
+-- golden/add-feature3.txt --
+  ┌── feature2
+  ├── feature3 ◀
+┌─┴ feature1
+main
+-- golden/add-feature4.txt --
+    ┌── feature2
+    ├── feature3
+  ┌─┴ feature4 ◀
+┌─┴ feature1
+main
+-- golden/add-feature5.txt --
+      ┌── feature2
+      ├── feature3
+    ┌─┴ feature4
+  ┌─┴ feature1
+┌─┴ feature5 ◀
+main
+-- golden/graph.txt --
+* 2996f1e (feature2) Add feature 2
+| * da27711 (feature3) Add feature 3
+|/  
+* 4cf138f (feature4) Add feature 4
+* 218877e (feature1) Add feature 1
+* bdbee4f (HEAD -> feature5) Add feature 5
+* 65011c2 (main) Initial commit


### PR DESCRIPTION
Allow specifying the target for a new branch
created with `branch create` with the `--target` flag.
This is called --target because it's not always base.

This is useful especially if you're in, say detached head mode.

Resolves #181