### PR TITLE
submit: Post comments with a stack visualization

### DIFF
--- a/.changes/unreleased/Added-20240721-182927.yaml
+++ b/.changes/unreleased/Added-20240721-182927.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: '{branch, downstack, upstack, stack} submit: Post a comment to PRs visualizing the stack and the PR''s position in it.'
+time: 2024-07-21T18:29:27.072375-07:00

--- a/downstack_submit.go
+++ b/downstack_submit.go
@@ -70,5 +70,16 @@ func (cmd *downstackSubmitCmd) Run(
 		}
 	}
 
-	return nil
+	if cmd.DryRun {
+		return nil
+	}
+
+	return syncStackComments(
+		ctx,
+		store,
+		svc,
+		session.remoteRepo.Require(),
+		log,
+		session.branches,
+	)
 }

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -187,6 +187,16 @@ type ChangeMetadata interface {
 	// ChangeID is a human-readable identifier for the change.
 	// This is presented to the user in the UI.
 	ChangeID() ChangeID
+
+	// StackCommentID is a comment left on the Change
+	// that contains a visualization of the stack.
+	StackCommentID() ChangeCommentID
+
+	// SetStackCommentID sets the ID of the stack comment
+	// on the chnage metadata to persist it later.
+	//
+	// The ID may be nil to indicate that there is no stack comment.
+	SetStackCommentID(ChangeCommentID)
 }
 
 // FindChangesOptions specifies filtering options

