### PR TITLE
refac(submitSession): Learn to fetch remote and remote repo

### DIFF
--- a/downstack_submit.go
+++ b/downstack_submit.go
@@ -58,13 +58,13 @@ func (cmd *downstackSubmitCmd) Run(
 
 	// TODO: generalize into a service-level method
 	// TODO: separate preparation of the stack from submission
-	// TODO: submits should be done in parallel
-	var session submitSession
+
+	session := newSubmitSession(repo, store, secretStash, opts, log)
 	for _, downstack := range downstacks {
 		err := (&branchSubmitCmd{
 			submitOptions: cmd.submitOptions,
 			Branch:        downstack,
-		}).run(ctx, &session, repo, store, svc, secretStash, log, opts)
+		}).run(ctx, session, repo, store, svc, log, opts)
 		if err != nil {
 			return fmt.Errorf("submit %v: %w", downstack, err)
 		}
@@ -74,11 +74,16 @@ func (cmd *downstackSubmitCmd) Run(
 		return nil
 	}
 
+	remoteRepo, err := session.RemoteRepo.Get(ctx)
+	if err != nil {
+		return err
+	}
+
 	return syncStackComments(
 		ctx,
 		store,
 		svc,
-		session.remoteRepo.Require(),
+		remoteRepo,
 		log,
 		cmd.NavigationComment,
 		session.branches,

--- a/stack_submit.go
+++ b/stack_submit.go
@@ -44,7 +44,7 @@ func (cmd *stackSubmitCmd) Run(
 	// TODO: generalize into a service-level method
 	// TODO: separate preparation of the stack from submission
 
-	var session submitSession
+	session := newSubmitSession(repo, store, secretStash, opts, log)
 	for _, branch := range stack {
 		if branch == store.Trunk() {
 			continue
@@ -53,7 +53,7 @@ func (cmd *stackSubmitCmd) Run(
 		err := (&branchSubmitCmd{
 			submitOptions: cmd.submitOptions,
 			Branch:        branch,
-		}).run(ctx, &session, repo, store, svc, secretStash, log, opts)
+		}).run(ctx, session, repo, store, svc, log, opts)
 		if err != nil {
 			return fmt.Errorf("submit %v: %w", branch, err)
 		}
@@ -63,11 +63,16 @@ func (cmd *stackSubmitCmd) Run(
 		return nil
 	}
 
+	remoteRepo, err := session.RemoteRepo.Get(ctx)
+	if err != nil {
+		return err
+	}
+
 	return syncStackComments(
 		ctx,
 		store,
 		svc,
-		session.remoteRepo.Require(),
+		remoteRepo,
 		log,
 		cmd.NavigationComment,
 		session.branches,


### PR DESCRIPTION
Instead of submitSession just being a value-holder,
teach it how to fetch the remote and remote repository,
and use that everywhere.

memoizedValue now more closely matches its name.

[skip changelog]: no user facing changes