### PR TITLE
Support setting GitHub URLs via configuration

### DIFF
--- a/.changes/unreleased/Added-20240807-075520.yaml
+++ b/.changes/unreleased/Added-20240807-075520.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'auth: Allow setting GitHub URLs with git-config.'
+time: 2024-08-07T07:55:20.266498-07:00

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -12,6 +12,8 @@ gs (git-spice) is a command line tool for stacking Git branches.
 * `-C`, `--dir=DIR`: Change to DIR before doing anything
 * `--[no-]prompt`: Whether to prompt for missing information
 
+**Configuration**: [spice.forge.github.url](/cli/config.md#spiceforgegithuburl), [spice.forge.github.apiUrl](/cli/config.md#spiceforgegithubapiurl)
+
 ## Shell
 
 ### gs shell completion

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -30,6 +30,20 @@ or at the repository level with the `--local` flag.
 
 ## Available options
 
+### spice.forge.github.apiUrl
+
+URL at which the GitHub API is available.
+Defaults to `$GITHUB_API_URL` if set, or `https://api.github.com` otherwise.
+
+See also: [GitHub Enterprise](../setup/auth.md#github-enterprise).
+
+### spice.forge.github.url
+
+URL of the GitHub instance used for GitHub requests.
+Defaults to `$GITHUB_URL` if set, or `https://github.com` otherwise.
+
+See also: [GitHub Enterprise](../setup/auth.md#github-enterprise).
+
 ### spice.log.all
 
 Whether $$gs log short$$ and $$gs log long$$ should show all stacks by default,

--- a/doc/src/setup/auth.md
+++ b/doc/src/setup/auth.md
@@ -201,6 +201,17 @@ export GITHUB_URL=https://github.example.com
 export GITHUB_API_URL=https://github.example.com/api
 ```
 
+Since <!-- gs:version unreleased -->,
+use the $$spice.forge.github.url$$ and $$spice.forge.github.apiUrl$$
+configuration options to set these values
+if environment variables are inconvenient.
+
+```freeze language="terminal"
+git config {green}spice.forge.github.url{reset} {mag}https://github.example.com{reset}
+git config {green}spice.forge.github.apiUrl{reset} {mag}https://github.example.com/api{reset}
+```
+
+
 ## Safety
 
 By default, git-spice stores your GitHub authentication token

--- a/internal/forge/github/forge.go
+++ b/internal/forge/github/forge.go
@@ -22,11 +22,11 @@ import (
 type Options struct {
 	// URL is the URL for GitHub.
 	// Override this for testing or GitHub Enterprise.
-	URL string `name:"github-url" hidden:"" env:"GITHUB_URL" help:"Base URL for GitHub web requests"`
+	URL string `name:"github-url" hidden:"" config:"forge.github.url" env:"GITHUB_URL" help:"Base URL for GitHub web requests"`
 
 	// APIURL is the URL for the GitHub API.
 	// Override this for testing or GitHub Enterprise.
-	APIURL string `name:"github-api-url" hidden:"" env:"GITHUB_API_URL" help:"Base URL for GitHub API requests"`
+	APIURL string `name:"github-api-url" hidden:"" config:"forge.github.apiUrl" env:"GITHUB_API_URL" help:"Base URL for GitHub API requests"`
 
 	// Token is a fixed token used to authenticate with GitHub.
 	// This may be used to skip the login flow.


### PR DESCRIPTION
Setting GITHUB_URL and GITHUB_API_URL environment variables
can be inconvenient.
Allow setting these values via git config if desired.