--- a/internal/forge/github/change_meta.go
+++ b/internal/forge/github/change_meta.go
@@ -12,6 +12,8 @@ import (
 // PRMetadata is the metadata for a pull request.
 type PRMetadata struct {
 	PR *PR `json:"pr,omitempty"`
+
+	StackComment *PRComment `json:"comment,omitempty"`
 }
 
 var _ forge.ChangeMetadata = (*PRMetadata)(nil)
@@ -26,9 +28,30 @@ func (m *PRMetadata) ChangeID() forge.ChangeID {
 	return m.PR
 }
 
+// StackCommentID reports the comment ID of the stack comment
+// left on the pull request.
+func (m *PRMetadata) StackCommentID() forge.ChangeCommentID {
+	if m.StackComment == nil {
+		return nil
+	}
+	return m.StackComment
+}
+
+// SetStackCommentID sets the comment ID of the stack comment
+// left on the pull request.
+//
+// id may be nil.
+func (m *PRMetadata) SetStackCommentID(id forge.ChangeCommentID) {
+	m.StackComment = mustPRComment(id)
+}
+
 // NewChangeMetadata returns the metadata for a pull request.
-func (f *Repository) NewChangeMetadata(ctx context.Context, id forge.ChangeID) (forge.ChangeMetadata, error) {
+func (f *Repository) NewChangeMetadata(
+	ctx context.Context,
+	id forge.ChangeID,
+) (forge.ChangeMetadata, error) {
 	pr := mustPR(id)
+
 	var err error
 	pr.GQLID, err = f.graphQLID(ctx, pr) // ensure GQL ID is set
 	if err != nil {

--- a/internal/forge/shamhub/change_meta.go
+++ b/internal/forge/shamhub/change_meta.go
@@ -10,7 +10,8 @@ import (
 
 // ChangeMetadata records the metadata for a change on a ShamHub server.
 type ChangeMetadata struct {
-	Number int `json:"number"`
+	Number       int `json:"number"`
+	StackComment int `json:"stack_comment"`
 }
 
 // ForgeID reports the forge ID that owns this metadata.
@@ -23,9 +24,29 @@ func (m *ChangeMetadata) ChangeID() forge.ChangeID {
 	return ChangeID(m.Number)
 }
 
+// StackCommentID reports the comment ID of the stack comment.
+func (m *ChangeMetadata) StackCommentID() forge.ChangeCommentID {
+	if m.StackComment == 0 {
+		return nil
+	}
+	return ChangeCommentID(m.StackComment)
+}
+
+// SetStackCommentID sets the comment ID of the stack comment.
+// id may be nil.
+func (m *ChangeMetadata) SetStackCommentID(id forge.ChangeCommentID) {
+	if id == nil {
+		m.StackComment = 0
+	} else {
+		m.StackComment = int(id.(ChangeCommentID))
+	}
+}
+
 // NewChangeMetadata returns the metadata for a change on a ShamHub server.
 func (f *forgeRepository) NewChangeMetadata(ctx context.Context, id forge.ChangeID) (forge.ChangeMetadata, error) {
-	return &ChangeMetadata{Number: int(id.(ChangeID))}, nil
+	return &ChangeMetadata{
+		Number: int(id.(ChangeID)),
+	}, nil
 }
 
 // MarshalChangeMetadata marshals the given change metadata to JSON.

--- a/stack_submit.go
+++ b/stack_submit.go
@@ -59,5 +59,16 @@ func (cmd *stackSubmitCmd) Run(
 		}
 	}
 
-	return nil
+	if cmd.DryRun {
+		return nil
+	}
+
+	return syncStackComments(
+		ctx,
+		store,
+		svc,
+		session.remoteRepo.Require(),
+		log,
+		session.branches,
+	)
 }

--- a/submit.go
+++ b/submit.go
@@ -1,9 +1,17 @@
 package main
 
 import (
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
 	"sync"
 
+	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/must"
+	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/state"
 )
 
 // submitSession is a single session of submitting branches.
@@ -18,18 +26,319 @@ type submitSession struct {
 	branches []string
 
 	// Values that are memoized across multiple branch submits.
-	remote     memoizedValues[string, error]
-	remoteRepo memoizedValues[forge.Repository, error]
+	remote     memoizedValue[string]
+	remoteRepo memoizedValue[forge.Repository]
 }
 
-type memoizedValues[A, B any] struct {
-	once sync.Once
-
-	a A
-	b B
+// This whole type is a bit of a hack.
+// We should have better plumbing and retention of information
+// between the submits.
+// Maybe newSubmitSession should handle opening remote repo.
+type memoizedValue[A any] struct {
+	once  sync.Once
+	done  bool
+	value A
 }
 
-func (m *memoizedValues[A, B]) Get(f func() (A, B)) (A, B) {
-	m.once.Do(func() { m.a, m.b = f() })
-	return m.a, m.b
+func (m *memoizedValue[A]) Require() A {
+	must.Bef(m.done, "memoized value not set: Require called without Get")
+	return m.value
+}
+
+func (m *memoizedValue[A]) Get(f func() (A, error)) (_ A, err error) {
+	m.once.Do(func() {
+		m.value, err = f()
+		m.done = true
+	})
+	return m.value, err
+}
+
+// For each branch in the list of submitted branches,
+// we'll add or update a comment in the form:
+//
+//	This change is part of the following stack:
+//
+//	- #123
+//	  - #124 ◀
+//	    - #125
+//
+//	<sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+//
+// Where the arrow indicates the current branch.
+// For cases where this is the first time we're posting the comment,
+// we'll need to also update the store to record the comment ID for later.
+func syncStackComments(
+	ctx context.Context,
+	store *state.Store,
+	svc *spice.Service,
+	remoteRepo forge.Repository,
+	log *log.Logger,
+	submittedBranches []string,
+) error {
+	// Look up branch graph once, and share between all syncs.
+	trackedBranches, err := svc.LoadBranches(ctx)
+	if err != nil {
+		return fmt.Errorf("list tracked branches: %w", err)
+	}
+
+	type branchInfo struct {
+		Branch string
+		Meta   forge.ChangeMetadata
+	}
+
+	var (
+		nodes []*stackedChange
+		infos []branchInfo // info for nodes[i]
+	)
+	idxByBranch := make(map[string]int) // branch -> index in nodes
+
+	// First pass: add nodes but don't connect.
+	for _, b := range trackedBranches {
+		if b.Change == nil {
+			continue
+		}
+
+		idxByBranch[b.Name] = len(nodes)
+		nodes = append(nodes, &stackedChange{
+			Change: b.Change.ChangeID(),
+			Base:   -1,
+		})
+		infos = append(infos, branchInfo{
+			Branch: b.Name,
+			Meta:   b.Change,
+		})
+	}
+
+	// Second pass: connect Aboves.
+	for _, b := range trackedBranches {
+		nodeIdx, ok := idxByBranch[b.Name]
+		if !ok {
+			continue
+		}
+
+		baseIdx, ok := idxByBranch[b.Base]
+		if !ok {
+			continue
+		}
+
+		node := nodes[nodeIdx]
+		node.Base = baseIdx
+
+		base := nodes[baseIdx]
+		base.Aboves = append(base.Aboves, nodeIdx)
+	}
+
+	type (
+		postComment struct {
+			Branch string
+			Meta   forge.ChangeMetadata
+
+			Change forge.ChangeID
+			Body   string
+		}
+		updateComment struct {
+			Change  forge.ChangeID
+			Comment forge.ChangeCommentID
+			Body    string
+		}
+	)
+
+	postc := make(chan *postComment)
+	updatec := make(chan *updateComment)
+	var (
+		wg sync.WaitGroup
+
+		mu      sync.Mutex // guards upserts
+		upserts []state.UpsertRequest
+	)
+	for range min(runtime.GOMAXPROCS(0), len(submittedBranches)) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			postc := postc
+			updatec := updatec
+			for postc != nil || updatec != nil {
+				select {
+				case post, ok := <-postc:
+					if !ok {
+						postc = nil
+						continue
+					}
+
+					commentID, err := remoteRepo.PostChangeComment(ctx, post.Change, post.Body)
+					if err != nil {
+						log.Warn("Error posting comment",
+							"change", post.Change.String(),
+							"error", err,
+						)
+						continue
+					}
+
+					meta := post.Meta
+					meta.SetStackCommentID(commentID)
+					bs, err := remoteRepo.Forge().MarshalChangeMetadata(meta)
+					if err != nil {
+						log.Warn("Error marshaling change metadata",
+							"change", post.Change.String(),
+							"error", err,
+						)
+						continue
+					}
+
+					mu.Lock()
+					upserts = append(upserts, state.UpsertRequest{
+						Name:           post.Branch,
+						ChangeMetadata: bs,
+						ChangeForge:    remoteRepo.Forge().ID(),
+					})
+					mu.Unlock()
+
+				case update, ok := <-updatec:
+					if !ok {
+						updatec = nil
+						continue
+					}
+
+					err := remoteRepo.UpdateChangeComment(ctx, update.Comment, update.Body)
+					if err != nil {
+						log.Warn("Error updating comment",
+							"change", update.Change.String(),
+							"error", err,
+						)
+						continue
+					}
+				}
+			}
+		}()
+	}
+
+	// Concurrently post and update comments.
+	for _, branch := range submittedBranches {
+		idx, ok := idxByBranch[branch]
+		if !ok {
+			// This should never happen.
+			log.Warnf("branch %q not found in tracked branches", branch)
+			continue
+		}
+
+		info := infos[idx]
+		commentBody := generateStackComment(nodes, idx)
+		if info.Meta.StackCommentID() == nil {
+			postc <- &postComment{
+				Branch: branch,
+				Meta:   info.Meta,
+				Change: info.Meta.ChangeID(),
+				Body:   commentBody,
+			}
+		} else {
+			updatec <- &updateComment{
+				Change:  info.Meta.ChangeID(),
+				Comment: info.Meta.StackCommentID(),
+				Body:    commentBody,
+			}
+		}
+	}
+	close(postc)
+	close(updatec)
+	wg.Wait()
+
+	if len(upserts) == 0 {
+		return nil
+	}
+
+	var msg strings.Builder
+	msg.WriteString("Post stack comments\n\n")
+	for _, upsert := range upserts {
+		fmt.Fprintf(&msg, "- %s\n", upsert.Name)
+	}
+
+	err = store.UpdateBranch(ctx, &state.UpdateRequest{
+		Upserts: upserts,
+		Message: msg.String(),
+	})
+	if err != nil {
+		return fmt.Errorf("update state: %w", err)
+	}
+
+	return nil
+}
+
+type stackedChange struct {
+	Change forge.ChangeID
+
+	Base   int // -1 = no base PR
+	Aboves []int
+}
+
+const (
+	_commentHeader = "This change is part of the following stack:\n\n"
+	_commentFooter = "\n<sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>\n"
+)
+
+func generateStackComment(
+	nodes []*stackedChange,
+	current int,
+) string {
+	var sb strings.Builder
+	sb.WriteString(_commentHeader)
+	write := func(nodeIdx, indent int) {
+		node := nodes[nodeIdx]
+		for range indent {
+			sb.WriteString("    ")
+		}
+		fmt.Fprintf(&sb, "- %v", node.Change)
+		if nodeIdx == current {
+			sb.WriteString(" ◀")
+		}
+		sb.WriteString("\n")
+	}
+
+	// The graph is a DAG, so we don't expect cycles.
+	// Guard against it anyway.
+	visited := make([]bool, len(nodes))
+	ok := func(i int) bool {
+		if i < 0 || i >= len(nodes) || visited[i] {
+			return false
+		}
+		visited[i] = true
+		return true
+	}
+
+	// Write the downstacks, not including the current node.
+	// This will change the indent level.
+	// The downstacks leading up to the current branch are always linear.
+	var indent int
+	{
+		var downstacks []int
+		for base := nodes[current].Base; ok(base); base = nodes[base].Base {
+			downstacks = append(downstacks, base)
+		}
+
+		// Reverse order to print from base to current.
+		for i := len(downstacks) - 1; i >= 0; i-- {
+			write(downstacks[i], indent)
+			indent++
+		}
+	}
+
+	// For the upstacks, we'll need to traverse the graph
+	// and recursively write the upstacks.
+	// Indentation will increase for each subtree.
+	var visit func(int, int)
+	visit = func(nodeIdx, indent int) {
+		if !ok(nodeIdx) {
+			return
+		}
+
+		write(nodeIdx, indent)
+		for _, aboveIdx := range nodes[nodeIdx].Aboves {
+			visit(aboveIdx, indent+1)
+		}
+	}
+
+	// Current branch and its upstacks.
+	visit(current, indent)
+	sb.WriteString(_commentFooter)
+	return sb.String()
 }

--- a/submit_test.go
+++ b/submit_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateStackComment(t *testing.T) {
+	tests := []struct {
+		name    string
+		graph   []*stackedChange
+		current int
+		want    string
+	}{
+		{
+			name: "Single",
+			graph: []*stackedChange{
+				{Change: _changeID("123"), Base: -1},
+			},
+			current: 0,
+			want: joinLines(
+				"- #123 ◀",
+			),
+		},
+		{
+			name: "Downstack",
+			graph: []*stackedChange{
+				{Change: _changeID("123"), Base: -1},
+				{Change: _changeID("124"), Base: 0},
+				{Change: _changeID("125"), Base: 1},
+			},
+			current: 2,
+			want: joinLines(
+				"- #123",
+				"    - #124",
+				"        - #125 ◀",
+			),
+		},
+		{
+			name: "Upstack/Linear",
+			graph: []*stackedChange{
+				{Change: _changeID("123"), Base: -1},
+				{Change: _changeID("124"), Base: 0},
+				{Change: _changeID("125"), Base: 1},
+			},
+			current: 0,
+			want: joinLines(
+				"- #123 ◀",
+				"    - #124",
+				"        - #125",
+			),
+		},
+		{
+			name: "Upstack/NonLinear",
+			graph: []*stackedChange{
+				{Change: _changeID("123"), Base: -1},
+				{Change: _changeID("124"), Base: 0}, // 1
+				{Change: _changeID("125"), Base: 0}, // 2
+				{Change: _changeID("126"), Base: 1},
+				{Change: _changeID("127"), Base: 2},
+			},
+			current: 0,
+			want: joinLines(
+				"- #123 ◀",
+				"    - #124",
+				"        - #126",
+				"    - #125",
+				"        - #127",
+			),
+		},
+		{
+			name: "MidStack",
+			graph: []*stackedChange{
+				{Change: _changeID("123"), Base: -1}, // 0
+				{Change: _changeID("124"), Base: 0},  // 1
+				{Change: _changeID("125"), Base: 1},  // 2
+				{Change: _changeID("126"), Base: 0},  // 3
+				{Change: _changeID("127"), Base: 3},  // 4
+			},
+			// 1 has a sibling (3), but that won't be shown
+			// as it's not in the path to the current branch.
+			current: 1,
+			want: joinLines(
+				"- #123",
+				"    - #124 ◀",
+				"        - #125",
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Connect the upstacks.
+			// Easier to write the test cases this way.
+			for i, n := range tt.graph {
+				if n.Base == -1 {
+					continue
+				}
+				tt.graph[n.Base].Aboves = append(tt.graph[n.Base].Aboves, i)
+			}
+
+			want := _commentHeader + tt.want + _commentFooter
+			got := generateStackComment(tt.graph, tt.current)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+type _changeID string
+
+func (s _changeID) String() string {
+	return "#" + string(s)
+}
+
+func joinLines(lines ...string) string {
+	return strings.Join(lines, "\n") + "\n"
+}

--- a/testdata/script/branch_submit_by_name.txt
+++ b/testdata/script/branch_submit_by_name.txt
@@ -29,6 +29,8 @@ stderr 'Created #1'
 shamhub dump changes
 cmpenvJSON stdout $WORK/golden/pulls.json
 
+shamhub dump comments
+cmp stdout $WORK/golden/comments.json
 
 -- repo/feature1.txt --
 Contents of feature1
@@ -52,3 +54,11 @@ Contents of feature1
   }
 ]
 
+-- golden/comments.json --
+- change: 1
+  body: |
+    This change is part of the following stack:
+
+    - #1 ◀
+
+    <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>

--- a/testdata/script/branch_submit_detect_existing.txt
+++ b/testdata/script/branch_submit_detect_existing.txt
@@ -42,6 +42,12 @@ stderr 'Updated #'
 shamhub dump changes
 cmpenvJSON stdout $WORK/golden/update.json
 
+# We'll have a duplicate comment
+# because we'll have lost information
+# about the previous comment.
+shamhub dump comments
+cmp stdout $WORK/golden/comments.txt
+
 -- repo/feature1.txt --
 Contents of feature1
 
@@ -66,3 +72,19 @@ New contents of feature1
     }
   }
 ]
+
+-- golden/comments.txt --
+- change: 1
+  body: |
+    This change is part of the following stack:
+
+    - #1 ◀
+
+    <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+- change: 1
+  body: |
+    This change is part of the following stack:
+
+    - #1 ◀
+
+    <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>

--- a/testdata/script/branch_submit_no_publish.txt
+++ b/testdata/script/branch_submit_no_publish.txt
@@ -44,6 +44,9 @@ gs bs --no-publish
 shamhub dump changes
 cmp stdout $WORK/golden/no-pulls.txt
 
+shamhub dump comments
+cmp stdout $WORK/golden/no-comments.txt
+
 # finally publish a PR
 gs bs --fill
 shamhub dump changes
@@ -65,6 +68,8 @@ feature 1.2
 -- repo/feature1.3.txt --
 feature 1.3
 -- golden/no-pulls.txt --
+[]
+-- golden/no-comments.txt --
 []
 -- golden/post-push.txt --
 * 9282351 (origin/feature1) feature1

--- a/testdata/script/branch_submit_rename.txt
+++ b/testdata/script/branch_submit_rename.txt
@@ -28,6 +28,9 @@ stderr 'Created #'
 shamhub dump changes
 cmpenvJSON stdout $WORK/golden/create.json
 
+shamhub dump comments
+cmp stdout $WORK/golden/create-comments.txt
+
 # rename the branch
 gs branch rename feature1-new-name
 
@@ -40,6 +43,8 @@ gs bs
 stderr 'Updated #'
 shamhub dump changes
 cmpenvJSON stdout $WORK/golden/update.json
+shamhub dump comments
+cmp stdout $WORK/golden/update-comments.txt
 
 -- repo/feature1.txt --
 Contents of feature1
@@ -66,6 +71,14 @@ New contents of feature1
   }
 ]
 
