### PR TITLE
Post terminal prompts to stderr instead of stdout

### DIFF
--- a/.changes/unreleased/Changed-20240613-073352.yaml
+++ b/.changes/unreleased/Changed-20240613-073352.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Prompts are now posted to stderr instead of stdout.
+time: 2024-06-13T07:33:52.091381-07:00

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -122,7 +123,7 @@ func NewForm(fields ...Field) *Form {
 // Run runs the form and blocks until it's accepted or canceled.
 // It returns a combination of all errors returned by the fields.
 func (f *Form) Run() error {
-	if _, err := tea.NewProgram(f).Run(); err != nil {
+	if _, err := tea.NewProgram(f, tea.WithOutput(os.Stderr)).Run(); err != nil {
 		return err
 	}
 

--- a/testdata/script/branch_checkout_prompt.txt
+++ b/testdata/script/branch_checkout_prompt.txt
@@ -111,4 +111,5 @@ Select a branch to checkout:
   bar
 ▶ baz
 
+WRN baz: branch not tracked
 Do you want to track this branch now?: [Y/n]

--- a/testdata/script/branch_checkout_track_prompt.txt
+++ b/testdata/script/branch_checkout_track_prompt.txt
@@ -17,7 +17,6 @@ git commit -m 'Add foo.txt'
 git checkout main
 
 with-term $WORK/input.txt -- gs branch checkout feature
-stderr 'feature: branch not tracked'
 cmp stdout $WORK/golden/prompt.txt
 
 gs ls -a
@@ -33,6 +32,7 @@ feed y
 await
 
 -- golden/prompt.txt --
+WRN feature: branch not tracked
 Do you want to track this branch now?: [Y/n]
 -- golden/ls.txt --
 ┌── feature ◀

--- a/testdata/script/branch_submit_long_body.txt
+++ b/testdata/script/branch_submit_long_body.txt
@@ -26,7 +26,6 @@ cmp stdout $WORK/input/commit-msg
 # submit the branch
 with-term $WORK/input/prompt.txt -- gs branch submit
 cmp stdout $WORK/golden/prompt.txt
-stderr 'Created #1'
 
 gh-dump-pull
 stdout 'End of message.'

--- a/testdata/script/branch_submit_pr_template_prompt.txt
+++ b/testdata/script/branch_submit_pr_template_prompt.txt
@@ -23,9 +23,8 @@ gs bc feature
 
 mkdir $WORK/output
 env MOCKEDIT_GIVE= MOCKEDIT_RECORD=$WORK/output/pr-body.txt
-with-term $WORK/input/prompt.txt -- gs branch submit
-stderr 'Created #1'
-cmp stdout $WORK/golden/prompt.txt
+with-term -final exit $WORK/input/prompt.txt -- gs branch submit
+cmpenv stdout $WORK/golden/prompt.txt
 
 cmp $WORK/output/pr-body.txt $WORK/golden/pr-body.txt
 
@@ -76,6 +75,11 @@ Title: Add feature
 Body: Press [e] to open mockedit or [enter/tab] to skip
 Draft: [y/N]
 Mark the pull request as a draft?
+### exit ###
+Title: Add feature
+Body: Press [e] to open mockedit or [enter/tab] to skip
+Draft: [y/N]
+INF Created #1: $SHAMHUB_URL/alice/example/change/1
 -- golden/pr-body.txt --
 This adds a feature.
 The feature does things.

--- a/testdata/script/branch_submit_remote_prompt.txt
+++ b/testdata/script/branch_submit_remote_prompt.txt
@@ -35,6 +35,7 @@ feed \r
 
 -- golden/prompt.txt --
 ### dialog ###
+WRN No remote was specified at init time
 Please select a remote:
 
 ▶ origin

--- a/testdata/script/repo_init_prompt_multiple_local.txt
+++ b/testdata/script/repo_init_prompt_multiple_local.txt
@@ -21,6 +21,7 @@ feed \r
 
 -- golden/dialog.txt --
 ### dialog ###
+WRN No remotes found. Commands that require a remote will fail.
 Please select the trunk branch:
 
   bar

--- a/testdata/script/repo_init_prompt_upstream.txt
+++ b/testdata/script/repo_init_prompt_upstream.txt
@@ -26,6 +26,7 @@ feed \r
 
 -- golden/dialog.txt --
 ### dialog ###
+INF Using remote: origin
 Please select the trunk branch:
 
   bar

--- a/testdata/script/repo_sync_external_pr_head_mismatch.txt
+++ b/testdata/script/repo_sync_external_pr_head_mismatch.txt
@@ -32,9 +32,8 @@ gh-merge alice/example 1
 
 # Re-track the branch and sync in interactive mode.
 gs branch track --base=main feature
-with-term $WORK/input/prompt.txt -- gs rs
+with-term -final exit $WORK/input/prompt.txt -- gs rs
 cmp stdout $WORK/golden/prompt.txt
-stderr 'feature: deleted \(was 4513f9f\)'
 
 git graph --branches
 cmp stdout $WORK/golden/merged-log.txt
@@ -52,8 +51,13 @@ feed y
 await
 
 -- golden/prompt.txt --
+INF main: pulled 2 new commit(s)
 Delete feature?: [y/N]
-#1 was merged but local SHA (4513f9f) does not match remote SHA (a1b54
+#1 was merged but local SHA (4513f9f) does not match remote SHA (a1b54a6)
+### exit ###
+INF main: pulled 2 new commit(s)
+Delete feature?: [Y/n]
+INF feature: deleted (was 4513f9f)
 -- golden/merged-log.txt --
 *   f512e87 (HEAD -> main, origin/main) Merge change #1
 |\  

--- a/testdata/script/top_multiple_prompt.txt
+++ b/testdata/script/top_multiple_prompt.txt
@@ -87,7 +87,7 @@ Pick a branch:
   f1-s1
   f1-s2-s
 
-There are multiple top-level branches reachable from the current branc
+There are multiple top-level branches reachable from the current branch.
 -- input/f1-prompt.txt --
 await Pick a branch
 snapshot
@@ -98,4 +98,4 @@ Pick a branch:
 ▶ f1-s1
   f1-s2-s
 
-There are multiple top-level branches reachable from the current branc
+There are multiple top-level branches reachable from the current branch.


### PR DESCRIPTION
This is necessary for `gs up -n` (#186) to be able to prompt
while still being piped to another command, e.g.

    git checkout -p $(gs up -n) -- some file