### PR TITLE
fliptree: Use a square to mark nodes

### DIFF
--- a/.changes/unreleased/Changed-20240616-114723.yaml
+++ b/.changes/unreleased/Changed-20240616-114723.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'log short: Make branch labels more visually distinct with an icon next to them.'
+time: 2024-06-16T11:47:23.288609-07:00

--- a/internal/ui/fliptree/testdata/write.yaml
+++ b/internal/ui/fliptree/testdata/write.yaml
@@ -8,11 +8,11 @@
     c: [d]
     d: [e]
   want: |2
-            ┌── e
-          ┌─┴ d
-        ┌─┴ c
-      ┌─┴ b
-    ┌─┴ a
+            ┏━□ e
+          ┏━┻□ d
+        ┏━┻□ c
+      ┏━┻□ b
+    ┏━┻□ a
     main
   wantOffsets:
     a: 4
@@ -28,13 +28,13 @@
     foo: [a, b, c]
     bar: [d, e, f]
   want: |
-    ┌── a
-    ├── b
-    ├── c
+    ┏━□ a
+    ┣━□ b
+    ┣━□ c
     foo
-    ┌── d
-    ├── e
-    ├── f
+    ┏━□ d
+    ┣━□ e
+    ┣━□ f
     bar
   wantOffsets:
     a: 0
@@ -60,17 +60,17 @@
     c: "c\n\nboop"
     d: "d\nbeep"
   want: |2
-          ┌── d
-          │   beep
-        ┌─┴ c
-        │
-        │   boop
-      ┌─┴ b
-      │   |
-      │   more stuff
-    ┌─┴ a
-    │   |
-    │   stuff
+          ┏━□ d
+          ┃   beep
+        ┏━┻□ c
+        ┃
+        ┃    boop
+      ┏━┻□ b
+      ┃    |
+      ┃    more stuff
+    ┏━┻□ a
+    ┃    |
+    ┃    stuff
     main
     main stuff
   wantOffsets:
@@ -91,42 +91,42 @@
   graph:
     main: [a, b, c, d]
   want: |
-    ┌── x
-    │   y
-    │   z
-    ├── b	1
-    │   	2
-    │   	3
-    ├── i
-    │   ii
-    │   iii
-    │   iiii
-    │   iiiii
-    │   iiiiii
-    ├── a
-    │   b
-    │   c
-    │   d
-    │   e
-    │   f
-    │   g
-    │   h
-    │   i
-    │   j
-    │   k
-    │   l
-    │   m
-    │   n
-    │   o
-    │   p
-    │   q
-    │   r
-    │   s
-    │   t
-    │   u
-    │   v
-    │   w
-    │   x
+    ┏━□ x
+    ┃   y
+    ┃   z
+    ┣━□ b	1
+    ┃   	2
+    ┃   	3
+    ┣━□ i
+    ┃   ii
+    ┃   iii
+    ┃   iiii
+    ┃   iiiii
+    ┃   iiiiii
+    ┣━□ a
+    ┃   b
+    ┃   c
+    ┃   d
+    ┃   e
+    ┃   f
+    ┃   g
+    ┃   h
+    ┃   i
+    ┃   j
+    ┃   k
+    ┃   l
+    ┃   m
+    ┃   n
+    ┃   o
+    ┃   p
+    ┃   q
+    ┃   r
+    ┃   s
+    ┃   t
+    ┃   u
+    ┃   v
+    ┃   w
+    ┃   x
     main
   wantOffsets:
     a: 0
@@ -152,84 +152,84 @@
     k: [ba, bb, bc, bd, be, bf, bg, bh, bi, bj, bk, bl]
     l: [bm, bn, bo, bp, bq, br, bs, bt, bu, bv, bw, bx, by, bz]
   want: |2