+-- golden/create-comments.txt --
+- change: 1
+  body: |
+    This change is part of the following stack:
+
+    - #1 ◀
+
+    <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
 -- golden/update.json --
 [
   {
@@ -84,3 +97,12 @@ New contents of feature1
     }
   }
 ]
+
+-- golden/update-comments.txt --
+- change: 1
+  body: |
+    This change is part of the following stack:
+
+    - #1 ◀
+
+    <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>

--- a/testdata/script/downstack_submit.txt
+++ b/testdata/script/downstack_submit.txt
@@ -33,6 +33,9 @@ cmpenv stderr $WORK/golden/submit-log.txt
 shamhub dump changes
 cmpenvJSON stdout $WORK/golden/pulls.json
 
+shamhub dump comments
+cmp stdout $WORK/golden/comments.txt
+
 -- repo/feature1.txt --
 This is feature 1
 -- repo/feature2.txt --
@@ -91,3 +94,32 @@ INF Created #3: $SHAMHUB_URL/alice/example/change/3
     }
   }
 ]
+
+-- golden/comments.txt --
+- change: 1
+  body: |
+    This change is part of the following stack:
+
+    - #1 ◀
+        - #2
+            - #3
+
+    <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+- change: 2
+  body: |
+    This change is part of the following stack:
+
+    - #1
+        - #2 ◀
+            - #3
+
+    <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+- change: 3
+  body: |
+    This change is part of the following stack:
+
+    - #1
+        - #2
+            - #3 ◀
+
+    <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>

