### PR TITLE
storage/git: Fix ConcurrentSets flakiness

### DIFF
--- a/internal/storage/backend_test.go
+++ b/internal/storage/backend_test.go
@@ -112,7 +112,7 @@ func testStorageBackend(t *testing.T, backend Backend) {
 		// We could use a file-lock, but in practice, git-spice is not
 		// intended to be used with several concurrent operations
 		// on the same repository.
-		const NumWorkers, NumSets = 2, 5
+		const NumWorkers, NumSets = 2, 2
 
 		keys := make([]string, NumSets)
 		for i := range keys {


### PR DESCRIPTION
If the total number of attempts exceeds 5 (maximum attempts),
we're going to run into flakiness on this test regardless.