### PR TITLE
komplete: Drop external dependency

### DIFF
--- a/.changes/unreleased/Fixed-20240613-215326.yaml
+++ b/.changes/unreleased/Fixed-20240613-215326.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'shell completion: Better handling of quoted strings while predicting.'
+time: 2024-06-13T21:53:26.445604-07:00

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,13 @@ go 1.22.1
 
 require (
 	github.com/alecthomas/kong v0.9.0
+	github.com/buildkite/shellwords v0.0.0-20180315110454-59467a9b8e10
 	github.com/charmbracelet/bubbles v0.18.0
 	github.com/charmbracelet/bubbletea v0.26.4
 	github.com/charmbracelet/lipgloss v0.11.0
 	github.com/charmbracelet/log v0.4.0
 	github.com/creack/pty/v2 v2.0.1
 	github.com/mattn/go-isatty v0.0.20
-	github.com/posener/complete v1.2.3
 	github.com/rogpeppe/go-internal v1.12.0
 	github.com/shurcooL/githubv4 v0.0.0-20240429030203-be2daab69064
 	github.com/stretchr/testify v1.9.0
@@ -33,8 +33,6 @@ require (
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
-	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/buildkite/shellwords v0.0.0-20180315110454-59467a9b8e10 h1:XwHQ5xDtYPdtBbVPyRO6UZoWZe8/mbKUb076f8x7RvI=
+github.com/buildkite/shellwords v0.0.0-20180315110454-59467a9b8e10/go.mod h1:gv0DYOzHEsKgo31lTCDGauIg4DTTGn41Bzp+t3wSOlk=
 github.com/charmbracelet/bubbles v0.18.0 h1:PYv1A036luoBGroX6VWjQIE9Syf2Wby2oOl/39KLfy0=
 github.com/charmbracelet/bubbles v0.18.0/go.mod h1:08qhZhtIwzgrtBjAcJnij1t1H0ZRjwHyGsy6AL11PSw=
 github.com/charmbracelet/bubbletea v0.26.4 h1:2gDkkzLZaTjMl/dQBpNVtnvcCxsh/FCkimep7FC9c40=
@@ -26,7 +28,6 @@ github.com/charmbracelet/x/windows v0.1.2 h1:Iumiwq2G+BRmgoayww/qfcvof7W/3uLoelh
 github.com/charmbracelet/x/windows v0.1.2/go.mod h1:GLEO/l+lizvFDBPLIOk+49gdX49L9YWMB5t+DZd0jkQ=
 github.com/creack/pty/v2 v2.0.1 h1:RDY1VY5b+7m2mfPsugucOYPIxMp+xal5ZheSyVzUA+k=
 github.com/creack/pty/v2 v2.0.1/go.mod h1:2dSssKp3b86qYEMwA/FPwc3ff+kYpDdQI8osU8J7gxQ=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
@@ -35,12 +36,6 @@ github.com/go-logfmt/logfmt v0.6.0 h1:wGYYu3uicYdqXVgoYbvnkrPVXkuLM1p1ifugDMEdRi
 github.com/go-logfmt/logfmt v0.6.0/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
-github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
-github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
-github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
@@ -59,8 +54,6 @@ github.com/muesli/termenv v0.15.2 h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo
 github.com/muesli/termenv v0.15.2/go.mod h1:Epx+iuz8sNs7mNKhxzH4fWXGNpZwUaJKRS1noLXviQ8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
-github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
@@ -74,8 +67,6 @@ github.com/shurcooL/githubv4 v0.0.0-20240429030203-be2daab69064 h1:RCQBSFx5JrsbH
 github.com/shurcooL/githubv4 v0.0.0-20240429030203-be2daab69064/go.mod h1:zqMwyHmnN/eDOZOdiTohqIUKUrTFX62PNlu7IJdu0q8=
 github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466 h1:17JxqqJY66GmZVHkmAsGEkcIu0oCe3AM420QDgGwZx0=
 github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466/go.mod h1:9dIRpgIY7hVhoqfe0/FcYp0bpInZaT7dc3BYOprrIUE=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/vito/midterm v0.1.5-0.20240307214207-d0271a7ca452 h1:I5FdiUvkD++87hOiZYuDu0BqsaJXAnpOCed3kqkjCEE=
@@ -104,7 +95,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/dnaeon/go-vcr.v3 v3.2.0 h1:Rltp0Vf+Aq0u4rQXgmXgtgoRDStTnFN83cWgSGSoRzM=
 gopkg.in/dnaeon/go-vcr.v3 v3.2.0/go.mod h1:2IMOnnlx9I6u9x+YBsM3tAMx6AlOxnJ0pWxQAzZ79Ag=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 pgregory.net/rapid v1.1.0 h1:CMa0sjHSru3puNx+J0MIAuiiEV4N0qj8/cMWGBBCsjw=

--- a/internal/komplete/komplete_test.go
+++ b/internal/komplete/komplete_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/alecthomas/kong"
-	"github.com/posener/complete"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.abhg.dev/gs/internal/ioutil"
@@ -55,21 +54,21 @@ func TestCommandRun(t *testing.T) {
 func TestKongPredictor(t *testing.T) {
 	// Helper to construct a complete.Args from a list of arguments.
 	// The last argument is what's being typed right now.
-	compLine := func(args ...string) complete.Args {
+	compLine := func(args ...string) Args {
 		if len(args) == 0 {
-			return complete.Args{}
+			return Args{}
 		}
 
 		completed := args[:len(args)-1]
 		last := args[len(args)-1]
-		return complete.Args{
+		return Args{
 			Completed: completed,
 			Last:      last,
 		}
 	}
 
 	type completeCase struct {
-		give complete.Args
+		give Args
 		want []string
 	}
 
@@ -294,9 +293,9 @@ func TestKongPredictor(t *testing.T) {
 				t.Fatalf("exit(%d)", code)
 			}
 
-			named := make(map[string]complete.Predictor)
+			named := make(map[string]Predictor)
 			for name, predictor := range tt.named {
-				named[name] = complete.PredictFunc(func(args complete.Args) []string {
+				named[name] = PredictFunc(func(args Args) []string {
 					return predictor(args.Completed, args.Last)
 				})
 			}

--- a/main.go
+++ b/main.go
@@ -14,7 +14,6 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/log"
 	"github.com/mattn/go-isatty"
-	"github.com/posener/complete"
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/forge/github"
 	"go.abhg.dev/gs/internal/komplete"
@@ -151,10 +150,10 @@ func main() {
 			}
 			return args
 		}),
-		komplete.WithPredictor("branches", complete.PredictFunc(predictBranches)),
-		komplete.WithPredictor("trackedBranches", complete.PredictFunc(predictTrackedBranches)),
-		komplete.WithPredictor("remotes", complete.PredictFunc(predictRemotes)),
-		komplete.WithPredictor("dirs", complete.PredictDirs("")),
+		komplete.WithPredictor("branches", komplete.PredictFunc(predictBranches)),
+		komplete.WithPredictor("trackedBranches", komplete.PredictFunc(predictTrackedBranches)),
+		komplete.WithPredictor("remotes", komplete.PredictFunc(predictRemotes)),
+		komplete.WithPredictor("dirs", komplete.PredictFunc(predictDirs)),
 	)
 
 	kctx, err := parser.Parse(args)

--- a/shell_completion.go
+++ b/shell_completion.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
-	"github.com/posener/complete"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/komplete"
 	"go.abhg.dev/gs/internal/spice/state"
@@ -35,7 +37,7 @@ func (c *shellCompletionCmd) Help() string {
 	`)
 }
 
-func predictBranches(args complete.Args) (predictions []string) {
+func predictBranches(args komplete.Args) (predictions []string) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
@@ -56,7 +58,7 @@ func predictBranches(args complete.Args) (predictions []string) {
 	return predictions
 }
 
-func predictTrackedBranches(args complete.Args) (predictions []string) {
+func predictTrackedBranches(args komplete.Args) (predictions []string) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
@@ -78,7 +80,7 @@ func predictTrackedBranches(args complete.Args) (predictions []string) {
 	return branches
 }
 
-func predictRemotes(args complete.Args) (predictions []string) {
+func predictRemotes(args komplete.Args) (predictions []string) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
@@ -93,4 +95,32 @@ func predictRemotes(args complete.Args) (predictions []string) {
 	}
 
 	return remotes
+}
+
+func predictDirs(args komplete.Args) (predictions []string) {
+	dir, last := filepath.Split(args.Last)
+	dir = filepath.Clean(dir)
+
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	sep := string(filepath.Separator)
+
+	for _, ent := range ents {
+		if !ent.IsDir() || strings.HasPrefix(ent.Name(), ".") {
+			continue
+		}
+
+		if strings.HasPrefix(ent.Name(), last) {
+			name := filepath.Join(dir, ent.Name())
+			if !strings.HasSuffix(name, sep) {
+				name += sep
+			}
+
+			predictions = append(predictions, name)
+		}
+	}
+
+	return predictions
 }


### PR DESCRIPTION
Don't use the third-party library for plugging into the shell.
We were already generating our own completion script and logic,
so the only major functionality coming from the third party dependency
was grabbing COMP_LINE and COMP_POINT, which is easy to do ourselves.

Having the dependency, on the other hand, introducd some risk
because the dependency has since moved on to a v2 which doesn't provide
the same level of control over the completion logic,
so we have to pin to v1.

Without the dependency, we can also implement more accurate COMP_LINE
splitting logic, handlng shell-quoting and escaping correctly,
which the dependency didn't do.

Dropping this dependency also reduces the file size slightly with
`-ldflags=-s -w`:

```
❯ go build -ldflags '-s -w' && dua gs # main
   9.11 MB gs

❯ go build -ldflags '-s -w' && dua gs # this branch
   8.77 MB gs
```

Lastly, with full contorl over how shell completion works,
we can also expand to using bash function based completion
in the future, which would allow post-processing during completion,
e.g. producing help text for each completion,
and filtering it out in the bash function.