### PR TITLE
auth: use unsafe secret stash if secure is unavailable

### DIFF
--- a/.changes/unreleased/Added-20240723-222630.yaml
+++ b/.changes/unreleased/Added-20240723-222630.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'Authentication: If a secure storage is not available, fall back to plain text, but warn the user about it.'
+time: 2024-07-23T22:26:30.604158-07:00

--- a/doc/src/faq.md
+++ b/doc/src/faq.md
@@ -34,7 +34,7 @@ keeping them up-to-date and in sync with each other.
 ## Where is the GitHub authentication token stored?
 
 git-spice stores the GitHub authentication in a system-specific secure storage.
-See [Secret storage](guide/internals.md#secret-storage) for more details.
+See [Authentication > Safety](setup/auth.md#safety) for details.
 
 ## Why doesn't git-spice create one PR per commit?
 

--- a/doc/src/guide/internals.md
+++ b/doc/src/guide/internals.md
@@ -48,19 +48,6 @@ the following command in a repository using git-spice:
 git log --patch refs/spice/data
 ```
 
-## Secret storage
-
-git-spice stores your GitHub authentication token
-in a system-specific secure storage.
-
-On macOS, this is the system Keychain.
-On Linux, it uses the [Secret Service](https://specifications.freedesktop.org/secret-service/latest/),
-which is typically provided by [GNOME Keyring](https://specifications.freedesktop.org/secret-service/latest/).
-<!-- TODO (if we enable Windows): On Windows, it uses the Windows Credential Manager APIs. -->
-
-Credit goes to [zalando/go-keyring](https://github.com/zalando/go-keyring)
-for providing a cross-platform API for this purpose.
-
 ## Git interactions
 
 git-spice does not use a third-party Git implementation.

--- a/doc/src/setup/auth.md
+++ b/doc/src/setup/auth.md
@@ -187,7 +187,30 @@ However, it requires manual token management, making it less convenient.
 [GITHUB_TOKEN](#github_token) is the least convenient and the least secure method.
 It is intended only for CI/CD environments where you have no other choice.
 
-!!! question "Where is my token stored?"
+## Safety
 
-    The token is stored in a system-specific secure storage.
-    See [Secret storage](../guide/internals.md#secret-storage) for details.
+By default, git-spice stores your GitHub authentication token
+in a system-specific secure storage.
+On macOS, this is the system Keychain.
+On Linux, it uses the [Secret Service](https://specifications.freedesktop.org/secret-service/latest/),
+which is typically provided by [GNOME Keyring](https://specifications.freedesktop.org/secret-service/latest/).
+<!-- TODO (if we enable Windows): On Windows, it uses the Windows Credential Manager APIs. -->
+
+Since version <!-- gs:version unreleased -->,
+if your system does not provide a secure storage service,
+git-spice will fall back to storing secrets in a plain-text file
+at `$XDG_CONFIG_HOME/git-spice/secrets.json` or the user's configuration directory.
+If it does that, it will clearly indicate so at login time,
+reporting the full path to the secrets file.
+
+<details>
+  <summary>Example</summary>
+
+```freeze language="terminal"
+{green}${reset} gs auth login
+{gray}...{reset}
+{yellow}WRN{reset} Storing secrets in plain text at /home/user/.config/git-spice/secrets.json. Be careful!
+{green}INF{reset} github: successfully logged in
+```
+
+</details>

--- a/doc/src/setup/shell.md
+++ b/doc/src/setup/shell.md
@@ -1,5 +1,5 @@
 ---
-icon: material/console-line
+icon: material/bash
 description: >-
   Set up shell completion for Bash, Zsh, and Fish.
 ---

--- a/internal/secret/unsafe.go
+++ b/internal/secret/unsafe.go
@@ -116,7 +116,7 @@ func (f *UnsafeStash) save(data *unsafeStashData) error {
 	}
 
 	if firstTime {
-		f.Log.Warnf("Using plain text secrets stash at %s. Be careful!", f.Path)
+		f.Log.Warnf("Storing secrets in plain text at %s. Be careful!", f.Path)
 	}
 
 	return nil

--- a/testdata/script/auth_unsafe_storage.txt
+++ b/testdata/script/auth_unsafe_storage.txt
@@ -1,0 +1,47 @@
+# auth operations store secret information
+# in unsafe storage if secure storage is broken.
+
+as 'Test <test@example.com>'
+at '2024-08-23T22:29:32Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+gs repo init
+
+# Invalidate secret server URL
+# so we'll have to authenticate with unsafe storage.
+env OLD_SECRET_SERVER_URL=$SECRET_SERVER_URL
+env SECRET_SERVER_URL=
+
+env SHAMHUB_USERNAME=alice
+gs auth login --forge=shamhub
+cmpenv stderr $WORK/golden/login.stderr
+exists $WORK/home/.config/git-spice/secrets.json
+
+gs auth status
+stderr 'shamhub: currently logged in'
+
+gs auth logout
+stderr 'shamhub: logged out'
+! exists $WORK/home/.config/git-spice/secrets.json
+
+# Bring back secure storage.
+env SECRET_SERVER_URL=$OLD_SECRET_SERVER_URL
+
+# We aren't signed in anymore, but we can still do it.
+! gs auth status
+stderr 'not logged in'
+gs auth login --forge=shamhub
+cmp stderr $WORK/golden/login-secure.stderr
+
+-- golden/login.stderr --
+WRN Storing secrets in plain text at $WORK/home/.config/git-spice/secrets.json. Be careful!
+INF shamhub: successfully logged in
+-- golden/login-secure.stderr --
+INF shamhub: successfully logged in


### PR DESCRIPTION
Headless Linux machines (Docker environments and the like)
can't easily get access to GNOME Keyring or other secure storage.
In such cases, we should fall back to plain text storage,
but warn the user about it so they know what's going on.

Resolves #293