-        ┌── m
-        ├── n
-        ├── o
-      ┌─┴ d
-      │ ┌── p
-      │ ├── q
-      │ ├── r
-      ├─┴ e
-      │ ┌── s
-      │ ├── t
-      │ ├── u
-      │ ├── v
-      │ ├── w
-      │ ├── x
-      ├─┴ f
-    ┌─┴ a
-    │   ┌── y
-    │   ├── z
-    │   ├── aa
-    │   ├── ab
-    │ ┌─┴ g
-    │ │ ┌── ac
-    │ │ ├── ad
-    │ │ ├── ae
-    │ │ ├── af
-    │ │ ├── ag
-    │ │ ├── ah
-    │ ├─┴ h
-    ├─┴ b
-    │   ┌── ai
-    │   ├── aj
-    │   ├── ak
-    │   ├── al
-    │   ├── am
-    │   ├── an
-    │   ├── ao
-    │   ├── ap
-    │ ┌─┴ i
-    │ │ ┌── aq
-    │ │ ├── ar
-    │ │ ├── as
-    │ │ ├── at
-    │ │ ├── au
-    │ │ ├── av
-    │ │ ├── aw
-    │ │ ├── ax
-    │ │ ├── ay
-    │ │ ├── az
-    │ ├─┴ j
-    │ │ ┌── ba
-    │ │ ├── bb
-    │ │ ├── bc
-    │ │ ├── bd
-    │ │ ├── be
-    │ │ ├── bf
-    │ │ ├── bg
-    │ │ ├── bh
-    │ │ ├── bi
-    │ │ ├── bj
-    │ │ ├── bk
-    │ │ ├── bl
-    │ ├─┴ k
-    │ │ ┌── bm
-    │ │ ├── bn
-    │ │ ├── bo
-    │ │ ├── bp
-    │ │ ├── bq
-    │ │ ├── br
-    │ │ ├── bs
-    │ │ ├── bt
-    │ │ ├── bu
-    │ │ ├── bv
-    │ │ ├── bw
-    │ │ ├── bx
-    │ │ ├── by
-    │ │ ├── bz
-    │ ├─┴ l
-    ├─┴ c
+        ┏━□ m
+        ┣━□ n
+        ┣━□ o
+      ┏━┻□ d
+      ┃ ┏━□ p
+      ┃ ┣━□ q
+      ┃ ┣━□ r
+      ┣━┻□ e
+      ┃ ┏━□ s
+      ┃ ┣━□ t
+      ┃ ┣━□ u
+      ┃ ┣━□ v
+      ┃ ┣━□ w
+      ┃ ┣━□ x
+      ┣━┻□ f
+    ┏━┻□ a
+    ┃   ┏━□ y
+    ┃   ┣━□ z
+    ┃   ┣━□ aa
+    ┃   ┣━□ ab
+    ┃ ┏━┻□ g
+    ┃ ┃ ┏━□ ac
+    ┃ ┃ ┣━□ ad
+    ┃ ┃ ┣━□ ae
+    ┃ ┃ ┣━□ af
+    ┃ ┃ ┣━□ ag
+    ┃ ┃ ┣━□ ah
+    ┃ ┣━┻□ h
+    ┣━┻□ b
+    ┃   ┏━□ ai
+    ┃   ┣━□ aj
+    ┃   ┣━□ ak
+    ┃   ┣━□ al
+    ┃   ┣━□ am
+    ┃   ┣━□ an
+    ┃   ┣━□ ao
+    ┃   ┣━□ ap
+    ┃ ┏━┻□ i
+    ┃ ┃ ┏━□ aq
+    ┃ ┃ ┣━□ ar
+    ┃ ┃ ┣━□ as
+    ┃ ┃ ┣━□ at
+    ┃ ┃ ┣━□ au
+    ┃ ┃ ┣━□ av
+    ┃ ┃ ┣━□ aw
+    ┃ ┃ ┣━□ ax
+    ┃ ┃ ┣━□ ay
+    ┃ ┃ ┣━□ az
+    ┃ ┣━┻□ j
+    ┃ ┃ ┏━□ ba
+    ┃ ┃ ┣━□ bb
+    ┃ ┃ ┣━□ bc
+    ┃ ┃ ┣━□ bd
+    ┃ ┃ ┣━□ be
+    ┃ ┃ ┣━□ bf
+    ┃ ┃ ┣━□ bg
+    ┃ ┃ ┣━□ bh
+    ┃ ┃ ┣━□ bi
+    ┃ ┃ ┣━□ bj
+    ┃ ┃ ┣━□ bk
+    ┃ ┃ ┣━□ bl
+    ┃ ┣━┻□ k
+    ┃ ┃ ┏━□ bm
+    ┃ ┃ ┣━□ bn
+    ┃ ┃ ┣━□ bo
+    ┃ ┃ ┣━□ bp
+    ┃ ┃ ┣━□ bq
+    ┃ ┃ ┣━□ br
+    ┃ ┃ ┣━□ bs
+    ┃ ┃ ┣━□ bt
+    ┃ ┃ ┣━□ bu
+    ┃ ┃ ┣━□ bv
+    ┃ ┃ ┣━□ bw
+    ┃ ┃ ┣━□ bx
+    ┃ ┃ ┣━□ by
+    ┃ ┃ ┣━□ bz
+    ┃ ┣━┻□ l
+    ┣━┻□ c
     main
   wantOffsets:
     a: 15

--- a/testdata/script/branch_checkout_track_prompt.txt
+++ b/testdata/script/branch_checkout_track_prompt.txt
@@ -35,5 +35,5 @@ await
 WRN feature: branch not tracked
 Do you want to track this branch now?: [Y/n]
 -- golden/ls.txt --
-┌── feature ◀
+┏━□ feature ◀
 main

--- a/testdata/script/branch_create_target.txt
+++ b/testdata/script/branch_create_target.txt
@@ -53,22 +53,22 @@ feature 4
 feature 5
 
 -- golden/add-feature3.txt --
-  ┌── feature2
-  ├── feature3 ◀
-┌─┴ feature1
+  ┏━□ feature2
+  ┣━□ feature3 ◀
+┏━┻□ feature1
 main
 -- golden/add-feature4.txt --
