### PR TITLE
submit: Support navigation comment opt-out

### DIFF
--- a/.changes/unreleased/Added-20240806-211807.yaml
+++ b/.changes/unreleased/Added-20240806-211807.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: >-
+  submit: Support opting out or reducing navigation comment frequency with the --nav-comment flag.
+  The spice.submit.navigationComment configuration option may be used for the same purpose.
+time: 2024-08-06T21:18:07.260181-07:00

--- a/branch_submit.go
+++ b/branch_submit.go
@@ -26,6 +26,8 @@ type submitOptions struct {
 	Draft     *bool `negatable:"" help:"Whether to mark change requests as drafts"`
 	NoPublish bool  `name:"no-publish" help:"Push branches but don't create change requests"`
 
+	NavigationComment navigationCommentWhen `name:"nav-comment" config:"submit.navigationComment" placeholder:"true" help:"Whether to add a navigation comment to the change request. Must be one of: true, false, multiple."`
+
 	Force bool `help:"Force push, bypassing safety checks"`
 
 	// TODO: Other creation options e.g.:
@@ -43,6 +45,8 @@ and --[no-]draft to set the draft status.
 Omitting the draft flag will leave the status unchanged of open CRs.
 Use --no-publish to push branches without creating CRs.
 This has no effect if a branch already has an open CR.
+Use --nav-comment=false to disable navigation comments in CRs,
+or --nav-comment=multiple to post those comments only if there are multiple CRs in the stack.
 `
 
 type branchSubmitCmd struct {
@@ -70,6 +74,8 @@ func (*branchSubmitCmd) Help() string {
 
 		Use --no-publish to push the branch without creating a Change
 		Request.
+		Use --nav-comment=false to disable navigation comments in CRs,
+		or --nav-comment=multiple to post those comments only if there are multiple CRs in the stack.
 	`)
 }
 
@@ -99,6 +105,7 @@ func (cmd *branchSubmitCmd) Run(
 		svc,
 		session.remoteRepo.Require(),
 		log,
+		cmd.NavigationComment,
 		session.branches,
 	)
 }

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -194,6 +194,8 @@ and --[no-]draft to set the draft status.
 Omitting the draft flag will leave the status unchanged of open CRs.
 Use --no-publish to push branches without creating CRs.
 This has no effect if a branch already has an open CR.
+Use --nav-comment=false to disable navigation comments in CRs,
+or --nav-comment=multiple to post those comments only if there are multiple CRs in the stack.
 
 
 **Flags**
@@ -202,7 +204,10 @@ This has no effect if a branch already has an open CR.
 * `-c`, `--fill`: Fill in the change title and body from the commit messages
 * `--[no-]draft`: Whether to mark change requests as drafts
 * `--no-publish`: Push branches but don't create change requests
