### PR TITLE
ci: Run doc on PRs, just don't deploy them

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -3,6 +3,8 @@ name: GitHub Pages
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [ '*' ]
   workflow_dispatch:
 
 concurrency:
@@ -51,6 +53,9 @@ jobs:
 
   deploy:
     needs: build
+
+    # Deploy only on main builds, or for manual triggers.
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
 
     permissions:
       pages: write


### PR DESCRIPTION
Issues like b7a9571626f0df2083a237174271b74846e1f28e will be caught
before merging if we also attempt to build docs for PRs.

Just don't deploy them until they're merged.