### PR TITLE
forge: Allow injecting CLI flags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,11 +23,19 @@ Follow the usual GitHub contribution process for making changes
 with the following notes:
 
 - Add changelog entries for user-facing changes with `changie new`.
+  If a change is not user-facing, add a note in the following format
+  to the PR description:
+
+  ```
+  [skip changelog]: reason why no changelog entry is needed
+  ```
+
 - If you edit documentation in doc/, run `make README.md` to update the README.
   This requires stitchmd to be installed.
+
 - All commits must include meaningful commit messages.
 - Test new features and bug fixes.
-  If it doesn't have a test, it's not fixed.
+  If it does not have a test, the bug is not fixed.
 - Verify tests pass before submitting a pull request.
 
 ### Stacking changes

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,9 @@ coverage:
     project:
       default:
         informational: true
+    patch:
+      default:
+        informational: true
 comment: false
 github_checks:
   annotations: false

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -17,6 +17,13 @@ import (
 
 var _forgeRegistry sync.Map
 
+// All is an iterator that yields all registered forges.
+func All(yield func(Forge) bool) {
+	_forgeRegistry.Range(func(_, value any) bool {
+		return yield(value.(Forge))
+	})
+}
+
 // Register registers a forge with the given ID.
 // Returns a function to unregister the forge.
 func Register(f Forge) (unregister func()) {
@@ -72,10 +79,15 @@ type Forge interface {
 	// ID reports a unique identifier for the forge, e.g. "github".
 	ID() string
 
+	// CLIPlugin returns a Kong plugin for this Forge.
+	// Return nil if the forge does not require any extra CLI flags.
+	CLIPlugin() any
+	// TODO: Perhaps some validation function for the flags?
+
 	// MatchURL reports whether the given remote URL is hosted on the forge.
 	MatchURL(remoteURL string) bool
 
-	// OpenURL opens a repository hosted on the forge
+	// OpenURL opens a repository hosted on the Forge
 	// with the given remote URL.
 	//
 	// This will only be called if MatchURL reports true.

--- a/internal/forge/github/forge_test.go
+++ b/internal/forge/github/forge_test.go
@@ -63,7 +63,8 @@ func TestExtractRepoInfo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			owner, repo, err := extractRepoInfo(tt.githubURL, tt.give)
+			f := Forge{Options: Options{URL: tt.githubURL}}
+			owner, repo, err := extractRepoInfo(f.URL(), tt.give)
 			require.NoError(t, err)
 
 			assert.Equal(t, tt.wantOwner, owner, "owner")
@@ -108,7 +109,8 @@ func TestExtractRepoInfoErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := extractRepoInfo(tt.githubURL, tt.give)
+			f := Forge{Options: Options{URL: tt.githubURL}}
+			_, _, err := extractRepoInfo(f.URL(), tt.give)
 			require.Error(t, err)
 
 			for _, want := range tt.wantErr {

--- a/internal/spice/branch_test.go
+++ b/internal/spice/branch_test.go
@@ -46,9 +46,11 @@ func TestService_LookupBranch_changeAssociation(t *testing.T) {
 	t.Cleanup(shamhubServer.Close)
 
 	shamhubForge := &shamhub.Forge{
-		Log:    logtest.New(t),
-		URL:    shamhubServer.URL,
-		APIURL: shamhubServer.URL,
+		Log: logtest.New(t),
+		Options: shamhub.Options{
+			URL:    shamhubServer.URL,
+			APIURL: shamhubServer.URL,
+		},
 	}
 	t.Cleanup(forge.Register(shamhubForge))
 

--- a/script_test.go
+++ b/script_test.go
@@ -32,19 +32,7 @@ func TestMain(m *testing.M) {
 				Level: log.DebugLevel,
 			})
 
-			shamhubAPIURL := os.Getenv("SHAMHUB_API_URL")
-			shamhubURL := os.Getenv("SHAMHUB_URL")
-			if (shamhubURL != "") != (shamhubAPIURL != "") {
-				logger.Fatalf("gs: SHAMHUB_API_URL and SHAMHUB_URL must be set together")
-			}
-			if shamhubURL != "" {
-				forge.Register(&shamhub.Forge{
-					URL:    shamhubURL,
-					APIURL: shamhubAPIURL,
-					Log:    logger,
-				})
-			}
-
+			forge.Register(&shamhub.Forge{Log: logger})
 			main()
 			return 0
 		},


### PR DESCRIPTION
Allows forges to inject CLI flags and environment variable overrides
without leaking forge-specific information into the main function.

For example, all GitHub flags and env vars are now defined in the GitHub
package.

This logic is further refined for Device Flow authentication
in a future change.
