### PR TITLE
chore: Use range for forge.All

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -49,7 +49,13 @@ func resolveForge(ctx context.Context, log *log.Logger, globals *globalOptions, 
 	if forgeID != "" {
 		f, ok := forge.Lookup(forgeID)
 		if !ok {
-			log.Errorf("Forge ID must be one of: %s", strings.Join(forge.IDs(), ", "))
+			var available []string
+			for f := range forge.All {
+				available = append(available, f.ID())
+			}
+			slices.Sort(available)
+
+			log.Errorf("Forge ID must be one of: %s", strings.Join(available, ", "))
 			return nil, fmt.Errorf("unknown forge: %s", forgeID)
 		}
 		return f, nil
@@ -61,13 +67,12 @@ func resolveForge(ctx context.Context, log *log.Logger, globals *globalOptions, 
 	}
 
 	var opts []ui.SelectOption[forge.Forge]
-	forge.All(func(f forge.Forge) bool {
+	for f := range forge.All {
 		opts = append(opts, ui.SelectOption[forge.Forge]{
 			Label: f.ID(),
 			Value: f,
 		})
-		return true
-	})
+	}
 	slices.SortFunc(opts, func(a, b ui.SelectOption[forge.Forge]) int {
 		return cmp.Compare(a.Label, b.Label)
 	})

--- a/internal/cli/shorthand/builtin.go
+++ b/internal/cli/shorthand/builtin.go
@@ -2,6 +2,8 @@ package shorthand
 
 import (
 	"fmt"
+	"iter"
+	"maps"
 	"slices"
 	"strings"
 
@@ -82,13 +84,8 @@ func (s *BuiltinSource) ExpandShorthand(cmd string) ([]string, bool) {
 }
 
 // Keys returns the list of shorthand keys in the source.
-func (s *BuiltinSource) Keys() []string {
-	keys := make([]string, 0, len(s.items))
-	for key := range s.items {
-		keys = append(keys, key)
-	}
-	slices.Sort(keys)
-	return keys
+func (s *BuiltinSource) Keys() iter.Seq[string] {
+	return maps.Keys(s.items)
 }
 
 // Node returns the command node for the given shorthand key

--- a/internal/cli/shorthand/builtin_test.go
+++ b/internal/cli/shorthand/builtin_test.go
@@ -125,7 +125,7 @@ func TestBuiltinSource(t *testing.T) {
 
 			require.NoError(t, err)
 			got := make(map[string][]string)
-			for _, key := range src.Keys() {
+			for key := range src.Keys() {
 				var ok bool
 				got[key], ok = src.ExpandShorthand(key)
 				require.True(t, ok, "expand(%q)", key)

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sort"
 	"sync"
 
 	"go.abhg.dev/gs/internal/git"
@@ -24,17 +23,6 @@ func All(yield func(Forge) bool) {
 	_forgeRegistry.Range(func(_, value any) bool {
 		return yield(value.(Forge))
 	})
-}
-
-// IDs returns a sorted list of all registered forge IDs.
-func IDs() []string {
-	var names []string
-	All(func(f Forge) bool {
-		names = append(names, f.ID())
-		return true
-	})
-	sort.Strings(names)
-	return names
 }
 
 // Register registers a forge with the given ID.

--- a/internal/forge/forge_test.go
+++ b/internal/forge/forge_test.go
@@ -17,17 +17,13 @@ func TestRegister(t *testing.T) {
 
 	t.Run("All", func(t *testing.T) {
 		var ok bool
-		forge.All(func(f forge.Forge) bool {
+		for f := range forge.All {
 			if f.ID() == "a" {
 				ok = true
+				break
 			}
-			return !ok
-		})
+		}
 		assert.True(t, ok, "forge not found")
-	})
-
-	t.Run("IDs", func(t *testing.T) {
-		assert.Contains(t, forge.IDs(), "a", "forge not found")
 	})
 
 	t.Run("Lookup", func(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -98,12 +98,11 @@ func main() {
 
 	// Forges may register additional command line flags
 	// by implementing CLIPlugin.
-	forge.All(func(f forge.Forge) bool {
+	for f := range forge.All {
 		if plugin := f.CLIPlugin(); plugin != nil {
 			cmd.Plugins = append(cmd.Plugins, plugin)
 		}
-		return true
-	})
+	}
 
 	parser, err := kong.New(&cmd,
 		kong.Name("gs"),

--- a/shell_completion.go
+++ b/shell_completion.go
@@ -130,10 +130,9 @@ func predictDirs(args komplete.Args) (predictions []string) {
 
 func predictForges(args komplete.Args) (predictions []string) {
 	var ids []string
-	forge.All(func(f forge.Forge) bool {
+	for f := range forge.All {
 		ids = append(ids, f.ID())
-		return true
-	})
+	}
 	sort.Strings(ids)
 	return ids
 }


### PR DESCRIPTION
forge.All already matches the iter.Seq signature.
Use `range` to iterate over forge.All.