### PR TITLE
branch delete: Prompt for unmerged branches

### DIFF
--- a/.changes/unreleased/Changed-20240613-214448.yaml
+++ b/.changes/unreleased/Changed-20240613-214448.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'branch delete: Prompt to force delete unmerged branches instead of just letting Git fail.'
+time: 2024-06-13T21:44:48.472351-07:00

--- a/internal/ui/confirm.go
+++ b/internal/ui/confirm.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"fmt"
+
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -93,6 +95,18 @@ func (c *Confirm) Title() string {
 // WithDescription sets the desc for the confirm field.
 func (c *Confirm) WithDescription(desc string) *Confirm {
 	c.desc = desc
+	return c
+}
+
+// WithTitlef is a variant of WithTitle that accepts a format string.
+func (c *Confirm) WithTitlef(format string, args ...interface{}) *Confirm {
+	c.title = fmt.Sprintf(format, args...)
+	return c
+}
+
+// WithDescriptionf is a variant of WithDescription that accepts a format string.
+func (c *Confirm) WithDescriptionf(format string, args ...interface{}) *Confirm {
+	c.desc = fmt.Sprintf(format, args...)
 	return c
 }
 

--- a/testdata/script/branch_delete_unmerged.txt
+++ b/testdata/script/branch_delete_unmerged.txt
@@ -23,9 +23,25 @@ stderr 'try re-running with --force'
 git rev-parse --verify foo
 stdout 'd844dc8b311d27c74fee35f8501171610124ee7a'
 
-gs branch delete --force foo
-stderr 'foo: deleted \(was d844dc8'
+# delete with a prompt
+with-term -final exit $WORK/input/prompt.txt -- gs branch delete foo
+cmp stdout $WORK/golden/prompt.txt
+
+# doesn't exist anymore
 ! git rev-parse --verify foo
 
 -- repo/foo.txt --
 whatever
+-- input/prompt.txt --
+await Delete foo anyway?
+snapshot prompt
+feed Y
+-- golden/prompt.txt --
+### prompt ###
+WRN foo (d844dc8) is not reachable from HEAD
+Delete foo anyway?: [y/N]
+foo has not been merged into HEAD. This may result in data loss.
+### exit ###
+WRN foo (d844dc8) is not reachable from HEAD
+Delete foo anyway?: [Y/n]
+INF foo: deleted (was d844dc8)


### PR DESCRIPTION
If a branch being deleted is unmerged, Git will refuse to delete it.
Detect it pre-emptively, and if we have the ability to prompt,
allow the user to upgrade the branch deletion to a forceful deletion.

Resolves #14