### PR TITLE
commit {create, amend}: Don't restack current

### DIFF
--- a/.changes/unreleased/Fixed-20240622-072144.yaml
+++ b/.changes/unreleased/Fixed-20240622-072144.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'upstack restack: Fix --no-base ignored when there''s only one branch.'
+time: 2024-06-22T07:21:44.549109-07:00

--- a/.changes/unreleased/Fixed-20240622-072219.yaml
+++ b/.changes/unreleased/Fixed-20240622-072219.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'commit {create, amend}: Fix unintended restacking of current branch when there''s only one branch in the stack.'
+time: 2024-06-22T07:22:19.986177-07:00

--- a/testdata/script/issue208_commit_no_restack_current.txt
+++ b/testdata/script/issue208_commit_no_restack_current.txt
@@ -1,0 +1,67 @@
+# https://github.com/abhinav/git-spice/issues/208
+#
+# commit create and amend should not restack the current branch
+# even if it's the only branch on the stack.
+
+as 'Test <test@example.com>'
+at '2024-06-22T07:18:32Z'
+
+# setup
+cd repo
+git init
+git add init.txt
+git commit -m 'Initial commit'
+gs repo init
+
+git add feature1.txt
+gs bc -m feature1
+
+# move trunk so feature1 needs to be restacked
+gs trunk
+cp $WORK/extra/README.md README.md
+git add README.md
+git commit -m 'New initial state'
+
+gs up
+stderr 'feature1: needs to be restacked'
+
+# commit create
+cp $WORK/extra/feature1.2.txt feature1.2.txt
+git add feature1.2.txt
+gs cc -m 'Feature 1 part 2'
+
+# feature1 should not have been restacked
+! exists README.md
+
+# commit amend
+gs ca -m 'add part 2 of feature 1'
+# feature1 should not have been restacked
+! exists README.md
+
+git graph --branches
+cmp stdout $WORK/golden/graph.txt
+
+gs ls
+cmp stderr $WORK/golden/ls.txt
+
+-- repo/init.txt --
+initial state
+
+-- repo/feature1.txt --
+feature1
+
+-- extra/README.md --
+this repository does things
+
+-- extra/feature1.2.txt --
+part 2 of feature 1
+
+-- golden/graph.txt --
+* 2d05ced (HEAD -> feature1) add part 2 of feature 1
+* 2190093 feature1
+| * a2f130f (main) New initial state
+|/  
+* 43089bc Initial commit
+-- golden/ls.txt --
+┏━■ feature1 (needs restack) ◀
+main

--- a/upstack_restack.go
+++ b/upstack_restack.go
@@ -54,8 +54,11 @@ func (cmd *upstackRestackCmd) Run(ctx context.Context, log *log.Logger, opts *gl
 	if err != nil {
 		return fmt.Errorf("get upstack branches: %w", err)
 	}
-	if cmd.NoBase && len(upstacks) > 1 && upstacks[0] == cmd.Name {
+	if cmd.NoBase && len(upstacks) > 0 && upstacks[0] == cmd.Name {
 		upstacks = upstacks[1:]
+		if len(upstacks) == 0 {
+			return nil
+		}
 	}
 
 loop:


### PR DESCRIPTION
Part two of #187.
The `upstack restack --no-base` flag was ignored
when there was only one branch on the stack.
Fixing that also fixes `commit create` and `commit amend`.

Resolves #208