+* `--nav-comment=true` ([:material-wrench:{ .middle title="spice.submit.navigationComment" }](/cli/config.md#spicesubmitnavigationcomment)): Whether to add a navigation comment to the change request. Must be one of: true, false, multiple.
 * `--force`: Force push, bypassing safety checks
+
+**Configuration**: [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment)
 
 ### gs stack restack
 
@@ -261,6 +266,8 @@ and --[no-]draft to set the draft status.
 Omitting the draft flag will leave the status unchanged of open CRs.
 Use --no-publish to push branches without creating CRs.
 This has no effect if a branch already has an open CR.
+Use --nav-comment=false to disable navigation comments in CRs,
+or --nav-comment=multiple to post those comments only if there are multiple CRs in the stack.
 
 
 **Flags**
@@ -269,8 +276,11 @@ This has no effect if a branch already has an open CR.
 * `-c`, `--fill`: Fill in the change title and body from the commit messages
 * `--[no-]draft`: Whether to mark change requests as drafts
 * `--no-publish`: Push branches but don't create change requests
+* `--nav-comment=true` ([:material-wrench:{ .middle title="spice.submit.navigationComment" }](/cli/config.md#spicesubmitnavigationcomment)): Whether to add a navigation comment to the change request. Must be one of: true, false, multiple.
 * `--force`: Force push, bypassing safety checks
 * `--branch=NAME`: Branch to start at
+
+**Configuration**: [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment)
 
 ### gs upstack restack
 
@@ -348,6 +358,8 @@ and --[no-]draft to set the draft status.
 Omitting the draft flag will leave the status unchanged of open CRs.
 Use --no-publish to push branches without creating CRs.
 This has no effect if a branch already has an open CR.
+Use --nav-comment=false to disable navigation comments in CRs,
+or --nav-comment=multiple to post those comments only if there are multiple CRs in the stack.
 
 
 **Flags**
@@ -356,8 +368,11 @@ This has no effect if a branch already has an open CR.
 * `-c`, `--fill`: Fill in the change title and body from the commit messages
 * `--[no-]draft`: Whether to mark change requests as drafts
 * `--no-publish`: Push branches but don't create change requests
+* `--nav-comment=true` ([:material-wrench:{ .middle title="spice.submit.navigationComment" }](/cli/config.md#spicesubmitnavigationcomment)): Whether to add a navigation comment to the change request. Must be one of: true, false, multiple.
 * `--force`: Force push, bypassing safety checks
 * `--branch=NAME`: Branch to start at
+
+**Configuration**: [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment)
 
 ### gs downstack edit
 
@@ -705,6 +720,8 @@ Without the flag, the draft status is not changed.
 
 Use --no-publish to push the branch without creating a Change
 Request.
+Use --nav-comment=false to disable navigation comments in CRs,
+or --nav-comment=multiple to post those comments only if there are multiple CRs in the stack.
 
 **Flags**
 
@@ -712,10 +729,13 @@ Request.
 * `-c`, `--fill`: Fill in the change title and body from the commit messages
 * `--[no-]draft`: Whether to mark change requests as drafts
 * `--no-publish`: Push branches but don't create change requests
+* `--nav-comment=true` ([:material-wrench:{ .middle title="spice.submit.navigationComment" }](/cli/config.md#spicesubmitnavigationcomment)): Whether to add a navigation comment to the change request. Must be one of: true, false, multiple.
 * `--force`: Force push, bypassing safety checks
 * `--title=TITLE`: Title of the change request
 * `--body=BODY`: Body of the change request
 * `--branch=NAME`: Branch to submit
+
+**Configuration**: [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment)
 
 ## Commit
 

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -53,3 +53,15 @@ instead of showing just the current stack.
 
 - `true`
 - `false` (default)
+
+### spice.submit.navigationComment
+
+Specifies whether CR submission commands ($$gs branch submit$$ and friends)
+should post or update a navigation comment to the CR.
+
+**Accepted values:**
+
+- `true` (default): always post or update navigation comments
+- `false`: don't post or update navigation comments
+- `multiple`:
+  post or update navigation comments only for stacks with at least two CRs

--- a/doc/src/guide/pr.md
+++ b/doc/src/guide/pr.md
@@ -39,11 +39,16 @@ For example:
     so that you can push branches to it.
     See [Limitations](limits.md) for more information.
 
-Pull Requests created by git-spice will include a comment at the top
-with a visual representation of the stack,
+### Navigation comments
+
+Pull Requests created by git-spice will include a navigation comment
+at the top with a visual representation of the stack,
 and the position of the current branch in it.
 
 ![Example of a stack comment](../img/stack-comment.png)
+
+This behavior may be changed with the $$spice.submit.navigationComment$$
+configuration key.
 
 ### Non-interactive submission
 

--- a/downstack_submit.go
+++ b/downstack_submit.go
@@ -80,6 +80,7 @@ func (cmd *downstackSubmitCmd) Run(
 		svc,
 		session.remoteRepo.Require(),
 		log,
+		cmd.NavigationComment,
 		session.branches,
 	)
 }

--- a/internal/git/config_test.go
+++ b/internal/git/config_test.go
@@ -14,6 +14,60 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func TestConfigKey(t *testing.T) {
+	tests := []struct {
+		give string
+
+		canonical  string
+		section    string
+		subsection string
+		name       string
+	}{
+		{
+			give:      "key",
+			canonical: "key",
+			name:      "key",
+		},
+		{
+			give:      "section.key",
+			canonical: "section.key",
+			section:   "section",
+			name:      "key",
+		},
+		{
+			give:       "section.subsection.key",
+			canonical:  "section.subsection.key",
+			section:    "section",
+			subsection: "subsection",
+			name:       "key",
+		},
+		{
+			give:       "section.multiple.subsections.key",
+			canonical:  "section.multiple.subsections.key",
+			section:    "section",
+			subsection: "multiple.subsections",
+			name:       "key",
+		},
+		{
+			give:       "mixedCaseSection.mixedCaseSubsection.mixedCaseKey",
+			canonical:  "mixedcasesection.mixedCaseSubsection.mixedcasekey",
+			section:    "mixedCaseSection",
+			subsection: "mixedCaseSubsection",
+			name:       "mixedCaseKey",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.give, func(t *testing.T) {
+			key := ConfigKey(tt.give)
+			assert.Equal(t, tt.canonical, string(key.Canonical()))
+			assert.Equal(t, tt.section, key.Section())
+			assert.Equal(t, tt.subsection, key.Subsection())
+			assert.Equal(t, tt.name, key.Name())
+		})
+	}
+}
+
 func TestConfigListRegexp(t *testing.T) {
 	pair := func(key, value string) string {
 		return key + "\n" + value

--- a/stack_submit.go
+++ b/stack_submit.go
@@ -69,6 +69,7 @@ func (cmd *stackSubmitCmd) Run(
 		svc,
 		session.remoteRepo.Require(),
 		log,
+		cmd.NavigationComment,
 		session.branches,
 	)
 }

--- a/submit_test.go
+++ b/submit_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateStackComment(t *testing.T) {
@@ -106,6 +107,45 @@ func TestGenerateStackComment(t *testing.T) {
 			assert.Equal(t, want, got)
 		})
 	}
+}
+
+func TestNavigationCommentWhen_StringMarshal(t *testing.T) {
+	tests := []struct {
+		give string
+		want navigationCommentWhen
+		str  string
+	}{
+		{
+			give: "true",
+			want: navigationCommentAlways,
+			str:  "true",
+		},
+		{
+			give: "false",
+			want: navigationCommentNever,
+			str:  "false",
+		},
+		{
+			give: "multiple",
+			want: navigationCommentOnMultiple,
+			str:  "multiple",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.give, func(t *testing.T) {
+			var got navigationCommentWhen
+			require.NoError(t, got.UnmarshalText([]byte(tt.give)))
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.give, got.String())
+		})
+	}
+
+	t.Run("unknown", func(t *testing.T) {
+		var f navigationCommentWhen
+		require.Error(t, f.UnmarshalText([]byte("unknown")))
+		assert.Equal(t, "unknown", navigationCommentWhen(42).String())
+	})
 }
 
 type _changeID string

--- a/testdata/script/branch_submit_navigation_comment_opt_out_multiple.txt
+++ b/testdata/script/branch_submit_navigation_comment_opt_out_multiple.txt
@@ -1,0 +1,73 @@
+# branch submit supports opting in/out of navigation comment,
+# or to request that it's only posted for >1 PR stacks.
+
+as 'Test <test@example.com>'
+at '2024-08-07T18:17:16Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub register alice
+shamhub new origin alice/example.git
+git push origin main
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# feature1 -> feature2
+git add feature1.txt
+gs bc -m feature1
+git add feature2.txt
+gs bc -m feature2
+
+gs bco feature1
+
+# disable posting navigation PRs completely
+git config --local spice.submit.navigationComment false
+gs branch submit --fill
+shamhub dump comments
+stdout '\[\]'
+
+# enable posting navigation PRs for >1 PR stacks
+git config --local spice.submit.navigationComment multiple
+
+# No comments yet because there's only one PR
+gs branch submit
+shamhub dump comments
+stdout '\[\]'
+
+# Add a second PR to the stack
+gs up
+gs downstack submit --fill
+shamhub dump comments
+cmp stdout $WORK/golden/feat1-2.txt
+
+-- repo/feature1.txt --
+feature 1
+
+-- repo/feature2.txt --
+feature 2
+
+-- golden/test.txt --
+foo
+
+-- golden/feat1-2.txt --
+- change: 1
+  body: |
+    This change is part of the following stack:
+
+    - #1 ◀
+        - #2
+
+    <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+- change: 2
+  body: |
+    This change is part of the following stack:
+
+    - #1
+        - #2 ◀
+
+    <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>

--- a/upstack_submit.go
+++ b/upstack_submit.go
@@ -98,6 +98,7 @@ func (cmd *upstackSubmitCmd) Run(
 		svc,
 		session.remoteRepo.Require(),
 		log,
+		cmd.NavigationComment,
 		session.branches,
 	)
 }


### PR DESCRIPTION
Allow opting out of navigation comments in change requests,
or only posting them when there are multiple change requests.

This option may be set with the `--nav-comment` flag,
or the `spice.submit.navigationComment` configuration key.

Resolves #289
