### PR TITLE
all/submit: Share state between submit commands

### DIFF
--- a/.changes/unreleased/Fixed-20240721-144539.yaml
+++ b/.changes/unreleased/Fixed-20240721-144539.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: '{upstack, downstack, stack} submit: Drop a few redundant calls to GitHub API.'
+time: 2024-07-21T14:45:39.905863-07:00

--- a/downstack_submit.go
+++ b/downstack_submit.go
@@ -59,11 +59,12 @@ func (cmd *downstackSubmitCmd) Run(
 	// TODO: generalize into a service-level method
 	// TODO: separate preparation of the stack from submission
 	// TODO: submits should be done in parallel
+	var session submitSession
 	for _, downstack := range downstacks {
 		err := (&branchSubmitCmd{
 			submitOptions: cmd.submitOptions,
 			Branch:        downstack,
-		}).Run(ctx, secretStash, log, opts)
+		}).run(ctx, &session, repo, store, svc, secretStash, log, opts)
 		if err != nil {
 			return fmt.Errorf("submit %v: %w", downstack, err)
 		}

--- a/stack_submit.go
+++ b/stack_submit.go
@@ -43,7 +43,8 @@ func (cmd *stackSubmitCmd) Run(
 
 	// TODO: generalize into a service-level method
 	// TODO: separate preparation of the stack from submission
-	// TODO: submits should be done in parallel
+
+	var session submitSession
 	for _, branch := range stack {
 		if branch == store.Trunk() {
 			continue
@@ -52,7 +53,7 @@ func (cmd *stackSubmitCmd) Run(
 		err := (&branchSubmitCmd{
 			submitOptions: cmd.submitOptions,
 			Branch:        branch,
-		}).Run(ctx, secretStash, log, opts)
+		}).run(ctx, &session, repo, store, svc, secretStash, log, opts)
 		if err != nil {
 			return fmt.Errorf("submit %v: %w", branch, err)
 		}

--- a/submit.go
+++ b/submit.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"sync"
+
+	"go.abhg.dev/gs/internal/forge"
+)
+
+// submitSession is a single session of submitting branches.
+// This provides the ability to share state between
+// the multiple 'branch submit' invocations made by
+// 'stack submit', 'upstack submit', and 'downstack submit'.
+//
+// The zero value of this type is a valid empty session.
+type submitSession struct {
+	// Branches that have been submitted (created or updated)
+	// in this session.
+	branches []string
+
+	// Values that are memoized across multiple branch submits.
+	remote     memoizedValues[string, error]
+	remoteRepo memoizedValues[forge.Repository, error]
+}
+
+type memoizedValues[A, B any] struct {
+	once sync.Once
+
+	a A
+	b B
+}
+
+func (m *memoizedValues[A, B]) Get(f func() (A, B)) (A, B) {
+	m.once.Do(func() { m.a, m.b = f() })
+	return m.a, m.b
+}

--- a/upstack_submit.go
+++ b/upstack_submit.go
@@ -77,12 +77,12 @@ func (cmd *upstackSubmitCmd) Run(
 
 	// TODO: generalize into a service-level method
 	// TODO: separate preparation of the stack from submission
-	// TODO: submits should be done in parallel
+	var session submitSession
 	for _, b := range upstacks {
 		err := (&branchSubmitCmd{
 			submitOptions: cmd.submitOptions,
 			Branch:        b,
-		}).Run(ctx, secretStash, log, opts)
+		}).run(ctx, &session, repo, store, svc, secretStash, log, opts)
 		if err != nil {
 			return fmt.Errorf("submit %v: %w", b, err)
 		}


### PR DESCRIPTION
Add the ability to share some amount of state between the various
submit commands so we're not repeating initialization work.

The immediate effect of this is that we can share
information about the remote repository between submits,
which avoids one "get repository GraphQL ID" call per branch.

Long-term, we should just store the GraphQL ID in the local store
as it's not going to change.