### PR TITLE
fix: Use 'git var GIT_EDITOR' for PR body

### DIFF
--- a/.changes/unreleased/Fixed-20240723-070944.yaml
+++ b/.changes/unreleased/Fixed-20240723-070944.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'branch submit: Use the same editor used by Git for commit messages to author the PR body.'
+time: 2024-07-23T07:09:44.524288-07:00

--- a/.changes/unreleased/Fixed-20240723-071006.yaml
+++ b/.changes/unreleased/Fixed-20240723-071006.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'branch submit: Allow `$EDITOR` to be a shell command, not just an executable name.'
+time: 2024-07-23T07:10:06.624028-07:00

--- a/.changes/unreleased/Fixed-20240723-072206.yaml
+++ b/.changes/unreleased/Fixed-20240723-072206.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: '{downstack, stack} edit: Use Git editor to edit list of branches.'
+time: 2024-07-23T07:22:06.431301-07:00

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -231,7 +231,7 @@ Branches that are deleted from the list will be ignored.
 
 **Flags**
 
-* `--editor=STRING`: Editor to use for editing the branches.
+* `--editor=STRING`: Editor to use for editing the downstack. Defaults to Git's default editor.
 * `--branch=NAME`: Branch whose stack we're editing. Defaults to current branch.
 
 ### gs upstack submit
@@ -374,7 +374,7 @@ Branches that are upstack of the current branch will not be modified.
 
 **Flags**
 
-* `--editor=STRING`: Editor to use for editing the downstack.
+* `--editor=STRING`: Editor to use for editing the downstack. Defaults to Git's default editor.
 * `--branch=NAME`: Branch to edit from. Defaults to current branch.
 
 ## Branch

--- a/downstack_edit.go
+++ b/downstack_edit.go
@@ -13,7 +13,7 @@ import (
 )
 
 type downstackEditCmd struct {
-	Editor string `env:"EDITOR" help:"Editor to use for editing the downstack."`
+	Editor string `help:"Editor to use for editing the downstack. Defaults to Git's default editor."`
 
 	Branch string `placeholder:"NAME" help:"Branch to edit from. Defaults to current branch." predictor:"trackedBranches"`
 }
@@ -40,7 +40,7 @@ func (cmd *downstackEditCmd) Run(ctx context.Context, log *log.Logger, opts *glo
 	}
 
 	if cmd.Editor == "" {
-		return errors.New("an editor is required: use --editor or set $EDITOR")
+		cmd.Editor = gitEditor(ctx, repo)
 	}
 
 	if cmd.Branch == "" {

--- a/editor.go
+++ b/editor.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"cmp"
+	"context"
+	"os"
+
+	"go.abhg.dev/gs/internal/git"
+)
+
+// gitEditor returns the editor to use
+// to prompt the user to fill information.
+func gitEditor(ctx context.Context, repo *git.Repository) string {
+	gitEditor, err := repo.Var(ctx, "GIT_EDITOR")
+	if err != nil {
+		// 'git var GIT_EDITOR' will basically never fail,
+		// but if it does, fall back to EDITOR or vi.
+		return cmp.Or(os.Getenv("EDITOR"), "vi")
+	}
+	return gitEditor
+}

--- a/internal/execedit/editor.go
+++ b/internal/execedit/editor.go
@@ -1,0 +1,28 @@
+// Package execedit provides the ability to invoke external editors.
+package execedit
+
+import (
+	"os"
+	"os/exec"
+)
+
+// Command constructs a command to open the editor
+// with the given editor command.
+// The editor command may be a shell command or a binary name.
+func Command(edit string, args ...string) *exec.Cmd {
+	var cmd *exec.Cmd
+	if exe, err := exec.LookPath(edit); err == nil {
+		cmd = exec.Command(exe, args...)
+	} else {
+		// We'll run:
+		//   sh -c 'EDITOR "$@"' -- "$1" "$2" ...
+		// The shell will take care of quoting issues.
+		args = append([]string{"-c", edit + ` "$@"`, "--"}, args...)
+		cmd = exec.Command("sh", args...)
+	}
+
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd
+}

