### PR TITLE
doc: Don't download external resources for PRs

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -45,6 +45,7 @@ jobs:
         working-directory: doc
         env:
           CLOUDFLARE_ANALYTICS_TOKEN: ${{ secrets.CLOUDFLARE_ANALYTICS_TOKEN }}
+          MAIN_BUILD: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -62,7 +62,9 @@ exclude_docs: |
 plugins:
   - markdown-exec
   - privacy:
-      enabled: !ENV [CI, false]
+      # Don't download external resources in CI,
+      # except for main builds.
+      enabled: !ENV [MAIN_BUILD, false]
   - redirects:
       redirect_maps:
         'how-to.md': 'recipes.md'


### PR DESCRIPTION
The privacy plugin downloads external resources (like fonts).
This is not necessary for PRs as these builds are not published.