### PR TITLE
branch split: Fix panic for 2 commits

### DIFF
--- a/.changes/unreleased/Fixed-20240710-051406.yaml
+++ b/.changes/unreleased/Fixed-20240710-051406.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'branch split: Fix panicking prompt when there are only two commits in the branch.'
+time: 2024-07-10T05:14:06.918854-07:00

--- a/internal/ui/widget/branch_split.go
+++ b/internal/ui/widget/branch_split.go
@@ -51,7 +51,7 @@ func NewBranchSplit() *BranchSplit {
 
 // WithCommits sets the commits to be listed in a branch split widget.
 func (b *BranchSplit) WithCommits(commits ...CommitSummary) *BranchSplit {
-	must.Bef(len(commits) > 2, "cannot split a branch with fewer than 2 commits")
+	must.Bef(len(commits) >= 2, "cannot split a branch with fewer than 2 commits")
 	b.commits = commits
 	return b
 }


### PR DESCRIPTION
Incorrect precondition in the branch split widget
that caused a panic if the brnach being split had only two commits.