### PR TITLE
{up, down, top, bottom}: Add -n/--dry-run flag

### DIFF
--- a/.changes/unreleased/Added-20240613-210223.yaml
+++ b/.changes/unreleased/Added-20240613-210223.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: '{up, down, top, bottom}: Add -n/--dry-run flag. This will print the target branch name without checking it out. Output may be piped to other commands.'
+time: 2024-06-13T21:02:23.432088-07:00

--- a/bottom.go
+++ b/bottom.go
@@ -11,7 +11,9 @@ import (
 	"go.abhg.dev/gs/internal/text"
 )
 
-type bottomCmd struct{}
+type bottomCmd struct {
+	DryRun bool `short:"n" help:"Print the target branch without checking it out."`
+}
 
 func (*bottomCmd) Help() string {
 	return text.Dedent(`
@@ -20,7 +22,7 @@ func (*bottomCmd) Help() string {
 	`)
 }
 
-func (*bottomCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
+func (cmd *bottomCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
 	repo, err := git.Open(ctx, ".", git.OpenOptions{
 		Log: log,
 	})
@@ -48,6 +50,11 @@ func (*bottomCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions)
 	bottom, err := svc.FindBottom(ctx, current)
 	if err != nil {
 		return fmt.Errorf("find bottom: %w", err)
+	}
+
+	if cmd.DryRun {
+		fmt.Println(bottom)
+		return nil
 	}
 
 	return (&branchCheckoutCmd{Name: bottom}).Run(ctx, log, opts)

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -620,6 +620,10 @@ you will be prompted to pick one.
 
 * `n`: Number of branches to move up.
 
+**Flags**
+
+* `-n`, `--dry-run`: Print the target branch without checking it out.
+
 ### gs down
 
 ```
@@ -637,6 +641,10 @@ this command will move to the trunk branch.
 
 * `n`: Number of branches to move up.
 
+**Flags**
+
+* `-n`, `--dry-run`: Print the target branch without checking it out.
+
 ### gs top
 
 ```
@@ -649,6 +657,10 @@ Jumps to the top-most branch in the current branch's stack.
 If there are multiple top-most branches,
 you will be prompted to pick one.
 
+**Flags**
+
+* `-n`, `--dry-run`: Print the target branch without checking it out.
+
 ### gs bottom
 
 ```
@@ -659,6 +671,10 @@ Move to the bottom of the stack
 
 Jumps to the bottom-most branch below the current branch.
 This is the branch just above the trunk.
+
+**Flags**
+
+* `-n`, `--dry-run`: Print the target branch without checking it out.
 
 ### gs trunk
 

--- a/down.go
+++ b/down.go
@@ -12,6 +12,8 @@ import (
 
 type downCmd struct {
 	N int `arg:"" optional:"" help:"Number of branches to move up." default:"1"`
+
+	DryRun bool `short:"n" help:"Print the target branch without checking it out."`
 }
 
 func (*downCmd) Help() string {
@@ -73,6 +75,11 @@ outer:
 		}
 
 		current = below
+	}
+
+	if cmd.DryRun {
+		fmt.Println(below)
+		return nil
 	}
 
 	return (&branchCheckoutCmd{Name: below}).Run(ctx, log, opts)

--- a/testdata/script/up_down_top_bottom_prompt.txt
+++ b/testdata/script/up_down_top_bottom_prompt.txt
@@ -1,0 +1,124 @@
+# Moving in a linear stack with gs up/bd/bt/bb.
+
+as 'Test <test@example.com>'
+at '2024-03-30T14:59:32Z'
+
+# main with initial commit
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# set up a stack:
+# feature1 -> {feature2 -> feature3, feature4 -> feature5}
+
+gs bc -m feature1
+gs bc -m feature2
+gs bc -m feature3
+gs bco feature1
+gs bc -m feature4
+gs bc -m feature5
+gs trunk
+
+# sanity check
+gs ls -a
+cmp stderr $WORK/golden/ls.txt
+
+! gs down -n
+
+# up no prompt
+gs up -n
+stdout feature1
+gs up
+
+# up prompt
+with-term -final exit $WORK/input/up-prompt.txt -- gs up -n
+cmp stdout $WORK/golden/up-prompt.txt
+
+# top prompt
+with-term -final exit $WORK/input/top-prompt.txt -- gs top -n
+cmp stdout $WORK/golden/top-prompt.txt
+
+# top no prompt
+gs bco feature2
+gs top -n
+stdout feature3
+
+# bottom
+gs bottom -n
+stdout feature1
+
+# down
+gs up
+gs down -n
+stdout feature2
+
+# down [N]
+gs bco feature5
+gs down -n 2
+stdout feature1
+
+# up [N]
+gs trunk
+with-term -final exit $WORK/input/up-2-prompt.txt -- gs up -n 2
+cmp stdout $WORK/golden/up-2-prompt.txt
+
+-- golden/ls.txt --
+    ┌── feature3
+  ┌─┴ feature2
+  │ ┌── feature5
+  ├─┴ feature4
+┌─┴ feature1
+main ◀
+-- input/up-prompt.txt --
+await feature
+snapshot
+feed feature2\r
+-- golden/up-prompt.txt --
+Pick a branch:
+
+▶ feature2
+  feature4
+
+There are multiple branches above the current branch.
+### exit ###
+Pick a branch:
+
+▶ feature2
+
+feature2
+-- input/top-prompt.txt --
+await feature
+snapshot
+feed feature5\r
+-- golden/top-prompt.txt --
+Pick a branch:
+
+▶ feature3
+  feature5
+
+There are multiple top-level branches reachable from the current branch.
+### exit ###
+Pick a branch:
+
+▶ feature5
+
+feature5
+-- input/up-2-prompt.txt --
+await feature
+snapshot
+feed feature4\r
+-- golden/up-2-prompt.txt --
+Pick a branch:
+
+▶ feature2
+  feature4
+
+There are multiple branches above the current branch.
+### exit ###
+Pick a branch:
+
+▶ feature4
+
+feature4

--- a/top.go
+++ b/top.go
@@ -12,7 +12,9 @@ import (
 	"go.abhg.dev/gs/internal/ui"
 )
 
-type topCmd struct{}
+type topCmd struct {
+	DryRun bool `short:"n" help:"Print the target branch without checking it out."`
+}
 
 func (*topCmd) Help() string {
 	return text.Dedent(`
@@ -22,7 +24,7 @@ func (*topCmd) Help() string {
 	`)
 }
 
-func (*topCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
+func (cmd *topCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
 	repo, err := git.Open(ctx, ".", git.OpenOptions{
 		Log: log,
 	})
@@ -67,6 +69,11 @@ func (*topCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) er
 		if err := ui.Run(prompt); err != nil {
 			return fmt.Errorf("a branch is required: %w", err)
 		}
+	}
+
+	if cmd.DryRun {
+		fmt.Println(branch)
+		return nil
 	}
 
 	if branch == current {

--- a/up.go
+++ b/up.go
@@ -13,6 +13,8 @@ import (
 
 type upCmd struct {
 	N int `arg:"" optional:"" help:"Number of branches to move up." default:"1"`
+
+	DryRun bool `short:"n" help:"Print the target branch without checking it out."`
 }
 
 func (*upCmd) Help() string {
@@ -82,6 +84,11 @@ outer:
 		}
 
 		current = branch
+	}
+
+	if cmd.DryRun {
+		fmt.Println(branch)
+		return nil
 	}
 
 	return (&branchCheckoutCmd{Name: branch}).Run(ctx, log, opts)


### PR DESCRIPTION
Adds --dry-run flags to all relative navigation commands
to print the target branch without checking it out.

This is useful for scripting.

Resolves #186