--- a/testdata/script/stack_submit.txt
+++ b/testdata/script/stack_submit.txt
@@ -37,6 +37,9 @@ cmp stderr $WORK/golden/ls.txt
 shamhub dump changes
 cmpenvJSON stdout $WORK/golden/start.json
 
+shamhub dump comments
+cmp stdout $WORK/golden/start-comments.txt
+
 # Merge the bottom PR, sync, restack, and submit.
 shamhub merge alice/example 1
 gs rs
@@ -49,6 +52,8 @@ stderr 'Updated #3'
 shamhub dump changes
 cmpenvJSON stdout $WORK/golden/pr-1-merged.json
 
+shamhub dump comments
+cmp stdout $WORK/golden/pr-1-merged-comments.txt
 
 -- repo/feature1.txt --
 This is feature 1
@@ -110,6 +115,34 @@ INF Created #3: $SHAMHUB_URL/alice/example/change/3
   }
 ]
 
+-- golden/start-comments.txt --
+- change: 1
+  body: |
+    This change is part of the following stack:
+
+    - #1 ◀
+        - #2
+            - #3
+
+    <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+- change: 2
+  body: |
+    This change is part of the following stack:
+
+    - #1
+        - #2 ◀
+            - #3
+
+    <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+- change: 3
+  body: |
+    This change is part of the following stack:
+
+    - #1
+        - #2
+            - #3 ◀
+
+    <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
 -- golden/pr-1-merged.json --
 [
   {
@@ -160,6 +193,32 @@ INF Created #3: $SHAMHUB_URL/alice/example/change/3
   }
 ]
 
