### PR TITLE
state: Drop compatibility with old branchState

### DIFF
--- a/.changes/unreleased/Removed-20240715-051444.yaml
+++ b/.changes/unreleased/Removed-20240715-051444.yaml
@@ -1,0 +1,3 @@
+kind: Removed
+body: As promised in release notes for v0.1.0-beta5, drop support for old storage format for branch metadata.
+time: 2024-07-15T05:14:44.127377-07:00

--- a/internal/spice/state/branch_test.go
+++ b/internal/spice/state/branch_test.go
@@ -97,62 +97,6 @@ func TestBranchStateUnmarshal(t *testing.T) {
 				},
 			},
 		},
-
-		{
-			name: "UpgradeGitHub",
-			give: `{
-				"base": {"name": "main", "hash": "abc123"},
-				"upstream": {"branch": "main"},
-				"github": {"pr": 123}
-			}`,
-			want: &branchState{
-				Base: branchStateBase{
-					Name: "main",
-					Hash: "abc123",
-				},
-				Upstream: &branchUpstreamState{
-					Branch: "main",
-				},
-				Change: &branchChangeState{
-					Forge:  "github",
-					Change: json.RawMessage(`{"pr": 123}`),
-				},
-			},
-		},
-
-		{
-			name: "UpgradeGitHubConflict/SameForge",
-			give: `{
-				"base": {"name": "main", "hash": "abc123"},
-				"upstream": {"branch": "main"},
-				"github": {"pr": 123},
-				"change": {"github": {"number": 456}}
-			}`,
-			want: &branchState{
-				Base: branchStateBase{
-					Name: "main",
-					Hash: "abc123",
-				},
-				Upstream: &branchUpstreamState{
-					Branch: "main",
-				},
-				Change: &branchChangeState{
-					Forge:  "github",
-					Change: json.RawMessage(`{"number": 456}`),
-				},
-			},
-		},
-
-		{
-			name: "UpgradeGitHubConflict/OtherForge",
-			give: `{
-				"base": {"name": "main", "hash": "abc123"},
-				"upstream": {"branch": "main"},
-				"github": {"pr": 123},
-				"change": {"gitlab": {"number": 123}}
-			}`,
-			wantErr: "branch state has mixed forge metadata",
-		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
It's been ~1 month and 3 releases since v0.1.0-beta5
when we changed the internal storage format.
We can drop compatibility with the old format now.