### PR TITLE
fix(goreleaser): Use aarch64 for Linux

### DIFF
--- a/.changes/unreleased/Fixed-20240610-202756.yaml
+++ b/.changes/unreleased/Fixed-20240610-202756.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fix name for Linux AMD64 release tarball to match `uname -m` for easier fetching from scripts.
+time: 2024-06-10T20:27:56.061212-07:00

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,6 +21,7 @@ archives:
       {{- title .Os }}-
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
+      {{- else if (and (eq .Arch "arm64") (eq .Os "linux")) }}aarch64
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
 


### PR DESCRIPTION
To make the tarballs easily curl-able with `uname -s` and `uname -m`,
change linux-amd64 to linux-aarch64.