### PR TITLE
branch submit: Add --force flag

### DIFF
--- a/.changes/unreleased/Added-20240722-195530.yaml
+++ b/.changes/unreleased/Added-20240722-195530.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: '{branch, stack, upstack, downstack} submit: Add --force flag. This acts like ''git push --force''.'
+time: 2024-07-22T19:55:30.155613-07:00

--- a/.changes/unreleased/Fixed-20240722-200542.yaml
+++ b/.changes/unreleased/Fixed-20240722-200542.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'branch submit: Fix bug where updating an open PR would overwrite changes pushed to it by others. Use --force to overwrite these changes.'
+time: 2024-07-22T20:05:42.592509-07:00

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -196,6 +196,7 @@ This has no effect if a branch already has an open CR.
 * `--fill`: Fill in the change title and body from the commit messages
 * `--[no-]draft`: Whether to mark change requests as drafts
 * `--no-publish`: Push branches but don't create change requests
+* `--force`: Force push, bypassing safety checks
 
 ### gs stack restack
 
@@ -262,6 +263,7 @@ This has no effect if a branch already has an open CR.
 * `--fill`: Fill in the change title and body from the commit messages
 * `--[no-]draft`: Whether to mark change requests as drafts
 * `--no-publish`: Push branches but don't create change requests
+* `--force`: Force push, bypassing safety checks
 * `--branch=NAME`: Branch to start at
 
 ### gs upstack restack
@@ -348,6 +350,7 @@ This has no effect if a branch already has an open CR.
 * `--fill`: Fill in the change title and body from the commit messages
 * `--[no-]draft`: Whether to mark change requests as drafts
 * `--no-publish`: Push branches but don't create change requests
+* `--force`: Force push, bypassing safety checks
 * `--branch=NAME`: Branch to start at
 
 ### gs downstack edit
@@ -703,6 +706,7 @@ Request.
 * `--fill`: Fill in the change title and body from the commit messages
 * `--[no-]draft`: Whether to mark change requests as drafts
 * `--no-publish`: Push branches but don't create change requests
+* `--force`: Force push, bypassing safety checks
 * `--title=TITLE`: Title of the change request
 * `--body=BODY`: Body of the change request
 * `--branch=NAME`: Branch to submit

--- a/doc/src/guide/pr.md
+++ b/doc/src/guide/pr.md
@@ -77,6 +77,19 @@ you may also specify title and body directly.
     If the `--draft` or `--no-draft` flags are provided,
     the draft state of all PRs will be set accordingly.
 
+### Force pushing
+
+<!-- gs:version unreleased -->
+
+```freeze language="terminal" float="right"
+{green}${reset} gs branch submit --force
+```
+
+By default, git-spice will refuse to push to branches
+if the operation could result in data loss.
+To override these safety checks
+and push to a branch anyway, use the `--force` flag.
+
 ## Syncing with upstream
 
 To sync with the upstream repository,

--- a/internal/git/push.go
+++ b/internal/git/push.go
@@ -15,6 +15,9 @@ type PushOptions struct {
 	// the operation fails.
 	Remote string
 
+	// Force indicates that a push should overwrite the ref.
+	Force bool
+
 	// ForceWithLease indicates that a push should overwrite a ref
 	// even if the new value is not a descendant of the current value
 	// provided that our knowledge of the current value is up-to-date.
@@ -34,6 +37,9 @@ func (r *Repository) Push(ctx context.Context, opts PushOptions) error {
 	args := []string{"push"}
 	if lease := opts.ForceWithLease; lease != "" {
 		args = append(args, "--force-with-lease="+lease)
+	}
+	if opts.Force {
+		args = append(args, "--force")
 	}
 	if opts.Remote != "" {
 		args = append(args, opts.Remote)

--- a/testdata/script/branch_submit_force_push.txt
+++ b/testdata/script/branch_submit_force_push.txt
@@ -1,0 +1,61 @@
+# 'gs brnach submit --force' can overwrite remote changes.
+
+as 'Test <test@example.com>'
+at '2024-07-22T19:56:12Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub register alice
+shamhub new origin alice/example.git
+git push origin main
+
+# create a branch and go back to main
+git add feature1.txt
+gs bc -m 'Add feature1' feature1
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+gs branch submit --fill
+
+# Push to the branch from elsewhere.
+cd $WORK
+shamhub clone alice/example fork
+cd fork
+git checkout feature1
+cp $WORK/extra/feature1-conflict.txt feature1.txt
+git add feature1.txt
+git commit -m 'Introduce a conflict'
+git push
+
+cd $WORK/repo
+cp $WORK/extra/feature1-new.txt feature1.txt
+git add feature1.txt
+git commit -m 'Update feature1'
+
+! gs branch submit
+stderr 'Branch may have been updated by someone else'
+stderr 'failed to push some refs'
+
+gs branch submit --force
+
+# verify the result
+cd $WORK/fork
+git fetch
+git cat-file blob origin/feature1:feature1.txt
+cmp stdout $WORK/repo/feature1.txt
+
+-- repo/feature1.txt --
+Contents of feature1
+
+-- extra/feature1-new.txt --
+Contents of feature1
+with some fixes
+
+-- extra/feature1-conflict.txt --
+Contents of feature1
+with conflicting changes

--- a/testdata/script/branch_submit_needs_restack.txt
+++ b/testdata/script/branch_submit_needs_restack.txt
@@ -1,0 +1,67 @@
+# 'gs branch submit' with a branch that's lagging behind its base
+# rejects the push without --force.
+
+as 'Test <test@example.com>'
+at '2024-07-22T19:51:01Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub register alice
+shamhub new origin alice/example.git
+git push origin main
+
+# create a branch and go back to main
+git add feature1.txt
+gs bc -m 'Add feature1' feature1
+gs down
+
+# Move main ahead.
+git add README.md
+git commit -m 'Add a README'
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# Try to submit feature1
+gs up
+! gs branch submit --fill
+stderr 'Branch feature1 needs to be restacked'
+stderr 'refusing to submit outdated'
+cmp stdout $WORK/golden/empty.json
+
+gs branch submit --force --fill
+stderr 'Created #1'
+shamhub dump changes
+cmpenvJSON stdout $WORK/golden/pulls.json
+
+-- repo/README.md --
+documentation
+
+-- repo/feature1.txt --
+Contents of feature1
+
+-- golden/empty.json --
+-- golden/pulls.json --
+[
+  {
+    "number": 1,
+    "state": "open",
+    "title": "Add feature1",
+    "body": "",
+    "html_url": "$SHAMHUB_URL/alice/example/change/1",
+    "head": {
+      "ref": "feature1",
+      "sha": "cfb6dc9b08f78ac8e9214faacc745a06fbb58e8d"
+    },
+    "base": {
+      "ref": "main",
+      "sha": "66ae103f1e2d92ef05fa5730e77ff468801a57fa"
+    }
+  }
+]
+


### PR DESCRIPTION
This will force push even if there are conflicts.
In implementing this, also found a bug where --force-with-lease was
called with the wrong hash, so it would always overwrite what the remote
had.

Resolves #275