### PR TITLE
branch submit: Recover from failed pushes

### DIFF
--- a/.changes/unreleased/Added-20240703-053402.yaml
+++ b/.changes/unreleased/Added-20240703-053402.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'branch submit: If a submission fails, recover previously-filled metadata automatically in subsequent submit attempts.'
+time: 2024-07-03T05:34:02.244963-07:00

--- a/internal/spice/state/prepared.go
+++ b/internal/spice/state/prepared.go
@@ -1,0 +1,94 @@
+package state
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+
+	"go.abhg.dev/gs/internal/storage"
+)
+
+// _preparedDir is the directory holding information about branches
+// that are ready to submitted but not yet submitted.
+//
+// This is used by 'branch submit' command to recover
+// change metadata in case of failure in submitting.
+const _preparedDir = "prepared"
+
+type preparedBranchState struct {
+	Subject string `json:"subject"`
+	Body    string `json:"body"`
+}
+
+func (s *Store) preparedBranchJSON(name string) string {
+	return path.Join(_preparedDir, name)
+}
+
+// PreparedBranch is a branch that is ready to be submitted.
+type PreparedBranch struct {
+	// Name is the name of the branch.
+	Name string
+
+	// Subject is the subject of the change that was recorded.
+	Subject string
+
+	// Body is the body of the change that was recorded.
+	Body string
+}
+
+// SavePreparedBranch saves information about a branch that is ready for
+// submission.
+// This information may be retrieved later with TakePreparedBranch
+// to recover change metadata in case of failure in submitting.
+// If the branch is already saved, it will be overwritten.
+// Use ClearPreparedBranch to remove the saved information.
+func (s *Store) SavePreparedBranch(ctx context.Context, b *PreparedBranch) error {
+	state := preparedBranchState{
+		Subject: b.Subject,
+		Body:    b.Body,
+	}
+
+	err := s.db.Set(ctx, s.preparedBranchJSON(b.Name), state,
+		fmt.Sprintf("%v: save prepared branch", b.Name))
+	if err != nil {
+		return fmt.Errorf("set prepared branch state: %w", err)
+	}
+
+	return nil
+}
+
+// LoadPreparedBranch retrieves metadata about a branch submission
+// that was previously saved with SavePreparedBranch.
+// If there's no information saved, it returns nil.
+//
+// It may be used to recover from past failures in submitting a branch
+// so users do not have to re-enter the change metadata.
+func (s *Store) LoadPreparedBranch(ctx context.Context, name string) (*PreparedBranch, error) {
+	var state preparedBranchState
+	if err := s.db.Get(ctx, s.preparedBranchJSON(name), &state); err != nil {
+		if errors.Is(err, storage.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get prepared branch state: %w", err)
+	}
+
+	return &PreparedBranch{
+		Name:    name,
+		Subject: state.Subject,
+		Body:    state.Body,
+	}, nil
+}
+
+// ClearPreparedBranch removes the information saved about a branch
+// that was previously saved with SavePreparedBranch.
+// This is a no-op if the branch information isn't saved anymore.
+func (s *Store) ClearPreparedBranch(ctx context.Context, name string) error {
+	err := s.db.Delete(ctx, s.preparedBranchJSON(name),
+		fmt.Sprintf("%v: clear prepared branch", name))
+	if err != nil {
+		return fmt.Errorf("delete prepared branch state: %w", err)
+	}
+
+	return nil
+}

--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -58,7 +58,6 @@ func NewInput() *Input {
 // If the value is non-empty, it will be used as the initial value.
 func (i *Input) WithValue(value *string) *Input {
 	i.value = value
-	i.model.SetValue(*value)
 	return i
 }
 
@@ -101,6 +100,7 @@ func (i *Input) WithValidate(f func(string) error) *Input {
 
 // Init initializes the field.
 func (i *Input) Init() tea.Cmd {
+	i.model.SetValue(*i.value)
 	i.model.Err = nil
 	return i.model.Focus()
 }

--- a/testdata/script/branch_submit_recover_prepared.txt
+++ b/testdata/script/branch_submit_recover_prepared.txt
@@ -1,0 +1,98 @@
+# 'branch submit' can recover previously entered commit metadata
+# if a submission attempt fails.
+
+as 'Test <test@example.com>'
+at '2024-07-03T05:07:09Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a remote repository
+shamhub init
+shamhub register alice
+shamhub new origin alice/example.git
+git push origin main
+env SHAMHUB_USERNAME=alice
+gs repo init
+gs auth login
+
+# prepare for submission
+git add feature1.txt
+gs bc -m 'Add feature1' feature1
+
+# install a hook that will fail the submission
+cp $WORK/hooks/pre-push .git/hooks/pre-push
+chmod 755 .git/hooks/pre-push
+
+# submit; should fail
+env EDITOR=mockedit MOCKEDIT_GIVE=$WORK/input/pr-body-first.txt
+! with-term -final exit $WORK/input/prompt-first.txt -- gs branch submit
+stdout 'Add feature1 to do things'
+stdout 'failed to push'
+
+# verify nothing submitted
+shamhub dump changes
+stdout '\[\]'
+
+# fix the hook, try again
+rm .git/hooks/pre-push
+mkdir $WORK/got
+env EDITOR=mockedit MOCKEDIT_GIVE= MOCKEDIT_RECORD=$WORK/got/pr-body.txt
+with-term -cols 80 -final exit $WORK/input/prompt.txt -- gs branch submit
+cmpenv stdout $WORK/golden/submit.txt
+
+cmp $WORK/got/pr-body.txt $WORK/golden/pr-body.txt
+
+-- repo/feature1.txt --
+Contents of feature1
+
+-- hooks/pre-push --
+#!/bin/sh
+
+exit 1
+
+-- input/pr-body-first.txt --
+This adds feature1.
+Feature1 does a thing.
+It is very well tested.
+-- input/prompt-first.txt --
+await Add feature
+feed  to do things\r
+await Body
+feed e
+await Draft
+feed \r
+
+-- input/prompt.txt --
+await Recover previously filled
+snapshot recover
+feed \r
+await Add feature
+snapshot title
+feed \r
+await Body
+feed e
+await Draft
+feed \r
+
+-- golden/submit.txt --
+### recover ###
+Recover previously filled information?: [Y/n]
+We found previously filled information for this branch.
+Would you like to recover and edit it?
+### title ###
+Recover previously filled information?: [Y/n]
+Title: Add feature1 to do things
+Short summary of the pull request
+### exit ###
+Recover previously filled information?: [Y/n]
+Title: Add feature1 to do things
+Body: Press [e] to open mockedit or [enter/tab] to skip
+Draft: [y/N]
+INF Created #1: $SHAMHUB_URL/alice/example/change/1
+-- golden/pr-body.txt --
+This adds feature1.
+Feature1 does a thing.
+It is very well tested.


### PR DESCRIPTION
If a 'branch submit' fails to actually submit
(due to a failing pre-push hook, for example)
we can lose whatever PR metadata the user has already filled in.
This can be annoying if the PR body diverges significantly
from the commit body because some amount of work is lost.

As a UX improvement here, we'll record the title/body
after the user fills the form in case the submission fails.
We'll recover this saved information when the user re-submits,
prompting them to let them use the recovered information,
and edit it if necessary.

Resolves #221
