### PR TITLE
add 'branch split' command

### DIFF
--- a/.changes/unreleased/Added-20240623-094932.yaml
+++ b/.changes/unreleased/Added-20240623-094932.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add 'branch split' command to split an existing branch with multiple commits into one or more new branches.
+time: 2024-06-23T09:49:32.655626-07:00

--- a/branch.go
+++ b/branch.go
@@ -22,6 +22,7 @@ type branchCmd struct {
 	Create branchCreateCmd `cmd:"" aliases:"c" help:"Create a new branch"`
 	Delete branchDeleteCmd `cmd:"" aliases:"d,rm" help:"Delete a branch"`
 	Fold   branchFoldCmd   `cmd:"" aliases:"fo" help:"Merge a branch into its base"`
+	Split  branchSplitCmd  `cmd:"" aliases:"sp" help:"Split a branch on commits"`
 
 	// Mutation
 	Edit    branchEditCmd    `cmd:"" aliases:"e" help:"Edit the commits in a branch"`

--- a/branch_split.go
+++ b/branch_split.go
@@ -1,0 +1,258 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/alecthomas/kong"
+	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/spice/state"
+	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
+	"go.abhg.dev/gs/internal/ui/widget"
+)
+
+// branchSplitCmd splits a branch into two or more branches
+// along commit boundaries.
+type branchSplitCmd struct {
+	At     []branchSplit `placeholder:"COMMIT:NAME" help:"Commits to split the branch at."`
+	Branch string        `arg:"" optional:"" help:"Branch to split commits of."`
+}
+
+func (*branchSplitCmd) Help() string {
+	return text.Dedent(`
+		Splits a branch (the current branch by default)
+		into two or more branches at specific commits,
+		inserting the new branches into the stack
+		at the positions of the commits.
+
+		By default, the command runs in interactive mode.
+		To use this command non-interactively, supply the --at flag
+		one or more times:
+
+			--at COMMIT:NAME
+
+		Where COMMIT resolves to a commit per gitrevisions(7),
+		and NAME is the name of the new branch.
+		For example:
+
+			# split at a specific commit
+			gs branch split --at 1234567:newbranch
+
+			# split at the previous commit
+			gs branch split --at HEAD^:newbranch
+	`)
+}
+
+func (cmd *branchSplitCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
+	repo, store, svc, err := openRepo(ctx, log, opts)
+	if err != nil {
+		return err
+	}
+
+	if cmd.Branch == "" {
+		cmd.Branch, err = repo.CurrentBranch(ctx)
+		if err != nil {
+			return fmt.Errorf("get current branch: %w", err)
+		}
+	}
+
+	if cmd.Branch == store.Trunk() {
+		return fmt.Errorf("cannot split trunk")
+	}
+
+	branch, err := svc.LookupBranch(ctx, cmd.Branch)
+	if err != nil {
+		return fmt.Errorf("lookup branch %q: %w", cmd.Branch, err)
+	}
+
+	// Commits are in oldest-to-newest order,
+	// with last commit being branch head.
+	branchCommits, err := repo.ListCommitsDetails(ctx,
+		git.CommitRangeFrom(branch.Head).
+			ExcludeFrom(branch.BaseHash).
+			Reverse())
+	if err != nil {
+		return fmt.Errorf("list commits: %w", err)
+	}
+
+	branchCommitHashes := make(map[git.Hash]struct{}, len(branchCommits))
+	for _, commit := range branchCommits {
+		branchCommitHashes[commit.Hash] = struct{}{}
+	}
+
+	// If len(cmd.At) == 0, run in interactive mode to build up cmd.At.
+	if len(cmd.At) == 0 {
+		if !opts.Prompt {
+			return fmt.Errorf("use --at to split non-interactively: %w", errNoPrompt)
+		}
+
+		if len(branchCommits) < 2 {
+			return errors.New("cannot split a branch with fewer than 2 commits")
+		}
+
+		commits := make([]widget.CommitSummary, len(branchCommits))
+		for i, commit := range branchCommits {
+			commits[i] = widget.CommitSummary{
+				ShortHash:  commit.ShortHash,
+				Subject:    commit.Subject,
+				AuthorDate: commit.AuthorDate,
+			}
+		}
+
+		selectWidget := widget.NewBranchSplit().
+			WithTitle("Select commits").
+			WithHEAD(cmd.Branch).
+			WithDescription("Select commits to split the branch at").
+			WithCommits(commits...)
+		if err := ui.Run(selectWidget); err != nil {
+			return fmt.Errorf("prompt: %w", err)
+		}
+
+		selectedIdxes := selectWidget.Selected()
+		if len(selectedIdxes) < 1 {
+			return errors.New("no commits selected")
+		}
+
+		selected := make([]git.CommitDetail, len(selectedIdxes))
+		for i, idx := range selectedIdxes {
+			selected[i] = branchCommits[idx]
+		}
+
+		fields := make([]ui.Field, len(selected))
+		branchNames := make([]string, len(selected))
+		for i, commit := range selected {
+			var desc strings.Builder
+			desc.WriteString("  □ ")
+			(&widget.CommitSummary{
+				ShortHash:  commit.ShortHash,
+				Subject:    commit.Subject,
+				AuthorDate: commit.AuthorDate,
+			}).Render(&desc, widget.DefaultCommitSummaryStyle)
+
+			input := ui.NewInput().
+				WithTitle("Branch name").
+				WithDescription(desc.String()).
+				WithValidate(func(value string) error {
+					if strings.TrimSpace(value) == "" {
+						return errors.New("branch name cannot be empty")
+					}
+					if repo.BranchExists(ctx, value) {
+						return fmt.Errorf("branch name already taken: %v", value)
+					}
+					return nil
+				}).
+				WithValue(&branchNames[i])
+			fields[i] = input
+		}
+
+		if err := ui.NewForm(fields...).Run(); err != nil {
+			return fmt.Errorf("prompt: %w", err)
+		}
+
+		for i, split := range selected {
+			cmd.At = append(cmd.At, branchSplit{
+				Commit: split.Hash.String(),
+				Name:   branchNames[i],
+			})
+		}
+	}
+
+	// Turn each commitish into a commit.
+	commitHashes := make([]git.Hash, len(cmd.At))
+	newTakenNames := make(map[string]int, len(cmd.At))
+	for i, split := range cmd.At {
+		// Interactive prompt verifies if the branch name is taken,
+		// but we have to check again here.
+		if repo.BranchExists(ctx, split.Name) {
+			return fmt.Errorf("--at[%d]: branch already exists: %v", i, split.Name)
+		}
+
+		// Also prevent duplicate branch names speciifed as input.
+		if otherIdx, ok := newTakenNames[split.Name]; ok {
+			return fmt.Errorf("--at[%d]: branch name already taken by --at[%d]: %v", i, otherIdx, split.Name)
+		}
+		newTakenNames[split.Name] = i
+
+		commitHash, err := repo.PeelToCommit(ctx, split.Commit)
+		if err != nil {
+			return fmt.Errorf("--at[%d]: resolve commit %q: %w", i, split.Commit, err)
+		}
+
+		// All commits must in base..head.
+		// So you can't do 'split --at HEAD~10:newbranch'.
+		if _, ok := branchCommitHashes[commitHash]; !ok {
+			return fmt.Errorf("--at[%d]: %v (%v) is not in range %v..%v", i,
+				split.Commit, commitHash, branch.Base, cmd.Branch)
+		}
+		commitHashes[i] = commitHash
+	}
+
+	// Split the branch. The commits are in oldest-to-newst order,
+	// so we can just go through them in order.
+	upserts := make([]state.UpsertRequest, 0, len(cmd.At)+1)
+	base := branch.Base
+	baseHash := branch.BaseHash
+	for idx, split := range cmd.At {
+		if err := repo.CreateBranch(ctx, git.CreateBranchRequest{
+			Name: split.Name,
+			Head: commitHashes[idx].String(),
+		}); err != nil {
+			return fmt.Errorf("create branch %q: %w", split.Name, err)
+		}
+
+		upserts = append(upserts, state.UpsertRequest{
+			Name:     split.Name,
+			Base:     base,
+			BaseHash: baseHash,
+		})
+
+		base = split.Name
+		baseHash = commitHashes[idx]
+	}
+
+	// The last branch is the remainder of the original branch.
+	upserts = append(upserts, state.UpsertRequest{
+		Name:     cmd.Branch,
+		Base:     base,
+		BaseHash: baseHash,
+	})
+
+	if err := store.UpdateBranch(ctx, &state.UpdateRequest{
+		Upserts: upserts,
+		Message: fmt.Sprintf("%v: split %d new branches", cmd.Branch, len(cmd.At)),
+	}); err != nil {
+		return fmt.Errorf("update store: %w", err)
+	}
+
+	return nil
+}
+
+type branchSplit struct {
+	Commit string
+	Name   string
+}
+
+func (b *branchSplit) Decode(ctx *kong.DecodeContext) error {
+	var spec string
+	if err := ctx.Scan.PopValueInto("at", &spec); err != nil {
+		return err
+	}
+
+	idx := strings.LastIndex(spec, ":")
+	switch {
+	case idx == -1:
+		return fmt.Errorf("expected COMMIT:NAME, got %q", spec)
+	case len(spec[:idx]) == 0:
+		return fmt.Errorf("part before : cannot be empty: %q", spec)
+	case len(spec[idx+1:]) == 0:
+		return fmt.Errorf("part after : cannot be empty: %q", spec)
+	}
+
+	b.Commit = spec[:idx]
+	b.Name = spec[idx+1:]
+	return nil
+}

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -466,6 +466,43 @@ on top of the base branch.
 
 * `name`: Name of the branch
 
