### PR TITLE
commit split: Don't break on Ctrl-C

### DIFF
--- a/.changes/unreleased/Fixed-20240723-172718.yaml
+++ b/.changes/unreleased/Fixed-20240723-172718.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'commit split: Fix bug where canceling the split would fail to revert to original state.'
+time: 2024-07-23T17:27:18.6663-07:00

--- a/commit_split.go
+++ b/commit_split.go
@@ -48,6 +48,12 @@ func (cmd *commitSplitCmd) Run(ctx context.Context, log *log.Logger, opts *globa
 
 	defer func() {
 		if err != nil {
+			// The operation may have failed
+			// because the user pressed Ctrl-C.
+			// That would invalidate the current context.
+			// Create an uncanceled context to perform the rollback.
+			ctx := context.WithoutCancel(ctx)
+
 			log.Warn("rolling back to previous commit", "commit", head)
 			err = errors.Join(err, repo.Reset(ctx, head.String(), git.ResetOptions{
 				Mode: git.ResetMixed,

--- a/testdata/script/commit_split_incomplete_rollback.txt
+++ b/testdata/script/commit_split_incomplete_rollback.txt
@@ -1,0 +1,52 @@
+# Ctrl-C in the middle of a 'commit split' should go back to original state.
+#
+# https://github.com/abhinav/git-spice/issues/291
+
+as 'Test <test@example.com>'
+at '2024-08-23T17:08:32Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git add feature.txt
+gs bc -m 'Add feature' feature
+
+! with-term -final exit $WORK/input.txt -- gs commit split -m 'not used'
+cmp stdout $WORK/golden/terminal.txt
+
+git status --porcelain
+! stdout '.'  # empty
+
+git graph --branches
+cmp stdout $WORK/golden/graph.txt
+
+-- repo/feature.txt --
+feature 1
+feature 2
+
+-- input.txt --
+await feature 1
+feed \x03
+await signal: interrupt
+
+-- golden/graph.txt --
+* 5aac347 (HEAD -> feature) Add feature
+* 24b232e (main) Initial commit
+-- golden/terminal.txt --
+### exit ###
+INF Select hunks to extract into a new commit
+diff --git b/feature.txt a/feature.txt
+new file mode 100644
+index 0000000..010379a
+--- /dev/null
++++ a/feature.txt
+@@ -0,0 +1,3 @@
++feature 1
++feature 2
++
+(1/1) Apply addition to index [y,n,q,a,d,e,p,?]? ^CINF Cleaning up. Press Ctrl-C again to exit immediately.
+WRN rolling back to previous commit commit=5aac347854f3fe9599eb5b7712a5560aded52d55
+FTL gs: select hunks: git reset: signal: interrupt


### PR DESCRIPTION
When the user cancels the commit split with Ctrl-C,
our main() cancels the context we're operating with.
We were previously attempting to reuse that same context
for the rollback command.
This obviously caused the rollback to fail with "context canceled".

Fix this by giving the rollback a still-valid context.

Resolves #291