+-- golden/pr-1-merged-comments.txt --
+- change: 1
+  body: |
+    This change is part of the following stack:
+
+    - #1 ◀
+        - #2
+            - #3
+
+    <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+- change: 2
+  body: |
+    This change is part of the following stack:
+
+    - #2 ◀
+        - #3
+
+    <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+- change: 3
+  body: |
+    This change is part of the following stack:
+
+    - #2
+        - #3 ◀
+
+    <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
 -- golden/ls.txt --
     ┏━□ feature3 (#3)
   ┏━┻□ feature2 (#2)

--- a/testdata/script/stack_submit_update_leave_draft.txt
+++ b/testdata/script/stack_submit_update_leave_draft.txt
@@ -44,6 +44,9 @@ cmp stderr $WORK/golden/submit-dry-run.txt
 shamhub dump changes
 cmpenvJSON stdout $WORK/golden/start.json
 
+shamhub dump comments
+cmp stdout $WORK/golden/comments/initial.txt
+
 # Merge the bottom PR, sync, restack, and submit.
 shamhub merge alice/example 1
 gs rs
@@ -55,6 +58,9 @@ stderr 'Updated #3'
 
 shamhub dump changes
 cmpenvJSON stdout $WORK/golden/pr-1-merged.json
+
+shamhub dump comments
+cmp stdout $WORK/golden/comments/pr-1-merged.txt
 
 -- repo/feature1.txt --
 This is feature 1
@@ -171,3 +177,53 @@ INF Pull request #3 is up-to-date
     }
   }
 ]
