### PR TITLE
all: Fix 'gs branch restack' message

### DIFF
--- a/.changes/unreleased/Fixed-20240729-194855.yaml
+++ b/.changes/unreleased/Fixed-20240729-194855.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fix 'gs branch restack' message arguments in error messages instructing on restacking.
+time: 2024-07-29T19:48:55.032041-07:00

--- a/branch_checkout.go
+++ b/branch_checkout.go
@@ -61,7 +61,7 @@ func (cmd *branchCheckoutCmd) Run(ctx context.Context, log *log.Logger, opts *gl
 		var restackErr *spice.BranchNeedsRestackError
 		switch {
 		case errors.As(err, &restackErr):
-			log.Warnf("%v: needs to be restacked: run 'gs branch restack %v'", cmd.Branch, cmd.Branch)
+			log.Warnf("%v: needs to be restacked: run 'gs branch restack --branch=%v'", cmd.Branch, cmd.Branch)
 		case errors.Is(err, state.ErrNotExist):
 			if store.Trunk() != cmd.Branch {
 				if !opts.Prompt {

--- a/branch_submit.go
+++ b/branch_submit.go
@@ -135,7 +135,7 @@ func (cmd *branchSubmitCmd) run(
 		if err := svc.VerifyRestacked(ctx, cmd.Branch); err != nil {
 			log.Errorf("Branch %s needs to be restacked.", cmd.Branch)
 			log.Errorf("Run the following command to fix this:")
-			log.Errorf("  gs branch restack %s", cmd.Branch)
+			log.Errorf("  gs branch restack --branch=%s", cmd.Branch)
 			log.Errorf("Or, try again with --force to submit anyway.")
 			return errors.New("refusing to submit outdated branch")
 			// TODO: this can be made optional with a --force or a prompt.

--- a/branch_track.go
+++ b/branch_track.go
@@ -162,7 +162,7 @@ func (cmd *branchTrackCmd) Run(ctx context.Context, log *log.Logger, opts *globa
 	if err := svc.VerifyRestacked(ctx, cmd.Branch); err != nil {
 		var restackErr *spice.BranchNeedsRestackError
 		if errors.As(err, &restackErr) {
-			log.Warnf("%v: needs to be restacked: run 'gs branch restack %v'", cmd.Branch, cmd.Branch)
+			log.Warnf("%v: needs to be restacked: run 'gs branch restack --branch=%v'", cmd.Branch, cmd.Branch)
 		}
 		log.Warnf("error checking branch: %v", err)
 	}


### PR DESCRIPTION
The message instructing users to run 'gs branch restack'
advises the form:

    gs branch restack <branch>

This is a leftover from when the argument was positional.
It is now a flag; fix the mssage to match.

Resolves #308