### PR TITLE
branch checkout: Add config analog for --untracked

### DIFF
--- a/.changes/unreleased/Added-20240810-100319.yaml
+++ b/.changes/unreleased/Added-20240810-100319.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'branch checkout: Add ''spice.branchCheckout.showUntracked'' configuration to always show untracked branches in checkout prompt.'
+time: 2024-08-10T10:03:19.137432-07:00

--- a/branch_checkout.go
+++ b/branch_checkout.go
@@ -14,7 +14,7 @@ import (
 )
 
 type branchCheckoutCmd struct {
-	Untracked bool   `short:"u" help:"Show untracked branches if one isn't supplied"`
+	Untracked bool   `short:"u" config:"branchCheckout.showUntracked" help:"Show untracked branches if one isn't supplied"`
 	Branch    string `arg:"" optional:"" help:"Name of the branch to delete" predictor:"branches"`
 }
 

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -460,7 +460,9 @@ Use -u/--untracked to show untracked branches in the prompt.
 
 **Flags**
 
-* `-u`, `--untracked`: Show untracked branches if one isn't supplied
+* `-u`, `--untracked` ([:material-wrench:{ .middle title="spice.branchCheckout.showUntracked" }](/cli/config.md#spicebranchcheckoutshowuntracked)): Show untracked branches if one isn't supplied
+
+**Configuration**: [spice.branchCheckout.showUntracked](/cli/config.md#spicebranchcheckoutshowuntracked)
 
 ### gs branch create
 

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -30,6 +30,17 @@ or at the repository level with the `--local` flag.
 
 ## Available options
 
+### spice.branchCheckout.showUntracked
+
+When running $$gs branch checkout$$ without any arguments,
+git-spice presents a prompt to select a branch to checkout.
+This option controls whether untracked branches are shown in the prompt.
+
+**Accepted values:**
+
+- `true`
+- `false` (default)
+
 ### spice.forge.github.apiUrl
 
 URL at which the GitHub API is available.

--- a/testdata/script/branch_checkout_prompt.txt
+++ b/testdata/script/branch_checkout_prompt.txt
@@ -43,6 +43,14 @@ cmp stdout $WORK/golden/prompt-all.txt
 git branch --show-current
 stdout 'baz'
 
+# showing all branches via config
+gs branch untrack baz
+gs trunk
+with-term -rows 8 -cols 50 $WORK/input/all.txt -- gs branch checkout -u
+cmp stdout $WORK/golden/prompt-all.txt
+git branch --show-current
+stdout 'baz'
+
 -- repo/foo.txt --
 whatever
 


### PR DESCRIPTION
gs bco provides an --untracked flag that will show untracked branches
in the branch checkout flag.

Add a configuration option to make this the default behavior.