+
+-- golden/comments/initial.txt --
+- change: 1
+  body: |
+    This change is part of the following stack:
+
+    - #1 ◀
+
+    <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+- change: 2
+  body: |
+    This change is part of the following stack:
+
+    - #1
+        - #2 ◀
+
+    <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+- change: 3
+  body: |
+    This change is part of the following stack:
+
+    - #1
+        - #2
+            - #3 ◀
+
+    <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+-- golden/comments/pr-1-merged.txt --
+- change: 1
+  body: |
+    This change is part of the following stack:
+
+    - #1 ◀
+
+    <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+- change: 2
+  body: |
+    This change is part of the following stack:
+
+    - #2 ◀
+        - #3
+
+    <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+- change: 3
+  body: |
+    This change is part of the following stack:
+
+    - #2
+        - #3 ◀
+
+    <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>

--- a/testdata/script/upstack_submit_main.txt
+++ b/testdata/script/upstack_submit_main.txt
@@ -53,6 +53,9 @@ cmp stderr $WORK/golden/ls-after.txt
 shamhub dump changes
 cmpenvJSON stdout $WORK/golden/changes.json
 
+shamhub dump comments
+cmp stdout $WORK/golden/comments.json
+
 -- repo/feature1.txt --
 This is feature 1
 -- repo/feature2.txt --
