### PR TITLE
Use fliptree view for branch prompt

### DIFF
--- a/.changes/unreleased/Changed-20240707-112350.yaml
+++ b/.changes/unreleased/Changed-20240707-112350.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Branch prompt now presents a tree-style view where possible. This includes 'branch checkout', 'branch onto', 'up', and more.
+time: 2024-07-07T11:23:50.188422-07:00

--- a/branch_checkout.go
+++ b/branch_checkout.go
@@ -45,10 +45,12 @@ func (cmd *branchCheckoutCmd) Run(ctx context.Context, log *log.Logger, opts *gl
 		}
 
 		cmd.Branch, err = (&branchPrompt{
-			Exclude:           []string{currentBranch},
-			ExcludeCheckedOut: true,
-			TrackedOnly:       !cmd.Untracked,
-			Title:             "Select a branch to checkout",
+			Disabled: func(b git.LocalBranch) bool {
+				return b.Name != currentBranch && b.CheckedOut
+			},
+			Default:     currentBranch,
+			TrackedOnly: !cmd.Untracked,
+			Title:       "Select a branch to checkout",
 		}).Run(ctx, repo, store)
 		if err != nil {
 			return fmt.Errorf("select branch: %w", err)

--- a/branch_delete.go
+++ b/branch_delete.go
@@ -48,7 +48,9 @@ func (cmd *branchDeleteCmd) Run(ctx context.Context, log *log.Logger, opts *glob
 		}
 
 		cmd.Branch, err = (&branchPrompt{
-			Exclude: []string{store.Trunk()},
+			Disabled: func(b git.LocalBranch) bool {
+				return b.Name == store.Trunk()
+			},
 			Default: currentBranch,
 			Title:   "Select a branch to delete",
 		}).Run(ctx, repo, store)

--- a/branch_onto.go
+++ b/branch_onto.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
@@ -70,7 +71,9 @@ func (cmd *branchOntoCmd) Run(ctx context.Context, log *log.Logger, opts *global
 		}
 
 		cmd.Onto, err = (&branchPrompt{
-			Exclude:     []string{cmd.Branch},
+			Disabled: func(b git.LocalBranch) bool {
+				return b.Name == cmd.Branch
+			},
 			TrackedOnly: true,
 			Default:     branch.Base,
 			Title:       "Select a branch to move onto",

--- a/testdata/script/branch_checkout_prompt.txt
+++ b/testdata/script/branch_checkout_prompt.txt
@@ -72,7 +72,7 @@ snapshot after-ba
 feed \x1b[B
 await
 snapshot select
-feed \r
+feed z\r
 await Do you want to track
 snapshot track
 feed \r
@@ -80,31 +80,29 @@ feed \r
 -- golden/prompt-tracked.txt --
 ### init ###
 Select a branch to checkout:
-
-▶ bar
-  foo
+┏━■ bar ◀
+┣━□ foo
+main
 ### after ###
 Select a branch to checkout:
-
-▶ bar
+bar ◀
 -- golden/prompt-all.txt --
 ### init ###
 Select a branch to checkout:
-
-▶ bar
-  baz
-  foo
-  ▼▼▼
+baz ◀
+┏━□ bar
+┣━□ foo
+main
+quux
+qux
 ### after-ba ###
 Select a branch to checkout:
-
-▶ bar
-  baz
+baz ◀
+bar
 ### select ###
 Select a branch to checkout:
-
-  bar
-▶ baz
+baz
+bar ◀
 ### track ###
 Select a branch to checkout: baz
 WRN baz: branch not tracked

--- a/testdata/script/branch_checkout_prompt_trunk.txt
+++ b/testdata/script/branch_checkout_prompt_trunk.txt
@@ -27,5 +27,5 @@ snapshot
 feed ma\r
 -- golden/prompt.txt --
 Select a branch to checkout:
-
-▶ main
+┏━■ feature ◀
+main

--- a/testdata/script/top_multiple_prompt.txt
+++ b/testdata/script/top_multiple_prompt.txt
@@ -82,10 +82,10 @@ snapshot
 feed \r
 -- golden/main-prompt.txt --
 Pick a branch:
-
-▶ f2
-  f1-s1
-  f1-s2-s
+┏━■ f2 ◀
+┣━□ f1-s1
+┣━□ f1-s2-s
+main
 
 There are multiple top-level branches reachable from the current branch.
 -- input/f1-prompt.txt --
@@ -94,8 +94,8 @@ snapshot
 feed \r
 -- golden/f1-prompt.txt --
 Pick a branch:
-
-▶ f1-s1
-  f1-s2-s
+┏━■ f1-s1 ◀
+┣━□ f1-s2-s
+f1
 
 There are multiple top-level branches reachable from the current branch.

--- a/testdata/script/up_down_top_bottom_prompt.txt
+++ b/testdata/script/up_down_top_bottom_prompt.txt
@@ -77,9 +77,9 @@ snapshot
 feed feature2\r
 -- golden/up-prompt.txt --
 Pick a branch:
-
-▶ feature2
-  feature4
+┏━■ feature2 ◀
+┣━□ feature4
+feature1
 
 There are multiple branches above the current branch.
 ### exit ###
@@ -91,9 +91,9 @@ snapshot
 feed feature5\r
 -- golden/top-prompt.txt --
 Pick a branch:
-
-▶ feature3
-  feature5
+┏━■ feature3 ◀
+┣━□ feature5
+feature1
 
 There are multiple top-level branches reachable from the current branch.
 ### exit ###
@@ -105,9 +105,9 @@ snapshot
 feed feature4\r
 -- golden/up-2-prompt.txt --
 Pick a branch:
-
-▶ feature2
-  feature4
+┏━■ feature2 ◀
+┣━□ feature4
+feature1
 
 There are multiple branches above the current branch.
 ### exit ###

--- a/testdata/script/up_multiple_prompt.txt
+++ b/testdata/script/up_multiple_prompt.txt
@@ -44,18 +44,18 @@ feed \r
 -- golden/interact.txt --
 ### dialog ###
 Pick a branch:
-
-▶ head1
-  head2
-  head3
+┏━■ head1 ◀
+┣━□ head2
+┣━□ head3
+main
 
 There are multiple branches above the current branch.
 ### select ###
 Pick a branch:
-
-  head1
-▶ head2
-  head3
+┏━□ head1
+┣━■ head2 ◀
+┣━□ head3
+main
 
 There are multiple branches above the current branch.
 -- golden/state-git-log.txt --

--- a/top.go
+++ b/top.go
@@ -8,6 +8,7 @@ import (
 	"go.abhg.dev/gs/internal/must"
 	"go.abhg.dev/gs/internal/text"
 	"go.abhg.dev/gs/internal/ui"
+	"go.abhg.dev/gs/internal/ui/widget"
 )
 
 type topCmd struct {
@@ -49,11 +50,19 @@ func (cmd *topCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions
 			return errNoPrompt
 		}
 
+		items := make([]widget.BranchTreeItem, len(tops))
+		for i, b := range tops {
+			items[i] = widget.BranchTreeItem{
+				Branch: b,
+				Base:   current,
+			}
+		}
+
 		// If there are multiple top-most branches,
 		// prompt the user to pick one.
-		prompt := ui.NewSelect[string]().
+		prompt := widget.NewBranchTreeSelect().
 			WithValue(&branch).
-			With(ui.ComparableOptions(branch, tops...)).
+			WithItems(items...).
 			WithTitle("Pick a branch").
 			WithDescription(desc)
 		if err := ui.Run(prompt); err != nil {

--- a/up.go
+++ b/up.go
@@ -7,6 +7,7 @@ import (
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/text"
 	"go.abhg.dev/gs/internal/ui"
+	"go.abhg.dev/gs/internal/ui/widget"
 )
 
 type upCmd struct {
@@ -62,12 +63,19 @@ outer:
 				return errNoPrompt
 			}
 
-			prompt := ui.NewSelect[string]().
+			items := make([]widget.BranchTreeItem, len(aboves))
+			for i, b := range aboves {
+				items[i] = widget.BranchTreeItem{
+					Branch: b,
+					Base:   current,
+				}
+			}
+
+			prompt := widget.NewBranchTreeSelect().
 				WithValue(&branch).
-				With(ui.ComparableOptions(branch, aboves...)).
+				WithItems(items...).
 				WithTitle("Pick a branch").
 				WithDescription(desc)
-
 			if err := ui.Run(prompt); err != nil {
 				return fmt.Errorf("a branch is required: %w", err)
 			}

--- a/upstack_onto.go
+++ b/upstack_onto.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
@@ -68,7 +69,9 @@ func (cmd *upstackOntoCmd) Run(ctx context.Context, log *log.Logger, opts *globa
 		}
 
 		cmd.Onto, err = (&branchPrompt{
-			Exclude:     []string{cmd.Branch},
+			Disabled: func(b git.LocalBranch) bool {
+				return b.Name == cmd.Branch
+			},
 			TrackedOnly: true,
 			Default:     branch.Base,
 			Title:       "Select a branch to move onto",


### PR DESCRIPTION
Develop a custom widget that makes use of fliptree
to render a tree-style view of branches to select from.
This presents more information during 'branch checkout'.

Resolves #180
