### PR TITLE
branch submit: Add -c short form for --fill

### DIFF
--- a/.changes/unreleased/Added-20240724-121944.yaml
+++ b/.changes/unreleased/Added-20240724-121944.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: New short flag, `-c`, for the `--fill` flag in the `gs branch submit` command.
+time: 2024-07-24T12:19:44.56674951-07:00

--- a/.changes/unreleased/Added-20240724-121944.yaml
+++ b/.changes/unreleased/Added-20240724-121944.yaml
@@ -1,3 +1,3 @@
 kind: Added
-body: New short flag, `-c`, for the `--fill` flag in the `gs branch submit` command.
+body: 'gs branch submit: Add short form `-c` for the `--fill` flag.'
 time: 2024-07-24T12:19:44.56674951-07:00

--- a/branch_submit.go
+++ b/branch_submit.go
@@ -21,7 +21,7 @@ import (
 // submitOptions defines options that are common to all submit commands.
 type submitOptions struct {
 	DryRun bool `short:"n" help:"Don't actually submit the stack"`
-	Fill   bool `help:"Fill in the change title and body from the commit messages"`
+	Fill   bool `short:"c" help:"Fill in the change title and body from the commit messages"`
 	// TODO: Default to Fill if --no-prompt?
 	Draft     *bool `negatable:"" help:"Whether to mark change requests as drafts"`
 	NoPublish bool  `name:"no-publish" help:"Push branches but don't create change requests"`

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -193,7 +193,7 @@ This has no effect if a branch already has an open CR.
 **Flags**
 
 * `-n`, `--dry-run`: Don't actually submit the stack
-* `--fill`: Fill in the change title and body from the commit messages
+* `-c`, `--fill`: Fill in the change title and body from the commit messages
 * `--[no-]draft`: Whether to mark change requests as drafts
 * `--no-publish`: Push branches but don't create change requests
 * `--force`: Force push, bypassing safety checks
@@ -260,7 +260,7 @@ This has no effect if a branch already has an open CR.
 **Flags**
 
 * `-n`, `--dry-run`: Don't actually submit the stack
-* `--fill`: Fill in the change title and body from the commit messages
+* `-c`, `--fill`: Fill in the change title and body from the commit messages
 * `--[no-]draft`: Whether to mark change requests as drafts
 * `--no-publish`: Push branches but don't create change requests
 * `--force`: Force push, bypassing safety checks
@@ -347,7 +347,7 @@ This has no effect if a branch already has an open CR.
 **Flags**
 
 * `-n`, `--dry-run`: Don't actually submit the stack
-* `--fill`: Fill in the change title and body from the commit messages
+* `-c`, `--fill`: Fill in the change title and body from the commit messages
 * `--[no-]draft`: Whether to mark change requests as drafts
 * `--no-publish`: Push branches but don't create change requests
 * `--force`: Force push, bypassing safety checks
@@ -703,7 +703,7 @@ Request.
 **Flags**
 
 * `-n`, `--dry-run`: Don't actually submit the stack
-* `--fill`: Fill in the change title and body from the commit messages
+* `-c`, `--fill`: Fill in the change title and body from the commit messages
 * `--[no-]draft`: Whether to mark change requests as drafts
 * `--no-publish`: Push branches but don't create change requests
 * `--force`: Force push, bypassing safety checks

--- a/testdata/script/upstack_submit_main.txt
+++ b/testdata/script/upstack_submit_main.txt
@@ -44,7 +44,7 @@ cmp stderr $WORK/golden/submit-dry-run.txt
 
 # submit the entire stack from main
 gs trunk
-gs upstack submit --fill
+gs upstack submit -c
 cmpenv stderr $WORK/golden/submit-log.txt
 
 gs ls


### PR DESCRIPTION
I use the `--fill` option a lot. Can we get a short flag for it?