### PR TITLE
ui: Add List field

### DIFF
--- a/branch_submit.go
+++ b/branch_submit.go
@@ -373,9 +373,9 @@ func (f *branchSubmitForm) templateField(changeTemplatesCh <-chan []*forge.Chang
 			return nil
 
 		default:
-			opts := make([]ui.Option[*forge.ChangeTemplate], len(templates))
+			opts := make([]ui.SelectOption[*forge.ChangeTemplate], len(templates))
 			for i, tmpl := range templates {
-				opts[i] = ui.Option[*forge.ChangeTemplate]{
+				opts[i] = ui.SelectOption[*forge.ChangeTemplate]{
 					Label: tmpl.Filename,
 					Value: tmpl,
 				}

--- a/internal/ui/list.go
+++ b/internal/ui/list.go
@@ -1,0 +1,235 @@
+package ui
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// ListKeyMap defines key bindings for [List].
+type ListKeyMap struct {
+	Up     key.Binding
+	Down   key.Binding
+	Accept key.Binding
+}
+
+// DefaultListKeyMap specifies the default key bindings for [List].
+var DefaultListKeyMap = ListKeyMap{
+	Up: key.NewBinding(
+		key.WithKeys("up", "k"),
+		key.WithHelp("up/k", "go up"),
+	),
+	Down: key.NewBinding(
+		key.WithKeys("down", "j"),
+		key.WithHelp("down/j", "go down"),
+	),
+	Accept: key.NewBinding(
+		key.WithKeys("enter", "tab"),
+		key.WithHelp("enter/tab", "accept"),
+	),
+}
+
+// ListStyle defines the styles for [List].
+type ListStyle struct {
+	Cursor lipgloss.Style
+
+	ItemTitle       lipgloss.Style
+	ItemDescription lipgloss.Style
+
+	SelectedItemTitle       lipgloss.Style
+	SelectedItemDescription lipgloss.Style
+}
+
+// DefaultListStyle is the default style for a [List].
+var DefaultListStyle = ListStyle{
+	Cursor:                  NewStyle().Foreground(Yellow).Bold(true).SetString("▶"),
+	ItemTitle:               NewStyle().Foreground(Gray),
+	ItemDescription:         NewStyle().Foreground(Gray).PaddingLeft(2),
+	SelectedItemTitle:       NewStyle().Foreground(Yellow),
+	SelectedItemDescription: NewStyle().Foreground(Plain).PaddingLeft(2),
+}
+
+// List is a prompt that allows selecting from a list of options.
+// This is similar to [Select] but without the fuzzy filter.
+// Each item in a List can have a title, description, and a value.
+type List[T any] struct {
+	KeyMap ListKeyMap
+	Style  ListStyle
+
+	title string
+	desc  string
+	items []ListItem[T]
+	value *T
+
+	width    int
+	selected int
+	accepted bool
+}
+
+var _ Field = (*List[int])(nil)
+
+// ListItem is an item in a [List].
+type ListItem[T any] struct {
+	Title       string
+	Description string
+	Value       T
+}
+
+// NewList creates a new [List] with default settings.
+func NewList[T any]() *List[T] {
+	return &List[T]{
+		KeyMap: DefaultListKeyMap,
+		Style:  DefaultListStyle,
+		value:  new(T),
+	}
+}
+
+// WithValue sets the destination pointer for the selected item's value.
+// When the user selects an item, the value will be copied to the pointer.
+func (l *List[T]) WithValue(value *T) *List[T] {
+	l.value = value
+	return l
+}
+
+// Value retrieevs the selected item's value.
+func (l *List[T]) Value() *T {
+	return l.value
+}
+
+// WithTitle sets the title of the [List].
+func (l *List[T]) WithTitle(title string) *List[T] {
+	l.title = title
+	return l
+}
+
+// Title retrieves the title of the [List].
+func (l *List[T]) Title() string {
+	return l.title
+}
+
+// WithDescription sets the description of the [List].
+func (l *List[T]) WithDescription(desc string) *List[T] {
+	l.desc = desc
+	return l
+}
+
+// Description retrieves the description of the [List].
+func (l *List[T]) Description() string {
+	return l.desc
+}
+
+// WithItems fills the list with items.
+// By default the first of these items will be selected.
+func (l *List[T]) WithItems(items ...ListItem[T]) *List[T] {
+	l.items = items
+	return l
+}
+
+// WithSelected sets the index of the selected item.
+func (l *List[T]) WithSelected(selected int) *List[T] {
+	l.selected = selected
+	return l
+}
+
+// With is a helper to pass in a list of customizations at once.
+func (l *List[T]) With(f func(l *List[T])) *List[T] {
+	f(l)
+	return l
+}
+
+// ComparableListItems configures a [List]
+// to list the presented items and select 'selected' by default.
+func ComparableListItems[T comparable](selected T, items ...T) func(*List[T]) {
+	var selectedIdx int
+	options := make([]ListItem[T], len(items))
+	for i, v := range items {
+		options[i] = ListItem[T]{
+			Title: fmt.Sprintf("%v", v),
+			Value: v,
+		}
+		if v == selected {
+			selectedIdx = i
+		}
+	}
+
+	return func(l *List[T]) {
+		l.WithItems(options...)
+		l.WithSelected(selectedIdx)
+	}
+}
+
+// Err returns nil.
+func (l *List[T]) Err() error { return nil }
+
+// Init initializes the [List].
+func (l *List[T]) Init() tea.Cmd {
+	return nil
+}
+
+// Update receives a message from bubbletea
+// and updates the internal state of the list.
+func (l *List[T]) Update(msg tea.Msg) tea.Cmd {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		l.width = msg.Width
+
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, l.KeyMap.Up):
+			l.selected--
+			if l.selected < 0 {
+				l.selected = len(l.items) - 1
+			}
+
+		case key.Matches(msg, l.KeyMap.Down):
+			l.selected++
+			if l.selected >= len(l.items) {
+				l.selected = 0
+			}
+
+		case key.Matches(msg, l.KeyMap.Accept):
+			if l.selected >= 0 && l.selected < len(l.items) {
+				*l.value = l.items[l.selected].Value
+				l.accepted = true
+				return AcceptField
+			}
+		}
+	}
+
+	return nil
+}
+
+// Render renders the list to the screen.
+func (l *List[T]) Render(w Writer) {
+	if l.accepted {
+		w.WriteString(l.items[l.selected].Title)
+		return
+	}
+
+	for i, item := range l.items {
+		titleStyle := l.Style.ItemTitle
+		descStyle := l.Style.ItemDescription
+		cursor := "  "
+		if i == l.selected {
+			cursor = l.Style.Cursor.String() + " "
+			titleStyle = l.Style.SelectedItemTitle
+			descStyle = l.Style.SelectedItemDescription
+		} else {
+			w.WriteString(" ")
+		}
+		descStyle = descStyle.Width(l.width - 4)
+
+		w.WriteString("\n")
+		w.WriteString(lipgloss.JoinHorizontal(
+			lipgloss.Top,
+			cursor,
+			lipgloss.JoinVertical(
+				lipgloss.Left,
+				titleStyle.Render(item.Title),
+				descStyle.Render(item.Description),
+			),
+		))
+	}
+}

