### PR TITLE
onto: Apply even if branch is already on target

### DIFF
--- a/.changes/unreleased/Changed-20240816-054428.yaml
+++ b/.changes/unreleased/Changed-20240816-054428.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: >-
+  {branch, upstack} onto: Rebase commits even if the branch's base matches the target.
+  This better matches expectations when the branch falls behind the target.
+time: 2024-08-16T05:44:28.62315-07:00

--- a/branch_onto.go
+++ b/branch_onto.go
@@ -109,24 +109,20 @@ func (cmd *branchOntoCmd) Run(ctx context.Context, log *log.Logger, opts *global
 
 	// Only after the upstacks have been moved
 	// will we move the branch itself and update its internal state.
-	if branch.Base != cmd.Onto {
-		if err := svc.BranchOnto(ctx, &spice.BranchOntoRequest{
-			Branch: cmd.Branch,
-			Onto:   cmd.Onto,
-		}); err != nil {
-			// If the rebase is interrupted,
-			// we'll just re-run this command again later.
-			return svc.RebaseRescue(ctx, spice.RebaseRescueRequest{
-				Err:     err,
-				Command: []string{"branch", "onto", cmd.Onto},
-				Branch:  cmd.Branch,
-				Message: fmt.Sprintf("interrupted: %s: branch onto %s", cmd.Branch, cmd.Onto),
-			})
-		}
-	} else if len(aboves) == 0 {
-		log.Infof("%s: already on %s", cmd.Branch, cmd.Onto)
-		return nil
+	if err := svc.BranchOnto(ctx, &spice.BranchOntoRequest{
+		Branch: cmd.Branch,
+		Onto:   cmd.Onto,
+	}); err != nil {
+		// If the rebase is interrupted,
+		// we'll just re-run this command again later.
+		return svc.RebaseRescue(ctx, spice.RebaseRescueRequest{
+			Err:     err,
+			Command: []string{"branch", "onto", cmd.Onto},
+			Branch:  cmd.Branch,
+			Message: fmt.Sprintf("interrupted: %s: branch onto %s", cmd.Branch, cmd.Onto),
+		})
 	}
 
+	log.Infof("%s: moved onto %s", cmd.Branch, cmd.Onto)
 	return repo.Checkout(ctx, cmd.Branch)
 }

--- a/testdata/script/branch_onto.txt
+++ b/testdata/script/branch_onto.txt
@@ -24,6 +24,7 @@ exists feature1.txt feature2.txt feature3.txt
 
 # Move feature3 to be based on feature1
 gs branch onto feature1
+stderr 'feature3: moved onto feature1'
 exists feature1.txt
 ! exists feature2.txt
 exists feature3.txt
@@ -38,7 +39,7 @@ stderr 'cannot move trunk'
 # Already based on feature1.
 git checkout feature2
 gs branch onto feature1
-stderr 'already on feature1'
+stderr 'feature2: moved onto feature1'
 
 -- repo/feature1.txt --
 Feature 1

--- a/testdata/script/branch_onto_diverged_from_base.txt
+++ b/testdata/script/branch_onto_diverged_from_base.txt
@@ -1,0 +1,51 @@
+# 'branch onto' rebases the branch
+# if it has fallen behind target
+# even if the base already matches.
+
+as 'Test <test@example.com>'
+at '2024-08-16T08:00:00Z'
+
+# set up
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# set up main -> feat1 -> feat2
+gs bc --no-commit feat1
+git add feat2.txt
+gs bc feat2 -m 'Add feature 2'
+gs ll
+cmp stderr $WORK/golden/ls-before.txt
+
+# add a commit to feat1
+gs down
+git add feat1.txt
+git commit -m 'Add feature 1'
+
+gs up
+stderr 'feat2: needs to be restacked'
+
+gs branch onto feat1
+stderr 'feat2: moved onto feat1'
+
+gs ll
+cmp stderr $WORK/golden/ls-after.txt
+
+-- repo/feat1.txt --
+feature 1
+
+-- repo/feat2.txt --
+feature 2
+
+-- golden/ls-before.txt --
+  ┏━■ feat2 ◀
+  ┃   e3b0e7d Add feature 2 (now)
+┏━┻□ feat1
+main
+-- golden/ls-after.txt --
+  ┏━■ feat2 ◀
+  ┃   9995287 Add feature 2 (now)
+┏━┻□ feat1
+┃    c6747e9 Add feature 1 (now)
+main

--- a/testdata/script/branch_onto_extract.txt
+++ b/testdata/script/branch_onto_extract.txt
@@ -22,6 +22,8 @@ gs bc -m feature3
 # move feature2 onto main
 git checkout feature2
 gs branch onto main
+stderr 'feature3: moved upstack onto feature1'
+stderr 'feature2: moved onto main'
 
 git graph --branches
 cmp stdout $WORK/golden/branches-graph.txt

--- a/testdata/script/upstack_onto_diverged_from_base.txt
+++ b/testdata/script/upstack_onto_diverged_from_base.txt
@@ -1,0 +1,61 @@
+# 'upstack onto' rebases the branch
+# if it has fallen behind target
+# even if the base already matches.
+
+as 'Test <test@example.com>'
+at '2024-08-16T08:00:00Z'
+
+# set up
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# set up main -> feat1 -> feat2 -> feat3
+gs bc --no-commit feat1
+git add feat2.txt
+gs bc feat2 -m 'Add feature 2'
+git add feat3.txt
+gs bc feat3 -m 'Add feature 3'
+gs ll
+cmp stderr $WORK/golden/ls-before.txt
+
+# add a commit to feat1
+gs bottom
+git add feat1.txt
+git commit -m 'Add feature 1'
+
+gs up
+stderr 'feat2: needs to be restacked'
+
+gs upstack onto feat1
+stderr 'feat2: moved upstack onto feat1'
+stderr 'feat3: restacked on feat2'
+
+gs ll
+cmp stderr $WORK/golden/ls-after.txt
+
+-- repo/feat1.txt --
+feature 1
+
+-- repo/feat2.txt --
+feature 2
+
+-- repo/feat3.txt --
+feature 3
+
+-- golden/ls-before.txt --
+    ┏━■ feat3 ◀
+    ┃   e6984b4 Add feature 3 (now)
+  ┏━┻□ feat2
+  ┃    e3b0e7d Add feature 2 (now)
+┏━┻□ feat1
+main
+-- golden/ls-after.txt --
+    ┏━□ feat3
+    ┃   d4de41e Add feature 3 (now)
+  ┏━┻■ feat2 ◀
+  ┃    9995287 Add feature 2 (now)
+┏━┻□ feat1
+┃    c6747e9 Add feature 1 (now)
+main

--- a/upstack_onto.go
+++ b/upstack_onto.go
@@ -82,11 +82,6 @@ func (cmd *upstackOntoCmd) Run(ctx context.Context, log *log.Logger, opts *globa
 		}
 	}
 
-	if branch.Base == cmd.Onto {
-		log.Infof("%s: already on %s", cmd.Branch, cmd.Onto)
-		return nil
-	}
-
 	// Implementation note:
 	// This is a pretty straightforward operation despite the large scope.
 	// It starts by rebasing only the current branch onto the target
@@ -106,6 +101,7 @@ func (cmd *upstackOntoCmd) Run(ctx context.Context, log *log.Logger, opts *globa
 			Message: fmt.Sprintf("interrupted: %s: upstack onto %s", cmd.Branch, cmd.Onto),
 		})
 	}
+	log.Infof("%v: moved upstack onto %v", cmd.Branch, cmd.Onto)
 
 	return (&upstackRestackCmd{
 		SkipStart: true, // we've already moved the current branch


### PR DESCRIPTION
The onto operations do two things:

- update internal state of the branch to target a new base
- rebase commits $oldBase..$branch onto $newBase

There's an expectation from users that if branch is already on target,
the command should still rebase the commits if the target is ahead of
the branch.

This change makes the onto operations always run,
even if the branch is already on target.

Resolves #321