### PR TITLE
branch submit/template: Don't add newlines if there's no body

### DIFF
--- a/.changes/unreleased/Fixed-20240619-043611.yaml
+++ b/.changes/unreleased/Fixed-20240619-043611.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'branch submit: If there''s a PR template but no commit body, don''t add extraneous newlines at the start of the default PR description.'
+time: 2024-06-19T04:36:11.516142-07:00

--- a/branch_submit.go
+++ b/branch_submit.go
@@ -397,10 +397,12 @@ func (f *branchSubmitForm) bodyField(body *string) ui.Field {
 	return ui.Defer(func() ui.Field {
 		// By this point, the template field should have already run.
 		if f.tmpl != nil {
-			*body += "\n\n" + f.tmpl.Body
+			if *body != "" {
+				*body += "\n\n"
+			}
+			*body += f.tmpl.Body
 		}
 
-		// TODO: Delete defaultFunc
 		return ui.NewOpenEditor().
 			WithValue(body).
 			WithTitle("Body").

--- a/testdata/script/branch_submit_pr_template_no_body.txt
+++ b/testdata/script/branch_submit_pr_template_no_body.txt
@@ -1,0 +1,89 @@
+# 'branch submit' with a PR template and no additional commit body
+# places the template at the top.
+
+as 'Test <test@example.com>'
+at '2024-06-19T04:32:32Z'
+
+# setup
+cd repo
+git init
+git add .shamhub
+git commit -m 'Initial commit'
+
+# set up a fake remote
+gh-init
+gh-add-remote origin alice/example.git
+git push origin main
+
+# create a branch and submit a PR
+git add feature.txt
+
+git add feature.txt
+gs bc feature -m 'Add feature'
+env EDITOR=true
+with-term -final exit $WORK/input/prompt.txt -- gs branch submit
+cmpenv stdout $WORK/golden/prompt.txt
+
+gh-dump-pull
+cmpenvJSON stdout $WORK/golden/pulls.json
+
+-- repo/.shamhub/CHANGE_TEMPLATE.md --
+## Summary
+
+Details
+
+## Test plan
+
+Explain
+
+Issue:
+-- repo/feature.txt --
+feature
+
+-- input/prompt.txt --
+await Add feature
+snapshot title
+feed \r
+await Body
+snapshot body
+feed e
+await Draft
+snapshot draft
+feed \r
+
+-- golden/prompt.txt --
+### title ###
+Title: Add feature
+Short summary of the pull request
+### body ###
+Title: Add feature
+Body: Press [e] to open true or [enter/tab] to skip
+Open your editor to write a detailed description of the pull request
+### draft ###
+Title: Add feature
+Body: Press [e] to open true or [enter/tab] to skip
+Draft: [y/N]
+Mark the pull request as a draft?
+### exit ###
+Title: Add feature
+Body: Press [e] to open true or [enter/tab] to skip
+Draft: [y/N]
+INF Created #1: $SHAMHUB_URL/alice/example/change/1
+-- golden/pulls.json --
+[
+  {
+    "number": 1,
+    "html_url": "$SHAMHUB_URL/alice/example/change/1",
+    "state": "open",
+    "title": "Add feature",
+    "body": "## Summary\n\nDetails\n\n## Test plan\n\nExplain\n\nIssue:\n",
+    "base": {
+      "ref": "main",
+      "sha": "4020e221d672d4c2865f31dad27c42438f491f56"
+    },
+    "head": {
+      "ref": "feature",
+      "sha": "26a1011fd724f56ba25514e0b48e1f864f7b6118"
+    }
+  }
+]


### PR DESCRIPTION
If there's no commit body, don't add newlines before the template
because that just results in two empty lines at the start for no reason.
