### PR TITLE
refac: Extract shorthand support into a separate package

### DIFF
--- a/dumpmd.go
+++ b/dumpmd.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/alecthomas/kong"
+	"go.abhg.dev/gs/internal/cli/shorthand"
 )
 
 // dumpMarkdownCmd is a hidden commnad that dumps
@@ -19,7 +20,7 @@ type dumpMarkdownCmd struct {
 	Shorthands string `name:"shorthands" help:"Output file for shorthands table."`
 }
 
-func (cmd *dumpMarkdownCmd) Run(app *kong.Kong, shorts shorthands) (err error) {
+func (cmd *dumpMarkdownCmd) Run(app *kong.Kong, shorts *shorthand.BuiltinSource) (err error) {
 	ref, err := os.Create(cmd.Ref)
 	if err != nil {
 		return err
@@ -40,17 +41,13 @@ func (cmd *dumpMarkdownCmd) Run(app *kong.Kong, shorts shorthands) (err error) {
 	return nil
 }
 
-func dumpShorthands(w io.Writer, shorts shorthands) {
-	keys := make([]string, 0, len(shorts))
-	for key := range shorts {
-		keys = append(keys, key)
-	}
-	slices.Sort(keys)
+func dumpShorthands(w io.Writer, shorts *shorthand.BuiltinSource) {
+	keys := shorts.Keys()
 
 	var t table
 	t.appendHeaders("Shorthand", "Long form")
 	for _, key := range keys {
-		cmd := cmdFullName(shorts[key].Command)
+		cmd := cmdFullName(shorts.Node(key))
 		link := fmt.Sprintf("[%v](/cli/reference.md#%v)", cmd, strings.ReplaceAll(cmd, " ", "-"))
 		t.addRow("gs "+key, link)
 	}

--- a/internal/cli/shorthand/builtin.go
+++ b/internal/cli/shorthand/builtin.go
@@ -1,0 +1,101 @@
+package shorthand
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/alecthomas/kong"
+)
+
+// BuiltinSource is a source of shorthand expansions
+// built into a Kong CLI based on command aliases.
+//
+// The shorthand for each command is built by joining
+// the first alias at each level of the command hierarchy.
+// For example, for:
+//
+//	branch (b) create (c)
+//
+// The shorthand would be "bc".
+type BuiltinSource struct {
+	items map[string]builtinShorthand
+}
+
+var _ Source = (*BuiltinSource)(nil)
+
+type builtinShorthand struct {
+	Expanded []string
+	Command  *kong.Node
+}
+
+// NewBuiltin builds a new BuiltinSource from the given Kong application.
+// It extracts the shorthands from the command aliases.
+func NewBuiltin(app *kong.Application) (*BuiltinSource, error) {
+	items := make(map[string]builtinShorthand)
+
+	// For each leaf subcommand, define a combined shorthand alias.
+	// For example, if the command was "branch (b) create (c)",
+	// the shorthand would be "bc".
+	// For commands with multiple aliases, only the first is used.
+commands:
+	for _, n := range app.Leaves(false) {
+		if n.Type != kong.CommandNode || len(n.Aliases) == 0 {
+			continue
+		}
+
+		var fragments []string
+		for c := n; c != nil && c.Type == kong.CommandNode; c = c.Parent {
+			if len(c.Aliases) < 1 {
+				// The command has an alias, but one of its parents doesn't.
+				// No alias to add in this case.
+				continue commands
+			}
+			fragments = append(fragments, c.Aliases[0])
+		}
+		if len(fragments) < 2 {
+			// If the command is already a single word, don't add an alias.
+			continue
+		}
+
+		slices.Reverse(fragments)
+		short := strings.Join(fragments, "")
+		if other, ok := items[short]; ok {
+			return nil, fmt.Errorf("shorthand %q for %v is already in use by %v", short, n.Path(), other.Command.Path())
+		}
+
+		items[short] = builtinShorthand{
+			Expanded: fragments,
+			Command:  n,
+		}
+	}
+
+	return &BuiltinSource{items: items}, nil
+}
+
+// ExpandShorthand expands the given shorthand command.
+func (s *BuiltinSource) ExpandShorthand(cmd string) ([]string, bool) {
+	if short, ok := s.items[cmd]; ok {
+		return short.Expanded, true
+	}
+	return nil, false
+}
+
+// Keys returns the list of shorthand keys in the source.
+func (s *BuiltinSource) Keys() []string {
+	keys := make([]string, 0, len(s.items))
+	for key := range s.items {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+// Node returns the command node for the given shorthand key
+// or nil if it doesn't exist.
+func (s *BuiltinSource) Node(key string) *kong.Node {
+	if short, ok := s.items[key]; ok {
+		return short.Command
+	}
+	return nil
+}

--- a/internal/cli/shorthand/builtin_test.go
+++ b/internal/cli/shorthand/builtin_test.go
@@ -1,0 +1,170 @@
+package shorthand_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/cli/shorthand"
+)
+
+func TestBuiltinSource(t *testing.T) {
+	tests := []struct {
+		name string
+		app  any // CLI grammar
+
+		want    map[string][]string
+		wantErr []string // non-empty if failure is expected
+	}{
+		{
+			name: "NoCommands",
+			app:  struct{}{},
+			want: map[string][]string{},
+		},
+		{
+			name: "SingleCommand",
+			app: struct {
+				Commit struct{} `cmd:"" aliases:"c"`
+			}{},
+			want: map[string][]string{}, // no entry
+		},
+		{
+			name: "SingleAlias",
+			app: struct {
+				Branch struct {
+					Create struct {
+						Name string `arg:""`
+					} `cmd:"" aliases:"c"`
+				} `cmd:"" aliases:"b"`
+			}{},
+			want: map[string][]string{
+				"bc": {"b", "c"},
+			},
+		},
+		{
+			name: "MultipleAliases",
+			app: struct {
+				Branch struct {
+					Create struct {
+						Name string `arg:""`
+					} `cmd:"" aliases:"c"`
+				} `cmd:"" aliases:"b,br"`
+			}{},
+			want: map[string][]string{
+				"bc": {"b", "c"},
+			},
+		},
+		{
+			name: "MultiLetterAlias",
+			app: struct {
+				Branch struct {
+					Create struct {
+						Name string `arg:""`
+					} `cmd:"" aliases:"cr"`
+				} `cmd:"" aliases:"b"`
+			}{},
+			want: map[string][]string{
+				"bcr": {"b", "cr"},
+			},
+		},
+
+		{
+			name: "NoAliases",
+			app: struct {
+				Branch struct {
+					Create struct {
+						Name string `arg:""`
+					} `cmd:""`
+				} `cmd:""`
+			}{},
+			want: map[string][]string{},
+		},
+		{
+			// If a command has an alias but one of its parents
+			// does not, then there's no shorthand.
+			name: "ParentMissingAlias",
+			app: struct {
+				Branch struct {
+					Create struct {
+						Name string `arg:""`
+					} `cmd:"" aliases:"c"`
+				} `cmd:""`
+			}{},
+			want: map[string][]string{},
+		},
+		{
+			name: "ConflictingShorthand",
+			app: struct {
+				Branch struct {
+					Create struct{} `cmd:"" aliases:"c"`
+					Commit struct{} `cmd:"" aliases:"c"`
+				} `cmd:"" aliases:"b"`
+			}{},
+			wantErr: []string{
+				`shorthand "bc" for branch (b) commit (c) is already in use`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cli := reflect.New(reflect.TypeOf(tt.app)).Interface()
+			parser, err := kong.New(cli)
+			require.NoError(t, err)
+
+			src, err := shorthand.NewBuiltin(parser.Model)
+			if len(tt.wantErr) > 0 {
+				require.Error(t, err)
+				for _, wantErr := range tt.wantErr {
+					assert.ErrorContains(t, err, wantErr)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			got := make(map[string][]string)
+			for _, key := range src.Keys() {
+				var ok bool
+				got[key], ok = src.ExpandShorthand(key)
+				require.True(t, ok, "expand(%q)", key)
+			}
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestBuiltinSourceNode(t *testing.T) {
+	var cli struct {
+		Branch struct {
+			Create struct {
+				Name string `arg:""`
+			} `cmd:"" aliases:"c"`
+		} `cmd:"" aliases:"b"`
+		Commit struct {
+			Create struct{} `cmd:"" aliases:"c"`
+		} `cmd:"" aliases:"c"`
+	}
+
+	parser, err := kong.New(&cli)
+	require.NoError(t, err)
+
+	src, err := shorthand.NewBuiltin(parser.Model)
+	require.NoError(t, err)
+
+	_, ok := src.ExpandShorthand("bs")
+	assert.False(t, ok, "no shorthand expected for 'bs'")
+
+	_, ok = src.ExpandShorthand("bc")
+	assert.True(t, ok, "shorthand 'bc' expected")
+	_, ok = src.ExpandShorthand("cc")
+	assert.True(t, ok, "shorthand 'cc' expected")
+
+	bcNode := src.Node("bc")
+	if assert.NotNil(t, bcNode, "expected node for 'bc'") {
+		assert.Equal(t, "branch (b) create (c)", bcNode.Path())
+	}
+	assert.Nil(t, src.Node("foo"), "expected nil for unknown node")
+}

--- a/internal/cli/shorthand/expand.go
+++ b/internal/cli/shorthand/expand.go
@@ -1,0 +1,50 @@
+// Package shorthand implements support for shorthand commands for the
+// git-spice CLI.
+package shorthand
+
+import (
+	"slices"
+)
+
+// Source is a source of shorthand expansions.
+type Source interface {
+	// ExpandShorthand expands the given shorthand command
+	// into a list of arguments.
+	//
+	// If the command is not a shorthand, it returns false.
+	ExpandShorthand(string) ([]string, bool)
+}
+
+// Expand expands the given arguments using the given source repeatedly
+// until there's nothing left to expand.
+//
+// A single pattern is expanded only once.
+// That is, if "commit" is declared as shorthand for "commit --amend",
+// we will expand the "commit" shorthand only once.
+func Expand(src Source, args []string) []string {
+	if len(args) == 0 {
+		return args
+	}
+
+	seen := make(map[string]struct{}) // to prevent infinite loops
+	expanded, ok := src.ExpandShorthand(args[0])
+	for ok {
+		seen[args[0]] = struct{}{}
+		args = slices.Replace(args, 0, 1, expanded...)
+
+		if len(args) == 0 {
+			// Unlikely but possible that the shorthand
+			// just no-ops the arguments.
+			break
+		}
+
+		// Don't expand the same string twice.
+		if _, done := seen[args[0]]; done {
+			break
+		}
+
+		expanded, ok = src.ExpandShorthand(args[0])
+	}
+
+	return args
+}

--- a/internal/cli/shorthand/expand_test.go
+++ b/internal/cli/shorthand/expand_test.go
@@ -1,0 +1,85 @@
+package shorthand_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.abhg.dev/gs/internal/cli/shorthand"
+)
+
+func TestExpand(t *testing.T) {
+	tests := []struct {
+		name string
+		src  shorthand.Source
+		args []string
+		want []string
+	}{
+		{
+			name: "NoArgs",
+			args: []string{},
+			want: []string{},
+		},
+		{
+			name: "NoShorthand",
+			src:  shorthandMap{},
+			args: []string{"foo", "bar"},
+			want: []string{"foo", "bar"},
+		},
+		{
+			name: "SingleMatch",
+			src: shorthandMap{
+				"foo": {"bar", "baz"},
+			},
+			args: []string{"foo", "qux"},
+			want: []string{"bar", "baz", "qux"},
+		},
+		{
+			name: "MultipleMatches",
+			src: shorthandMap{
+				"can": {"ca", "--no-edit"},
+				"ca":  {"c", "--amend"},
+				"c":   {"commit"},
+			},
+			args: []string{"can", "--all"},
+			want: []string{"commit", "--amend", "--no-edit", "--all"},
+		},
+		{
+			name: "DeleteArgument",
+			src: shorthandMap{
+				"foo": {"baz"},
+				"baz": {},
+			},
+			args: []string{"foo"},
+			want: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shorthand.Expand(tt.src, tt.args)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestExpand_noInfiniteLoop(t *testing.T) {
+	// It should not be possible to create an infinite loop
+	// with mutually recursive shorthands.
+	src := shorthandMap{
+		"foo": {"bar", "baz"},
+		"bar": {"foo", "qux"},
+	}
+
+	args := []string{"foo"}
+	got := shorthand.Expand(src, args)
+	assert.Equal(t, []string{"foo", "qux", "baz"}, got)
+}
+
+type shorthandMap map[string][]string
+
+func (m shorthandMap) ExpandShorthand(s string) ([]string, bool) {
+	if expanded, ok := m[s]; ok {
+		return expanded, true
+	}
+	return nil, false
+}


### PR DESCRIPTION
Extracts support for adding shorthands to the CLI
into a separate package with composable "Source" types
for providing the expansions.
We start with only a built-in source, with rooom for more in the future.

This also ends up testing the shorthand expansion thoroughly.
