### PR TITLE
branch submit: Fix "branch is not tracked" warning with --no-publish

### DIFF
--- a/.changes/unreleased/Fixed-20240722-184205.yaml
+++ b/.changes/unreleased/Fixed-20240722-184205.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: >-
+  branch submit: Fix incorrect warning about current branch not being tracked
+  when --no-publish is used.
+time: 2024-07-22T18:42:05.631607-07:00

--- a/branch_submit.go
+++ b/branch_submit.go
@@ -137,7 +137,7 @@ func (cmd *branchSubmitCmd) run(
 		// TODO: this can be made optional with a --force or a prompt.
 	}
 
-	if !cmd.DryRun {
+	if !cmd.DryRun && !cmd.NoPublish {
 		session.branches = append(session.branches, cmd.Branch)
 	}
 

--- a/testdata/script/branch_submit_no_publish.txt
+++ b/testdata/script/branch_submit_no_publish.txt
@@ -21,7 +21,7 @@ gs auth login
 git add feature1.txt
 gs bc -m feature1
 gs branch submit --no-publish
-stderr 'Pushed feature1'
+cmp stderr $WORK/golden/first-submit.stderr
 
 # verify no PRs
 shamhub dump changes
@@ -67,6 +67,8 @@ feature 1
 feature 1.2
 -- repo/feature1.3.txt --
 feature 1.3
+-- golden/first-submit.stderr --
+INF Pushed feature1
 -- golden/no-pulls.txt --
 []
 -- golden/no-comments.txt --


### PR DESCRIPTION
Part of the code responsible for updating the comments in PRs
will print a warning when --no-publish is used.

Resolves #277