### PR TITLE
Check if $EDITOR env var is empty

### DIFF
--- a/.changes/unreleased/Fixed-20240729-192426.yaml
+++ b/.changes/unreleased/Fixed-20240729-192426.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'branch submit: Fail if Git editor is explicitly unset and there''s no fallback.'
+time: 2024-07-29T19:24:26.018128-07:00

--- a/branch_submit.go
+++ b/branch_submit.go
@@ -490,11 +490,15 @@ func (f *branchSubmitForm) bodyField(body *string) ui.Field {
 			*body += f.tmpl.Body
 		}
 
-		return ui.NewOpenEditor(editor).
+		ed := ui.NewOpenEditor(editor).
 			WithValue(body).
 			WithTitle("Body").
 			WithDescription("Open your editor to write " +
 				"a detailed description of the change")
+		ed.Style.NoEditorMessage = "" +
+			"Please configure a Git core.editor, " +
+			"or set the EDITOR environment variable."
+		return ed
 	})
 }
 

--- a/internal/ui/open_editor.go
+++ b/internal/ui/open_editor.go
@@ -194,6 +194,10 @@ func (a *OpenEditor) Update(msg tea.Msg) tea.Cmd {
 
 		case key.Matches(msg, a.KeyMap.Accept):
 			return AcceptField
+
+		case a.Editor.Command == "":
+			a.err = errors.New("please set $EDITOR environment variable")
+			return tea.Quit
 		}
 	}
 

--- a/internal/ui/open_editor.go
+++ b/internal/ui/open_editor.go
@@ -35,12 +35,15 @@ var DefaultOpenEditorKeyMap = OpenEditorKeyMap{
 type OpenEditorStyle struct {
 	Key    lipgloss.Style // how to highlight keys
 	Editor lipgloss.Style
+
+	NoEditorMessage string
 }
 
 // DefaultOpenEditorStyle is the default style for an [OpenEditor] field.
 var DefaultOpenEditorStyle = OpenEditorStyle{
-	Key:    NewStyle().Foreground(Magenta),
-	Editor: NewStyle().Foreground(Green),
+	Key:             NewStyle().Foreground(Magenta),
+	Editor:          NewStyle().Foreground(Green),
+	NoEditorMessage: "please set an editor",
 }
 
 // Editor configures the editor to open.
@@ -196,7 +199,7 @@ func (a *OpenEditor) Update(msg tea.Msg) tea.Cmd {
 			return AcceptField
 
 		case a.Editor.Command == "":
-			a.err = errors.New("please set $EDITOR environment variable")
+			a.err = errors.New(a.Style.NoEditorMessage)
 			return tea.Quit
 		}
 	}

--- a/testdata/script/branch_submit_no_editor.txt
+++ b/testdata/script/branch_submit_no_editor.txt
@@ -1,0 +1,38 @@
+# branch submit fails if there's no editor.
+# https://github.com/abhinav/git-spice/issues/310
+
+as 'Test <test@example.com>'
+at '2024-07-29T19:25:12Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+git add feature.txt
+gs bc feature -m 'Add feature'
+
+env GIT_EDITOR= EDITOR=
+! with-term $WORK/input/prompt.txt -- gs branch submit
+stdout 'Please configure a Git core.editor, or set the EDITOR environment variable.'
+
+-- repo/feature.txt --
+Contents of feature
+
+-- input/prompt.txt --
+await Title:
+feed \r
+await Body:
+snapshot init
+feed e
+await Please configure
+snapshot err

--- a/testdata/script/branch_submit_use_git_editor.txt
+++ b/testdata/script/branch_submit_use_git_editor.txt
@@ -18,7 +18,6 @@ git push origin main
 env SHAMHUB_USERNAME=alice
 gs auth login
 
-# create a branch with a long body
 git add feature.txt
 gs bc feature -m 'Add feature'
 


### PR DESCRIPTION
Currently `OpenEditor` does not take into account when the $EDITOR env var is not set - in which case the Command just errors out and continues to ask the next question on whether to mark the PR as draft.

The fix is quite simple - add a case for checking if the env var is set and return tea.Quit if that's the case. 

Fix #310.

