### PR TITLE
commit {create, amend}: Don't restack current branch

### DIFF
--- a/.changes/unreleased/Added-20240613-053911.yaml
+++ b/.changes/unreleased/Added-20240613-053911.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'upstack restack: Accept name of base branch as an argument. Defaults to current branch.'
+time: 2024-06-13T05:39:11.610373-07:00

--- a/.changes/unreleased/Added-20240613-053937.yaml
+++ b/.changes/unreleased/Added-20240613-053937.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'upstack restack: Add --no-base flag to skip restacking the starting base branch.'
+time: 2024-06-13T05:39:37.704553-07:00

--- a/.changes/unreleased/Fixed-20240613-053846.yaml
+++ b/.changes/unreleased/Fixed-20240613-053846.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'commit {create, amend}: Don''t restack the current branch on commit. Only the upstacks will be restacked.'
+time: 2024-06-13T05:38:46.052377-07:00

--- a/commit_amend.go
+++ b/commit_amend.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/charmbracelet/log"
@@ -45,6 +46,17 @@ func (cmd *commitAmendCmd) Run(ctx context.Context, log *log.Logger, opts *globa
 		return nil
 	}
 
-	// TODO: handle not tracked
-	return (&upstackRestackCmd{}).Run(ctx, log, opts)
+	currentBranch, err := repo.CurrentBranch(ctx)
+	if err != nil {
+		// No restack needed if we're in a detached head state.
+		if errors.Is(err, git.ErrDetachedHead) {
+			return nil
+		}
+		return fmt.Errorf("get current branch: %w", err)
+	}
+
+	return (&upstackRestackCmd{
+		Name:   currentBranch,
+		NoBase: true,
+	}).Run(ctx, log, opts)
 }

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -126,18 +126,33 @@ Restack the current stack
 ### gs upstack restack
 
 ```
-gs upstack (us) restack (r)
+gs upstack (us) restack (r) [<name>] [flags]
 ```
 
 Restack this branch those above it
 
-Restacks the current branch and all branches above it
-on top of their respective bases.
-If multiple branches use another branch as their base,
-they will all be restacked on top of the updated base.
+Restacks the given branch and all branches above it
+on top of the new heads of their base branches.
+If multiple branches use this branch as their base,
+they will all be restacked.
 
+If a branch name is not provided,
+the current branch will be used.
 Run this command from the trunk branch
 to restack all managed branches.
+
+By default, the provided branch is also restacked
+on top of its base branch.
+Use the --no-base flag to only restack branches above it,
+and leave the branch itself untouched.
+
+**Arguments**
+
+* `name`: Branch to restack the upstack of
+
+**Flags**
+
+* `--no-base`: Do not restack the base branch
 
 ### gs upstack onto
 

--- a/testdata/script/commit_restack_upstack_only.txt
+++ b/testdata/script/commit_restack_upstack_only.txt
@@ -1,0 +1,73 @@
+# https://github.com/abhinav/git-spice/issues/185
+#
+# commit create and amend should restack the upstack of the current branch
+# but not the current branch itself.
+
+as 'Test <test@example.com>'
+at '2024-06-13T05:17:32Z'
+
+# setup
+cd repo
+git init
+git add init.txt
+git commit -m 'Initial commit'
+gs repo init
+
+git add feature1.txt
+gs bc -m feature1
+
+git add feature2.txt
+gs bc -m feature2
+
+# move trunk so feature1 needs to be restacked
+gs trunk
+cp $WORK/extra/README.md README.md
+git add README.md
+git commit -m 'New initial state'
+
+gs up
+stderr 'feature1: needs to be restacked'
+
+# commit create
+cp $WORK/extra/feature1.2.txt feature1.2.txt
+git add feature1.2.txt
+gs cc -m 'Feature 1 part 2'
+
+# feature1 should not have been restacked
+! exists README.md
+# feature2 should have been restacked
+gs up
+exists feature1.2.txt
+
+gs down
+
+# commit amend
+gs ca -m 'add part 2 of feature 1'
+# feature1 should not have been restacked
+! exists README.md
+
+git graph --branches
+cmp stdout $WORK/golden/graph.txt
+
+-- repo/init.txt --
+initial state
+
+-- repo/feature1.txt --
+feature1
+
+-- repo/feature2.txt --
+feature2
+
+-- extra/README.md --
+this repository does things
+
+-- extra/feature1.2.txt --
+part 2 of feature 1
+
+-- golden/graph.txt --
+* 04a299e (feature2) feature2
+* 24241e1 (HEAD -> feature1) add part 2 of feature 1
+* 8910965 feature1
+| * 8392e5c (main) New initial state
+|/  
+* cd96984 Initial commit


### PR DESCRIPTION
This was a surprising behavior and an oversight.
Current branch should not be restacked on commit,
only its upstack should be restacked.

Resolves #185
