### PR TITLE
log long: More like --oneline

### DIFF
--- a/log.go
+++ b/log.go
@@ -168,8 +168,6 @@ func (cmd *branchLogCmd) run(ctx context.Context, opts *branchLogOptions) (err e
 		return fliptree.DefaultNodeMarker
 	}
 
-	jointStyle := treeStyle.Joint
-
 	var s strings.Builder
 	err = fliptree.Write(&s, fliptree.Graph[*branchInfo]{
 		Roots:  []int{trunkIdx},
@@ -203,13 +201,8 @@ func (cmd *branchLogCmd) run(ctx context.Context, opts *branchLogOptions) (err e
 				commitTimeStyle = commitTimeStyle.Faint(true)
 			}
 
-			for idx, commit := range b.Commits {
+			for _, commit := range b.Commits {
 				o.WriteString("\n")
-				if idx < len(b.Commits)-1 {
-					o.WriteString(jointStyle.Render("├○ "))
-				} else {
-					o.WriteString(jointStyle.Render("└○ "))
-				}
 				o.WriteString(commitHashStyle.Render(commit.ShortHash.String()))
 				o.WriteString(" ")
 				o.WriteString(commitSubjectStyle.Render(commit.Subject))

--- a/testdata/script/log_long.txt
+++ b/testdata/script/log_long.txt
@@ -61,56 +61,56 @@ more
 
 -- golden/linear.txt --
         ┏━■ feature5 ◀
-        ┃   └○ 32bf40a Add feature5 (now)
+        ┃   32bf40a Add feature5 (now)
       ┏━┻□ feature4
-      ┃    └○ 16fd303 Add feature4 (16 minutes ago)
+      ┃    16fd303 Add feature4 (16 minutes ago)
     ┏━┻□ feature3
-    ┃    └○ 66b6e9e Add feature3 (30 minutes ago)
+    ┃    66b6e9e Add feature3 (30 minutes ago)
   ┏━┻□ feature2
-  ┃    └○ 04d722a Add feature2 (48 minutes ago)
+  ┃    04d722a Add feature2 (48 minutes ago)
 ┏━┻□ feature1
-┃    └○ b649e21 Add feature1 (1 hour ago)
+┃    b649e21 Add feature1 (1 hour ago)
 main
 -- golden/linear_next_day.txt --
         ┏━□ feature5
-        ┃   └○ 165476c Add feature5 (1 day ago)
+        ┃   165476c Add feature5 (1 day ago)
       ┏━┻□ feature4
-      ┃    └○ 97739c2 Add feature4 (1 day ago)
+      ┃    97739c2 Add feature4 (1 day ago)
     ┏━┻■ feature3 ◀
-    ┃    ├○ 87cc709 thing (now)
-    ┃    └○ 66b6e9e Add feature3 (1 day ago)
+    ┃    87cc709 thing (now)
+    ┃    66b6e9e Add feature3 (1 day ago)
   ┏━┻□ feature2
-  ┃    └○ 04d722a Add feature2 (1 day ago)
+  ┃    04d722a Add feature2 (1 day ago)
 ┏━┻□ feature1
-┃    └○ b649e21 Add feature1 (1 day ago)
+┃    b649e21 Add feature1 (1 day ago)
 main
 -- golden/linear_next_month.txt --
         ┏━□ feature5
-        ┃   └○ 02d2ceb Add feature5 (1 month ago)
+        ┃   02d2ceb Add feature5 (1 month ago)
       ┏━┻□ feature4
-      ┃    └○ 88bfff0 Add feature4 (1 month ago)
+      ┃    88bfff0 Add feature4 (1 month ago)
     ┏━┻□ feature3
-    ┃    ├○ 254a4f7 thing (1 month ago)
-    ┃    └○ 5a530c8 Add feature3 (1 month ago)
+    ┃    254a4f7 thing (1 month ago)
+    ┃    5a530c8 Add feature3 (1 month ago)
   ┏━┻■ feature2 ◀
-  ┃    ├○ 9abe2e6 stuff (now)
-  ┃    └○ 04d722a Add feature2 (1 month ago)
+  ┃    9abe2e6 stuff (now)
+  ┃    04d722a Add feature2 (1 month ago)
 ┏━┻□ feature1
-┃    └○ b649e21 Add feature1 (1 month ago)
+┃    b649e21 Add feature1 (1 month ago)
 main
 -- golden/merge_commit.txt --
         ┏━□ feature5
-        ┃   └○ 02d2ceb Add feature5 (1 month ago)
+        ┃   02d2ceb Add feature5 (1 month ago)
       ┏━┻□ feature4
-      ┃    └○ 88bfff0 Add feature4 (1 month ago)
+      ┃    88bfff0 Add feature4 (1 month ago)
     ┏━┻□ feature3
-    ┃    ├○ 254a4f7 thing (1 month ago)
-    ┃    └○ 5a530c8 Add feature3 (1 month ago)
+    ┃    254a4f7 thing (1 month ago)
+    ┃    5a530c8 Add feature3 (1 month ago)
   ┏━┻□ feature2 (needs restack)
-  ┃    ├○ 9abe2e6 stuff (30 minutes ago)
-  ┃    └○ 04d722a Add feature2 (1 month ago)
+  ┃    9abe2e6 stuff (30 minutes ago)
+  ┃    04d722a Add feature2 (1 month ago)
 ┏━┻■ feature1 ◀
-┃    ├○ a7e3da4 Merge feature2 into feature1 (now)
-┃    ├○ 210162b more (now)
-┃    └○ b649e21 Add feature1 (1 month ago)
+┃    a7e3da4 Merge feature2 into feature1 (now)
+┃    210162b more (now)
+┃    b649e21 Add feature1 (1 month ago)
 main

--- a/testdata/script/up_down_top_bottom.txt
+++ b/testdata/script/up_down_top_bottom.txt
@@ -142,13 +142,13 @@ cmp stderr $WORK/golden/git_ll_a.output
 main ◀
 -- golden/git_ll_a.output --
         ┏━□ feature5
-        ┃   └○ a9357f7 Add feature5 (now)
+        ┃   a9357f7 Add feature5 (now)
       ┏━┻□ feature4
-      ┃    └○ 93a1ae5 Add feature4 (now)
+      ┃    93a1ae5 Add feature4 (now)
     ┏━┻□ feature3
-    ┃    └○ 9fc19e9 Add feature3 (now)
+    ┃    9fc19e9 Add feature3 (now)
   ┏━┻□ feature2
-  ┃    └○ 953fcd4 Add feature2 (now)
+  ┃    953fcd4 Add feature2 (now)
 ┏━┻□ feature1
-┃    └○ 4d52225 Add feature1 (now)
+┃    4d52225 Add feature1 (now)
 main ◀


### PR DESCRIPTION
The connecting joints are nice but may be confusing.
Use a `--oneline`-style output for now.

[skip changelog] Not yet released.