--- a/internal/ui/select.go
+++ b/internal/ui/select.go
@@ -76,6 +76,12 @@ type Select[T any] struct {
 	err      error // error state
 }
 
+// SelectOption is a single option for a select field.
+type SelectOption[T any] struct {
+	Label string
+	Value T
+}
+
 type selectOption[T any] struct {
 	Label      string // label to show for this option
 	Value      T      // value to set when selected
@@ -105,12 +111,6 @@ func (s *Select[T]) Value() T {
 	return *s.value
 }
 
-// Option is a single option for a select field.
-type Option[T any] struct {
-	Label string
-	Value T
-}
-
 // With runs the given function with the select field.
 func (s *Select[T]) With(f func(*Select[T])) *Select[T] {
 	f(s)
@@ -123,12 +123,12 @@ func (s *Select[T]) With(f func(*Select[T])) *Select[T] {
 // The defeault string representation of the value is used as the label.
 func ComparableOptions[T comparable](selected T, opts ...T) func(*Select[T]) {
 	var selectedIdx int
-	options := make([]Option[T], len(opts))
+	options := make([]SelectOption[T], len(opts))
 	for i, v := range opts {
 		if v == selected {
 			selectedIdx = i
 		}
-		options[i] = Option[T]{
+		options[i] = SelectOption[T]{
 			Label: fmt.Sprintf("%v", v),
 			Value: v,
 		}
@@ -143,7 +143,7 @@ func ComparableOptions[T comparable](selected T, opts ...T) func(*Select[T]) {
 // WithOptions sets the available options for the select field.
 // The options will be presented in the order they are provided.
 // Existing options will be replaced.
-func (s *Select[T]) WithOptions(opts ...Option[T]) *Select[T] {
+func (s *Select[T]) WithOptions(opts ...SelectOption[T]) *Select[T] {
 	options := make([]selectOption[T], len(opts))
 	matched := make([]int, len(options))
 	for i, v := range opts {


### PR DESCRIPTION
Adds a field to ui
that presents a list of items with descriptions,
and allows picking between them.

Unlike ui.Select, this does not support fuzzy matching,
The Option type used by Select has been renamed to SelectOption
to avoid confusion with the new ListOption type.