@@ -145,3 +148,40 @@ main ◀
     }
   }
 ]
+-- golden/comments.json --
+- change: 1
+  body: |
+    This change is part of the following stack:
+
+    - #1 ◀
+        - #2
+        - #3
+            - #4
+
+    <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+- change: 2
+  body: |
+    This change is part of the following stack:
+
+    - #1
+        - #2 ◀
+
+    <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+- change: 3
+  body: |
+    This change is part of the following stack:
+
+    - #1
+        - #3 ◀
+            - #4
+
+    <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+- change: 4
+  body: |
+    This change is part of the following stack:
+
+    - #1
+        - #3
+            - #4 ◀
+
+    <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>

--- a/upstack_submit.go
+++ b/upstack_submit.go
@@ -88,5 +88,16 @@ func (cmd *upstackSubmitCmd) Run(
 		}
 	}
 
-	return nil
+	if cmd.DryRun {
+		return nil
+	}
+
+	return syncStackComments(
+		ctx,
+		store,
+		svc,
+		session.remoteRepo.Require(),
+		log,
+		session.branches,
+	)
 }


### PR DESCRIPTION
For all CR submission commands,
track which branches are being submitted.

For all such branches, add a comment with a visualization of the stack
marking the position of that CR in the stack.

The visualization does not include the entire stack:
for each CR, it only includes changes that are downstack from it,
the CR itself, and the changes that are upstack from it.
It does not include siblings or cousins.

Resolves #142