### PR TITLE
doc: Enumerate configurations under each command

### DIFF
--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -152,6 +152,8 @@ Use with the -a/--all flag to show all tracked branches.
 
 * `-a`, `--all` ([:material-wrench:{ .middle title="spice.log.all" }](/cli/config.md#spicelogall)): Show all tracked branches, not just the current stack.
 
+**Configuration**: [spice.log.all](/cli/config.md#spicelogall)
+
 ### gs log long
 
 ```
@@ -167,6 +169,8 @@ Use with the -a/--all flag to show all tracked branches.
 **Flags**
 
 * `-a`, `--all` ([:material-wrench:{ .middle title="spice.log.all" }](/cli/config.md#spicelogall)): Show all tracked branches, not just the current stack.
+
+**Configuration**: [spice.log.all](/cli/config.md#spicelogall)
 
 ## Stack
 

--- a/dumpmd.go
+++ b/dumpmd.go
@@ -131,6 +131,8 @@ func (cmd *cliDumper) dump(app *kong.Application) {
 	}
 	cmd.println()
 
+	cmd.dumpConfigFooter(app.Node)
+
 	for i, key := range groupKeys {
 		lvl := 2
 		title := groupTitles[i]
@@ -182,8 +184,37 @@ func (cmd cliDumper) dumpCommand(node *kong.Node, level int) {
 		cmd.println()
 	}
 
+	cmd.dumpConfigFooter(node)
+
 	for _, child := range node.Children {
 		cmd.dumpCommand(child, level+1)
+	}
+}
+
+func (cmd cliDumper) dumpConfigFooter(node *kong.Node) {
+	var configKeys []string
+	for _, flag := range node.Flags {
+		key := flag.Tag.Get("config")
+		if key == "" {
+			continue
+		}
+		configKeys = append(configKeys, key)
+	}
+
+	if len(configKeys) == 0 {
+		return
+	}
+
+	cmd.print("**Configuration**:")
+	defer cmd.printf("\n\n")
+
+	for i, key := range configKeys {
+		key := "spice." + key
+		id := strings.ToLower(strings.ReplaceAll(key, ".", ""))
+		if i > 0 {
+			cmd.print(",")
+		}
+		cmd.printf(" [%v](/cli/config.md#%s)", key, id)
 	}
 }
 


### PR DESCRIPTION
For each command, enumerate configuration keys that affect it,
and link to the configuration reference.

This will be especially handy for config-only options
that don't have corresponding public flags.