### PR TITLE
Use a non-zero exit code for 'gs' without arguments

### DIFF
--- a/.changes/unreleased/Changed-20240723-091300.yaml
+++ b/.changes/unreleased/Changed-20240723-091300.yaml
@@ -1,3 +1,3 @@
 kind: Changed
-body: 'cli: Run the help command when no subcommands are included'
+body: 'cli: Show --help when run without arguments'
 time: 2024-07-23T09:13:00.419337+09:00

--- a/main.go
+++ b/main.go
@@ -160,14 +160,6 @@ func main() {
 		}
 	}
 
-	args := os.Args[1:]
-	if len(args) == 0 {
-		args = []string{"--help"}
-	} else if short, ok := shorthands[args[0]]; ok {
-		// TODO: Replace first non-flag argument instead.
-		args = slices.Replace(args, 0, 1, short.Expanded...)
-	}
-
 	komplete.Run(parser,
 		komplete.WithTransformCompleted(func(args []string) []string {
 			if len(args) > 0 {
@@ -183,6 +175,23 @@ func main() {
 		komplete.WithPredictor("dirs", komplete.PredictFunc(predictDirs)),
 		komplete.WithPredictor("forges", komplete.PredictFunc(predictForges)),
 	)
+
+	args := os.Args[1:]
+	if len(args) == 0 {
+		// If invoked with no arguments, show help,
+		// but then exit with a non-zero status code.
+		args = []string{"--help"}
+		parser.Exit = func(int) {
+			logger.Print("")
+			logger.Fatal("gs: please provide a command")
+		}
+	} else {
+		// Otherwise, expand the first argument if it's a shorthand.
+		if short, ok := shorthands[args[0]]; ok {
+			// TODO: Replace first non-flag argument instead.
+			args = slices.Replace(args, 0, 1, short.Expanded...)
+		}
+	}
 
 	kctx, err := parser.Parse(args)
 	if err != nil {

--- a/testdata/script/no_args.txt
+++ b/testdata/script/no_args.txt
@@ -1,0 +1,7 @@
+# Running 'gs' with no arguments
+# exits with a non-zero status code,
+# but prints a help message to stderr.
+
+! gs
+stdout 'Usage: gs '
+stderr 'please provide a command'


### PR DESCRIPTION
Follow up to #278

We present --help when invoked without any arguments,
but that's still an invalid invocation,
so we should fail with a non-zero exit code.
