### PR TITLE
prompt: Color based on stderr, not stdout

### DIFF
--- a/internal/ui/confirm.go
+++ b/internal/ui/confirm.go
@@ -38,7 +38,7 @@ type ConfirmStyle struct {
 
 // DefaultConfirmStyle is the default style for a [Confirm] field.
 var DefaultConfirmStyle = ConfirmStyle{
-	Key: lipgloss.NewStyle().Foreground(Magenta),
+	Key: NewStyle().Foreground(Magenta),
 }
 
 // Confirm is a boolean confirmation field that takes a yes or no answer.

--- a/internal/ui/fliptree/tree.go
+++ b/internal/ui/fliptree/tree.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 // Graph defines a directed graph.
@@ -56,7 +57,7 @@ type Style struct {
 // DefaultStyle returns the default style for rendering trees.
 func DefaultStyle() *Style {
 	return &Style{
-		Joint: lipgloss.NewStyle().Faint(true),
+		Joint: ui.NewStyle().Faint(true),
 	}
 }
 

--- a/internal/ui/fliptree/tree_test.go
+++ b/internal/ui/fliptree/tree_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"unicode"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/ui"
 	"gopkg.in/yaml.v3"
 	"pgregory.net/rapid"
 )
@@ -20,7 +20,7 @@ var _update = flag.Bool("update", false, "update fixtures")
 
 func plainStyle() *Style {
 	return &Style{
-		Joint: lipgloss.NewStyle(),
+		Joint: ui.NewStyle(),
 	}
 }
 

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -40,12 +40,12 @@ type FormStyle struct {
 
 // DefaultFormStyle is the default style for a [Form].
 var DefaultFormStyle = FormStyle{
-	Error:         lipgloss.NewStyle().Foreground(Red),
+	Error:         NewStyle().Foreground(Red),
 	Title:         _titleStyle,
 	Description:   _descriptionStyle,
 	AcceptedTitle: _acceptedTitleStyle,
 
-	AcceptedField: lipgloss.NewStyle().Faint(true),
+	AcceptedField: NewStyle().Faint(true),
 }
 
 type acceptFieldMsg struct{}
@@ -183,6 +183,10 @@ func (f *Form) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			f.err = errors.New("user cancelled")
 			return f, tea.Quit
 		}
+	}
+
+	if f.focused >= len(f.fields) {
+		return f, tea.Quit
 	}
 
 	return f, f.fields[f.focused].Update(msg)

