### PR TITLE
all: Rework --help, prefer --branch flag

### DIFF
--- a/.changes/unreleased/Changed-20240623-180309.yaml
+++ b/.changes/unreleased/Changed-20240623-180309.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'upstack restack: Rename --no-base to --skip-start.'
+time: 2024-06-23T18:03:09.389623-07:00

--- a/.changes/unreleased/Changed-20240623-181151.yaml
+++ b/.changes/unreleased/Changed-20240623-181151.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'upstack restack: Target branch name is now a --branch flag.'
+time: 2024-06-23T18:11:51.283741-07:00

--- a/.changes/unreleased/Changed-20240623-182028.yaml
+++ b/.changes/unreleased/Changed-20240623-182028.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'downstack submit: Optional positional branch argument is now --branch flag.'
+time: 2024-06-23T18:20:28.467858-07:00

--- a/.changes/unreleased/Changed-20240623-182507.yaml
+++ b/.changes/unreleased/Changed-20240623-182507.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'downstack edit: Optional positional branch argument is now a --branch flag.'
+time: 2024-06-23T18:25:07.211419-07:00

--- a/.changes/unreleased/Changed-20240623-202355.yaml
+++ b/.changes/unreleased/Changed-20240623-202355.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'branch fold: The optional branch name argument is now a flag.'
+time: 2024-06-23T20:23:55.080492-07:00

--- a/.changes/unreleased/Changed-20240623-203917.yaml
+++ b/.changes/unreleased/Changed-20240623-203917.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'branch restack: The optional positional argument is now a --branch flag.'
+time: 2024-06-23T20:39:17.967871-07:00

--- a/.changes/unreleased/Changed-20240623-204332.yaml
+++ b/.changes/unreleased/Changed-20240623-204332.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'branch submit: Optional branch positional argument is now the --branch flag.'
+time: 2024-06-23T20:43:32.41291-07:00

--- a/bottom.go
+++ b/bottom.go
@@ -15,8 +15,8 @@ type bottomCmd struct {
 
 func (*bottomCmd) Help() string {
 	return text.Dedent(`
-		Jumps to the bottom-most branch below the current branch.
-		This is the branch just above the trunk.
+		Checks out the bottom-most branch in the current branch's stack.
+		Use the -n flag to print the branch without checking it out.
 	`)
 }
 
@@ -46,5 +46,5 @@ func (cmd *bottomCmd) Run(ctx context.Context, log *log.Logger, opts *globalOpti
 		return nil
 	}
 
-	return (&branchCheckoutCmd{Name: bottom}).Run(ctx, log, opts)
+	return (&branchCheckoutCmd{Branch: bottom}).Run(ctx, log, opts)
 }

