### PR TITLE
all: Normalize terminology to "CR"

### DIFF
--- a/.changes/unreleased/Changed-20240721-184408.yaml
+++ b/.changes/unreleased/Changed-20240721-184408.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'all: Adjust terminology in messaging to refer to Change Requests consistently.'
+time: 2024-07-21T18:44:08.526801-07:00

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,7 @@ with the following notes:
   ```
 
 - If you edit documentation in doc/,
-  run `pipenv install && pipenv run mkdocs serve` to preview changes.
-
+  install `pipenv` and run `make serve` to preview changes.
 - All commits must include meaningful commit messages.
 - Test new features and bug fixes.
   If it does not have a test, the bug is not fixed.

--- a/branch_track.go
+++ b/branch_track.go
@@ -143,10 +143,6 @@ func (cmd *branchTrackCmd) Run(ctx context.Context, log *log.Logger, opts *globa
 		return fmt.Errorf("peel to commit: %w", err)
 	}
 
-	// TODO:
-	// if GitHub information is available, check if branch has an
-	// open PR and associate it with the branch.
-
 	err = store.UpdateBranch(ctx, &state.UpdateRequest{
 		Upserts: []state.UpsertRequest{
 			{

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -193,9 +193,9 @@ This has no effect if a branch already has an open CR.
 **Flags**
 
 * `-n`, `--dry-run`: Don't actually submit the stack
-* `--fill`: Fill in the pull request title and body from the commit messages
-* `--[no-]draft`: Whether to mark pull requests as drafts
-* `--no-publish`: Push branches but don't create pull requests
+* `--fill`: Fill in the change title and body from the commit messages
+* `--[no-]draft`: Whether to mark change requests as drafts
+* `--no-publish`: Push branches but don't create change requests
 
 ### gs stack restack
 
@@ -259,9 +259,9 @@ This has no effect if a branch already has an open CR.
 **Flags**
 
 * `-n`, `--dry-run`: Don't actually submit the stack
-* `--fill`: Fill in the pull request title and body from the commit messages
-* `--[no-]draft`: Whether to mark pull requests as drafts
-* `--no-publish`: Push branches but don't create pull requests
+* `--fill`: Fill in the change title and body from the commit messages
+* `--[no-]draft`: Whether to mark change requests as drafts
+* `--no-publish`: Push branches but don't create change requests
 * `--branch=NAME`: Branch to start at
 
 ### gs upstack restack
@@ -345,9 +345,9 @@ This has no effect if a branch already has an open CR.
 **Flags**
 
 * `-n`, `--dry-run`: Don't actually submit the stack
-* `--fill`: Fill in the pull request title and body from the commit messages
-* `--[no-]draft`: Whether to mark pull requests as drafts
-* `--no-publish`: Push branches but don't create pull requests
+* `--fill`: Fill in the change title and body from the commit messages
+* `--[no-]draft`: Whether to mark change requests as drafts
+* `--no-publish`: Push branches but don't create change requests
 * `--branch=NAME`: Branch to start at
 
 ### gs downstack edit
@@ -689,7 +689,7 @@ Use the --branch flag to target a different branch.
 For new Change Requests, a prompt will allow filling metadata.
 Use the --title and --body flags to skip the prompt,
 or the --fill flag to use the commit message to fill them in.
-The --draft flag marks the pull request as a draft.
+The --draft flag marks the change request as a draft.
 For updating Change Requests,
 use --draft/--no-draft to change its draft status.
 Without the flag, the draft status is not changed.
@@ -700,11 +700,11 @@ Request.
 **Flags**
 
 * `-n`, `--dry-run`: Don't actually submit the stack
-* `--fill`: Fill in the pull request title and body from the commit messages
-* `--[no-]draft`: Whether to mark pull requests as drafts
-* `--no-publish`: Push branches but don't create pull requests
-* `--title=TITLE`: Title of the pull request
-* `--body=BODY`: Body of the pull request
+* `--fill`: Fill in the change title and body from the commit messages
+* `--[no-]draft`: Whether to mark change requests as drafts
+* `--no-publish`: Push branches but don't create change requests
+* `--title=TITLE`: Title of the change request
+* `--body=BODY`: Body of the change request
 * `--branch=NAME`: Branch to submit
 
 ## Commit

--- a/repo_sync.go
+++ b/repo_sync.go
@@ -206,11 +206,11 @@ func (cmd *repoSyncCmd) deleteMergedBranches(
 ) error {
 	// There are two options for detecting merged branches:
 	//
-	// 1. Query the PR status for each submitted branch.
+	// 1. Query the CR status for each submitted branch.
 	//    This is more accurate, but requires a lot of API calls.
 	// 2. List recently merged PRs and match against tracked branches.
 	//    The number of API calls here is smaller,
-	//    but the matching is less accurate because the PR may have been
+	//    but the matching is less accurate because the CR may have been
 	//    submitted by someone else.
 	//
 	// For now, we'll go for (1) with the assumption that the number of
@@ -243,7 +243,7 @@ func (cmd *repoSyncCmd) deleteMergedBranches(
 	// 2. Branches that the user submitted PRs for manually
 	//    with 'gh pr create' or similar.
 	//
-	// For the first, we can perform a cheaper API call to check the PR status.
+	// For the first, we can perform a cheaper API call to check the CR status.
 	// For the second, we need to find recently merged PRs with that branch
 	// name, and match the remote head SHA to the branch head SHA.
 	//
@@ -274,7 +274,7 @@ func (cmd *repoSyncCmd) deleteMergedBranches(
 					// we can combine all submitted PRs into one query.
 					merged, err := remoteRepo.ChangeIsMerged(ctx, b.Change)
 					if err != nil {
-						log.Error("Failed to query PR status", "pr", b.Change, "error", err)
+						log.Error("Failed to query CR status", "change", b.Change, "error", err)
 						continue
 					}
 

--- a/submit.go
+++ b/submit.go
@@ -267,7 +267,7 @@ func syncStackComments(
 type stackedChange struct {
 	Change forge.ChangeID
 
-	Base   int // -1 = no base PR
+	Base   int // -1 = no base CR
 	Aboves []int
 }
 

--- a/testdata/script/branch_submit_detect_existing.txt
+++ b/testdata/script/branch_submit_detect_existing.txt
@@ -36,7 +36,7 @@ git add feature1.txt
 git commit -m 'update feature1'
 
 gs branch submit
-stderr 'feature1: Found existing PR #'
+stderr 'feature1: Found existing CR #'
 stderr 'Updated #'
 
 shamhub dump changes

--- a/testdata/script/branch_submit_long_body.txt
+++ b/testdata/script/branch_submit_long_body.txt
@@ -69,9 +69,9 @@ feed \r
 -- golden/prompt.txt --
 ### initial ###
 Title: Add feature
-Short summary of the pull request
+Short summary of the change
 ### last ###
 Title: Add feature
 Body: Press [e] to open mockedit or [enter/tab] to skip
 Draft: [y/N]
-Mark the pull request as a draft?
+Mark the change as a draft?

--- a/testdata/script/branch_submit_multiple_pr_templates.txt
+++ b/testdata/script/branch_submit_multiple_pr_templates.txt
@@ -62,7 +62,7 @@ Template:
   CHANGE_TEMPLATE.md
   ▼▼▼
 
-Choose a template for the pull request body
+Choose a template for the change body
 ### exit ###
 Title: Add feature
 Template: .shamhub/CHANGE_TEMPLATE.md

--- a/testdata/script/branch_submit_pr_template_no_body.txt
+++ b/testdata/script/branch_submit_pr_template_no_body.txt
@@ -58,16 +58,16 @@ feed \r
 -- golden/prompt.txt --
 ### title ###
 Title: Add feature
-Short summary of the pull request
+Short summary of the change
 ### body ###
 Title: Add feature
 Body: Press [e] to open true or [enter/tab] to skip
-Open your editor to write a detailed description of the pull request
+Open your editor to write a detailed description of the change
 ### draft ###
 Title: Add feature
 Body: Press [e] to open true or [enter/tab] to skip
 Draft: [y/N]
-Mark the pull request as a draft?
+Mark the change as a draft?
 ### exit ###
 Title: Add feature
 Body: Press [e] to open true or [enter/tab] to skip

--- a/testdata/script/branch_submit_pr_template_prompt.txt
+++ b/testdata/script/branch_submit_pr_template_prompt.txt
@@ -69,16 +69,16 @@ feed \r
 -- golden/prompt.txt --
 ### title ###
 Title: Add feature
-Short summary of the pull request
+Short summary of the change
 ### body ###
 Title: Add feature
 Body: Press [e] to open mockedit or [enter/tab] to skip
-Open your editor to write a detailed description of the pull request
+Open your editor to write a detailed description of the change
 ### draft ###
 Title: Add feature
 Body: Press [e] to open mockedit or [enter/tab] to skip
 Draft: [y/N]
-Mark the pull request as a draft?
+Mark the change as a draft?
 ### exit ###
 Title: Add feature
 Body: Press [e] to open mockedit or [enter/tab] to skip

--- a/testdata/script/branch_submit_recover_prepared.txt
+++ b/testdata/script/branch_submit_recover_prepared.txt
@@ -85,7 +85,7 @@ Would you like to recover and edit it?
 ### title ###
 Recover previously filled information?: [Y/n]
 Title: Add feature1 to do things
-Short summary of the pull request
+Short summary of the change
 ### exit ###
 Recover previously filled information?: [Y/n]
 Title: Add feature1 to do things

--- a/testdata/script/stack_submit_update_leave_draft.txt
+++ b/testdata/script/stack_submit_update_leave_draft.txt
@@ -38,7 +38,7 @@ git checkout feature2
 
 # Dry run
 gs stack submit --dry-run
-cmp stderr $WORK/golden/submit-dry-run.txt
+cmpenv stderr $WORK/golden/submit-dry-run.txt
 ! stderr 'draft' # draft status should not be changed
 
 shamhub dump changes
@@ -70,9 +70,9 @@ This is feature 2
 This is feature 3
 
 -- golden/submit-dry-run.txt --
-INF Pull request #1 is up-to-date
-INF Pull request #2 is up-to-date
-INF Pull request #3 is up-to-date
+INF CR #1 is up-to-date: $SHAMHUB_URL/alice/example/change/1
+INF CR #2 is up-to-date: $SHAMHUB_URL/alice/example/change/2
+INF CR #3 is up-to-date: $SHAMHUB_URL/alice/example/change/3
 -- golden/start.json --
 [
   {

--- a/testdata/script/upstack_submit_main.txt
+++ b/testdata/script/upstack_submit_main.txt
@@ -65,10 +65,10 @@ This is feature 3
 -- repo/feature4.txt --
 This is feature 4
 -- golden/submit-dry-run.txt --
-INF WOULD create a pull request for feature1
-INF WOULD create a pull request for feature2
-INF WOULD create a pull request for feature3
-INF WOULD create a pull request for feature4
+INF WOULD create a CR for feature1
+INF WOULD create a CR for feature2
+INF WOULD create a CR for feature3
+INF WOULD create a CR for feature4
 -- golden/submit-log.txt --
 INF Created #1: $SHAMHUB_URL/alice/example/change/1
 INF Created #2: $SHAMHUB_URL/alice/example/change/2


### PR DESCRIPTION
We've been using Pull Request and Change Request in messaging
interchangeably.
Originally, most code was written with Pull Request as the tool was
coupled to GitHub.
However, with the refactor to extract the Forge type,
we can now support other code forges, so don't need that coupling.
Since then, messaging uses "CR" or Change Request.

Take a pass over any user-facing messages that are referencing PRs
instead of CRs and fix them.