### PR TITLE
branch delete: Drop short-form --force flag

### DIFF
--- a/.changes/unreleased/Removed-20240724-120607.yaml
+++ b/.changes/unreleased/Removed-20240724-120607.yaml
@@ -1,0 +1,3 @@
+kind: Removed
+body: 'branch delete: Drop short form `-f` for the `--force` flag.'
+time: 2024-07-24T12:06:07.858133-07:00

--- a/branch_delete.go
+++ b/branch_delete.go
@@ -14,7 +14,7 @@ import (
 )
 
 type branchDeleteCmd struct {
-	Force  bool   `short:"f" help:"Force deletion of the branch"`
+	Force  bool   `help:"Force deletion of the branch"`
 	Branch string `arg:"" optional:"" help:"Name of the branch to delete" predictor:"branches"`
 }
 

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -530,7 +530,7 @@ Provide a name as an argument to skip the prompt.
 
 **Flags**
 
-* `-f`, `--force`: Force deletion of the branch
+* `--force`: Force deletion of the branch
 
 ### gs branch fold
 


### PR DESCRIPTION
In interactive mode, the command will prompt for force-deletion
regardless.
In non-interactive mode, the long-form isn't much of a burden.
