### PR TITLE
test: Add fixturetest to generate semi-random string

### DIFF
--- a/internal/fixturetest/fixturetest.go
+++ b/internal/fixturetest/fixturetest.go
@@ -1,0 +1,91 @@
+// Package fixturetest allows generating values using a possibly-random source
+// on the first run of a test, and stores it in a file for subsequent runs.
+//
+// # Usage
+//
+// In your test, add a flag or other means of requesting the update mode:
+//
+//	var _update = flag.Bool("update", false, "update golden files")
+//
+// Configure the fixtures with the update flag:
+//
+//	var _fixtures = fixturetest.Config{Update: _update}
+//
+// Set up one or more fixtures:
+//
+//	branchNameFixture := fixturetest.New(_fixtures, "branchName", func() string {
+//		return randomBranchName()
+//	})
+//
+// Generate or fetch values using the Get method:
+//
+//	branchNameFixture.Get(t)
+//
+// If the test is in update mode, the provided function will be called,
+// and the value persisted to disk.
+// Otherwise, the value will be read from disk and passed to the function.
+package fixturetest
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestingT is a subset of the testing.TB interface.
+type TestingT interface {
+	Helper()
+	Name() string
+	Errorf(format string, args ...interface{})
+	FailNow()
+}
+
+// Config configures the behavior of the fixture system.
+type Config struct {
+	// Update is a pointer to a value speciftying
+	// whether we're in update mode or read mode.
+	//
+	// This must not be nil.
+	Update *bool // required
+}
+
+// Fixture is a value that is sourced from a function in update mode,
+// and from a file in read mode.
+type Fixture[T any] struct {
+	cfg  Config
+	name string
+	gen  func() T
+}
+
+// New creates a new fixture with the given configuration.
+func New[T any](cfg Config, name string, gen func() T) Fixture[T] {
+	return Fixture[T]{cfg, name, gen}
+}
+
+// Get returns the value of the fixture.
+// If in update mode, the value is generated using the provided function.
+// Otherwise, the value is read from disk.
+func (f Fixture[T]) Get(t TestingT) T {
+	t.Helper()
+
+	fpath := filepath.Join("testdata", t.Name(), f.name)
+	if *f.cfg.Update {
+		v := f.gen()
+
+		require.NoError(t, os.MkdirAll(filepath.Dir(fpath), 0o755))
+		bs, err := json.MarshalIndent(v, "", "  ")
+		require.NoError(t, err)
+
+		require.NoError(t, os.WriteFile(fpath, bs, 0o644))
+		return v
+	}
+
+	bs, err := os.ReadFile(fpath)
+	require.NoError(t, err)
+
+	var v T
+	require.NoError(t, json.Unmarshal(bs, &v))
+	return v
+}

--- a/internal/fixturetest/fixturetest_test.go
+++ b/internal/fixturetest/fixturetest_test.go
@@ -1,0 +1,56 @@
+package fixturetest_test
+
+import (
+	"math/rand"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/fixturetest"
+)
+
+func TestFixture(t *testing.T) {
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() {
+		assert.NoError(t, os.Chdir(cwd))
+	})
+
+	cfg := fixturetest.Config{Update: new(bool)}
+	fixture := fixturetest.New(cfg, "number", rand.Int)
+
+	// Initial generation.
+	*cfg.Update = true
+	v1 := fixture.Get(t)
+
+	// Read from disk.
+	*cfg.Update = false
+	assert.Equal(t, v1, fixture.Get(t))
+
+	// Update again.
+	*cfg.Update = true
+	// At least one attempt out of N should succeed.
+	assert.EventuallyWithT(t, func(t *assert.CollectT) {
+		v2 := fixture.Get(collectTAdapter{t, "Update"})
+		assert.NotEqual(t, v1, v2)
+	}, time.Second, 10*time.Millisecond)
+}
+
+type collectTAdapter struct {
+	*assert.CollectT
+
+	name string
+}
+
+var _ fixturetest.TestingT = collectTAdapter{}
+
+func (collectTAdapter) Helper() {}
+
+func (c collectTAdapter) Name() string {
+	return c.name
+}

--- a/internal/forge/github/testdata/TestIntegration_Repository_SubmitEditChange/ChangeBase/new-base
+++ b/internal/forge/github/testdata/TestIntegration_Repository_SubmitEditChange/ChangeBase/new-base
@@ -1,1 +1,1 @@
-Fhr9q7Dn
+"Fhr9q7Dn"

--- a/internal/forge/github/testdata/TestIntegration_Repository_SubmitEditChange/branch
+++ b/internal/forge/github/testdata/TestIntegration_Repository_SubmitEditChange/branch
@@ -1,1 +1,1 @@
-khUwPziZ
+"khUwPziZ"


### PR DESCRIPTION
The integration tests for GitHub use a repeated pattern
where they generate a random string if run with `-update`,
but store those in files for later runs for deterministic behavior.

As we'll be needing more of this, this extracts that functionality
into a separate fixturetest package.
This allows for a pluggable `func() T` to generate the value,
and stores it in a file as JSON for later runs.

[skip changelog]: Not user facing