### PR TITLE
Support 'gh' CLI for authentication

### DIFF
--- a/.changes/unreleased/Added-20240703-183729.yaml
+++ b/.changes/unreleased/Added-20240703-183729.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'auth login: Support logging in with GitHub CLI.'
+time: 2024-07-03T18:37:29.533831-07:00

--- a/internal/forge/github/auth_int_test.go
+++ b/internal/forge/github/auth_int_test.go
@@ -1,0 +1,36 @@
+package github
+
+import (
+	"context"
+	"io"
+	"os/exec"
+	"testing"
+
+	"github.com/charmbracelet/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/secret"
+)
+
+func TestAuthCLI(t *testing.T) {
+	f := Forge{
+		Log: log.New(io.Discard),
+	}
+	var stash secret.MemoryStash
+
+	{
+		tok, err := (&CLIAuthenticator{
+			GH: "gh",
+			runCmd: func(*exec.Cmd) error {
+				return nil
+			},
+		}).Authenticate(context.Background())
+		require.NoError(t, err)
+		require.NoError(t, f.SaveAuthenticationToken(&stash, tok))
+	}
+
+	tok, err := f.LoadAuthenticationToken(&stash)
+	require.NoError(t, err)
+
+	assert.True(t, tok.(*AuthenticationToken).GitHubCLI)
+}

--- a/internal/forge/github/auth_test.go
+++ b/internal/forge/github/auth_test.go
@@ -52,6 +52,21 @@ func TestAuthHasGitHubToken(t *testing.T) {
 	})
 }
 
+func TestLoadAuthenticationTokenOldFormat(t *testing.T) {
+	f := github.Forge{
+		Log: log.New(io.Discard),
+	}
+
+	var stash secret.MemoryStash
+	require.NoError(t, stash.SaveSecret(f.URL(), "token", "old-token"))
+
+	tok, err := f.LoadAuthenticationToken(&stash)
+	require.NoError(t, err)
+
+	assert.Equal(t, "old-token",
+		tok.(*github.AuthenticationToken).AccessToken)
+}
+
 func TestPATAuthenticator(t *testing.T) {
 	stdin, stdinW := io.Pipe()
 	defer func() {

--- a/internal/forge/github/token.go
+++ b/internal/forge/github/token.go
@@ -1,0 +1,26 @@
+package github
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"golang.org/x/oauth2"
+)
+
+// CLITokenSource is an oauth2 token source
+// that uses the GitHub CLI to get a token.
+//
+// This is not super safe and we should probably nuke it.
+type CLITokenSource struct{}
+
+// Token returns an oauth2 token using the GitHub CLI.
+func (ts *CLITokenSource) Token() (*oauth2.Token, error) {
+	bs, err := exec.Command("gh", "auth", "token").Output()
+	if err != nil {
+		return nil, fmt.Errorf("get token from gh CLI: %w", err)
+	}
+	return &oauth2.Token{
+		AccessToken: strings.TrimSpace(string(bs)),
+	}, nil
+}


### PR DESCRIPTION
Adds back support for gh CLI based authentication removed in #237.
Useful for when you don't want to set up PAT or OAuth.
