### PR TITLE
Add a configuration system based on git-config

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -13,6 +13,61 @@
     and add a link from the old entry to the new one.
 -->
 
+## 2024-08-04: git-spice configuration will reside in Git configuration
+
+The decision to use `git-config` for git-spice configuration raises the
+question whether git-spice configuration will reside in its own file
+(that just happens to match Git configuration format)
+or whether it will be part of the user's regular Git configuration.
+
+While the former is isolated, it makes for a rougher user experience.
+Users either have to edit the file manually or we have to
+provide `gs config` commands (which we may do anyway in the future),
+as `git config --file=path/to/gs/config` is a bit unwieldy.
+
+On the other hand, if we use regular Git configuration,
+besides a familiar path for users to set configuration,
+we also get the benefit of Git's configuration hierarchy for free.
+Options may be set at system-, user-, repository-, or worktree-level.
+The level of flexibility this provides is a good match for more workflows,
+and we're able to provide this without adding significant complexity to the UX
+to provide similar functionality.
+
+## 2024-08-04: Configuration will use git-config
+
+Thus far, git-spice hasn't provided much in terms of configuration dials.
+Behavior is either derived from Git configuration or doesn't have flexibility.
+Examples of places where we need configuration include:
+
+- Whether to post a stack visualization comment on PRs.
+  Right now, we do this unconditionally.
+  We'd like for users to be able to turn this off,
+  or have it be posted only of there are at least two branches in the stack.
+- Ability to add a prefix to all created branch names--possibly derived
+  from an external command.
+- Support for custom shorthands in addition to built-ins.
+
+To support this, we'll need a configuration system.
+The usual discussions around YAML, TOML, etc. could be had,
+but given that Git is a pre-requisite for git-spice,
+we can leverage `git-config`.
+
+The following flags can be used for the bulk of the work here.
+
+    --get-regexp <name-pattern>
+    --null
+
+Example configuration keys:
+
+- `spice.submit.navigationComment`: true, false, multiple
+- `spice.create.branchPrefix`: prefix for new branches
+- `spice.alias.*`: custom aliases and shorthands
+
+Note that regardless of configuration system in use,
+custom short hands will be special cased:
+while most configuration options will have flag-level analogs,
+shorthands will not as we expand them before parsing command line flags.
+
 ## 2024-05-28: Rebase continuations need a queue
 
 If a re-entrant operation performs several independent interruptible rebases,

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -115,6 +115,7 @@ nav:
   - CLI:
     - cli/index.md
     - cli/reference.md
