### PR TITLE
git storage: Don't commit if there are no changes

### DIFF
--- a/internal/storage/git.go
+++ b/internal/storage/git.go
@@ -214,6 +214,11 @@ func (g *GitBackend) Update(ctx context.Context, req UpdateRequest) error {
 			return fmt.Errorf("update tree: %w", err)
 		}
 
+		// The tree didn't change, so we don't need to commit.
+		if prevTree == newTree {
+			return nil
+		}
+
 		commitReq := git.CommitTreeRequest{
 			Tree:    newTree,
 			Message: req.Message,

--- a/internal/storage/git_test.go
+++ b/internal/storage/git_test.go
@@ -1,0 +1,41 @@
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/logtest"
+)
+
+func TestGitBackendUpdateNoChanges(t *testing.T) {
+	ctx := context.Background()
+	repo, err := git.Init(ctx, t.TempDir(), git.InitOptions{
+		Log: logtest.New(t),
+	})
+	require.NoError(t, err)
+
+	backend := NewGitBackend(GitConfig{
+		Repo:        repo,
+		Ref:         "refs/data",
+		AuthorName:  "Test Author",
+		AuthorEmail: "test@example.com",
+		Log:         logtest.New(t),
+	})
+
+	db := NewDB(backend)
+	require.NoError(t, db.Set(ctx, "foo", "bar", "initial set"))
+
+	start, err := repo.PeelToCommit(ctx, "refs/data")
+	require.NoError(t, err)
+
+	require.NoError(t, db.Set(ctx, "foo", "bar", "shrug"))
+
+	end, err := repo.PeelToCommit(ctx, "refs/data")
+	require.NoError(t, err)
+
+	assert.Equal(t, start, end,
+		"there should be no changes in the repository")
+}


### PR DESCRIPTION
If the tree didn't change, we don't need to commit.

[skip changelog]: Not a user facing change.
