### PR TITLE
ui: Generalize commit rendering

### DIFF
--- a/internal/ui/widget/commit.go
+++ b/internal/ui/widget/commit.go
@@ -1,0 +1,68 @@
+package widget
+
+import (
+	"os"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/dustin/go-humanize"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/ui"
+)
+
+// CommitSummary is the summary of a single commit.
+type CommitSummary struct {
+	ShortHash  git.Hash
+	Subject    string
+	AuthorDate time.Time
+}
+
+// CommitSummaryStyle is the style for rendering a CommitSummary.
+type CommitSummaryStyle struct {
+	Hash    lipgloss.Style
+	Subject lipgloss.Style
+	Time    lipgloss.Style
+}
+
+// Faint returns a copy of the style with the faint attribute set to f.
+func (s CommitSummaryStyle) Faint(f bool) CommitSummaryStyle {
+	s.Hash = s.Hash.Faint(f)
+	s.Subject = s.Subject.Faint(f)
+	s.Time = s.Time.Faint(f)
+	return s
+}
+
+// DefaultCommitSummaryStyle is the default style
+// for rendering a CommitSummary.
+var DefaultCommitSummaryStyle = CommitSummaryStyle{
+	Hash:    ui.NewStyle().Foreground(ui.Yellow),
+	Subject: ui.NewStyle().Foreground(ui.Plain),
+	Time:    ui.NewStyle().Foreground(ui.Gray),
+}
+
+// Render renders a CommitSummary to the given writer.
+func (c *CommitSummary) Render(w ui.Writer, style CommitSummaryStyle) {
+	w.WriteString(style.Hash.Render(c.ShortHash.String()))
+	w.WriteString(" ")
+	w.WriteString(style.Subject.Render(c.Subject))
+	w.WriteString(" ")
+	w.WriteString(style.Time.Render("(" + humanizeTime(c.AuthorDate) + ")"))
+}
+
+var _timeNow = time.Now
+
+func init() {
+	now := os.Getenv("GIT_SPICE_NOW")
+	if now != "" {
+		t, err := time.Parse(time.RFC3339, now)
+		if err == nil {
+			_timeNow = func() time.Time {
+				return t
+			}
+		}
+	}
+}
+
+func humanizeTime(t time.Time) string {
+	return humanize.RelTime(t, _timeNow(), "ago", "from now")
+}

--- a/internal/ui/widget/doc.go
+++ b/internal/ui/widget/doc.go
@@ -1,0 +1,3 @@
+// Package widget implements more complex user interface components
+// on top of the primitives offered in the ui package.
+package widget

--- a/script_test.go
+++ b/script_test.go
@@ -99,10 +99,10 @@ func TestScript(t *testing.T) {
 				gittest.CmdAt(ts, b, s)
 
 				// Set the Git-speciifc environment variables,
-				// as well as git-spice's own GIT_SPICE_LOG_NOW.
+				// as well as git-spice's own GIT_SPICE_NOW.
 				// Tests that want a different behavior for log
-				// can set GIT_SPICE_LOG_NOW to a different value.
-				ts.Setenv("GIT_SPICE_LOG_NOW", ts.Getenv("GIT_COMMITTER_DATE"))
+				// can set GIT_SPICE_NOW to a different value.
+				ts.Setenv("GIT_SPICE_NOW", ts.Getenv("GIT_COMMITTER_DATE"))
 			},
 
 			"cmpenvJSON": cmdCmpenvJSON,


### PR DESCRIPTION
Generalize how we render commits for `gs log` commands into a re-usable
component.

This will be useful for `gs branch split` that needs to present
a list of commits to pick from.