+    - cli/config.md
     - cli/shorthand.md
   - how-to.md
   - FAQ: faq.md

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -1,0 +1,29 @@
+---
+title: Configuration
+icon: material/wrench
+description: >-
+  Customizing the behavior of the git-spice CLI.
+---
+
+# CLI configuration
+
+<!-- gs:version unreleased -->
+
+The behavior of git-spice can be customized with `git config`.
+Configuration options may be set at the user level with the `--global` flag,
+or at the repository level with the `--local` flag.
+
+```freeze language="terminal"
+{gray}# Set an option for current user{reset}
+{green}${reset} git config --global spice.{red}<key>{reset} {mag}<value>{reset}
+
+{gray}# Set an option for current repository{reset}
+{green}${reset} git config --local spice.{red}<key>{reset} {mag}<value>{reset}
+```
+
+??? question "What about `--system` and `--worktree`?"
+
+    All configuration levels supported by `git config` are allowed,
+    although `--system` and `--worktree` are less commonly used.
+    Use `--worktree` to override repository-level settings
+    for a specific [git-worktree](https://git-scm.com/docs/git-worktree).

--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -1,0 +1,145 @@
+package git
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/charmbracelet/log"
+)
+
+// Config provides access to Git configuration in the current context.
+type Config struct {
+	log  *log.Logger
+	dir  string
+	env  []string
+	exec execer
+}
+
+// ConfigOptions configures the behavior of a [Config].
+type ConfigOptions struct {
+	// Dir specifies the directory to run Git commands in.
+	// Defaults to the current working directory if empty.
+	Dir string
+
+	// Env specifies additional environment variables
+	// to set when running Git commands.
+	Env []string
+
+	// Log used for logging messages to the user.
+	// If nil, no messages are logged.
+	Log *log.Logger
+
+	exec execer
+}
+
+// NewConfig builds a new [Config] object for accessing Git configuration.
+func NewConfig(opts ConfigOptions) *Config {
+	exec := opts.exec
+	if exec == nil {
+		exec = _realExec
+	}
+
+	if opts.Log == nil {
+		opts.Log = log.New(io.Discard)
+	}
+
+	return &Config{
+		log:  opts.Log,
+		dir:  opts.Dir,
+		env:  opts.Env,
+		exec: exec,
+	}
+}
+
+// ConfigEntry is a single key-value pair in Git configuration.
+type ConfigEntry struct {
+	Key   string
+	Value string
+}
+
+// ListRegexp lists all configuration entries that match the given pattern.
+// If pattern is empty, '.' is used to match all entries.
+func (cfg *Config) ListRegexp(ctx context.Context, pattern string) (
+	func(yield func(ConfigEntry, error) bool),
+	error,
+) {
+	if pattern == "" {
+		pattern = "."
+	}
+	return cfg.list(ctx, "--get-regexp", pattern)
+}
+
+var _newline = []byte("\n")
+
+func (cfg *Config) list(ctx context.Context, args ...string) (
+	func(yield func(ConfigEntry, error) bool),
+	error,
+) {
+	args = append([]string{"config", "--null"}, args...)
+	cmd := newGitCmd(ctx, cfg.log, args...).
+		Dir(cfg.dir).
+		AppendEnv(cfg.env...)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(cfg.exec); err != nil {
+		return nil, fmt.Errorf("start git-config: %w", err)
+	}
+
+	log := cfg.log
+	return func(yield func(ConfigEntry, error) bool) {
+		// Always wait for the command to finish when this returns.
+		// Ignore the error because git-config fails if there are no matches.
+		// It's not an error for us if there are no matches.
+		defer func() {
+			_ = cmd.Wait(cfg.exec)
+		}()
+
+		// With the --null flag, output is in the form:
+		//
+		//	key1\nvalue1\0
+		//	key2\nvalue2\0
+		scan := bufio.NewScanner(stdout)
+		scan.Split(scanNullDelimited)
+		for scan.Scan() {
+			entry := scan.Bytes()
+			key, value, ok := bytes.Cut(entry, _newline)
+			if !ok {
+				log.Warnf("skipping invalid entry: %q", entry)
+				continue
+			}
+
+			if !yield(ConfigEntry{
+				Key:   string(key),
+				Value: string(value),
+			}, nil) {
+				return
+			}
+		}
+
+		if err := scan.Err(); err != nil {
+			_ = yield(ConfigEntry{}, fmt.Errorf("scan git-config output: %w", err))
+		}
+	}, nil
+}
+
+// scanNullDelimited is a bufio.SplitFunc that splits on null bytes.
+func scanNullDelimited(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	if i := bytes.IndexByte(data, 0); i >= 0 {
+		return i + 1, data[:i], nil
+	}
+	if atEOF {
+		// No trailing null byte. Unlikely but easy to handle.
+		return len(data), data, nil
+	}
+	return 0, nil, nil // request more data
+}

