### PR TITLE
ui: make Select generic over the value type

### DIFF
--- a/branch.go
+++ b/branch.go
@@ -114,8 +114,8 @@ nextBranch:
 	}
 
 	value := p.Default
-	prompt := ui.NewSelect().
-		WithOptions(branches...).
+	prompt := ui.NewSelect[string]().
+		With(ui.ComparableOptions(p.Default, branches...)).
 		WithTitle(p.Title).
 		WithValue(&value).
 		WithDescription(p.Description)

--- a/repo_init.go
+++ b/repo_init.go
@@ -64,10 +64,10 @@ func (cmd *repoInitCmd) Run(ctx context.Context, log *log.Logger, globalOpts *gl
 				must.Failf("unknown guess operation: %v", op)
 			}
 
-			result := selected
-			prompt := ui.NewSelect().
+			var result string
+			prompt := ui.NewSelect[string]().
 				WithValue(&result).
-				WithOptions(opts...).
+				With(ui.ComparableOptions(selected, opts...)).
 				WithTitle(msg).
 				WithDescription(desc)
 			if err := ui.Run(prompt); err != nil {
@@ -186,9 +186,9 @@ func ensureRemote(
 			}
 
 			result := selected
-			prompt := ui.NewSelect().
+			prompt := ui.NewSelect[string]().
 				WithValue(&result).
-				WithOptions(opts...).
+				With(ui.ComparableOptions(selected, opts...)).
 				WithTitle("Please select a remote").
 				WithDescription("Changes will be pushed to this remote")
 			if err := ui.Run(prompt); err != nil {

--- a/top.go
+++ b/top.go
@@ -50,9 +50,9 @@ func (cmd *topCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions
 
 		// If there are multiple top-most branches,
 		// prompt the user to pick one.
-		prompt := ui.NewSelect().
+		prompt := ui.NewSelect[string]().
 			WithValue(&branch).
-			WithOptions(tops...).
+			With(ui.ComparableOptions(branch, tops...)).
 			WithTitle("Pick a branch").
 			WithDescription(desc)
 		if err := ui.Run(prompt); err != nil {

--- a/up.go
+++ b/up.go
@@ -61,9 +61,9 @@ outer:
 				return errNoPrompt
 			}
 
-			prompt := ui.NewSelect().
+			prompt := ui.NewSelect[string]().
 				WithValue(&branch).
-				WithOptions(aboves...).
+				With(ui.ComparableOptions(branch, aboves...)).
 				WithTitle("Pick a branch").
 				WithDescription(desc)
 


### PR DESCRIPTION
For an upcoming change, we need to be able to use Select
to prompt for values of types other than strings
without having a unique key to match them back with.

[skip changelog] Not a user facing change.