### PR TITLE
{up,down,}stack submit: Add --[no-]draft, --no-publish

### DIFF
--- a/.changes/unreleased/Added-20240702-195319.yaml
+++ b/.changes/unreleased/Added-20240702-195319.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: '{stack, upstack, downstack} submit: Add --draft/--no-draft flags for changing the reviewability status of a PR.'
+time: 2024-07-02T19:53:19.588858-07:00

--- a/.changes/unreleased/Added-20240702-195343.yaml
+++ b/.changes/unreleased/Added-20240702-195343.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: '{stack, upstack, downstack} subimt: Add --no-publish to push stack branches without posting PRs for them.'
+time: 2024-07-02T19:53:43.838659-07:00

--- a/branch_submit.go
+++ b/branch_submit.go
@@ -18,22 +18,36 @@ import (
 	"go.abhg.dev/gs/internal/ui"
 )
 
-type branchSubmitCmd struct {
+// submitOptions defines options that are common to all submit commands.
+type submitOptions struct {
 	DryRun bool `short:"n" help:"Don't actually submit the stack"`
-
-	Title string `help:"Title of the pull request" placeholder:"TITLE"`
-	Body  string `help:"Body of the pull request" placeholder:"BODY"`
-	Draft *bool  `negatable:"" help:"Whether to mark the pull request as draft"`
-	Fill  bool   `help:"Fill in the pull request title and body from the commit messages"`
-	// TODO: Default to Fill if --no-prompt
-
-	NoPublish bool `name:"no-publish" help:"Push the branch, but donn't create a pull request"`
+	Fill   bool `help:"Fill in the pull request title and body from the commit messages"`
+	// TODO: Default to Fill if --no-prompt?
+	Draft     *bool `negatable:"" help:"Whether to mark pull requests as drafts"`
+	NoPublish bool  `name:"no-publish" help:"Push branches but don't create pull requests"`
 
 	// TODO: Other creation options e.g.:
 	// - assignees
 	// - labels
 	// - milestone
 	// - reviewers
+}
+
+const _submitHelp = `
+Use --dry-run to print what would be submitted without submitting it.
+For new Change Requests, a prompt will allow filling metadata.
+Use --fill to populate title and body from the commit messages,
+and --[no-]draft to set the draft status.
+Omitting the draft flag will leave the status unchanged of open CRs.
+Use --no-publish to push branches without creating CRs.
+This has no effect if a branch already has an open CR.
+`
+
+type branchSubmitCmd struct {
+	submitOptions
+
+	Title string `help:"Title of the pull request" placeholder:"TITLE"`
+	Body  string `help:"Body of the pull request" placeholder:"BODY"`
 
 	Branch string `placeholder:"NAME" help:"Branch to submit" predictor:"trackedBranches"`
 }

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -164,15 +164,22 @@ Submit a stack
 
 Change Requests are created or updated
 for all branches in the current stack.
-A prompt will ask for a title and body for each Change Request.
-Use --fill to populate these from the commit messages.
-Use --dry-run to see what would be submitted
-without actually submitting anything.
+
+Use --dry-run to print what would be submitted without submitting it.
+For new Change Requests, a prompt will allow filling metadata.
+Use --fill to populate title and body from the commit messages,
+and --[no-]draft to set the draft status.
+Omitting the draft flag will leave the status unchanged of open CRs.
+Use --no-publish to push branches without creating CRs.
+This has no effect if a branch already has an open CR.
+
 
 **Flags**
 
 * `-n`, `--dry-run`: Don't actually submit the stack
 * `--fill`: Fill in the pull request title and body from the commit messages
+* `--[no-]draft`: Whether to mark pull requests as drafts
+* `--no-publish`: Push branches but don't create pull requests
 
 ### gs stack restack
 
@@ -224,15 +231,21 @@ If the base of the current branch is not trunk,
 it must have already been submitted by a prior command.
 Use --branch to start at a different branch.
 
-A prompt will ask for a title and body for each Change Request.
-Use --fill to populate these from the commit messages.
-Use --dry-run to see what would be submitted
-without actually submitting anything.
+Use --dry-run to print what would be submitted without submitting it.
+For new Change Requests, a prompt will allow filling metadata.
+Use --fill to populate title and body from the commit messages,
+and --[no-]draft to set the draft status.
+Omitting the draft flag will leave the status unchanged of open CRs.
+Use --no-publish to push branches without creating CRs.
+This has no effect if a branch already has an open CR.
+
 
 **Flags**
 
 * `-n`, `--dry-run`: Don't actually submit the stack
 * `--fill`: Fill in the pull request title and body from the commit messages
+* `--[no-]draft`: Whether to mark pull requests as drafts
+* `--no-publish`: Push branches but don't create pull requests
 * `--branch=NAME`: Branch to start at
 
 ### gs upstack restack
@@ -304,15 +317,21 @@ Change Requests are created or updated
 for the current branch and all branches below it until trunk.
 Use --branch to start at a different branch.
 
-A prompt will ask for a title and body for each Change Request.
-Use --fill to populate these from the commit messages.
-Use --dry-run to see what would be submitted
-without actually submitting anything.
+Use --dry-run to print what would be submitted without submitting it.
+For new Change Requests, a prompt will allow filling metadata.
+Use --fill to populate title and body from the commit messages,
+and --[no-]draft to set the draft status.
+Omitting the draft flag will leave the status unchanged of open CRs.
+Use --no-publish to push branches without creating CRs.
+This has no effect if a branch already has an open CR.
+
 
 **Flags**
 
 * `-n`, `--dry-run`: Don't actually submit the stack
 * `--fill`: Fill in the pull request title and body from the commit messages
+* `--[no-]draft`: Whether to mark pull requests as drafts
+* `--no-publish`: Push branches but don't create pull requests
 * `--branch=NAME`: Branch to start at
 
 ### gs downstack edit
@@ -661,11 +680,11 @@ Request.
 **Flags**
 
 * `-n`, `--dry-run`: Don't actually submit the stack
+* `--fill`: Fill in the pull request title and body from the commit messages
+* `--[no-]draft`: Whether to mark pull requests as drafts
+* `--no-publish`: Push branches but don't create pull requests
 * `--title=TITLE`: Title of the pull request
 * `--body=BODY`: Body of the pull request
-* `--[no-]draft`: Whether to mark the pull request as draft
-* `--fill`: Fill in the pull request title and body from the commit messages
-* `--no-publish`: Push the branch, but donn't create a pull request
 * `--branch=NAME`: Branch to submit
 
 ## Commit

--- a/downstack_submit.go
+++ b/downstack_submit.go
@@ -13,8 +13,7 @@ import (
 )
 
 type downstackSubmitCmd struct {
-	DryRun bool `short:"n" help:"Don't actually submit the stack"`
-	Fill   bool `help:"Fill in the pull request title and body from the commit messages"`
+	submitOptions
 
 	Branch string `placeholder:"NAME" help:"Branch to start at" predictor:"trackedBranches"`
 }
@@ -24,12 +23,7 @@ func (*downstackSubmitCmd) Help() string {
 		Change Requests are created or updated
 		for the current branch and all branches below it until trunk.
 		Use --branch to start at a different branch.
-
-		A prompt will ask for a title and body for each Change Request.
-		Use --fill to populate these from the commit messages.
-		Use --dry-run to see what would be submitted
-		without actually submitting anything.
-	`)
+	`) + "\n" + _submitHelp
 }
 
 func (cmd *downstackSubmitCmd) Run(
@@ -67,9 +61,8 @@ func (cmd *downstackSubmitCmd) Run(
 	// TODO: submits should be done in parallel
 	for _, downstack := range downstacks {
 		err := (&branchSubmitCmd{
-			DryRun: cmd.DryRun,
-			Fill:   cmd.Fill,
-			Branch: downstack,
+			submitOptions: cmd.submitOptions,
+			Branch:        downstack,
 		}).Run(ctx, secretStash, log, opts)
 		if err != nil {
 			return fmt.Errorf("submit %v: %w", downstack, err)

--- a/stack_submit.go
+++ b/stack_submit.go
@@ -10,19 +10,14 @@ import (
 )
 
 type stackSubmitCmd struct {
-	DryRun bool `short:"n" help:"Don't actually submit the stack"`
-	Fill   bool `help:"Fill in the pull request title and body from the commit messages"`
+	submitOptions
 }
 
 func (*stackSubmitCmd) Help() string {
 	return text.Dedent(`
 		Change Requests are created or updated
 		for all branches in the current stack.
-		A prompt will ask for a title and body for each Change Request.
-		Use --fill to populate these from the commit messages.
-		Use --dry-run to see what would be submitted
-		without actually submitting anything.
-	`)
+	`) + "\n" + _submitHelp
 }
 
 func (cmd *stackSubmitCmd) Run(
@@ -55,9 +50,8 @@ func (cmd *stackSubmitCmd) Run(
 		}
 
 		err := (&branchSubmitCmd{
-			DryRun: cmd.DryRun,
-			Fill:   cmd.Fill,
-			Branch: branch,
+			submitOptions: cmd.submitOptions,
+			Branch:        branch,
 		}).Run(ctx, secretStash, log, opts)
 		if err != nil {
 			return fmt.Errorf("submit %v: %w", branch, err)

--- a/upstack_submit.go
+++ b/upstack_submit.go
@@ -11,8 +11,7 @@ import (
 )
 
 type upstackSubmitCmd struct {
-	DryRun bool `short:"n" help:"Don't actually submit the stack"`
-	Fill   bool `help:"Fill in the pull request title and body from the commit messages"`
+	submitOptions
 
 	Branch string `placeholder:"NAME" help:"Branch to start at" predictor:"trackedBranches"`
 }
@@ -24,12 +23,7 @@ func (*upstackSubmitCmd) Help() string {
 		If the base of the current branch is not trunk,
 		it must have already been submitted by a prior command.
 		Use --branch to start at a different branch.
-
-		A prompt will ask for a title and body for each Change Request.
-		Use --fill to populate these from the commit messages.
-		Use --dry-run to see what would be submitted
-		without actually submitting anything.
-	`)
+	`) + "\n" + _submitHelp
 }
 
 func (cmd *upstackSubmitCmd) Run(
@@ -86,9 +80,8 @@ func (cmd *upstackSubmitCmd) Run(
 	// TODO: submits should be done in parallel
 	for _, b := range upstacks {
 		err := (&branchSubmitCmd{
-			DryRun: cmd.DryRun,
-			Fill:   cmd.Fill,
-			Branch: b,
+			submitOptions: cmd.submitOptions,
+			Branch:        b,
 		}).Run(ctx, secretStash, log, opts)
 		if err != nil {
 			return fmt.Errorf("submit %v: %w", b, err)


### PR DESCRIPTION
Adds --draft/--no-draft and --no-publish flags
to all the submit commands.

Flag sharing now comes from a shared embedded struct.