### PR TITLE
branch submit: Prompt if there are multiple templates

### DIFF
--- a/.changes/unreleased/Added-20240615-220455.yaml
+++ b/.changes/unreleased/Added-20240615-220455.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'branch submit: If a repository has multiple templates, allow picking between them in the submission prompt.'
+time: 2024-06-15T22:04:55.535592-07:00

--- a/internal/ui/defer.go
+++ b/internal/ui/defer.go
@@ -1,0 +1,70 @@
+package ui
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// Deferred is a field that is not constructed
+// until initialization time.
+//
+// This is useful for fields that depend on other fields.
+type Deferred struct {
+	f  Field
+	fn func() Field
+}
+
+var _ Field = (*Deferred)(nil)
+
+// Defer defers field construction using the given function.
+// If the function returns nil, the field will be ignored.
+func Defer(fn func() Field) *Deferred {
+	return &Deferred{fn: fn}
+}
+
+// Init initializes the field.
+func (d *Deferred) Init() tea.Cmd {
+	d.f = d.fn()
+	if d.f == nil {
+		return SkipField
+	}
+
+	return d.f.Init()
+}
+
+// Title returns the title of the deferred field.
+func (d *Deferred) Title() string {
+	if d.f == nil {
+		return ""
+	}
+	return d.f.Title()
+}
+
+// Description returns the description of the deferred field.
+func (d *Deferred) Description() string {
+	if d.f == nil {
+		return ""
+	}
+	return d.f.Description()
+}
+
+// Err returns an error if the field is in an error state.
+func (d *Deferred) Err() error {
+	if d.f == nil {
+		return nil
+	}
+	return d.f.Err()
+}
+
+// Render renders the deferred field.
+func (d *Deferred) Render(w Writer) {
+	if d.f == nil {
+		return
+	}
+	d.f.Render(w)
+}
+
+// Update receives a new event.
+func (d *Deferred) Update(msg tea.Msg) tea.Cmd {
+	if d.f == nil {
+		return nil
+	}
+	return d.f.Update(msg)
+}

--- a/internal/ui/open_editor.go
+++ b/internal/ui/open_editor.go
@@ -79,9 +79,8 @@ type OpenEditor struct {
 	title string
 	desc  string
 
-	defaultFunc func() string
-	value       *string
-	err         error
+	value *string
+	err   error
 }
 
 var _ Field = (*OpenEditor)(nil)
@@ -116,15 +115,6 @@ func (a *OpenEditor) WithValue(value *string) *OpenEditor {
 	return a
 }
 
