### PR TITLE
goreleaser: snapshot.name_template is deprecated

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -73,4 +73,4 @@ checksum:
   name_template: 'checksums.txt'
 
 snapshot:
-  name_template: "{{ incminor .Tag }}-dev"
+  version_template: "{{ incminor .Tag }}-dev"


### PR DESCRIPTION
Before:

```
snapshot:
  name_template: 'foo'
```

After:

```
snapshot:
  version_template: 'foo'
```

Ref: https://goreleaser.com/deprecations/#snapshotname_template