--- a/internal/ui/open_editor.go
+++ b/internal/ui/open_editor.go
@@ -39,8 +39,8 @@ type OpenEditorStyle struct {
 
 // DefaultOpenEditorStyle is the default style for an [OpenEditor] field.
 var DefaultOpenEditorStyle = OpenEditorStyle{
-	Key:    lipgloss.NewStyle().Foreground(Magenta),
-	Editor: lipgloss.NewStyle().Foreground(Green),
+	Key:    NewStyle().Foreground(Magenta),
+	Editor: NewStyle().Foreground(Green),
 }
 
 // Editor configures the editor to open.

--- a/internal/ui/renderer.go
+++ b/internal/ui/renderer.go
@@ -1,0 +1,22 @@
+package ui
+
+import (
+	"os"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Renderer is a lipgloss renderer that writes to stderr.
+//
+// We print prompts to stderr, so that's what we should use
+// to check for colorization of lipgloss.
+var Renderer = lipgloss.NewRenderer(os.Stderr)
+
+func init() {
+	lipgloss.SetDefaultRenderer(Renderer)
+}
+
+// NewStyle returns a new lipgloss style based on our default renderer.
+func NewStyle() lipgloss.Style {
+	return Renderer.NewStyle()
+}

--- a/internal/ui/select.go
+++ b/internal/ui/select.go
@@ -50,9 +50,9 @@ type SelectStyle struct {
 
 // DefaultSelectStyle is the default style for a [Select].
 var DefaultSelectStyle = SelectStyle{
-	Selected:     lipgloss.NewStyle().Foreground(Yellow),
-	Highlight:    lipgloss.NewStyle().Foreground(Cyan),
-	ScrollMarker: lipgloss.NewStyle().Foreground(Gray),
+	Selected:     NewStyle().Foreground(Yellow),
+	Highlight:    NewStyle().Foreground(Cyan),
+	ScrollMarker: NewStyle().Foreground(Gray),
 }
 
 // Select is a prompt that allows selecting from a list of options
@@ -311,7 +311,7 @@ func (s *Select) Render(out Writer) {
 
 	for matchIdx, optionIdx := range matched {
 		matchIdx += offset
-		style := lipgloss.NewStyle()
+		style := NewStyle()
 		if matchIdx == s.selected {
 			style = s.Style.Selected
 			out.WriteString("▶ ")

--- a/internal/ui/style.go
+++ b/internal/ui/style.go
@@ -12,7 +12,7 @@ var (
 	Magenta = lipgloss.AdaptiveColor{Light: "5", Dark: "13"}
 	Gray    = lipgloss.AdaptiveColor{Light: "8", Dark: "8"}
 
-	_titleStyle         = lipgloss.NewStyle().Foreground(Green).Bold(true)
-	_descriptionStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("8")).Faint(true)
-	_acceptedTitleStyle = lipgloss.NewStyle().Foreground(Plain)
+	_titleStyle         = NewStyle().Foreground(Green).Bold(true)
+	_descriptionStyle   = NewStyle().Foreground(lipgloss.Color("8")).Faint(true)
+	_acceptedTitleStyle = NewStyle().Foreground(Plain)
 )

--- a/log_short.go
+++ b/log_short.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/spice"
@@ -17,15 +16,15 @@ import (
 )
 
 var (
-	_currentBranchStyle = lipgloss.NewStyle().
+	_currentBranchStyle = ui.NewStyle().
 				Foreground(ui.Cyan).
 				Bold(true)
 
-	_needsRestackStyle = lipgloss.NewStyle().
+	_needsRestackStyle = ui.NewStyle().
 				Foreground(ui.Gray).
 				SetString(" (needs restack)")
 
-	_markerStyle = lipgloss.NewStyle().
+	_markerStyle = ui.NewStyle().
 			Foreground(ui.Yellow).
 			Bold(true).
 			SetString("◀")

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/forge/github"
 	"go.abhg.dev/gs/internal/komplete"
+	"go.abhg.dev/gs/internal/ui"
 	"golang.org/x/oauth2"
 )
 
@@ -31,11 +32,11 @@ func main() {
 	})
 
 	styles := log.DefaultStyles()
-	styles.Levels[log.DebugLevel] = lipgloss.NewStyle().SetString("DBG").Bold(true)
-	styles.Levels[log.InfoLevel] = lipgloss.NewStyle().SetString("INF").Foreground(lipgloss.Color("10")).Bold(true) // green
-	styles.Levels[log.WarnLevel] = lipgloss.NewStyle().SetString("WRN").Foreground(lipgloss.Color("11")).Bold(true) // yellow
-	styles.Levels[log.ErrorLevel] = lipgloss.NewStyle().SetString("ERR").Foreground(lipgloss.Color("9")).Bold(true) // red
-	styles.Levels[log.FatalLevel] = lipgloss.NewStyle().SetString("FTL").Foreground(lipgloss.Color("9")).Bold(true) // red
+	styles.Levels[log.DebugLevel] = ui.NewStyle().SetString("DBG").Bold(true)
+	styles.Levels[log.InfoLevel] = ui.NewStyle().SetString("INF").Foreground(lipgloss.Color("10")).Bold(true) // green
+	styles.Levels[log.WarnLevel] = ui.NewStyle().SetString("WRN").Foreground(lipgloss.Color("11")).Bold(true) // yellow
+	styles.Levels[log.ErrorLevel] = ui.NewStyle().SetString("ERR").Foreground(lipgloss.Color("9")).Bold(true) // red
+	styles.Levels[log.FatalLevel] = ui.NewStyle().SetString("FTL").Foreground(lipgloss.Color("9")).Bold(true) // red
 	logger.SetStyles(styles)
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
With #189, terminal prompts are posted to stderr, not stdout.
lipgloss uses a stdout-based renderer by default,
so it'll stop coloring if stdout is redirected (e.g. for #186)

    echo "branch: $(gs up -n)"

This fixes that by creating a stderr based renderer,
and using that for all lipgloss styles.

[skip changelog] #189 isn't released yet.