### PR TITLE
Add -a flag to commit amend

### DIFF
--- a/commit_amend.go
+++ b/commit_amend.go
@@ -11,6 +11,7 @@ import (
 )
 
 type commitAmendCmd struct {
+	All     bool   `short:"a" help:"Stage all changes before committing."`
 	Message string `short:"m" placeholder:"MSG" help:"Use the given message as the commit message."`
 	NoEdit  bool   `short:"n" help:"Don't edit the commit message"`
 }
@@ -36,6 +37,7 @@ func (cmd *commitAmendCmd) Run(ctx context.Context, log *log.Logger, opts *globa
 		Message: cmd.Message,
 		Amend:   true,
 		NoEdit:  cmd.NoEdit,
+		All:     cmd.All,
 	}); err != nil {
 		return fmt.Errorf("commit: %w", err)
 	}

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -744,6 +744,7 @@ followed by 'gs upstack restack'.
 
 **Flags**
 
+* `-a`, `--all`: Stage all changes before committing.
 * `-m`, `--message=MSG`: Use the given message as the commit message.
 * `-n`, `--no-edit`: Don't edit the commit message
 

--- a/testdata/script/commit_amend_rebase.txt
+++ b/testdata/script/commit_amend_rebase.txt
@@ -29,13 +29,21 @@ git rebase -i HEAD~3
 git rev-parse HEAD
 stdout 94ce19e
 
-# add a commit with 'commit create'
+# amend the feature 1 commit
 mv $WORK/extra/feature1-part2.txt feature1-part2.txt
 git add feature1-part2.txt
 gs commit amend -n
 
 git rev-parse HEAD
 stdout 95044b5
+git rebase --continue
+
+# amend the feature 2 commit with -a flag
+mv $WORK/extra/new-feature2.txt feature2.txt
+gs commit amend -a -n
+
+git rev-parse HEAD
+stdout ad5037b
 git rebase --continue
 
 git graph HEAD
@@ -59,12 +67,16 @@ Contents of feature 3.
 pick 94ce19e Add feature 1
 break
 pick 556ae49 Add feature 2
+break
 pick 4041fd7 Add feature 3
 
 -- extra/feature1-part2.txt --
 Part 2 of feature 1.
+-- extra/new-feature2.txt --
+New contents of feature2.txt
+
 -- golden/graph-after.txt --
-* 20cdfa1 (HEAD -> feature3) Add feature 3
-* bfd39aa Add feature 2
+* 28fb9e0 (HEAD -> feature3) Add feature 3
+* ad5037b Add feature 2
 * 95044b5 Add feature 1
 * 63c927d (main) Initial commit


### PR DESCRIPTION
https://github.com/abhinav/git-spice/issues/259

Adds a `-a` flag to `gs commit amend` which stages all changes before committing, similar to `gs commit create`.