### PR TITLE
termtest: Don't fail on 'file already closed'

### DIFF
--- a/internal/termtest/with_term.go
+++ b/internal/termtest/with_term.go
@@ -297,7 +297,7 @@ loop:
 			}
 		}
 		if err != nil {
-			if !errors.Is(err, io.EOF) {
+			if !errors.Is(err, io.EOF) && !errors.Is(err, os.ErrClosed) {
 				m.logf("read error: %v", err)
 			}
 			break loop


### PR DESCRIPTION
There's a race on closing the file and stopping to read from it.
It's not a failure to have a closed pty here instead of EOF.

[skip changelog]: not user facing