-    ┌── feature2
-    ├── feature3
-  ┌─┴ feature4 ◀
-┌─┴ feature1
+    ┏━□ feature2
+    ┣━□ feature3
+  ┏━┻□ feature4 ◀
+┏━┻□ feature1
 main
 -- golden/add-feature5.txt --
-      ┌── feature2
-      ├── feature3
-    ┌─┴ feature4
-  ┌─┴ feature1
-┌─┴ feature5 ◀
+      ┏━□ feature2
+      ┣━□ feature3
+    ┏━┻□ feature4
+  ┏━┻□ feature1
+┏━┻□ feature5 ◀
 main
 -- golden/graph.txt --
 * 2996f1e (feature2) Add feature 2

--- a/testdata/script/branch_delete_heal.txt
+++ b/testdata/script/branch_delete_heal.txt
@@ -66,6 +66,6 @@ feature 3
 * aa78494 feature1
 * 102a190 (HEAD -> main) Initial commit
 -- golden/ls.txt --
-┌── feature2
-├── feature3
+┏━□ feature2
+┣━□ feature3
 main ◀

--- a/testdata/script/branch_fold.txt
+++ b/testdata/script/branch_fold.txt
@@ -46,9 +46,9 @@ bar
 * 588349e Add foo.txt
 * 9bad92b (main) Initial commit
 -- golden/ls-before.txt --
-  ┌── bar ◀
-┌─┴ foo
+  ┏━□ bar ◀
+┏━┻□ foo
 main
 -- golden/ls-after.txt --
-┌── foo ◀
+┏━□ foo ◀
 main

--- a/testdata/script/branch_onto_conflict_hell.txt
+++ b/testdata/script/branch_onto_conflict_hell.txt
@@ -135,8 +135,8 @@ DU feature.txt
 |/  
 * 53ec458 (main) Initial commit
 -- golden/list-short.txt --
-  ┌── feature1
-┌─┴ feature0
-├── feature2
-├── feature3 ◀
+  ┏━□ feature1
+┏━┻□ feature0
+┣━□ feature2
+┣━□ feature3 ◀
 main

--- a/testdata/script/branch_restack_dirty_tree.txt
+++ b/testdata/script/branch_restack_dirty_tree.txt
@@ -58,5 +58,5 @@ another file
 * 31b0f28 (main) Diverge
 * 9315e88 Initial commit
 -- golden/ls.txt --
-┌── feature (needs restack) ◀
+┏━□ feature (needs restack) ◀
 main

--- a/testdata/script/branch_submit_create_update.txt
+++ b/testdata/script/branch_submit_create_update.txt
@@ -81,5 +81,5 @@ New contents of feature1
 ]
 
 -- golden/ls.txt --
-┌── feature1 (#1) ◀
+┏━□ feature1 (#1) ◀
 main

--- a/testdata/script/stack_submit.txt
+++ b/testdata/script/stack_submit.txt
@@ -157,7 +157,7 @@ INF Created #3: $SHAMHUB_URL/alice/example/change/3
 ]
 
 -- golden/ls.txt --
-    ┌── feature3 (#3)
-  ┌─┴ feature2 (#2)
-┌─┴ feature1 (#1) ◀
+    ┏━□ feature3 (#3)
+  ┏━┻□ feature2 (#2)
+┏━┻□ feature1 (#1) ◀
 main

--- a/testdata/script/up_down_top_bottom.txt
+++ b/testdata/script/up_down_top_bottom.txt
@@ -130,9 +130,9 @@ cmp stderr $WORK/golden/git_ls_a.output
 * feature5
   main
 -- golden/git_ls_a.output --
-        ┌── feature5
-      ┌─┴ feature4
-    ┌─┴ feature3
-  ┌─┴ feature2
-┌─┴ feature1
+        ┏━□ feature5
+      ┏━┻□ feature4
+    ┏━┻□ feature3
+  ┏━┻□ feature2
+┏━┻□ feature1
 main ◀

--- a/testdata/script/up_down_top_bottom_prompt.txt
+++ b/testdata/script/up_down_top_bottom_prompt.txt
@@ -65,11 +65,11 @@ with-term -final exit $WORK/input/up-2-prompt.txt -- gs up -n 2
 cmp stdout $WORK/golden/up-2-prompt.txt
 
 -- golden/ls.txt --
-    ┌── feature3
-  ┌─┴ feature2
-  │ ┌── feature5
-  ├─┴ feature4
-┌─┴ feature1
+    ┏━□ feature3
+  ┏━┻□ feature2
+  ┃ ┏━□ feature5
+  ┣━┻□ feature4
+┏━┻□ feature1
 main ◀
 -- input/up-prompt.txt --
 await feature


### PR DESCRIPTION
Make branches in the tree more visually distinct
by adding a square marker next to them.

This will differentiate those nodes from the upcoming commit markers.