+### gs branch split
+
+```
+gs branch (b) split (sp) [<branch>] [flags]
+```
+
+Split a branch on commits
+
+Splits a branch (the current branch by default)
+into two or more branches at specific commits,
+inserting the new branches into the stack
+at the positions of the commits.
+
+By default, the command runs in interactive mode.
+To use this command non-interactively, supply the --at flag
+one or more times:
+
+	--at COMMIT:NAME
+
+Where COMMIT resolves to a commit per gitrevisions(7),
+and NAME is the name of the new branch.
+For example:
+
+	# split at a specific commit
+	gs branch split --at 1234567:newbranch
+
+	# split at the previous commit
+	gs branch split --at HEAD^:newbranch
+
+**Arguments**
+
+* `branch`: Branch to split commits of.
+
+**Flags**
+
+* `--at=COMMIT:NAME,...`: Commits to split the branch at.
+
 ### gs branch edit
 
 ```

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -101,12 +101,20 @@ type CreateBranchRequest struct {
 	// Head is the commitish to start the branch from.
 	// Defaults to the current HEAD.
 	Head string
+
+	// Force specifies that the branch should be created
+	// at the given Head even if a branch with the same name
+	// already exists.
+	Force bool
 }
 
 // CreateBranch creates a new branch in the repository.
 // This operation fails if a branch with the same name already exists.
 func (r *Repository) CreateBranch(ctx context.Context, req CreateBranchRequest) error {
 	args := []string{"branch", req.Name}
+	if req.Force {
+		args = append(args, "--force")
+	}
 	if req.Head != "" {
 		args = append(args, req.Head)
 	}
@@ -114,6 +122,12 @@ func (r *Repository) CreateBranch(ctx context.Context, req CreateBranchRequest) 
 		return fmt.Errorf("git branch: %w", err)
 	}
 	return nil
+}
+
+// BranchExists reports whether a branch with the given name exists.
+func (r *Repository) BranchExists(ctx context.Context, branch string) bool {
+	return r.gitCmd(ctx, "rev-parse", "--verify", "refs/heads/"+branch).
+		Run(r.exec) == nil
 }
 
 // DetachHead detaches the HEAD from the current branch

--- a/internal/must/must.go
+++ b/internal/must/must.go
@@ -9,6 +9,20 @@ import (
 	"strings"
 )
 
+// Bef panics if b is false.
+func Bef(b bool, format string, args ...any) {
+	if !b {
+		panicErrorf(format, args...)
+	}
+}
+
+// NotBef panics if b is true.
+func NotBef(b bool, format string, args ...any) {
+	if b {
+		panicErrorf(format, args...)
+	}
+}
+
 // BeEqualf panics if a != b.
 func BeEqualf[T comparable](a, b T, format string, args ...any) {
 	if a != b {

--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -99,6 +99,7 @@ func (i *Input) WithValidate(f func(string) error) *Input {
 
 // Init initializes the field.
 func (i *Input) Init() tea.Cmd {
+	i.model.Err = nil
 	return i.model.Focus()
 }
 

--- a/internal/ui/multi_select.go
+++ b/internal/ui/multi_select.go
@@ -1,0 +1,303 @@
+package ui
+
+import (
+	"slices"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"go.abhg.dev/gs/internal/must"
+)
+
+// MultiSelectKeyMap defines the key bindings for [MultiSelect].
+type MultiSelectKeyMap struct {
+	Up, Down key.Binding
+	Toggle   key.Binding
+	Accept   key.Binding
+}
+
+// DefaultMultiSelectKeyMap is the default key map for a [MultiSelect].
+var DefaultMultiSelectKeyMap = MultiSelectKeyMap{
+	Up: key.NewBinding(
+		key.WithKeys("up", "k"),
+		key.WithHelp("up/k", "move up"),
+	),
+	Down: key.NewBinding(
+		key.WithKeys("down", "j"),
+		key.WithHelp("down/j", "move down"),
+	),
+	Toggle: key.NewBinding(
+		key.WithKeys(" ", "right"),
+		key.WithHelp("space", "toggle split"),
+	),
+	Accept: key.NewBinding(
+		key.WithKeys("enter", "tab"),
+		key.WithHelp("enter/tab", "accept"),
+	),
+}
+
+// MultiSelectStyle defines the styles for [MultiSelect].
+type MultiSelectStyle struct {
+	// Cursor is the string to use for the cursor.
+	Cursor lipgloss.Style
+
+	// Done is the string for the Done button.
+	Done lipgloss.Style
+
+	// ScrollUp is the string for the scroll up marker.
+	ScrollUp lipgloss.Style
+
+	// ScrollDown is the string for the scroll down marker.
+	ScrollDown lipgloss.Style
+}
+
+// DefaultMultiSelectStyle is the default style for a [MultiSelect].
+var DefaultMultiSelectStyle = MultiSelectStyle{
+	Cursor:     NewStyle().Foreground(Yellow).Bold(true).SetString("▶"),
+	Done:       NewStyle().Foreground(Green).SetString("Done"),
+	ScrollUp:   NewStyle().Foreground(Gray).SetString("▲▲▲"),
+	ScrollDown: NewStyle().Foreground(Gray).SetString("▼▼▼"),
+}
+
+// MultiSelect is a prompt that allows selecting one or more options.
+type MultiSelect[T any] struct {
+	KeyMap MultiSelectKeyMap
+	Style  MultiSelectStyle
+
+	title string
+	desc  string
+
+	renderOption func(Writer, int, MultiSelectOption[T])
+	options      []MultiSelectOption[T]
+
+	cursor  mutliSelectCursor
+	visible int // number of visible options
+	offset  int // offset of the first visible option
+
+	accepted bool
+}
+
+var _ Field = (*MultiSelect[int])(nil)
+
+// NewMultiSelect constructs a new multi-select field.
+func NewMultiSelect[T any](render func(Writer, int, MultiSelectOption[T])) *MultiSelect[T] {
+	return &MultiSelect[T]{
+		renderOption: render,
+		KeyMap:       DefaultMultiSelectKeyMap,
+		Style:        DefaultMultiSelectStyle,
+	}
+}
+
+// Selected returns the indexes of the selected options.
+func (s *MultiSelect[T]) Selected() []int {
+	var selected []int
+	for i, option := range s.options {
+		if option.Selected {
+			selected = append(selected, i)
+		}
+	}
+	return selected
+}
+
+// Value returns a slice of the selected values.
+func (s *MultiSelect[T]) Value() []T {
+	items := make([]T, 0, len(s.options))
+	for _, option := range s.options {
+		if option.Selected {
+			items = append(items, option.Value)
+		}
+	}
+	return items
+}
+
+// MultiSelectOption is an option for a multi-select field.
+type MultiSelectOption[T any] struct {
+	// Value of the option.
+	Value T
+
+	// Selected indicates whether the option is already selected.
+	Selected bool
+
+	// Skip indicates whether the option should be skipped.
+	// Skipped options are not selectable
+	// and will never be included in the result.
+	Skip bool
+}
+
+// WithOptions sets the options for the multi-select field.
+// Options will be presented in the order they are provided.
+// The existing options, if any, will be replaced.
+func (s *MultiSelect[T]) WithOptions(opts ...MultiSelectOption[T]) *MultiSelect[T] {
+	s.options = slices.Clone(opts)
+	return s
+}
+
+// WithTitle sets the title of the multi-select field.
+func (s *MultiSelect[T]) WithTitle(title string) *MultiSelect[T] {
+	s.title = title
+	return s
+}
+
+// Title returns the title of the multi-select field.
+func (s *MultiSelect[T]) Title() string {
+	return s.title
+}
+
+// WithDescription sets the description of the multi-select field.
+func (s *MultiSelect[T]) WithDescription(desc string) *MultiSelect[T] {
+	s.desc = desc
+	return s
+}
+
+// Description returns the description of the multi-select field.
+func (s *MultiSelect[T]) Description() string {
+	return s.desc
+}
+
+// Err returns nil.
+func (s *MultiSelect[T]) Err() error {
+	return nil
+}
+
+// Init initializes the multi-select field.
+func (s *MultiSelect[T]) Init() tea.Cmd {
+	s.cursor = mutliSelectCursor{len: len(s.options)}
+	return nil
+}
+
+// Update updates the multi-select field.
+func (s *MultiSelect[T]) Update(msg tea.Msg) tea.Cmd {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		s.visible = msg.Height - 5 // two scroll markers + Done
+
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, s.KeyMap.Up):
+			s.moveCursor(false /* backwards */)
+
+		case key.Matches(msg, s.KeyMap.Down):
+			s.moveCursor(true /* forwards */)
+
+		case key.Matches(msg, s.KeyMap.Accept):
+			if s.cursor.done() {
+				s.accepted = true
+				return tea.Quit
+			}
+
+			// Convenience:
+			// Allow Enter to toggle the focused option.
+			fallthrough
+
+		case key.Matches(msg, s.KeyMap.Toggle):
+			if s.cursor.done() {
+				break // no-op
+			}
+
+			must.NotBef(s.options[s.cursor.idx].Skip,
+				"skipped option should not be toggled: %d", s.cursor.idx)
+			s.options[s.cursor.idx].Selected = !s.options[s.cursor.idx].Selected
+			s.moveCursor(true /* forwards */)
+		}
+	}
+
+	return nil
+}
+
+// multiSelectCursor has one of two states:
+// it's focused on an option, or it's focused on the Done button.
+// When idx == len, the cursor is focused on the Done button.
+type mutliSelectCursor struct{ idx, len int }
+
+func (c mutliSelectCursor) add(delta int) mutliSelectCursor {
+	c.idx += delta
+	if c.idx < 0 {
+		c.idx = c.len
+	}
+	if c.idx > c.len {
+		c.idx = 0
+	}
+	return c
+}
+
+func (c mutliSelectCursor) done() bool {
+	return c.idx == c.len
+}
+
+func (s *MultiSelect[T]) moveCursor(forwards bool) {
+	delta := 1
+	if !forwards {
+		delta = -1
+	}
+
+	cursor := s.cursor.add(delta) // will always be in bounds or == len
+	for !cursor.done() && s.options[cursor.idx].Skip {
+		cursor = cursor.add(delta)
+	}
+
+	s.cursor = cursor
+
+	// Adjust pagination if necessary.
+	itemIdx := s.cursor.idx
+	if s.cursor.done() {
+		itemIdx = s.cursor.len - 1
+	}
+	if itemIdx < s.offset {
+		s.offset = itemIdx
+	}
+	if itemIdx >= s.offset+s.visible {
+		s.offset = itemIdx - s.visible + 1
+	}
+}
+
+// Render renders the multi-select field.
+func (s *MultiSelect[T]) Render(w Writer) {
+	options := s.options
+	var offset int
+
+	// Need a scrollbar above the list.
+	if s.visible < len(options) && !s.accepted {
+		options = options[s.offset : s.offset+s.visible]
+		offset = s.offset
+
+		w.WriteString("\n")
+		if s.offset > 0 {
+			w.WriteString(s.Style.ScrollUp.String())
+		}
+	}
+
+	for offsetIdx, option := range options {
+		idx := offset + offsetIdx
+
+		w.WriteString("\n")
+		if idx == s.cursor.idx {
+			w.WriteString(s.Style.Cursor.String())
+		} else {
+			w.WriteString(" ")
+		}
+
+		w.WriteString(" ")
+
+		s.renderOption(w, idx, option)
+	}
+
+	// Need a scrollbar below the list.
+	if s.visible < len(s.options) && !s.accepted {
+		w.WriteString("\n")
+		if s.offset+s.visible < len(s.options)-1 {
+			w.WriteString(s.Style.ScrollDown.String())
+		}
+	}
+
+	// Done button.
+	if !s.accepted {
+		w.WriteString("\n")
+		if s.cursor.done() {
+			w.WriteString(s.Style.Cursor.String())
+		} else {
+			w.WriteString(" ")
+		}
+		w.WriteString(" ")
+		w.WriteString(s.Style.Done.String())
+	}
+}

--- a/internal/ui/widget/branch_split.go
+++ b/internal/ui/widget/branch_split.go
@@ -1,0 +1,145 @@
+package widget
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"go.abhg.dev/gs/internal/must"
+	"go.abhg.dev/gs/internal/ui"
+)
+
+// BranchSplitStyle defines the styles for [BranchSplit].
+type BranchSplitStyle struct {
+	Commit     CommitSummaryStyle
+	HeadCommit CommitSummaryStyle
+
+	SplitMarker lipgloss.Style
+	HeadMarker  lipgloss.Style
+}
+
+// DefaultBranchSplitStyle is the default style for a [BranchSplit].
+var DefaultBranchSplitStyle = BranchSplitStyle{
+	Commit:      DefaultCommitSummaryStyle,
+	HeadCommit:  DefaultCommitSummaryStyle.Faint(true),
+	SplitMarker: ui.NewStyle().SetString("□"),
+	HeadMarker:  ui.NewStyle().SetString("■"),
+}
+
+// BranchSplit is a widget that allows users to pick out commits to split
+// from the current branch.
+//
+// It displays a list of commits, the last of which is not selectable.
+type BranchSplit struct {
+	Style BranchSplitStyle
+
+	model   *ui.MultiSelect[CommitSummary]
+	commits []CommitSummary
+	head    string
+}
+
+var _ ui.Field = (*BranchSplit)(nil)
+
+// NewBranchSplit creates a new [BranchSplit] widget.
+func NewBranchSplit() *BranchSplit {
+	bs := &BranchSplit{
+		Style: DefaultBranchSplitStyle,
+	}
+	bs.model = ui.NewMultiSelect(bs.renderCommit)
+	bs.model.Style.ScrollUp = ui.NewStyle().Foreground(ui.Gray).SetString("    ▲▲▲")
+	bs.model.Style.ScrollDown = ui.NewStyle().Foreground(ui.Gray).SetString("    ▼▼▼")
+	return bs
+}
+
+// WithCommits sets the commits to be listed in a branch split widget.
+func (b *BranchSplit) WithCommits(commits ...CommitSummary) *BranchSplit {
+	must.Bef(len(commits) > 2, "cannot split a branch with fewer than 2 commits")
+	b.commits = commits
+	return b
+}
+
+// Selected returns the indexes of the selected commits.
+func (b *BranchSplit) Selected() []int {
+	return b.model.Selected()
+}
+
+// Title returns the title of the widget.
+func (b *BranchSplit) Title() string {
+	return b.model.Title()
+}
+
+// WithTitle sets the title of the widget.
+func (b *BranchSplit) WithTitle(title string) *BranchSplit {
+	b.model = b.model.WithTitle(title)
+	return b
+}
+
+// Description returns the description of the widget.
+func (b *BranchSplit) Description() string {
+	return b.model.Description()
+}
+
+// WithDescription sets the description of the widget.
+func (b *BranchSplit) WithDescription(desc string) *BranchSplit {
+	b.model = b.model.WithDescription(desc)
+	return b
+}
+
+// WithHEAD sets the name of the head commit: the last commit in the branch.
+// This name, if present, is shown next to the head commit.
+func (b *BranchSplit) WithHEAD(head string) *BranchSplit {
+	b.head = head
+	return b
+}
+
+// Err returns nil.
+func (b *BranchSplit) Err() error { return nil }
+
+// Init initializes the widget.
+func (b *BranchSplit) Init() tea.Cmd {
+	options := make([]ui.MultiSelectOption[CommitSummary], len(b.commits))
+	for idx, commit := range b.commits {
+		options[idx] = ui.MultiSelectOption[CommitSummary]{
+			Value: commit,
+			Skip:  idx == len(b.commits)-1,
+		}
+	}
+	b.model = b.model.WithOptions(options...)
+	return b.model.Init()
+}
+
+// Update updates the widget based on the message.
+func (b *BranchSplit) Update(msg tea.Msg) tea.Cmd {
+	return b.model.Update(msg)
+}
+
+func (b *BranchSplit) renderCommit(w ui.Writer, idx int, option ui.MultiSelectOption[CommitSummary]) {
+	commitStyle := b.Style.Commit
+	headIdx := len(b.commits) - 1
+	switch {
+	case idx == headIdx:
+		commitStyle = b.Style.HeadCommit
+		w.WriteString(b.Style.HeadMarker.String())
+	case option.Selected:
+		w.WriteString(b.Style.SplitMarker.String())
+	default:
+		w.WriteString(" ")
+	}
+
+	w.WriteString(" ")
+	commit := option.Value
+	(&CommitSummary{
+		ShortHash:  commit.ShortHash,
+		Subject:    commit.Subject,
+		AuthorDate: commit.AuthorDate,
+	}).Render(w, commitStyle)
+
+	if idx == headIdx && b.head != "" {
+		w.WriteString(" [")
+		w.WriteString(b.Style.HeadCommit.Subject.Render(b.head))
+		w.WriteString("]")
+	}
+}
+
+// Render renders the widget to the given writer.
+func (b *BranchSplit) Render(w ui.Writer) {
+	b.model.Render(w)
+}

--- a/testdata/script/branch_split.txt
+++ b/testdata/script/branch_split.txt
@@ -1,0 +1,46 @@
+as 'Test <test@example.com>'
+at '2024-06-23T09:50:12Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git add feature1.txt
+gs bc features -m 'Add feature1'
+
+git add feature2.txt
+gs cc -m 'Add feature2'
+
+git add feature3.txt
+gs cc -m 'Add feature3'
+
+gs ls -a
+cmp stderr $WORK/golden/before.txt
+
+gs branch split --at HEAD~2:feature1 --at HEAD^:feature2
+
+gs ls -a
+cmp stderr $WORK/golden/after.txt
+git graph --branches
+cmp stdout $WORK/golden/graph.txt
+
+-- repo/feature1.txt --
+feature1
+-- repo/feature2.txt --
+feature2
+-- repo/feature3.txt --
+feature3
+-- golden/before.txt --
+┏━■ features ◀
+main
+-- golden/after.txt --
+    ┏━■ features ◀
+  ┏━┻□ feature2
+┏━┻□ feature1
+main
+-- golden/graph.txt --
+* 99827e4 (HEAD -> features) Add feature3
+* a1192a4 (feature2) Add feature2
+* b9014d5 (feature1) Add feature1
+* 5c2596e (main) Initial commit

--- a/testdata/script/branch_split_err.txt
+++ b/testdata/script/branch_split_err.txt
@@ -1,0 +1,54 @@
+as 'Test <test@example.com>'
+at '2024-06-23T09:50:12Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+! gs branch split
+stderr 'cannot split trunk'
+
+git add feature0.txt
+gs bc feature0 -m 'Add feature0'
+
+git add feature1.txt
+gs bc features -m 'Add feature1'
+
+git add feature2.txt
+gs cc -m 'Add feature2'
+
+git add feature3.txt
+gs cc -m 'Add feature3'
+
+gs ll -a
+cmp stderr $WORK/golden/before.txt
+
+# commit out of range
+! gs branch split --at HEAD~3:featureX
+stderr 'b28a94c'
+stderr 'not in range feature0..features'
+
+# branch already exists
+! gs branch split --at HEAD~1:feature0
+stderr 'branch already exists'
+
+# duplicate branch name
+! gs branch split --at HEAD~2:featureX --at HEAD~1:featureX
+stderr 'branch name already taken'
+
+-- repo/feature0.txt --
+-- repo/feature1.txt --
+feature1
+-- repo/feature2.txt --
+feature2
+-- repo/feature3.txt --
+feature3
+-- golden/before.txt --
+  ┏━■ features ◀
+  ┃   20c96d0 Add feature3 (now)
+  ┃   31bf33e Add feature2 (now)
+  ┃   97bc101 Add feature1 (now)
+┏━┻□ feature0
+┃    b28a94c Add feature0 (now)
+main

--- a/testdata/script/branch_split_prompt.txt
+++ b/testdata/script/branch_split_prompt.txt
@@ -1,0 +1,94 @@
+as 'Test <test@example.com>'
+at '2024-06-23T10:00:12Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git add feature1.txt
+gs bc -m 'Add feature1' features
+git add feature2.txt
+gs cc -m 'Add feature2'
+git add feature3.txt
+gs cc -m 'Add feature3'
+
+gs ll -a
+cmp stderr $WORK/golden/before.txt
+
+with-term $WORK/input/prompt.txt -- gs branch split
+cmp stdout $WORK/golden/prompt.txt
+
+gs ll -a
+cmp stderr $WORK/golden/after.txt
+
+-- repo/feature1.txt --
+feature1
+-- repo/feature2.txt --
+feature2
+-- repo/feature3.txt --
+feature3
+-- golden/before.txt --
+┏━■ features ◀
+┃   1b17c72 Add feature3 (now)
+┃   0c7ed55 Add feature2 (now)
+┃   a3a4c59 Add feature1 (now)
+main
+-- golden/after.txt --
+    ┏━■ features ◀
+    ┃   1b17c72 Add feature3 (now)
+  ┏━┻□ feature2
+  ┃    0c7ed55 Add feature2 (now)
+┏━┻□ feature1
+┃    a3a4c59 Add feature1 (now)
+main
+-- input/prompt.txt --
+# Select the commits
+await Select commits
+snapshot init
+feed \r\r
+await
+snapshot selected
+feed \r
+
+clear
+
+# Pick branch names
+await Add feature1
+snapshot branch1
+clear
+feed feature1\r
+await Add feature2
+snapshot branch2
+feed feature2\r
+
+-- golden/prompt.txt --
+### init ###
+Select commits:
+▶   a3a4c59 Add feature1 (now)
+    0c7ed55 Add feature2 (now)
+  ■ 1b17c72 Add feature3 (now) [features]
+  Done
+Select commits to split the branch at
+### selected ###
+Select commits:
+  □ a3a4c59 Add feature1 (now)
+  □ 0c7ed55 Add feature2 (now)
+  ■ 1b17c72 Add feature3 (now) [features]
+▶ Done
+Select commits to split the branch at
+### branch1 ###
+Select commits:
+  □ a3a4c59 Add feature1 (now)
+  □ 0c7ed55 Add feature2 (now)
+  ■ 1b17c72 Add feature3 (now) [features]
+Branch name:
+  □ a3a4c59 Add feature1 (now)
+### branch2 ###
+Select commits:
+  □ a3a4c59 Add feature1 (now)
+  □ 0c7ed55 Add feature2 (now)
+  ■ 1b17c72 Add feature3 (now) [features]
+Branch name: feature1
+Branch name:
+  □ 0c7ed55 Add feature2 (now)


### PR DESCRIPTION
Adds a 'gs branch split' (gs bsp) command
that allows introducing a new branch on an existing commit.

In non-interactive mode, commits to split on are specified explicitly
with `--at`.

In interactiev mode, the user is presented with a list of commits
and they mark the ones they want to split on.
Names are then requested for the new branches.

Resolves #33
