### PR TITLE
feat(cli): show help command when no command present

### DIFF
--- a/.changes/unreleased/Changed-20240723-091300.yaml
+++ b/.changes/unreleased/Changed-20240723-091300.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'cli: Run the help command when no subcommands are included'
+time: 2024-07-23T09:13:00.419337+09:00

--- a/main.go
+++ b/main.go
@@ -161,11 +161,11 @@ func main() {
 	}
 
 	args := os.Args[1:]
-	if len(args) > 0 {
-		if short, ok := shorthands[args[0]]; ok {
-			// TODO: Replace first non-flag argument instead.
-			args = slices.Replace(args, 0, 1, short.Expanded...)
-		}
+	if len(args) == 0 {
+		args = []string{"--help"}
+	} else if short, ok := shorthands[args[0]]; ok {
+		// TODO: Replace first non-flag argument instead.
+		args = slices.Replace(args, 0, 1, short.Expanded...)
 	}
 
 	komplete.Run(parser,


### PR DESCRIPTION
This commit is a small change to the cli that runs the --help command when no args are present.