### PR TITLE
refac(git/config): Use an iterator for ListRegexp

### DIFF
--- a/internal/git/config_test.go
+++ b/internal/git/config_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.abhg.dev/gs/internal/logtest"
+	"go.abhg.dev/gs/internal/sliceutil"
 	"go.uber.org/mock/gomock"
 )
 
@@ -146,16 +147,8 @@ func TestConfigListRegexp(t *testing.T) {
 				exec: execer,
 			})
 
-			iter, err := cfg.ListRegexp(context.Background(), ".")
+			got, err := sliceutil.CollectErr(cfg.ListRegexp(context.Background(), "."))
 			require.NoError(t, err)
-
-			var got []ConfigEntry
-			iter(func(entry ConfigEntry, err error) bool {
-				require.NoError(t, err)
-				got = append(got, entry)
-				return true
-			})
-
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -251,15 +244,8 @@ func TestIntegrationConfigListRegexp(t *testing.T) {
 				Log: log,
 			})
 
-			var got []ConfigEntry
-			iter, err := cfg.ListRegexp(ctx, tt.pattern)
+			got, err := sliceutil.CollectErr(cfg.ListRegexp(ctx, tt.pattern))
 			require.NoError(t, err)
-			iter(func(entry ConfigEntry, err error) bool {
-				require.NoError(t, err)
-				got = append(got, entry)
-				return true
-			})
-
 			assert.ElementsMatch(t, tt.want, got)
 		})
 	}

--- a/internal/sliceutil/collect.go
+++ b/internal/sliceutil/collect.go
@@ -1,0 +1,18 @@
+// Package sliceutil contains utility functions for working with slices.
+// It's an extension of the std slices package.
+package sliceutil
+
+import "iter"
+
+// CollectErr collects items from a sequence of items and errors,
+// stopping at the first error and returning it.
+func CollectErr[T any](ents iter.Seq2[T, error]) ([]T, error) {
+	var items []T
+	for item, err := range ents {
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	return items, nil
+}

--- a/internal/sliceutil/collect_test.go
+++ b/internal/sliceutil/collect_test.go
@@ -1,0 +1,68 @@
+package sliceutil_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/sliceutil"
+)
+
+func TestCollectErr(t *testing.T) {
+	type pair struct {
+		val int
+		err error
+	}
+
+	tests := []struct {
+		name string
+		give []pair
+
+		want    []int
+		wantErr error
+	}{
+		{
+			name: "Empty",
+			give: nil,
+			want: nil,
+		},
+		{
+			name: "NoErrors",
+			give: []pair{
+				{val: 1},
+				{val: 2},
+				{val: 3},
+			},
+			want: []int{1, 2, 3},
+		},
+		{
+			name: "Error",
+			give: []pair{
+				{val: 1},
+				{err: assert.AnError},
+				{val: 3},
+			},
+			wantErr: assert.AnError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sliceutil.CollectErr(func(yield func(int, error) bool) {
+				for _, p := range tt.give {
+					if !yield(p.val, p.err) {
+						break
+					}
+				}
+			})
+
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/internal/spice/stack_edit.go
+++ b/internal/spice/stack_edit.go
@@ -44,7 +44,7 @@ func (s *Service) StackEdit(ctx context.Context, req *StackEditRequest) (*StackE
 	must.NotContainf(req.Stack, s.store.Trunk(), "cannot edit trunk")
 	must.NotBeBlankf(req.Editor, "editor is required")
 
-	branches, err := editStackFile(ctx, req.Editor, req.Stack)
+	branches, err := editStackFile(req.Editor, req.Stack)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func (s *Service) StackEdit(ctx context.Context, req *StackEditRequest) (*StackE
 // The response list will be in the same order as the input list.
 //
 // Returns ErrStackEditAborted if the user aborts the edit operation.
-func editStackFile(ctx context.Context, editor string, branches []string) ([]string, error) {
+func editStackFile(editor string, branches []string) ([]string, error) {
 	originals := make(map[string]struct{}, len(branches))
 	for _, branch := range branches {
 		originals[branch] = struct{}{}


### PR DESCRIPTION
TODO from when ListRegexp was originally implemented.
Use an iter.Seq now that we're using Go 1.23 to build.