### PR TITLE
submit: detect navigation comment in imported CRs

### DIFF
--- a/.changes/unreleased/Added-20240824-115459.yaml
+++ b/.changes/unreleased/Added-20240824-115459.yaml
@@ -1,0 +1,7 @@
+kind: Added
+body: >-
+  submit: When importing existing CRs,
+  git-spice will also detect existing stack navigation comments
+  and update them instead of posting duplicates.
+  This will work only for comments posted by this version or newer.
+time: 2024-08-24T11:54:59.628818-07:00

--- a/doc/src/guide/pr.md
+++ b/doc/src/guide/pr.md
@@ -111,3 +111,45 @@ use $$gs repo sync$$ (or $$gs repo sync|gs rs$$).
 This will update the trunk branch (e.g. `main`)
 with the latest changes from the upstream repository,
 and delete any local branches whose PRs have been merged.
+
+## Importing pull requests
+
+You can import an existing PR into git-spice
+by checking it out locally, tracking the branch with git-spice,
+and re-submitting it.
+
+For example, if you have the GitHub CLI installed:
+
+```freeze language="terminal"
+{gray}# Check out the PR locally{reset}
+{green}${reset} gh pr checkout 359
+
+{gray}# Track it with git-spice{reset}
+{green}${reset} gs branch track
+
+{gray}# Re-submit it{reset}
+{green}${reset} gs branch submit
+{green}INF{reset} comment-recovery: Found existing CR #359
+{green}INF{reset} CR #359 is up-to-date: https://github.com/abhinav/git-spice/pull/359
+```
+
+!!! important
+
+    For this to work, the following MUST all be true:
+
+    - The PR is pushed to a branch in the upstream repository
+    - The local branch name exactly matches the upstream branch name
+
+This will work even for PRs that were not created by git-spice,
+or authored by someone else, as long as the above conditions are met.
+
+In <!-- gs:version unreleased --> or newer,
+this will also auto-detect [navigation comments](#navigation-comments)
+posted to the PR by git-spice, and update them if necessary.
+
+```freeze language="terminal"
+{green}${reset} gs branch submit
+{green}INF{reset} comment-recovery: Found existing CR #359
+{green}INF{reset} comment-recovery: Found existing navigation comment: {gray}...{reset}
+```
+

--- a/internal/forge/github/comment_test.go
+++ b/internal/forge/github/comment_test.go
@@ -1,0 +1,15 @@
+package github
+
+import "testing"
+
+// SetListChangeCommentsPageSize changes the page size
+// used for listing change comments.
+//
+// It restores the old value after the test finishes.
+func SetListChangeCommentsPageSize(t testing.TB, pageSize int) {
+	old := _listChangeCommentsPageSize
+	_listChangeCommentsPageSize = pageSize
+	t.Cleanup(func() {
+		_listChangeCommentsPageSize = old
+	})
+}

--- a/internal/forge/github/testdata/TestIntegration_Repository_ListChangeComments_paginated/comments
+++ b/internal/forge/github/testdata/TestIntegration_Repository_ListChangeComments_paginated/comments
@@ -1,0 +1,12 @@
+[
+  "ZkUrkZLWO3uKM2TgGJ2NcMfrOlFA7OVB",
+  "vMbR8bxMxIdgRkXA9enkJyxka7tRgUR2",
+  "zv8M2Z1w4Ne5i1t1g0b1CiyKz03Fv9pJ",
+  "9i06pbfbrAvJInkdwDkXZOgsAUJOqd6v",
+  "bYLjinZFLEBSVHcZwWgbgosLo5uZdwWG",
+  "eBltBXJ7Qj4kFhdEatCb2xKHhU0S5Nv4",
+  "xqxaJpATHPf9SPGUWTZEaFFgQlGvX33A",
+  "6VulTEHptNUwm9wtHudUfmeTNVi3ccwo",
+  "GvTbL6gpL8LSQTc8Mo1eWORQX5TacFrQ",
+  "GauZjuYRLQtNBqB3kDrl0mB19R8ZhAek"
+]

--- a/internal/forge/github/testdata/fixtures/TestIntegration_Repository_ListChangeComments_paginated.yaml
+++ b/internal/forge/github/testdata/fixtures/TestIntegration_Repository_ListChangeComments_paginated.yaml
@@ -1,0 +1,819 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 200
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"query":"mutation($input:AddCommentInput!){addComment(input: $input){commentEdge{node{id,url}}}}","variables":{"input":{"subjectId":"PR_kwDOMVd0xs51N_9r","body":"ZkUrkZLWO3uKM2TgGJ2NcMfrOlFA7OVB"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"addComment":{"commentEdge":{"node":{"id":"IC_kwDOMVd0xs6JmHiA","url":"https://github.com/abhinav/test-repo/pull/4#issuecomment-2308470912"}}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 547.303708ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 200
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"query":"mutation($input:AddCommentInput!){addComment(input: $input){commentEdge{node{id,url}}}}","variables":{"input":{"subjectId":"PR_kwDOMVd0xs51N_9r","body":"vMbR8bxMxIdgRkXA9enkJyxka7tRgUR2"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"addComment":{"commentEdge":{"node":{"id":"IC_kwDOMVd0xs6JmHiI","url":"https://github.com/abhinav/test-repo/pull/4#issuecomment-2308470920"}}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 527.955417ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 200
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"query":"mutation($input:AddCommentInput!){addComment(input: $input){commentEdge{node{id,url}}}}","variables":{"input":{"subjectId":"PR_kwDOMVd0xs51N_9r","body":"zv8M2Z1w4Ne5i1t1g0b1CiyKz03Fv9pJ"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"addComment":{"commentEdge":{"node":{"id":"IC_kwDOMVd0xs6JmHiL","url":"https://github.com/abhinav/test-repo/pull/4#issuecomment-2308470923"}}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 419.810792ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 200
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"query":"mutation($input:AddCommentInput!){addComment(input: $input){commentEdge{node{id,url}}}}","variables":{"input":{"subjectId":"PR_kwDOMVd0xs51N_9r","body":"9i06pbfbrAvJInkdwDkXZOgsAUJOqd6v"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"addComment":{"commentEdge":{"node":{"id":"IC_kwDOMVd0xs6JmHiP","url":"https://github.com/abhinav/test-repo/pull/4#issuecomment-2308470927"}}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 395.587458ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 200
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"query":"mutation($input:AddCommentInput!){addComment(input: $input){commentEdge{node{id,url}}}}","variables":{"input":{"subjectId":"PR_kwDOMVd0xs51N_9r","body":"bYLjinZFLEBSVHcZwWgbgosLo5uZdwWG"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"addComment":{"commentEdge":{"node":{"id":"IC_kwDOMVd0xs6JmHiT","url":"https://github.com/abhinav/test-repo/pull/4#issuecomment-2308470931"}}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 396.434042ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 200
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"query":"mutation($input:AddCommentInput!){addComment(input: $input){commentEdge{node{id,url}}}}","variables":{"input":{"subjectId":"PR_kwDOMVd0xs51N_9r","body":"eBltBXJ7Qj4kFhdEatCb2xKHhU0S5Nv4"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"addComment":{"commentEdge":{"node":{"id":"IC_kwDOMVd0xs6JmHiW","url":"https://github.com/abhinav/test-repo/pull/4#issuecomment-2308470934"}}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 384.888209ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 200
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"query":"mutation($input:AddCommentInput!){addComment(input: $input){commentEdge{node{id,url}}}}","variables":{"input":{"subjectId":"PR_kwDOMVd0xs51N_9r","body":"xqxaJpATHPf9SPGUWTZEaFFgQlGvX33A"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"addComment":{"commentEdge":{"node":{"id":"IC_kwDOMVd0xs6JmHia","url":"https://github.com/abhinav/test-repo/pull/4#issuecomment-2308470938"}}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 469.67825ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 200
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"query":"mutation($input:AddCommentInput!){addComment(input: $input){commentEdge{node{id,url}}}}","variables":{"input":{"subjectId":"PR_kwDOMVd0xs51N_9r","body":"6VulTEHptNUwm9wtHudUfmeTNVi3ccwo"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"addComment":{"commentEdge":{"node":{"id":"IC_kwDOMVd0xs6JmHif","url":"https://github.com/abhinav/test-repo/pull/4#issuecomment-2308470943"}}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 396.943958ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 200
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"query":"mutation($input:AddCommentInput!){addComment(input: $input){commentEdge{node{id,url}}}}","variables":{"input":{"subjectId":"PR_kwDOMVd0xs51N_9r","body":"GvTbL6gpL8LSQTc8Mo1eWORQX5TacFrQ"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"addComment":{"commentEdge":{"node":{"id":"IC_kwDOMVd0xs6JmHii","url":"https://github.com/abhinav/test-repo/pull/4#issuecomment-2308470946"}}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 494.437458ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 200
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"query":"mutation($input:AddCommentInput!){addComment(input: $input){commentEdge{node{id,url}}}}","variables":{"input":{"subjectId":"PR_kwDOMVd0xs51N_9r","body":"GauZjuYRLQtNBqB3kDrl0mB19R8ZhAek"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"addComment":{"commentEdge":{"node":{"id":"IC_kwDOMVd0xs6JmHil","url":"https://github.com/abhinav/test-repo/pull/4#issuecomment-2308470949"}}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 450.64675ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 294
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"query":"query($after:String$first:Int!$id:ID!){node(id: $id){... on PullRequest{comments(first: $first, after: $after){pageInfo{endCursor,hasNextPage},nodes{id,body,url,viewerCanUpdate,viewerDidAuthor,createdAt,updatedAt}}}}}","variables":{"after":null,"first":3,"id":"PR_kwDOMVd0xs51N_9r"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"node":{"comments":{"pageInfo":{"endCursor":"Y3Vyc29yOnYyOpHOiZh4iw==","hasNextPage":true},"nodes":[{"id":"IC_kwDOMVd0xs6JmHiA","body":"ZkUrkZLWO3uKM2TgGJ2NcMfrOlFA7OVB","url":"https://github.com/abhinav/test-repo/pull/4#issuecomment-2308470912","viewerCanUpdate":true,"viewerDidAuthor":true,"createdAt":"2024-08-24T17:48:30Z","updatedAt":"2024-08-24T17:48:30Z"},{"id":"IC_kwDOMVd0xs6JmHiI","body":"vMbR8bxMxIdgRkXA9enkJyxka7tRgUR2","url":"https://github.com/abhinav/test-repo/pull/4#issuecomment-2308470920","viewerCanUpdate":true,"viewerDidAuthor":true,"createdAt":"2024-08-24T17:48:31Z","updatedAt":"2024-08-24T17:48:31Z"},{"id":"IC_kwDOMVd0xs6JmHiL","body":"zv8M2Z1w4Ne5i1t1g0b1CiyKz03Fv9pJ","url":"https://github.com/abhinav/test-repo/pull/4#issuecomment-2308470923","viewerCanUpdate":true,"viewerDidAuthor":true,"createdAt":"2024-08-24T17:48:31Z","updatedAt":"2024-08-24T17:48:31Z"}]}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 286.806667ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 317
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"query":"query($after:String!$first:Int!$id:ID!){node(id: $id){... on PullRequest{comments(first: $first, after: $after){pageInfo{endCursor,hasNextPage},nodes{id,body,url,viewerCanUpdate,viewerDidAuthor,createdAt,updatedAt}}}}}","variables":{"after":"Y3Vyc29yOnYyOpHOiZh4iw==","first":3,"id":"PR_kwDOMVd0xs51N_9r"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"node":{"comments":{"pageInfo":{"endCursor":"Y3Vyc29yOnYyOpHOiZh4lg==","hasNextPage":true},"nodes":[{"id":"IC_kwDOMVd0xs6JmHiP","body":"9i06pbfbrAvJInkdwDkXZOgsAUJOqd6v","url":"https://github.com/abhinav/test-repo/pull/4#issuecomment-2308470927","viewerCanUpdate":true,"viewerDidAuthor":true,"createdAt":"2024-08-24T17:48:32Z","updatedAt":"2024-08-24T17:48:32Z"},{"id":"IC_kwDOMVd0xs6JmHiT","body":"bYLjinZFLEBSVHcZwWgbgosLo5uZdwWG","url":"https://github.com/abhinav/test-repo/pull/4#issuecomment-2308470931","viewerCanUpdate":true,"viewerDidAuthor":true,"createdAt":"2024-08-24T17:48:32Z","updatedAt":"2024-08-24T17:48:32Z"},{"id":"IC_kwDOMVd0xs6JmHiW","body":"eBltBXJ7Qj4kFhdEatCb2xKHhU0S5Nv4","url":"https://github.com/abhinav/test-repo/pull/4#issuecomment-2308470934","viewerCanUpdate":true,"viewerDidAuthor":true,"createdAt":"2024-08-24T17:48:33Z","updatedAt":"2024-08-24T17:48:33Z"}]}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 286.778041ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 317
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"query":"query($after:String!$first:Int!$id:ID!){node(id: $id){... on PullRequest{comments(first: $first, after: $after){pageInfo{endCursor,hasNextPage},nodes{id,body,url,viewerCanUpdate,viewerDidAuthor,createdAt,updatedAt}}}}}","variables":{"after":"Y3Vyc29yOnYyOpHOiZh4lg==","first":3,"id":"PR_kwDOMVd0xs51N_9r"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"node":{"comments":{"pageInfo":{"endCursor":"Y3Vyc29yOnYyOpHOiZh4og==","hasNextPage":true},"nodes":[{"id":"IC_kwDOMVd0xs6JmHia","body":"xqxaJpATHPf9SPGUWTZEaFFgQlGvX33A","url":"https://github.com/abhinav/test-repo/pull/4#issuecomment-2308470938","viewerCanUpdate":true,"viewerDidAuthor":true,"createdAt":"2024-08-24T17:48:33Z","updatedAt":"2024-08-24T17:48:33Z"},{"id":"IC_kwDOMVd0xs6JmHif","body":"6VulTEHptNUwm9wtHudUfmeTNVi3ccwo","url":"https://github.com/abhinav/test-repo/pull/4#issuecomment-2308470943","viewerCanUpdate":true,"viewerDidAuthor":true,"createdAt":"2024-08-24T17:48:33Z","updatedAt":"2024-08-24T17:48:33Z"},{"id":"IC_kwDOMVd0xs6JmHii","body":"GvTbL6gpL8LSQTc8Mo1eWORQX5TacFrQ","url":"https://github.com/abhinav/test-repo/pull/4#issuecomment-2308470946","viewerCanUpdate":true,"viewerDidAuthor":true,"createdAt":"2024-08-24T17:48:34Z","updatedAt":"2024-08-24T17:48:34Z"}]}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 237.353833ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 317
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"query":"query($after:String!$first:Int!$id:ID!){node(id: $id){... on PullRequest{comments(first: $first, after: $after){pageInfo{endCursor,hasNextPage},nodes{id,body,url,viewerCanUpdate,viewerDidAuthor,createdAt,updatedAt}}}}}","variables":{"after":"Y3Vyc29yOnYyOpHOiZh4og==","first":3,"id":"PR_kwDOMVd0xs51N_9r"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"node":{"comments":{"pageInfo":{"endCursor":"Y3Vyc29yOnYyOpHOiZh4pQ==","hasNextPage":false},"nodes":[{"id":"IC_kwDOMVd0xs6JmHil","body":"GauZjuYRLQtNBqB3kDrl0mB19R8ZhAek","url":"https://github.com/abhinav/test-repo/pull/4#issuecomment-2308470949","viewerCanUpdate":true,"viewerDidAuthor":true,"createdAt":"2024-08-24T17:48:34Z","updatedAt":"2024-08-24T17:48:34Z"}]}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 248.790292ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 158
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"query":"mutation($input:DeleteIssueCommentInput!){deleteIssueComment(input: $input){clientMutationId}}","variables":{"input":{"id":"IC_kwDOMVd0xs6JmHiA"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"deleteIssueComment":{"clientMutationId":null}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 448.304042ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 158
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"query":"mutation($input:DeleteIssueCommentInput!){deleteIssueComment(input: $input){clientMutationId}}","variables":{"input":{"id":"IC_kwDOMVd0xs6JmHiI"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"deleteIssueComment":{"clientMutationId":null}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 543.926625ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 158
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"query":"mutation($input:DeleteIssueCommentInput!){deleteIssueComment(input: $input){clientMutationId}}","variables":{"input":{"id":"IC_kwDOMVd0xs6JmHiL"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"deleteIssueComment":{"clientMutationId":null}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 599.343584ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 158
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"query":"mutation($input:DeleteIssueCommentInput!){deleteIssueComment(input: $input){clientMutationId}}","variables":{"input":{"id":"IC_kwDOMVd0xs6JmHiP"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"deleteIssueComment":{"clientMutationId":null}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 452.826208ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 158
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"query":"mutation($input:DeleteIssueCommentInput!){deleteIssueComment(input: $input){clientMutationId}}","variables":{"input":{"id":"IC_kwDOMVd0xs6JmHiT"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"deleteIssueComment":{"clientMutationId":null}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 473.950167ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 158
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"query":"mutation($input:DeleteIssueCommentInput!){deleteIssueComment(input: $input){clientMutationId}}","variables":{"input":{"id":"IC_kwDOMVd0xs6JmHiW"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"deleteIssueComment":{"clientMutationId":null}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 551.506333ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 158
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"query":"mutation($input:DeleteIssueCommentInput!){deleteIssueComment(input: $input){clientMutationId}}","variables":{"input":{"id":"IC_kwDOMVd0xs6JmHia"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"deleteIssueComment":{"clientMutationId":null}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 386.255416ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 158
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"query":"mutation($input:DeleteIssueCommentInput!){deleteIssueComment(input: $input){clientMutationId}}","variables":{"input":{"id":"IC_kwDOMVd0xs6JmHif"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"deleteIssueComment":{"clientMutationId":null}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 406.336708ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 158
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"query":"mutation($input:DeleteIssueCommentInput!){deleteIssueComment(input: $input){clientMutationId}}","variables":{"input":{"id":"IC_kwDOMVd0xs6JmHii"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"deleteIssueComment":{"clientMutationId":null}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 436.08025ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 158
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"query":"mutation($input:DeleteIssueCommentInput!){deleteIssueComment(input: $input){clientMutationId}}","variables":{"input":{"id":"IC_kwDOMVd0xs6JmHil"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"deleteIssueComment":{"clientMutationId":null}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 466.324583ms

--- a/internal/forge/github/testdata/fixtures/TestIntegration_Repository_ListChangeComments_simple.yaml
+++ b/internal/forge/github/testdata/fixtures/TestIntegration_Repository_ListChangeComments_simple.yaml
@@ -1,0 +1,37 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 295
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"query":"query($after:String$first:Int!$id:ID!){node(id: $id){... on PullRequest{comments(first: $first, after: $after){pageInfo{endCursor,hasNextPage},nodes{id,body,url,viewerCanUpdate,viewerDidAuthor,createdAt,updatedAt}}}}}","variables":{"after":null,"first":10,"id":"PR_kwDOJ2BQKs55Hpxz"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"node":{"comments":{"pageInfo":{"endCursor":"Y3Vyc29yOnYyOpHOiVynzg==","hasNextPage":false},"nodes":[{"id":"IC_kwDOJ2BQKs6JXKfO","body":"This change is part of the following stack:\n\n- #356 ◀\n\n<sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>\n","url":"https://github.com/abhinav/git-spice/pull/356#issuecomment-2304550862","viewerCanUpdate":true,"viewerDidAuthor":true,"createdAt":"2024-08-22T12:29:50Z","updatedAt":"2024-08-22T12:29:50Z"}]}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 277.212709ms

--- a/submit_test.go
+++ b/submit_test.go
@@ -102,9 +102,20 @@ func TestGenerateStackNavigationComment(t *testing.T) {
 				tt.graph[n.Base].Aboves = append(tt.graph[n.Base].Aboves, i)
 			}
 
-			want := _commentHeader + tt.want + _commentFooter
+			want := _commentHeader + "\n\n" +
+				tt.want + "\n" +
+				_commentFooter + "\n" +
+				_commentMarker + "\n"
 			got := generateStackNavigationComment(tt.graph, tt.current)
 			assert.Equal(t, want, got)
+
+			// Sanity check: All generated comments must match
+			// these regular expressions.
+			t.Run("Regexp", func(t *testing.T) {
+				for _, re := range _navCommentRegexes {
+					assert.True(t, re.MatchString(got), "regexp %q failed", re)
+				}
+			})
 		})
 	}
 }

--- a/testdata/script/branch_submit_by_name.txt
+++ b/testdata/script/branch_submit_by_name.txt
@@ -62,3 +62,4 @@ Contents of feature1
     - #1 ◀
 
     <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+    <!-- gs:navigation comment -->

--- a/testdata/script/branch_submit_detect_existing.txt
+++ b/testdata/script/branch_submit_detect_existing.txt
@@ -24,7 +24,29 @@ gs bc -m 'Add feature1' feature1
 gs branch submit --fill
 stderr 'Created #'
 
+# Verify initial state
+
+shamhub dump changes
+cmpenvJSON stdout $WORK/golden/pulls-initial.json
+
+shamhub dump comments
+cmpenv stdout $WORK/golden/comments-initial.txt
+
 # forget all state, and re-track the branch
+gs repo init --reset --trunk=main --remote=origin
+gs branch track --base=main feature1
+
+# re-submitting should detect that the PR already exists
+gs branch submit
+stderr 'feature1: Found existing CR #'
+stderr 'feature1: Found existing navigation comment'
+stderr 'CR #\d+ is up-to-date'
+
+# no changes to comments
+shamhub dump comments
+cmpenv stdout $WORK/golden/comments-initial.txt
+
+# again: forget all state, and re-track the branch
 gs repo init --reset --trunk=main --remote=origin
 gs branch track --base=main feature1
 
@@ -35,18 +57,23 @@ cp $WORK/extra/feature1-update.txt feature1.txt
 git add feature1.txt
 git commit -m 'update feature1'
 
-gs branch submit
+# Stack another branch on top.
+mv $WORK/extra/feature2.txt feature2.txt
+git add feature2.txt
+gs bc -m 'Add feature2' feature2
+
+gs downstack submit --fill
 stderr 'feature1: Found existing CR #'
+stderr 'feature1: Found existing navigation comment'
 stderr 'Updated #'
+stderr 'Created #'
 
 shamhub dump changes
-cmpenvJSON stdout $WORK/golden/update.json
+cmpenvJSON stdout $WORK/golden/pulls-updated.json
 
-# We'll have a duplicate comment
-# because we'll have lost information
-# about the previous comment.
+# There's no duplicate comment.
 shamhub dump comments
-cmp stdout $WORK/golden/comments.txt
+cmp stdout $WORK/golden/comments-updated.txt
 
 -- repo/feature1.txt --
 Contents of feature1
@@ -54,7 +81,38 @@ Contents of feature1
 -- extra/feature1-update.txt --
 New contents of feature1
 
--- golden/update.json --
+-- extra/feature2.txt --
+feature 2
+
+-- golden/pulls-initial.json --
+[
+  {
+    "number": 1,
+    "state": "open",
+    "title": "Add feature1",
+    "body": "",
+    "html_url": "$SHAMHUB_URL/alice/example/change/1",
+    "head": {
+      "ref": "feature1",
+      "sha": "854f3268c794eb5ec30439658dfb43ac494d9074"
+    },
+    "base": {
+      "ref": "main",
+      "sha": "9df31764fb4252f719c92d53fae05a766f019a17"
+    }
+  }
+]
+
+-- golden/comments-initial.txt --
+- change: 1
+  body: |
+    This change is part of the following stack:
+
+    - #1 ◀
+
+    <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+    <!-- gs:navigation comment -->
+-- golden/pulls-updated.json --
 [
   {
     "number": 1,
@@ -70,21 +128,41 @@ New contents of feature1
       "ref": "main",
       "sha": "9df31764fb4252f719c92d53fae05a766f019a17"
     }
+  },
+  {
+  "base": {
+      "ref": "feature1",
+      "sha": "b805a8b9545d71929cc128fc81b0d86bb2def9ed"
+    },
+    "body": "",
+    "head": {
+      "ref": "feature2",
+      "sha": "a81df03d4738f5277d0b122b1a4e053a4e2b236e"
+    },
+    "html_url": "$SHAMHUB_URL/alice/example/change/2",
+    "number": 2,
+    "state": "open",
+    "title": "Add feature2"
   }
 ]
 
--- golden/comments.txt --
+
+-- golden/comments-updated.txt --
 - change: 1
   body: |
     This change is part of the following stack:
 
     - #1 ◀
+        - #2
 
     <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
-- change: 1
+    <!-- gs:navigation comment -->
+- change: 2
   body: |
     This change is part of the following stack:
 
-    - #1 ◀
+    - #1
+        - #2 ◀
 
     <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+    <!-- gs:navigation comment -->

--- a/testdata/script/branch_submit_navigation_comment_opt_out_multiple.txt
+++ b/testdata/script/branch_submit_navigation_comment_opt_out_multiple.txt
@@ -63,6 +63,7 @@ foo
         - #2
 
     <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+    <!-- gs:navigation comment -->
 - change: 2
   body: |
     This change is part of the following stack:
@@ -71,3 +72,4 @@ foo
         - #2 ◀
 
     <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+    <!-- gs:navigation comment -->

--- a/testdata/script/branch_submit_rename.txt
+++ b/testdata/script/branch_submit_rename.txt
@@ -79,6 +79,7 @@ New contents of feature1
     - #1 ◀
 
     <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+    <!-- gs:navigation comment -->
 -- golden/update.json --
 [
   {
@@ -106,3 +107,4 @@ New contents of feature1
     - #1 ◀
 
     <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+    <!-- gs:navigation comment -->

--- a/testdata/script/downstack_submit.txt
+++ b/testdata/script/downstack_submit.txt
@@ -105,6 +105,7 @@ INF Created #3: $SHAMHUB_URL/alice/example/change/3
             - #3
 
     <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+    <!-- gs:navigation comment -->
 - change: 2
   body: |
     This change is part of the following stack:
@@ -114,6 +115,7 @@ INF Created #3: $SHAMHUB_URL/alice/example/change/3
             - #3
 
     <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+    <!-- gs:navigation comment -->
 - change: 3
   body: |
     This change is part of the following stack:
@@ -123,3 +125,4 @@ INF Created #3: $SHAMHUB_URL/alice/example/change/3
             - #3 ◀
 
     <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+    <!-- gs:navigation comment -->

--- a/testdata/script/stack_submit.txt
+++ b/testdata/script/stack_submit.txt
@@ -125,6 +125,7 @@ INF Created #3: $SHAMHUB_URL/alice/example/change/3
             - #3
 
     <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+    <!-- gs:navigation comment -->
 - change: 2
   body: |
     This change is part of the following stack:
@@ -134,6 +135,7 @@ INF Created #3: $SHAMHUB_URL/alice/example/change/3
             - #3
 
     <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+    <!-- gs:navigation comment -->
 - change: 3
   body: |
     This change is part of the following stack:
@@ -143,6 +145,7 @@ INF Created #3: $SHAMHUB_URL/alice/example/change/3
             - #3 ◀
 
     <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+    <!-- gs:navigation comment -->
 -- golden/pr-1-merged.json --
 [
   {
@@ -203,6 +206,7 @@ INF Created #3: $SHAMHUB_URL/alice/example/change/3
             - #3
 
     <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+    <!-- gs:navigation comment -->
 - change: 2
   body: |
     This change is part of the following stack:
@@ -211,6 +215,7 @@ INF Created #3: $SHAMHUB_URL/alice/example/change/3
         - #3
 
     <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+    <!-- gs:navigation comment -->
 - change: 3
   body: |
     This change is part of the following stack:
@@ -219,6 +224,7 @@ INF Created #3: $SHAMHUB_URL/alice/example/change/3
         - #3 ◀
 
     <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+    <!-- gs:navigation comment -->
 -- golden/ls.txt --
     ┏━□ feature3 (#3)
   ┏━┻□ feature2 (#2)

--- a/testdata/script/stack_submit_update_leave_draft.txt
+++ b/testdata/script/stack_submit_update_leave_draft.txt
@@ -186,6 +186,7 @@ INF CR #3 is up-to-date: $SHAMHUB_URL/alice/example/change/3
     - #1 ◀
 
     <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+    <!-- gs:navigation comment -->
 - change: 2
   body: |
     This change is part of the following stack:
@@ -194,6 +195,7 @@ INF CR #3 is up-to-date: $SHAMHUB_URL/alice/example/change/3
         - #2 ◀
 
     <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+    <!-- gs:navigation comment -->
 - change: 3
   body: |
     This change is part of the following stack:
@@ -203,6 +205,7 @@ INF CR #3 is up-to-date: $SHAMHUB_URL/alice/example/change/3
             - #3 ◀
 
     <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+    <!-- gs:navigation comment -->
 -- golden/comments/pr-1-merged.txt --
 - change: 1
   body: |
@@ -211,6 +214,7 @@ INF CR #3 is up-to-date: $SHAMHUB_URL/alice/example/change/3
     - #1 ◀
 
     <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+    <!-- gs:navigation comment -->
 - change: 2
   body: |
     This change is part of the following stack:
@@ -219,6 +223,7 @@ INF CR #3 is up-to-date: $SHAMHUB_URL/alice/example/change/3
         - #3
 
     <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+    <!-- gs:navigation comment -->
 - change: 3
   body: |
     This change is part of the following stack:
@@ -227,3 +232,4 @@ INF CR #3 is up-to-date: $SHAMHUB_URL/alice/example/change/3
         - #3 ◀
 
     <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+    <!-- gs:navigation comment -->

--- a/testdata/script/upstack_submit_main.txt
+++ b/testdata/script/upstack_submit_main.txt
@@ -159,6 +159,7 @@ main ◀
             - #4
 
     <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+    <!-- gs:navigation comment -->
 - change: 2
   body: |
     This change is part of the following stack:
@@ -167,6 +168,7 @@ main ◀
         - #2 ◀
 
     <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+    <!-- gs:navigation comment -->
 - change: 3
   body: |
     This change is part of the following stack:
@@ -176,6 +178,7 @@ main ◀
             - #4
 
     <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+    <!-- gs:navigation comment -->
 - change: 4
   body: |
     This change is part of the following stack:
@@ -185,3 +188,4 @@ main ◀
             - #4 ◀
 
     <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+    <!-- gs:navigation comment -->


### PR DESCRIPTION
When importing CRs not currently known to git-spice,
detect any stack navigation comments on the CR and import them as well.

To reduce risk of hijacking unknown comments,
the comments must have both the following pieces:

- "This change is part of the following stack:"
- `<!-- gs:navigation comment -->`

The latter is new and placed at the bottom of stack navigation comments
starting this version.

If both pieces are present, and we have permission to edit that comment,
the comment is imported into the data store and updated as needed.

Resolves #325