-// WithDefaultFunc sets a function to generate the default value.
-// The function will be called when the field is initialized.
-//
-// If set, this overides the value set by [WithValue].
-func (a *OpenEditor) WithDefaultFunc(f func() string) *OpenEditor {
-	a.defaultFunc = f
-	return a
-}
-
 // WithTitle sets the title for the field.
 func (a *OpenEditor) WithTitle(title string) *OpenEditor {
 	a.title = title
@@ -149,9 +139,6 @@ func (a *OpenEditor) Description() string {
 
 // Init initializes the field.
 func (a *OpenEditor) Init() tea.Cmd {
-	if a.defaultFunc != nil {
-		*a.value = a.defaultFunc()
-	}
 	return nil
 }
 

--- a/internal/ui/select.go
+++ b/internal/ui/select.go
@@ -72,7 +72,8 @@ type Select[T any] struct {
 	visible int // number of visible options, 0 means all (immutable)
 	offset  int // offset of the first visible option (mutable)
 
-	err error // error state
+	accepted bool  // true after the field has been accepted
+	err      error // error state
 }
 
 type selectOption[T any] struct {
@@ -246,6 +247,7 @@ func (s *Select[T]) Update(msg tea.Msg) tea.Cmd {
 			if s.selected < len(s.matched) {
 				*s.value = s.options[s.matched[s.selected]].Value
 				cmds = append(cmds, AcceptField)
+				s.accepted = true
 			}
 
 		case key.Matches(msg, s.KeyMap.DeleteFilterChar):
@@ -320,6 +322,13 @@ func (s *Select[T]) matchOption(opt *selectOption[T]) bool {
 
 // Render renders the select field.
 func (s *Select[T]) Render(out Writer) {
+	// If the field has been accepted, only render the label
+	// for the selected option.
+	if s.accepted {
+		out.WriteString(s.options[s.matched[s.selected]].Label)
+		return
+	}
+
 	if s.title != "" {
 		// If there's a title, we're currently on the same line as the
 		// title following the ": " separator.

--- a/testdata/script/branch_checkout_prompt.txt
+++ b/testdata/script/branch_checkout_prompt.txt
@@ -106,10 +106,6 @@ Select a branch to checkout:
   bar
 ▶ baz
 ### track ###
-Select a branch to checkout:
-
-  bar
-▶ baz
-
+Select a branch to checkout: baz
 WRN baz: branch not tracked
 Do you want to track this branch now?: [Y/n]

--- a/testdata/script/branch_submit_multiple_pr_templates.txt
+++ b/testdata/script/branch_submit_multiple_pr_templates.txt
@@ -1,0 +1,71 @@
+# 'branch submit' shows a prompt if there are multiple PR templates.
+
+as 'Test <test@example.com>'
+at '2024-06-15T21:55:32Z'
+
+# setup
+cd repo
+git init
+git add .shamhub CHANGE_TEMPLATE.md
+git commit -m 'Initial commit'
+
+# set up a fake remote
+gh-init
+gh-add-remote origin alice/example.git
+git push origin main
+
+env EDITOR=mockedit MOCKEDIT_GIVE=$WORK/input/feature-commit-msg
+gs bc feature
+
+mkdir $WORK/output
+env MOCKEDIT_GIVE= MOCKEDIT_RECORD=$WORK/output/pr-body.txt
+with-term -final exit $WORK/input/prompt.txt -- gs branch submit
+cmpenv stdout $WORK/golden/prompt.txt
+
+cmp $WORK/output/pr-body.txt $WORK/golden/pr-body.txt
+
+-- repo/CHANGE_TEMPLATE.md --
+ROOT TEMPLATE
+
+-- repo/.shamhub/CHANGE_TEMPLATE.md --
+HIDDEN TEMPLATE
+
+-- repo/feature.txt --
+Feature
+
+-- input/feature-commit-msg --
+Add feature
+
+This adds a feature with a long original commit message.
+
+-- input/prompt.txt --
+await Add feature
+feed \r
+await Template
+snapshot template
+feed \r
+await Body
+feed e
+await Draft
+feed \r
+
+-- golden/prompt.txt --
+### template ###
+Title: Add feature
+Template:
+
+▶ .shamhub/CHANGE_TEMPLATE.md
+  CHANGE_TEMPLATE.md
+  ▼▼▼
+
+Choose a template for the pull request body
+### exit ###
+Title: Add feature
+Template: .shamhub/CHANGE_TEMPLATE.md
+Body: Press [e] to open mockedit or [enter/tab] to skip
+Draft: [y/N]
+INF Created #1: $SHAMHUB_URL/alice/example/change/1
+-- golden/pr-body.txt --
+This adds a feature with a long original commit message.
+
+HIDDEN TEMPLATE

--- a/testdata/script/up_down_top_bottom_prompt.txt
+++ b/testdata/script/up_down_top_bottom_prompt.txt
@@ -83,10 +83,7 @@ Pick a branch:
 
 There are multiple branches above the current branch.
 ### exit ###
-Pick a branch:
-
-▶ feature2
-
+Pick a branch: feature2
 feature2
 -- input/top-prompt.txt --
 await feature
@@ -100,10 +97,7 @@ Pick a branch:
 
 There are multiple top-level branches reachable from the current branch.
 ### exit ###
-Pick a branch:
-
-▶ feature5
-
+Pick a branch: feature5
 feature5
 -- input/up-2-prompt.txt --
 await feature
@@ -117,8 +111,5 @@ Pick a branch:
 
 There are multiple branches above the current branch.
 ### exit ###
-Pick a branch:
-
-▶ feature4
-
+Pick a branch: feature4
 feature4


### PR DESCRIPTION
If a repository has multiple PR templates,
we will allow the user to pick between the templates.

Also includes a minor improvement in the select widget:
after accepting, the rest of the widget disappears
and only the result is left.

Resolves #161