### PR TITLE
log short: Use a filled box for current branch

### DIFF
--- a/log.go
+++ b/log.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/git"
@@ -129,6 +130,14 @@ func branchLog(ctx context.Context, opts *branchLogOptions) (err error) {
 		}
 	}
 
+	treeStyle := fliptree.DefaultStyle()
+	treeStyle.NodeMarker = func(branch string) lipgloss.Style {
+		if branch == currentBranch {
+			return fliptree.DefaultNodeMarker.SetString("■")
+		}
+		return fliptree.DefaultNodeMarker
+	}
+
 	var s strings.Builder
 	// TODO: Maybe Graph is parameterized over the node type.
 	err = fliptree.Write(&s, fliptree.Graph{
@@ -157,7 +166,7 @@ func branchLog(ctx context.Context, opts *branchLogOptions) (err error) {
 			return o.String()
 		},
 		Edges: edgesFn,
-	}, fliptree.Options{})
+	}, fliptree.Options{Style: treeStyle})
 	if err != nil {
 		return fmt.Errorf("write tree: %w", err)
 	}

--- a/testdata/script/branch_checkout_track_prompt.txt
+++ b/testdata/script/branch_checkout_track_prompt.txt
@@ -35,5 +35,5 @@ await
 WRN feature: branch not tracked
 Do you want to track this branch now?: [Y/n]
 -- golden/ls.txt --
-┏━□ feature ◀
+┏━■ feature ◀
 main

--- a/testdata/script/branch_create_target.txt
+++ b/testdata/script/branch_create_target.txt
@@ -54,13 +54,13 @@ feature 5
 
 -- golden/add-feature3.txt --
   ┏━□ feature2
-  ┣━□ feature3 ◀
+  ┣━■ feature3 ◀
 ┏━┻□ feature1
 main
 -- golden/add-feature4.txt --
     ┏━□ feature2
     ┣━□ feature3
-  ┏━┻□ feature4 ◀
+  ┏━┻■ feature4 ◀
 ┏━┻□ feature1
 main
 -- golden/add-feature5.txt --
@@ -68,7 +68,7 @@ main
       ┣━□ feature3
     ┏━┻□ feature4
   ┏━┻□ feature1
-┏━┻□ feature5 ◀
+┏━┻■ feature5 ◀
 main
 -- golden/graph.txt --
 * 2996f1e (feature2) Add feature 2

--- a/testdata/script/branch_fold.txt
+++ b/testdata/script/branch_fold.txt
@@ -46,9 +46,9 @@ bar
 * 588349e Add foo.txt
 * 9bad92b (main) Initial commit
 -- golden/ls-before.txt --
-  ┏━□ bar ◀
+  ┏━■ bar ◀
 ┏━┻□ foo
 main
 -- golden/ls-after.txt --
-┏━□ foo ◀
+┏━■ foo ◀
 main

--- a/testdata/script/branch_onto_conflict_hell.txt
+++ b/testdata/script/branch_onto_conflict_hell.txt
@@ -138,5 +138,5 @@ DU feature.txt
   ┏━□ feature1
 ┏━┻□ feature0
 ┣━□ feature2
-┣━□ feature3 ◀
+┣━■ feature3 ◀
 main

--- a/testdata/script/branch_restack_dirty_tree.txt
+++ b/testdata/script/branch_restack_dirty_tree.txt
@@ -58,5 +58,5 @@ another file
 * 31b0f28 (main) Diverge
 * 9315e88 Initial commit
 -- golden/ls.txt --
-┏━□ feature (needs restack) ◀
+┏━■ feature (needs restack) ◀
 main

--- a/testdata/script/branch_submit_create_update.txt
+++ b/testdata/script/branch_submit_create_update.txt
@@ -81,5 +81,5 @@ New contents of feature1
 ]
 
 -- golden/ls.txt --
-┏━□ feature1 (#1) ◀
+┏━■ feature1 (#1) ◀
 main

--- a/testdata/script/stack_submit.txt
+++ b/testdata/script/stack_submit.txt
@@ -159,5 +159,5 @@ INF Created #3: $SHAMHUB_URL/alice/example/change/3
 -- golden/ls.txt --
     ┏━□ feature3 (#3)
   ┏━┻□ feature2 (#2)
-┏━┻□ feature1 (#1) ◀
+┏━┻■ feature1 (#1) ◀
 main


### PR DESCRIPTION
While we use an empty box marker for branches in the tree,
we'll use a filled box marker for the current branch
to make it even more prominent.

[skip changelog] Changelog for #200 is enough to cover this.