--- a/internal/git/config_test.go
+++ b/internal/git/config_test.go
@@ -1,0 +1,212 @@
+package git
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/logtest"
+	"go.uber.org/mock/gomock"
+)
+
+func TestConfigListRegexp(t *testing.T) {
+	pair := func(key, value string) string {
+		return key + "\n" + value
+	}
+
+	lines := func(lines ...string) string {
+		var buf bytes.Buffer
+		for _, line := range lines {
+			buf.WriteString(line)
+			buf.WriteByte(0)
+		}
+		return buf.String()
+	}
+
+	tests := []struct {
+		name string
+		give string
+		want []ConfigEntry
+	}{
+		{name: "Empty"},
+
+		{
+			name: "Single",
+			give: "user.name\nAlice",
+			want: []ConfigEntry{{Key: "user.name", Value: "Alice"}},
+		},
+		{
+			name: "Multiple",
+			give: lines(
+				pair("user.name", "Alice"),
+				pair("user.email", "alice@example.com"),
+			),
+			want: []ConfigEntry{
+				{Key: "user.name", Value: "Alice"},
+				{Key: "user.email", Value: "alice@example.com"},
+			},
+		},
+		{
+			name: "EmptyLines",
+			give: lines(
+				pair("user.name", "Alice"),
+				"",
+				pair("user.email", "alice@example.com"),
+			),
+			want: []ConfigEntry{
+				{Key: "user.name", Value: "Alice"},
+				{Key: "user.email", Value: "alice@example.com"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			execer := NewMockExecer(gomock.NewController(t))
+			execer.EXPECT().
+				Start(gomock.Any()).
+				Do(func(cmd *exec.Cmd) error {
+					// Writes to the command's stdout
+					// must happen in a goroutine
+					// because otherwise the pipe will deadlock.
+					go func() {
+						_, err := io.WriteString(cmd.Stdout, tt.give)
+						assert.NoError(t, err)
+						assert.NoError(t, cmd.Stdout.(io.Closer).Close())
+					}()
+					return nil
+				}).
+				Return(nil)
+			execer.EXPECT().
+				Wait(gomock.Any()).
+				Return(nil)
+
+			cfg := NewConfig(ConfigOptions{
+				Dir:  t.TempDir(),
+				Log:  logtest.New(t),
+				exec: execer,
+			})
+
+			iter, err := cfg.ListRegexp(context.Background(), ".")
+			require.NoError(t, err)
+
+			var got []ConfigEntry
+			iter(func(entry ConfigEntry, err error) bool {
+				require.NoError(t, err)
+				got = append(got, entry)
+				return true
+			})
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIntegrationConfigListRegexp(t *testing.T) {
+	tests := []struct {
+		name string
+
+		// Groups of arguments to pass to `git config`
+		// to set up the configuration.
+		// e.g. [["user.name", "Alice"], ["user.email", "alice@example.com"]]
+		sets [][]string
+
+		// The regular expression to search for in the configuration.
+		pattern string
+
+		want []ConfigEntry
+	}{
+		{name: "Empty"},
+		{
+			name: "Matches",
+			sets: [][]string{
+				{"user.name", "Alice"},
+				{"user.email", "alice@example.com"},
+			},
+			pattern: `^user\.`,
+			want: []ConfigEntry{
+				{Key: "user.name", Value: "Alice"},
+				{Key: "user.email", Value: "alice@example.com"},
+			},
+		},
+		{
+			name: "NoMatches",
+			sets: [][]string{
+				{"user.name", "Alice"},
+				{"user.email", "alice@example.com"},
+			},
+			pattern: `^foo\.`,
+		},
+		{
+			// config fields that can have multiple values.
+			name: "MultiValue",
+			sets: [][]string{
+				{"--add", "remote.origin.fetch", "+refs/heads/main:refs/remotes/origin/main"},
+				{"--add", "remote.origin.fetch", "+refs/heads/feature:refs/remotes/origin/feature"},
+				{"--add", "remote.origin.fetch", "+refs/heads/username/*:refs/remotes/origin/username/*"},
+			},
+			pattern: `^remote\.origin\.`,
+			want: []ConfigEntry{
+				{Key: "remote.origin.fetch", Value: "+refs/heads/main:refs/remotes/origin/main"},
+				{Key: "remote.origin.fetch", Value: "+refs/heads/feature:refs/remotes/origin/feature"},
+				{Key: "remote.origin.fetch", Value: "+refs/heads/username/*:refs/remotes/origin/username/*"},
+			},
+		},
+		{
+			name: "MultiLine",
+			sets: [][]string{
+				{"some.key", "value1\nvalue2\nvalue3"},
+			},
+			pattern: `^some\.`,
+			want: []ConfigEntry{
+				{Key: "some.key", Value: "value1\nvalue2\nvalue3"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			home := t.TempDir()
+			env := []string{
+				"HOME=" + home,
+				"XDG_CONFIG_HOME=" + filepath.Join(home, ".config"),
+				"GIT_CONFIG_NOSYSTEM=1",
+			}
+
+			ctx := context.Background()
+			log := logtest.New(t)
+			for _, set := range tt.sets {
+				args := append([]string{"config", "--global"}, set...)
+				err := newGitCmd(ctx, log, args...).
+					Dir(home).
+					AppendEnv(env...).
+					Run(_realExec)
+				require.NoError(t, err, "git-config: %v", args)
+			}
+
+			cfg := NewConfig(ConfigOptions{
+				Dir: home,
+				Env: env,
+				Log: log,
+			})
+
+			var got []ConfigEntry
+			iter, err := cfg.ListRegexp(ctx, tt.pattern)
+			require.NoError(t, err)
+			iter(func(entry ConfigEntry, err error) bool {
+				require.NoError(t, err)
+				got = append(got, entry)
+				return true
+			})
+
+			assert.ElementsMatch(t, tt.want, got)
+		})
+	}
+}

--- a/internal/spice/config.go
+++ b/internal/spice/config.go
@@ -1,0 +1,143 @@
+package spice
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/alecthomas/kong"
+	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/git"
+)
+
+const (
+	_configKey             = "config"
+	_configNamespace       = "spice"
+	_configNamespacePrefix = _configNamespace + "."
+)
+
+// GitConfigLister provides access to git-config output.
+type GitConfigLister interface {
+	ListRegexp(context.Context, string) (
+		func(yield func(git.ConfigEntry, error) bool),
+		error,
+	)
+}
+
+var _ GitConfigLister = (*git.Config)(nil)
+
+// Config defines the git-spice configuration source.
+// It can be passed into Kong as a [kong.Resolver] to fill in flag values.
+//
+// Configuration for git-spice is specified via git-config.
+// These can be system, user, repository, or worktree-level.
+//
+// The configuration keys are read from the root namespace "spice"
+// for keys in the CLI grammar tagged with the `config:"key"` tag.
+// Flags that are not tagged with `config:"key"` are ignored for configuration.
+//
+// For example:
+//
+//	type someCmd struct {
+//		Level string `config:"level"`
+//	}
+//
+// This will read the configuration key "spice.level" from git-config.
+//
+//	[spice]
+//	level = hot
+//
+// Values are decoded using the same mapper as the flag.
+// For single-valued fields, if multiple values are found in the configuration,
+// the last value is used.
+// For slice fields, all values are combined.
+//
+// If a flag is passed on the CLI, it takes precedence over the configuration.
+type Config struct {
+	// items is a map from configuration key (without the "spice." prefix)
+	// to list of values for that field.
+	items map[string][]string
+}
+
+// ConfigOptions spceifies options for the [Config].
+type ConfigOptions struct {
+	// Log specifies the logger to use for logging.
+	// Defaults to no logging.
+	Log *log.Logger
+}
+
+// LoadConfig loads configuration from the provided [GitConfig].
+func LoadConfig(ctx context.Context, cfg GitConfigLister, opts ConfigOptions) (*Config, error) {
+	if opts.Log == nil {
+		opts.Log = log.New(io.Discard)
+	}
+
+	entries, err := cfg.ListRegexp(ctx, `^`+_configNamespace+`\.`)
+	if err != nil {
+		return nil, fmt.Errorf("list configuration: %w", err)
+	}
+
+	items := make(map[string][]string)
+
+	err = nil // TODO: use a range loop after Go 1.23
+	entries(func(entry git.ConfigEntry, iterErr error) bool {
+		if iterErr != nil {
+			err = iterErr
+			return false
+		}
+
+		key, ok := strings.CutPrefix(entry.Key, _configNamespacePrefix)
+		if !ok {
+			// This will never happen if git config --get-regexp
+			// behaves correctly, but it's easy to handle.
+			return true
+		}
+
+		items[key] = append(items[key], entry.Value)
+		return true
+	})
+	if err != nil {
+		return nil, fmt.Errorf("read configuration: %w", err)
+	}
+
+	return &Config{
+		items: items,
+	}, nil
+}
+
+// Validate checks if the configuration is valid for the given application.
+// This is a no-op, as we allow unknown configuration keys.
+func (*Config) Validate(*kong.Application) error { return nil }
+
+// Resolve resolves the value for a flag from configuration.
+func (c *Config) Resolve(kctx *kong.Context, parent *kong.Path, flag *kong.Flag) (interface{}, error) {
+	key := flag.Tag.Get(_configKey)
+	if key == "" {
+		return nil, nil
+	}
+
+	values := c.items[key]
+	switch len(values) {
+	case 0:
+		return nil, nil
+
+	case 1:
+		return values[0], nil
+
+	default:
+		if flag.IsSlice() {
+			if flag.Tag.Sep != -1 {
+				// If there are multiple values, and a separator is defined,
+				// let Kong split the values.
+				return kong.JoinEscaped(values, flag.Tag.Sep), nil
+			}
+
+			return nil, fmt.Errorf("key %q has multiple values but no separator is defined", key)
+		}
+
+		// Last value wins if there are multiple instances
+		// for a single-valued flag.
+		return values[len(values)-1], nil
+	}
+}

--- a/internal/spice/config_test.go
+++ b/internal/spice/config_test.go
@@ -1,0 +1,214 @@
+package spice_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	reflect "reflect"
+	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/logtest"
+	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/text"
+)
+
+func TestIntegrationConfig_loadFromGit(t *testing.T) {
+	// Prevent current user's gitconfig from interfering with the test.
+	t.Setenv("HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	tests := []struct {
+		name   string
+		config string
+		args   []string
+		want   any
+
+		wantErr []string // non-empty if error messages are expected
+	}{
+		{name: "Empty", want: struct {
+			String  string `config:"string"`
+			Integer int    `config:"integer"`
+			Bool    bool   `config:"bool"`
+		}{}},
+
+		{
+			name: "Configured",
+			config: text.Dedent(`
+				[spice]
+				string = foo
+				integer = 42
+				bool = true
+			`),
+			want: struct {
+				String  string `config:"string"`
+				Integer int    `config:"integer"`
+				Bool    bool   `config:"bool"`
+			}{
+				String:  "foo",
+				Integer: 42,
+				Bool:    true,
+			},
+		},
+		{
+			name: "Configured/Override",
+			args: []string{"--string=bar"},
+			config: text.Dedent(`
+				[spice]
+				string = foo
+				integer = 42
+			`),
+			want: struct {
+				String  string `config:"string"`
+				Integer int    `config:"integer"`
+				Bool    bool   `config:"bool"`
+			}{String: "bar", Integer: 42},
+		},
+
+		{
+			name: "Enum/Flag",
+			want: struct {
+				Level string `config:"level" enum:"mild,medium,hot" required:""`
+			}{Level: "medium"},
+			args: []string{"--level=medium"},
+		},
+		{
+			name: "Enum/Config",
+			want: struct {
+				Level string `config:"level" enum:"mild,medium,hot" required:""`
+			}{Level: "hot"},
+			config: text.Dedent(`
+				[spice]
+				level = hot
+			`),
+		},
+		{
+			name: "Enum/ConfigInvalid",
+			config: text.Dedent(`
+				[spice]
+				level = unknown
+			`),
+			want: struct {
+				Level string `config:"level" enum:"mild,medium,hot" required:""`
+			}{},
+			wantErr: []string{`--level must be one of`, `got "unknown"`},
+		},
+
+		{
+			name: "Multiple",
+			config: text.Dedent(`
+				[spice.include]
+				path = foo
+				path = bar
+			`),
+			want: struct {
+				Include []string `config:"include.path"`
+			}{Include: []string{"foo", "bar"}},
+		},
+		{
+			name: "Multiple/Empty",
+			want: struct {
+				Include []string `config:"include.path"`
+			}{},
+		},
+		{
+			name: "Multiple/Override",
+			args: []string{"--include=foo", "--include=bar"},
+			config: text.Dedent(`
+				[spice.include]
+				path = baz
+			`),
+			want: struct {
+				Include []string `config:"include.path"`
+			}{Include: []string{"foo", "bar"}},
+		},
+		{
+			name: "Multiple/Ints",
+			config: text.Dedent(`
+				[spice.include]
+				path = 1
+				path = 2
+			`),
+			want: struct {
+				Include []int `config:"include.path"`
+			}{Include: []int{1, 2}},
+		},
+		{
+			name: "Multiple/NoSeparator",
+			config: text.Dedent(`
+				[spice.include]
+				path = foo
+				path = bar
+			`),
+			want: struct {
+				Include []string `config:"include.path" sep:"none"`
+			}{},
+			wantErr: []string{`multiple values but no separator`},
+		},
+		{
+			name: "Multiple/LastWins",
+			config: text.Dedent(`
+				[spice]
+				level = mild
+				level = medium
+				level = hot
+			`),
+			want: struct {
+				Level string `config:"level"`
+			}{Level: "hot"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Set up
+			home := t.TempDir()
+			require.NoError(t, os.WriteFile(
+				filepath.Join(home, ".gitconfig"),
+				[]byte(tt.config),
+				0o600,
+			), "write configuration file")
+
+			// Read configuration
+			ctx := context.Background()
+			gitCfg := git.NewConfig(git.ConfigOptions{
+				Log: logtest.New(t),
+				Dir: home,
+				Env: []string{
+					"HOME=" + home,
+					"USER=testuser",
+					"GIT_CONFIG_NOSYSTEM=1",
+				},
+			})
+			spicecfg, err := spice.LoadConfig(ctx, gitCfg, spice.ConfigOptions{
+				Log: logtest.New(t),
+			})
+			require.NoError(t, err, "load configuration")
+
+			// Parse flags
+			gotptr := reflect.New(reflect.TypeOf(tt.want)) // *T
+			cli, err := kong.New(
+				gotptr.Interface(),
+				kong.Resolvers(spicecfg),
+			)
+			require.NoError(t, err, "create app")
+
+			_, err = cli.Parse(tt.args)
+			if len(tt.wantErr) > 0 {
+				require.Error(t, err, "parse flags")
+				for _, msg := range tt.wantErr {
+					assert.ErrorContains(t, err, msg)
+				}
+				return
+			}
+
+			require.NoError(t, err, "parse flags")
+			assert.Equal(t, tt.want, gotptr.Elem().Interface())
+		})
+	}
+}


### PR DESCRIPTION
git-spice needs a source of configuration
to support customizing behaviors like `submit` navigation comments,
custom aliases, etc.
After some deliberation, we've decided to use git-config
as the configuration source for git-spice.

This will allow for a familiar configuration experience
with user-, repository-, and worktree-level overrides for options.

This PR does not implement any configuration options yet.
Those will be added in subsequent PRs.

Resolves #16