--- a/internal/git/var.go
+++ b/internal/git/var.go
@@ -1,0 +1,17 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// Var returns the value of the given Git variable.
+func (r *Repository) Var(ctx context.Context, name string) (string, error) {
+	cmd := newGitCmd(ctx, r.log, "var", name)
+	out, err := cmd.Output(r.exec)
+	if err != nil {
+		return "", fmt.Errorf("git var %s: %w", name, err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/internal/spice/stack_edit.go
+++ b/internal/spice/stack_edit.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"slices"
 
+	"go.abhg.dev/gs/internal/execedit"
 	"go.abhg.dev/gs/internal/must"
 )
 
@@ -82,10 +82,7 @@ func editStackFile(ctx context.Context, editor string, branches []string) ([]str
 		return nil, err
 	}
 
-	editCmd := exec.CommandContext(ctx, editor, branchesFile)
-	editCmd.Stdin = os.Stdin
-	editCmd.Stdout = os.Stdout
-	editCmd.Stderr = os.Stderr
+	editCmd := execedit.Command(editor, branchesFile)
 	if err := editCmd.Run(); err != nil {
 		return nil, fmt.Errorf("run editor: %w", err)
 	}

--- a/stack_edit.go
+++ b/stack_edit.go
@@ -12,7 +12,7 @@ import (
 )
 
 type stackEditCmd struct {
-	Editor string `env:"EDITOR" help:"Editor to use for editing the branches."`
+	Editor string `help:"Editor to use for editing the downstack. Defaults to Git's default editor."`
 
 	Branch string `placeholder:"NAME" help:"Branch whose stack we're editing. Defaults to current branch." predictor:"trackedBranches"`
 }
@@ -40,7 +40,7 @@ func (cmd *stackEditCmd) Run(ctx context.Context, log *log.Logger, opts *globalO
 	}
 
 	if cmd.Editor == "" {
-		return errors.New("an editor is required: use --editor or set $EDITOR")
+		cmd.Editor = gitEditor(ctx, repo)
 	}
 
 	if cmd.Branch == "" {

--- a/testdata/script/branch_submit_use_git_editor.txt
+++ b/testdata/script/branch_submit_use_git_editor.txt
@@ -1,0 +1,69 @@
+# branch submit uses the editor set by Git.
+# https://github.com/abhinav/git-spice/issues/274
+
+as 'Test <test@example.com>'
+at '2024-07-23T07:11:32Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# create a branch with a long body
+git add feature.txt
+gs bc feature -m 'Add feature'
+
+git config core.editor MOCKEDIT_GIVE=$WORK/input/pr-body.txt' mockedit'
+
+git config core.editor
+cmpenv stdout $WORK/golden/editor.txt
+
+with-term $WORK/input/prompt.txt -- gs branch submit
+
+shamhub dump changes
+cmpenvJSON stdout $WORK/golden/changes.txt
+
+-- repo/feature.txt --
+Contents of feature
+
+-- input/pr-body.txt --
+This is the body of the PR.
+It contains details about the change.
+
+-- input/prompt.txt --
+await Title:
+feed \r
+await Body:
+feed e
+await Draft:
+feed \r
+
+-- golden/editor.txt --
+MOCKEDIT_GIVE=$WORK/input/pr-body.txt mockedit
+-- golden/changes.txt --
+[
+  {
+    "number": 1,
+    "html_url": "$SHAMHUB_URL/alice/example/change/1",
+    "state": "open",
+    "title": "Add feature",
+    "body": "This is the body of the PR.\nIt contains details about the change.\n\n",
+    "base": {
+      "ref": "main",
+      "sha": "acab7ca3bb06c21544d59de8a41f06a7f5089e06"
+    },
+    "head": {
+      "ref": "feature",
+      "sha": "8834aad8a5ba54b7bdd43774e11a8c99a0ff98e8"
+    }
+  }
+]


### PR DESCRIPTION
We were using `$EDITOR` to fill in the PR body.
This is not correct.
We should use the output of 'git var GIT_EDITOR'.
The Git editor (and `$EDITOR`) are allowed to be shell commands,
not just executable names. Handle that correctly too.

Lastly, re-use the same logic for stack edit and downstack edit.

Resolves #274
