### PR TITLE
refac: rename stack comment to navigation comment

### DIFF
--- a/branch_submit.go
+++ b/branch_submit.go
@@ -99,7 +99,7 @@ func (cmd *branchSubmitCmd) Run(
 		return nil
 	}
 
-	return syncStackComments(
+	return updateNavigationComments(
 		ctx,
 		store,
 		svc,

--- a/doc/src/guide/pr.md
+++ b/doc/src/guide/pr.md
@@ -45,7 +45,7 @@ Pull Requests created by git-spice will include a navigation comment
 at the top with a visual representation of the stack,
 and the position of the current branch in it.
 
-![Example of a stack comment](../img/stack-comment.png)
+![Example of a stack navigation comment](../img/stack-comment.png)
 
 This behavior may be changed with the $$spice.submit.navigationComment$$
 configuration key.

--- a/downstack_submit.go
+++ b/downstack_submit.go
@@ -74,7 +74,7 @@ func (cmd *downstackSubmitCmd) Run(
 		return nil
 	}
 
-	return syncStackComments(
+	return updateNavigationComments(
 		ctx,
 		store,
 		svc,

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -176,15 +176,15 @@ type ChangeMetadata interface {
 	// This is presented to the user in the UI.
 	ChangeID() ChangeID
 
-	// StackCommentID is a comment left on the Change
+	// NavigationCommentID is a comment left on the Change
 	// that contains a visualization of the stack.
-	StackCommentID() ChangeCommentID
+	NavigationCommentID() ChangeCommentID
 
-	// SetStackCommentID sets the ID of the stack comment
+	// SetNavigationCommentID sets the ID of the navigation comment
 	// on the chnage metadata to persist it later.
 	//
-	// The ID may be nil to indicate that there is no stack comment.
-	SetStackCommentID(ChangeCommentID)
+	// The ID may be nil to indicate that there is no navigation comment.
+	SetNavigationCommentID(ChangeCommentID)
 }
 
 // FindChangesOptions specifies filtering options

--- a/internal/forge/github/change_meta.go
+++ b/internal/forge/github/change_meta.go
@@ -13,7 +13,7 @@ import (
 type PRMetadata struct {
 	PR *PR `json:"pr,omitempty"`
 
-	StackComment *PRComment `json:"comment,omitempty"`
+	NavigationComment *PRComment `json:"comment,omitempty"`
 }
 
 var _ forge.ChangeMetadata = (*PRMetadata)(nil)
@@ -28,21 +28,21 @@ func (m *PRMetadata) ChangeID() forge.ChangeID {
 	return m.PR
 }
 
-// StackCommentID reports the comment ID of the stack comment
+// NavigationCommentID reports the comment ID of the navigation comment
 // left on the pull request.
-func (m *PRMetadata) StackCommentID() forge.ChangeCommentID {
-	if m.StackComment == nil {
+func (m *PRMetadata) NavigationCommentID() forge.ChangeCommentID {
+	if m.NavigationComment == nil {
 		return nil
 	}
-	return m.StackComment
+	return m.NavigationComment
 }
 
-// SetStackCommentID sets the comment ID of the stack comment
+// SetNavigationCommentID sets the comment ID of the navigation comment
 // left on the pull request.
 //
 // id may be nil.
-func (m *PRMetadata) SetStackCommentID(id forge.ChangeCommentID) {
-	m.StackComment = mustPRComment(id)
+func (m *PRMetadata) SetNavigationCommentID(id forge.ChangeCommentID) {
+	m.NavigationComment = mustPRComment(id)
 }
 
 // NewChangeMetadata returns the metadata for a pull request.

--- a/internal/forge/shamhub/change_meta.go
+++ b/internal/forge/shamhub/change_meta.go
@@ -10,8 +10,9 @@ import (
 
 // ChangeMetadata records the metadata for a change on a ShamHub server.
 type ChangeMetadata struct {
-	Number       int `json:"number"`
-	StackComment int `json:"stack_comment"`
+	Number int `json:"number"`
+
+	NavigationComment int `json:"nav_comment"`
 }
 
 // ForgeID reports the forge ID that owns this metadata.
@@ -24,21 +25,21 @@ func (m *ChangeMetadata) ChangeID() forge.ChangeID {
 	return ChangeID(m.Number)
 }
 
-// StackCommentID reports the comment ID of the stack comment.
-func (m *ChangeMetadata) StackCommentID() forge.ChangeCommentID {
-	if m.StackComment == 0 {
+// NavigationCommentID reports the comment ID of the navigation comment.
+func (m *ChangeMetadata) NavigationCommentID() forge.ChangeCommentID {
+	if m.NavigationComment == 0 {
 		return nil
 	}
-	return ChangeCommentID(m.StackComment)
+	return ChangeCommentID(m.NavigationComment)
 }
 
-// SetStackCommentID sets the comment ID of the stack comment.
+// SetNavigationCommentID sets the comment ID of the navigation comment.
 // id may be nil.
-func (m *ChangeMetadata) SetStackCommentID(id forge.ChangeCommentID) {
+func (m *ChangeMetadata) SetNavigationCommentID(id forge.ChangeCommentID) {
 	if id == nil {
-		m.StackComment = 0
+		m.NavigationComment = 0
 	} else {
-		m.StackComment = int(id.(ChangeCommentID))
+		m.NavigationComment = int(id.(ChangeCommentID))
 	}
 }
 

--- a/stack_submit.go
+++ b/stack_submit.go
@@ -63,7 +63,7 @@ func (cmd *stackSubmitCmd) Run(
 		return nil
 	}
 
-	return syncStackComments(
+	return updateNavigationComments(
 		ctx,
 		store,
 		svc,

--- a/submit.go
+++ b/submit.go
@@ -132,7 +132,7 @@ func (f navigationCommentWhen) String() string {
 // Where the arrow indicates the current branch.
 // For cases where this is the first time we're posting the comment,
 // we'll need to also update the store to record the comment ID for later.
-func syncStackComments(
+func updateNavigationComments(
 	ctx context.Context,
 	store *state.Store,
 	svc *spice.Service,
@@ -255,7 +255,7 @@ func syncStackComments(
 					}
 
 					meta := post.Meta
-					meta.SetStackCommentID(commentID)
+					meta.SetNavigationCommentID(commentID)
 					bs, err := remoteRepo.Forge().MarshalChangeMetadata(meta)
 					if err != nil {
 						log.Warn("Error marshaling change metadata",
@@ -311,8 +311,8 @@ func syncStackComments(
 		}
 
 		info := infos[idx]
-		commentBody := generateStackComment(nodes, idx)
-		if info.Meta.StackCommentID() == nil {
+		commentBody := generateStackNavigationComment(nodes, idx)
+		if info.Meta.NavigationCommentID() == nil {
 			postc <- &postComment{
 				Branch: branch,
 				Meta:   info.Meta,
@@ -322,7 +322,7 @@ func syncStackComments(
 		} else {
 			updatec <- &updateComment{
 				Change:  info.Meta.ChangeID(),
-				Comment: info.Meta.StackCommentID(),
+				Comment: info.Meta.NavigationCommentID(),
 				Body:    commentBody,
 			}
 		}
@@ -336,7 +336,7 @@ func syncStackComments(
 	}
 
 	var msg strings.Builder
-	msg.WriteString("Post stack comments\n\n")
+	msg.WriteString("Post stack navigation comments\n\n")
 	for _, upsert := range upserts {
 		fmt.Fprintf(&msg, "- %s\n", upsert.Name)
 	}
@@ -364,7 +364,7 @@ const (
 	_commentFooter = "\n<sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>\n"
 )
 
-func generateStackComment(
+func generateStackNavigationComment(
 	nodes []*stackedChange,
 	current int,
 ) string {

--- a/submit_test.go
+++ b/submit_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGenerateStackComment(t *testing.T) {
+func TestGenerateStackNavigationComment(t *testing.T) {
 	tests := []struct {
 		name    string
 		graph   []*stackedChange
@@ -103,7 +103,7 @@ func TestGenerateStackComment(t *testing.T) {
 			}
 
 			want := _commentHeader + tt.want + _commentFooter
-			got := generateStackComment(tt.graph, tt.current)
+			got := generateStackNavigationComment(tt.graph, tt.current)
 			assert.Equal(t, want, got)
 		})
 	}

--- a/upstack_submit.go
+++ b/upstack_submit.go
@@ -92,7 +92,7 @@ func (cmd *upstackSubmitCmd) Run(
 		return nil
 	}
 
-	return syncStackComments(
+	return updateNavigationComments(
 		ctx,
 		store,
 		svc,


### PR DESCRIPTION
The in-code terminology does not match the user-facing terminology.
Update code references to 'stack comments' to 'navigation comments'
or 'stack navigation comments'.