### PR TITLE
ci: Enable -race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,7 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
 
     - name: Test
-      # TODO: Add -race
-      run: make cover TEST_FLAGS=
+      run: make cover
       shell: bash
 
     - name: Upload coverage

--- a/internal/termtest/with_term.go
+++ b/internal/termtest/with_term.go
@@ -148,7 +148,7 @@ func WithTerm() (exitCode int) {
 			awaitStripPrefix = emu.Snapshot()
 
 		case "await":
-			timeout := time.Second
+			timeout := 3 * time.Second
 			start := time.Now()
 
 			var match func([]string) bool

--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"github.com/charmbracelet/bubbles/cursor"
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -44,6 +45,7 @@ var _ Field = (*Input)(nil)
 func NewInput() *Input {
 	m := textinput.New()
 	m.Prompt = "" // we have our own prompt
+	m.Cursor.SetMode(cursor.CursorStatic)
 	return &Input{
 		KeyMap: DefaultInputKeyMap,
 		Style:  DefaultInputStyle,


### PR DESCRIPTION
Enable data-race detection in tests.

Fixes:

- The 'await' timeout had to be increased because some operations
  are just slower now.
- ui.Input now uses a static cursor.
  The blinking cursor just causes a data race
  and there doesn't appear to be a way to work around it.