--- a/branch.go
+++ b/branch.go
@@ -16,7 +16,6 @@ type branchCmd struct {
 	Track    branchTrackCmd    `cmd:"" aliases:"tr" help:"Track a branch"`
 	Untrack  branchUntrackCmd  `cmd:"" aliases:"untr" help:"Forget a tracked branch"`
 	Checkout branchCheckoutCmd `cmd:"" aliases:"co" help:"Switch to a branch"`
-	Onto     branchOntoCmd     `cmd:"" aliases:"on" help:"Move a branch onto another branch"`
 
 	// Creation and destruction
 	Create branchCreateCmd `cmd:"" aliases:"c" help:"Create a new branch"`
@@ -28,6 +27,7 @@ type branchCmd struct {
 	Edit    branchEditCmd    `cmd:"" aliases:"e" help:"Edit the commits in a branch"`
 	Rename  branchRenameCmd  `cmd:"" aliases:"rn,mv" help:"Rename a branch"`
 	Restack branchRestackCmd `cmd:"" aliases:"r" help:"Restack a branch"`
+	Onto    branchOntoCmd    `cmd:"" aliases:"on" help:"Move a branch onto another branch"`
 
 	// Pull request management
 	Submit branchSubmitCmd `cmd:"" aliases:"s" help:"Submit a branch"`

--- a/branch_create.go
+++ b/branch_create.go
@@ -19,22 +19,22 @@ type branchCreateCmd struct {
 	Below  bool   `help:"Place the branch below the target branch and restack its upstack"`
 	Target string `short:"t" placeholder:"BRANCH" help:"Branch to create the new branch above/below"`
 
-	Message string `short:"m" long:"message" optional:"" help:"Commit message"`
+	Message string `short:"m" placeholder:"MSG" help:"Commit message"`
 }
 
 func (*branchCreateCmd) Help() string {
 	return text.Dedent(`
-		Creates a new branch containing the staged changes
-		on top of the current branch, or --target if specified.
-		If there are no staged changes, creates an empty commit.
+		Staged changes will be committed to the new branch.
+		If there are no staged changes, an empty commit will be created.
+		If a branch name is not provided,
+		it will be generated from the commit message.
 
-		By default, the new branch is created on top of the target,
-		but it does not affect the rest of the stack.
-		Use the --insert flag to move the upstack branches of the
-		target onto the new branch.
-		Alternatively, use the --below flag to place the new branch
-		below the target branch, making the new branch the base of the
-		rest of the stack.
+		The new branch will use the current branch as its base.
+		Use --target to specify a different base branch.
+
+		--insert will move the branches upstack from the target branch
+		on top of the new branch.
+		--below will create the new branch below the target branch.
 
 		For example, given the following stack, with A checked out:
 
@@ -45,6 +45,8 @@ func (*branchCreateCmd) Help() string {
 
 		'gs branch create X' will have the following effects
 		with different flags:
+
+			         gs branch create X
 
 			 default  │   --insert   │  --below
 			──────────┼──────────────┼──────────
@@ -57,7 +59,7 @@ func (*branchCreateCmd) Help() string {
 		In all cases above, use of -t/--target flag will change the
 		target (A) to the specified branch:
 
-			              --target B
+			     gs branch create X --target B
 
 			 default  │   --insert   │  --below
 			──────────┼──────────────┼────────────

--- a/branch_edit.go
+++ b/branch_edit.go
@@ -16,10 +16,9 @@ type branchEditCmd struct{}
 
 func (*branchEditCmd) Help() string {
 	return text.Dedent(`
-		Begins an interactive rebase of a branch without affecting its
-		base branch. This allows you to edit the commits in the branch,
-		reword their messages, etc.
-		After the rebase, the branches upstack from the edited branch
+		Starts an interactive rebase with only the commits
+		in this branch.
+		Following the rebase, branches upstack from this branch
 		will be restacked.
 	`)
 }

--- a/branch_onto.go
+++ b/branch_onto.go
@@ -18,10 +18,13 @@ type branchOntoCmd struct {
 
 func (*branchOntoCmd) Help() string {
 	return text.Dedent(`
-		Transplants the commits of a branch on top of another branch
-		leaving the rest of the branch stack untouched.
-		Use this to extract a single branch from an otherwise unrelated
-		branch stack.
+		The commits of the current branch are transplanted onto another
+		branch.
+		Branches upstack are moved to point to its original base.
+		Use --branch to move a different branch than the current one.
+
+		A prompt will allow selecting the new base.
+		Provide the new base name as an argument to skip the prompt.
 
 		For example, given the following stack with B checked out,
 		running 'gs branch onto main' will move B onto main

--- a/branch_rename.go
+++ b/branch_rename.go
@@ -29,9 +29,9 @@ func (*branchRenameCmd) Help() string {
 			# Rename current branch interactively
 			gs branch rename
 
-		If you renamed a branch without this command,
-		track the new branch name with 'gs branch track',
-		and untrack the old name with 'gs branch untrack'.
+		For branches renamed with 'git branch -m',
+		use 'gs branch track' and 'gs branch untrack'
+		to update the branch tracking.
 	`)
 }
 

--- a/branch_split.go
+++ b/branch_split.go
@@ -19,19 +19,20 @@ import (
 // along commit boundaries.
 type branchSplitCmd struct {
 	At     []branchSplit `placeholder:"COMMIT:NAME" help:"Commits to split the branch at."`
-	Branch string        `arg:"" optional:"" help:"Branch to split commits of."`
+	Branch string        `placeholder:"NAME" help:"Branch to split commits of."`
 }
 
 func (*branchSplitCmd) Help() string {
 	return text.Dedent(`
-		Splits a branch (the current branch by default)
-		into two or more branches at specific commits,
-		inserting the new branches into the stack
+		Splits the current branch into two or more branches at specific
+		commits, inserting the new branches into the stack
 		at the positions of the commits.
+		Use the --branch flag to specify a different branch to split.
 
-		By default, the command runs in interactive mode.
-		To use this command non-interactively, supply the --at flag
-		one or more times:
+		By default, the command will prompt for commits to introduce
+		splits at.
+		Supply the --at flag one or more times to split a branch
+		without a prompt.
 
 			--at COMMIT:NAME
 

--- a/commit_amend.go
+++ b/commit_amend.go
@@ -11,16 +11,16 @@ import (
 )
 
 type commitAmendCmd struct {
-	Message string `short:"m" help:"Use the given message as the commit message."`
+	Message string `short:"m" placeholder:"MSG" help:"Use the given message as the commit message."`
 	NoEdit  bool   `short:"n" help:"Don't edit the commit message"`
 }
 
 func (*commitAmendCmd) Help() string {
 	return text.Dedent(`
-		Amends the last commit with the staged changes,
-		restacking upstack branches if necessary.
-		Use this to keep upstack branches in sync
-		as you update a branch in the middle of the stack.
+		Staged changes are amended into the topmost commit.
+		Branches upstack are restacked if necessary.
+		Use this as a shortcut for 'git commit --amend'
+		followed by 'gs upstack restack'.
 	`)
 }
 
@@ -56,7 +56,7 @@ func (cmd *commitAmendCmd) Run(ctx context.Context, log *log.Logger, opts *globa
 	}
 
 	return (&upstackRestackCmd{
-		Name:   currentBranch,
-		NoBase: true,
+		Branch:    currentBranch,
+		SkipStart: true,
 	}).Run(ctx, log, opts)
 }

--- a/commit_create.go
+++ b/commit_create.go
@@ -17,10 +17,10 @@ type commitCreateCmd struct {
 
 func (*commitCreateCmd) Help() string {
 	return text.Dedent(`
-		Commits the staged changes to the current branch,
-		restacking upstack branches if necessary.
-		Use this to keep upstack branches in sync
-		as you update a branch in the middle of the stack.
+		Staged changes are committed to the current branch.
+		Branches upstack are restacked if necessary.
+		Use this as a shortcut for 'git commit'
+		followed by 'gs upstack restack'.
 	`)
 }
 
@@ -55,7 +55,7 @@ func (cmd *commitCreateCmd) Run(ctx context.Context, log *log.Logger, opts *glob
 	}
 
 	return (&upstackRestackCmd{
-		Name:   currentBranch,
-		NoBase: true,
+		Branch:    currentBranch,
+		SkipStart: true,
 	}).Run(ctx, log, opts)
 }

--- a/down.go
+++ b/down.go
@@ -16,10 +16,10 @@ type downCmd struct {
 
 func (*downCmd) Help() string {
 	return text.Dedent(`
-		Moves down the stack to the branch below the current branch.
-		As a convenience,
-		if the current branch is at the bottom of the stack,
-		this command will move to the trunk branch.
+		Checks out the branch below the current branch.
+		If the current branch is at the bottom of the stack,
+		checks out the trunk branch.
+		Use the -n flag to print the branch without checking it out.
 	`)
 }
 
@@ -71,5 +71,5 @@ outer:
 		return nil
 	}
 
-	return (&branchCheckoutCmd{Name: below}).Run(ctx, log, opts)
+	return (&branchCheckoutCmd{Branch: below}).Run(ctx, log, opts)
 }

--- a/downstack.go
+++ b/downstack.go
@@ -1,6 +1,6 @@
 package main
 
 type downstackCmd struct {
-	Submit downstackSubmitCmd `cmd:"" aliases:"s" help:"Submit the current branch and those below it"`
-	Edit   downstackEditCmd   `cmd:"" aliases:"e" help:"Edit the order of branches below the current branch"`
+	Submit downstackSubmitCmd `cmd:"" aliases:"s" help:"Submit a branch and those below it"`
+	Edit   downstackEditCmd   `cmd:"" aliases:"e" help:"Edit the order of branches below a branch"`
 }

--- a/log.go
+++ b/log.go
@@ -18,8 +18,8 @@ import (
 )
 
 type logCmd struct {
-	Short logShortCmd `cmd:"" aliases:"s" help:"Short view of stack"`
-	Long  logLongCmd  `cmd:"" aliases:"l" help:"Long view of stack"`
+	Short logShortCmd `cmd:"" aliases:"s" help:"List branches"`
+	Long  logLongCmd  `cmd:"" aliases:"l" help:"List branches and commits"`
 }
 
 var (

--- a/log_long.go
+++ b/log_long.go
@@ -13,9 +13,7 @@ type logLongCmd struct {
 
 func (*logLongCmd) Help() string {
 	return text.Dedent(`
-		Provides a tree view of the branches in the current stack
-		and their commits,
-		By default, branches upstack and downstack from the current
+		Only branches that are upstack and downstack from the current
 		branch are shown.
 		Use with the -a/--all flag to show all tracked branches.
 	`)

--- a/log_short.go
+++ b/log_short.go
@@ -13,9 +13,7 @@ type logShortCmd struct {
 
 func (*logShortCmd) Help() string {
 	return text.Dedent(`
-		Provides a tree view of the branches in the current stack,
-		both upstack and downstack from it.
-		By default, branches upstack and downstack from the current
+		Only branches that are upstack and downstack from the current
 		branch are shown.
 		Use with the -a/--all flag to show all tracked branches.
 	`)

--- a/repo_init.go
+++ b/repo_init.go
@@ -18,23 +18,23 @@ type repoInitCmd struct {
 	Trunk  string `placeholder:"BRANCH" predictor:"branches" help:"Name of the trunk branch"`
 	Remote string `placeholder:"NAME" predictor:"remotes" help:"Name of the remote to push changes to"`
 
-	Reset bool `help:"Reset the store if it's already initialized"`
+	Reset bool `help:"Forget all information about the repository"`
 }
 
 func (*repoInitCmd) Help() string {
 	return text.Dedent(`
-		Sets up a repository for use.
-		This isn't strictly necessary to run as most commands will
-		auto-initialize the repository as needed.
+		A trunk branch is required.
+		This is the branch that changes will be merged into.
+		A prompt will ask for one if not provided with --trunk.
 
-		Use the --trunk flag to specify the trunk branch.
-		This is typically 'main' or 'master',
-		and picking one is required.
+		Most branch stacking operations are local
+		and do not require a network connection.
+		For operations that push or pull commits, a remote is required.
+		A prompt will ask for one during initialization
+		if not provided with --remote.
 
-		Use the --remote flag to specify the remote to push changes to.
-		A remote is not required--local stacking will work without it,
-		but any commands that require a remote will fail.
-		To add a remote later, re-run this command.
+		Re-run the command to change the trunk or remote.
+		Re-run with --reset to discard all stored information.
 	`)
 }
 

--- a/repo_sync.go
+++ b/repo_sync.go
@@ -23,9 +23,12 @@ type repoSyncCmd struct {
 
 func (*repoSyncCmd) Help() string {
 	return text.Dedent(`
-		Pulls the latest changes from the remote repository.
-		Deletes branches that have were merged into trunk,
-		and updates the base branches of branches upstack from those.
+		Branches with merged Change Requests
+		will be deleted after syncing.
+
+		The repository must have a remote associated for syncing.
+		A prompt will ask for one if the repository
+		was not initialized with a remote.
 	`)
 }
 
@@ -382,8 +385,8 @@ func (cmd *repoSyncCmd) deleteMergedBranches(
 	// (e.g. from the bottom of the stack up)
 	for _, branch := range branchesToDelete {
 		err := (&branchDeleteCmd{
-			Name:  branch,
-			Force: true,
+			Branch: branch,
+			Force:  true,
 		}).Run(ctx, log, opts)
 		if err != nil {
 			return fmt.Errorf("delete branch %v: %w", branch, err)

--- a/shell_completion.go
+++ b/shell_completion.go
@@ -19,12 +19,9 @@ type shellCompletionCmd struct {
 
 func (c *shellCompletionCmd) Help() string {
 	return text.Dedent(`
-		Generates shell completion scripts for the provided shell.
-		If a shell name is not provided, the command will attempt to
-		guess the shell based on environment variables.
-
-		To install the script, add the following line to your shell's
-		rc file.
+		To set up shell completion, eval the output of this command
+		from your shell's rc file.
+		For example:
 
 			# bash
 			eval "$(gs shell completion bash)"
@@ -34,6 +31,9 @@ func (c *shellCompletionCmd) Help() string {
 
 			# fish
 			eval "$(gs shell completion fish)"
+
+		If shell name is not provided, the current shell is guessed
+		using a heuristic.
 	`)
 }
 

--- a/stack.go
+++ b/stack.go
@@ -1,7 +1,7 @@
 package main
 
 type stackCmd struct {
-	Submit  stackSubmitCmd  `cmd:"" aliases:"s" help:"Submit the current stack"`
-	Restack stackRestackCmd `cmd:"" aliases:"r" help:"Restack the current stack"`
-	Edit    stackEditCmd    `cmd:"" aliases:"e" help:"Edit the order of branches in the stack"`
+	Submit  stackSubmitCmd  `cmd:"" aliases:"s" help:"Submit a stack"`
+	Restack stackRestackCmd `cmd:"" aliases:"r" help:"Restack a stack"`
+	Edit    stackEditCmd    `cmd:"" aliases:"e" help:"Edit the order of branches in a stack"`
 }

--- a/stack_restack.go
+++ b/stack_restack.go
@@ -8,9 +8,17 @@ import (
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/text"
 )
 
 type stackRestackCmd struct{}
+
+func (*stackRestackCmd) Help() string {
+	return text.Dedent(`
+		All branches in the current stack are rebased on top of their
+		respective bases, ensuring a linear history.
+	`)
+}
 
 func (*stackRestackCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
 	repo, store, svc, err := openRepo(ctx, log, opts)

--- a/stack_submit.go
+++ b/stack_submit.go
@@ -5,11 +5,23 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/text"
 )
 
 type stackSubmitCmd struct {
 	DryRun bool `short:"n" help:"Don't actually submit the stack"`
 	Fill   bool `help:"Fill in the pull request title and body from the commit messages"`
+}
+
+func (*stackSubmitCmd) Help() string {
+	return text.Dedent(`
+		Change Requests are created or updated
+		for all branches in the current stack.
+		A prompt will ask for a title and body for each Change Request.
+		Use --fill to populate these from the commit messages.
+		Use --dry-run to see what would be submitted
+		without actually submitting anything.
+	`)
 }
 
 func (cmd *stackSubmitCmd) Run(
@@ -43,7 +55,7 @@ func (cmd *stackSubmitCmd) Run(
 		err := (&branchSubmitCmd{
 			DryRun: cmd.DryRun,
 			Fill:   cmd.Fill,
-			Name:   branch,
+			Branch: branch,
 		}).Run(ctx, log, opts)
 		if err != nil {
 			return fmt.Errorf("submit %v: %w", branch, err)

--- a/testdata/script/branch_submit_by_name.txt
+++ b/testdata/script/branch_submit_by_name.txt
@@ -20,7 +20,7 @@ gs bc -m 'Add feature1' feature1
 git checkout main
 
 # submit the branch
-gs branch submit --fill feature1
+gs branch submit --fill --branch=feature1
 stderr 'Created #1'
 gh-dump-pull
 cmpenvJSON stdout $WORK/golden/pulls.json

--- a/top.go
+++ b/top.go
@@ -16,9 +16,10 @@ type topCmd struct {
 
 func (*topCmd) Help() string {
 	return text.Dedent(`
-		Jumps to the top-most branch in the current branch's stack.
-		If there are multiple top-most branches,
-		you will be prompted to pick one.
+		Checks out the top-most branch in the current branch's stack.
+		If there are multiple possible top-most branches,
+		a prompt will ask you to pick one.
+		Use the -n flag to print the branch without checking it out.
 	`)
 }
 
@@ -70,5 +71,5 @@ func (cmd *topCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions
 		return nil
 	}
 
-	return (&branchCheckoutCmd{Name: branch}).Run(ctx, log, opts)
+	return (&branchCheckoutCmd{Branch: branch}).Run(ctx, log, opts)
 }

--- a/trunk.go
+++ b/trunk.go
@@ -24,5 +24,5 @@ func (*trunkCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) 
 	}
 
 	trunk := store.Trunk()
-	return (&branchCheckoutCmd{Name: trunk}).Run(ctx, log, opts)
+	return (&branchCheckoutCmd{Branch: trunk}).Run(ctx, log, opts)
 }

--- a/up.go
+++ b/up.go
@@ -17,9 +17,10 @@ type upCmd struct {
 
 func (*upCmd) Help() string {
 	return text.Dedent(`
-		Moves up the stack to the branch on top of the current one.
+		Checks out the branch above the current one.
 		If there are multiple branches with the current branch as base,
-		you will be prompted to pick one.
+		a prompt will allow picking between them.
+		Use the -n flag to print the branch without checking it out.
 	`)
 }
 
@@ -80,5 +81,5 @@ outer:
 		return nil
 	}
 
-	return (&branchCheckoutCmd{Name: branch}).Run(ctx, log, opts)
+	return (&branchCheckoutCmd{Branch: branch}).Run(ctx, log, opts)
 }

--- a/upstack.go
+++ b/upstack.go
@@ -1,6 +1,6 @@
 package main
 
 type upstackCmd struct {
-	Restack upstackRestackCmd `cmd:"" aliases:"r" help:"Restack this branch those above it"`
-	Onto    upstackOntoCmd    `cmd:"" aliases:"o" help:"Move this branch onto another branch"`
+	Restack upstackRestackCmd `cmd:"" aliases:"r" help:"Restack a branch and its upstack"`
+	Onto    upstackOntoCmd    `cmd:"" aliases:"o" help:"Move a branch onto another branch"`
 }

--- a/upstack_onto.go
+++ b/upstack_onto.go
@@ -18,12 +18,15 @@ type upstackOntoCmd struct {
 
 func (*upstackOntoCmd) Help() string {
 	return text.Dedent(`
-		Moves a branch and its upstack branches onto another branch.
-		Use this to move a complete part of your branch stack to a
-		different base.
+		The current branch and its upstack will move onto the new base.
+		Use 'gs branch onto' to leave the branch's upstack alone.
+		Use --branch to move a different branch than the current one.
+
+		A prompt will allow selecting the new base.
+		Provide the new base name as an argument to skip the prompt.
 
 		For example, given the following stack with B checked out,
-		running 'gs upstack onto main' will move B and C onto main:
+		'gs upstack onto main' will have the following effect:
 
 			       gs upstack onto main
 
@@ -102,6 +105,6 @@ func (cmd *upstackOntoCmd) Run(ctx context.Context, log *log.Logger, opts *globa
 	}
 
 	return (&upstackRestackCmd{
-		NoBase: true, // we've already moved the current branch
+		SkipStart: true, // we've already moved the current branch
 	}).Run(ctx, log, opts)
 }


### PR DESCRIPTION
Prefer a --branch flag instead of a positional branch parameter
where possible.
For everything else, rework the --help text.
