### PR TITLE
branch submit: Fix directory+ref conflict

### DIFF
--- a/.changes/unreleased/Fixed-20240718-214230.yaml
+++ b/.changes/unreleased/Fixed-20240718-214230.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'branch submit: Fix inability to submit if a directory name in root matches the branch name.'
+time: 2024-07-18T21:42:30.760652-07:00

--- a/internal/git/commit.go
+++ b/internal/git/commit.go
@@ -158,8 +158,9 @@ func (r *Repository) Commit(ctx context.Context, req CommitRequest) error {
 
 // CommitSubject returns the subject of a commit.
 func (r *Repository) CommitSubject(ctx context.Context, commitish string) (string, error) {
-	out, err := r.gitCmd(ctx, "rev-list", "--no-commit-header", "-n1", "--format=%s", commitish).
-		OutputString(r.exec)
+	out, err := r.gitCmd(ctx, "rev-list",
+		"--no-commit-header", "-n1", "--format=%s", commitish, "--",
+	).OutputString(r.exec)
 	if err != nil {
 		return "", fmt.Errorf("git log: %w", err)
 	}
@@ -190,7 +191,8 @@ func (r *Repository) CommitMessageRange(ctx context.Context, start, stop string)
 	cmd := r.gitCmd(ctx, "rev-list",
 		"--no-commit-header",
 		"--format=%B%x00", // null-byte separated
-		start, "--not", stop)
+		start, "--not", stop, "--",
+	)
 	out, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, fmt.Errorf("pipe: %w", err)

--- a/testdata/script/branch_submit_ambiguous_branch.txt
+++ b/testdata/script/branch_submit_ambiguous_branch.txt
@@ -1,0 +1,31 @@
+# When there's a branch with the same name
+# as a directory or file in the root of the repo,
+# git rev-list doesn't know whether it's an ref or path.
+#
+# This is a repro and test for it.
+
+as 'Test <test@example.com>'
+at '2024-07-18T09:38:08Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+git add doc
+gs bc doc -m 'Add docs'
+gs branch submit --fill
+stderr 'Created #'
+
+-- repo/doc/README.md --
+Contents of README
+


### PR DESCRIPTION
'branch submit' doesn't work if we have a directory (or file)
in the root of the repository with the same name as the branch.
It fails because we use git-rev-list to resolve information about the
branch and commits in it, and git rev-list needs you to disambiguate
by using `--` to separate the branch name from the path.

```
> gs branch submit --fill
FTL gs: list commits: rev-list: exit status 128
stderr:
fatal: ambiguous argument 'doc': both revision and filename
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

To fix this, add '--' to git rev-list invocations
to disambiguate the branch name from the path.
