### PR TITLE
Windows support

### DIFF
--- a/.changes/unreleased/Added-20240907-161636.yaml
+++ b/.changes/unreleased/Added-20240907-161636.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Windows support.
+time: 2024-09-07T16:16:36.18073-07:00

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,10 @@
+# Don't magically change line endings by default,
+# but always use LF in test scripts.
+#
+# Ref:
+# - https://github.com/golang/go/blob/807e01db4840e25e4d98911b28a8fa54244b8dfa/.gitattributes
+# - https://github.com/rogpeppe/go-internal/pull/106
+* -text
+*.txt text eol=lf
+
 *.png filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     name: Test (${{ matrix.os}})
     strategy:
       matrix:
-        os: ["ubuntu-latest"] # TODO: ["windows-latest"]
+        os: ["ubuntu-latest", "windows-latest"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Go

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,12 +6,14 @@ builds:
       - CGO_ENABLED=0
     main: .
     binary: gs
-    goos: [darwin, linux]
+    goos: [darwin, linux, windows]
     goarch: [amd64, arm64, arm]
     goarm: [5, 6, 7]
     ldflags: '-s -w -X main._version={{.Version}}'
     ignore:
       - goos: darwin
+        goarch: arm
+      - goos: windows
         goarch: arm
     flags:
       - -trimpath

--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,6 @@ MOCKGEN = bin/mockgen
 REQUIREDFIELD = bin/requiredfield
 TOOLS = $(MOCKGEN) $(GS)
 
-# Non-test Go files.
-GO_SRC_FILES = $(shell find . \
-	   -path '*/.*' -prune -o \
-	   '(' -type f -a -name '*.go' -a -not -name '*_test.go' ')' -print)
-
 .PHONY: all
 all: build lint test
 
@@ -73,8 +68,11 @@ generate-lint: $(TOOLS)
 		git diff --exit-code || \
 		(echo "'go generate' changed files" && false)
 
-$(GS): $(GO_SRC_FILES) go.mod
+$(GS): _always
 	go install go.abhg.dev/gs
+
+.PHONY: _always
+_always:
 
 $(MOCKGEN): go.mod
 	go install go.uber.org/mock/mockgen

--- a/internal/git/gittest/config.go
+++ b/internal/git/gittest/config.go
@@ -11,6 +11,7 @@ func DefaultConfig() Config {
 	return Config{
 		"init.defaultBranch": "main",
 		"alias.graph":        "log --graph --decorate --oneline",
+		"core.autocrlf":      "false",
 	}
 }
 

--- a/testdata/script/auth_insecure_storage.txt
+++ b/testdata/script/auth_insecure_storage.txt
@@ -41,7 +41,7 @@ gs auth login --forge=shamhub
 cmp stderr $WORK/golden/login-secure.stderr
 
 -- golden/login.stderr --
-WRN Storing secrets in plain text at $WORK/home/.config/git-spice/secrets.json. Be careful!
+WRN Storing secrets in plain text at $WORK${/}home${/}.config${/}git-spice${/}secrets.json. Be careful!
 INF shamhub: successfully logged in
 -- golden/login-secure.stderr --
 INF shamhub: successfully logged in

--- a/testdata/script/auth_prompt_forge.txt
+++ b/testdata/script/auth_prompt_forge.txt
@@ -1,5 +1,7 @@
 # auth operations prompt for forge if it cannot be guessed
 
+[!unix] skip # pending github.com/creack/pty/pull/155
+
 as 'Test <test@example.com>'
 at '2024-07-01T04:30:32Z'
 

--- a/testdata/script/branch_checkout_prompt.txt
+++ b/testdata/script/branch_checkout_prompt.txt
@@ -1,6 +1,8 @@
 # branch checkout with lots of branches
 # and no argument prompts for branch name.
 
+[!unix] skip # pending github.com/creack/pty/pull/155
+
 as 'Test <test@example.com>'
 at '2024-03-30T14:59:32Z'
 

--- a/testdata/script/branch_checkout_prompt_trunk.txt
+++ b/testdata/script/branch_checkout_prompt_trunk.txt
@@ -1,6 +1,8 @@
 # branch checkout prompt shows trunk
 # if it's not checked out.
 
+[!unix] skip # pending github.com/creack/pty/pull/155
+
 as 'Test <test@example.com>'
 at '2024-06-03T20:06:07Z'
 

--- a/testdata/script/branch_checkout_track_prompt.txt
+++ b/testdata/script/branch_checkout_track_prompt.txt
@@ -1,6 +1,8 @@
 # branch checkout of an untracked branch
 # prompts to check it out.
 
+[!unix] skip # pending github.com/creack/pty/pull/155
+
 as 'Test <test@example.com>'
 at '2024-03-30T14:59:32Z'
 

--- a/testdata/script/branch_delete_prompt_untracked.txt
+++ b/testdata/script/branch_delete_prompt_untracked.txt
@@ -3,6 +3,8 @@
 #
 # https://github.com/abhinav/git-spice/issues/258
 
+[!unix] skip # pending github.com/creack/pty/pull/155
+
 as 'Test <test@example.com>'
 at '2024-07-20T22:53:32Z'
 

--- a/testdata/script/branch_delete_unmerged.txt
+++ b/testdata/script/branch_delete_unmerged.txt
@@ -1,5 +1,7 @@
 # --force is needed to delete an unmerged branch.
 
+[!unix] skip # pending github.com/creack/pty/pull/155
+
 as 'Test <test@example.com>'
 at '2024-03-30T14:59:32Z'
 

--- a/testdata/script/branch_rename_prompt.txt
+++ b/testdata/script/branch_rename_prompt.txt
@@ -1,6 +1,8 @@
 # Renaming a branch without a new name
 # prompts for a new name
 
+[!unix] skip # pending github.com/creack/pty/pull/155
+
 as 'Test <test@example.com>'
 at '2024-03-30T14:59:32Z'
 

--- a/testdata/script/branch_split_prompt.txt
+++ b/testdata/script/branch_split_prompt.txt
@@ -1,3 +1,5 @@
+[!unix] skip # pending https://github.com/creack/pty/pull/155
+
 as 'Test <test@example.com>'
 at '2024-06-23T10:00:12Z'
 

--- a/testdata/script/branch_submit_config_no_publish.txt
+++ b/testdata/script/branch_submit_config_no_publish.txt
@@ -39,7 +39,7 @@ shamhub dump changes
 cmp stdout $WORK/golden/no-pulls.txt
 
 # publish
-mv feature1-v3.txt feature1.txt
+cp feature1-v3.txt feature1.txt
 git add feature1.txt
 gs ca -n -m 'feature1 v3'
 gs branch submit --publish --fill

--- a/testdata/script/branch_submit_long_body.txt
+++ b/testdata/script/branch_submit_long_body.txt
@@ -1,6 +1,8 @@
 # branch submit should not truncate a long body.
 # https://github.com/abhinav/git-spice/issues/90
 
+[!unix] skip # pending github.com/creack/pty/pull/155
+
 as 'Test <test@example.com>'
 at '2024-05-23T20:06:32Z'
 

--- a/testdata/script/branch_submit_multiple_pr_templates.txt
+++ b/testdata/script/branch_submit_multiple_pr_templates.txt
@@ -1,5 +1,7 @@
 # 'branch submit' shows a prompt if there are multiple PR templates.
 
+[!unix] skip # pending github.com/creack/pty/pull/155
+
 as 'Test <test@example.com>'
 at '2024-06-15T21:55:32Z'
 

--- a/testdata/script/branch_submit_no_editor.txt
+++ b/testdata/script/branch_submit_no_editor.txt
@@ -1,6 +1,8 @@
 # branch submit fails if there's no editor.
 # https://github.com/abhinav/git-spice/issues/310
 
+[!unix] skip # pending github.com/creack/pty/pull/155
+
 as 'Test <test@example.com>'
 at '2024-07-29T19:25:12Z'
 

--- a/testdata/script/branch_submit_pr_template_no_body.txt
+++ b/testdata/script/branch_submit_pr_template_no_body.txt
@@ -1,6 +1,8 @@
 # 'branch submit' with a PR template and no additional commit body
 # places the template at the top.
 
+[!unix] skip # pending https://github.com/creack/pty/pull/155
+
 as 'Test <test@example.com>'
 at '2024-06-19T04:32:32Z'
 

--- a/testdata/script/branch_submit_pr_template_prompt.txt
+++ b/testdata/script/branch_submit_pr_template_prompt.txt
@@ -1,6 +1,8 @@
 # 'branch submit' uses the PR template if there is one
 # with the terminal prompt.
 
+[!unix] skip # pending github.com/creack/pty/pull/155
+
 as 'Test <test@example.com>'
 at '2024-06-03T08:32:32Z'
 

--- a/testdata/script/branch_submit_recover_prepared.txt
+++ b/testdata/script/branch_submit_recover_prepared.txt
@@ -1,6 +1,8 @@
 # 'branch submit' can recover previously entered commit metadata
 # if a submission attempt fails.
 
+[!unix] skip # pending github.com/creack/pty/pull/155
+
 as 'Test <test@example.com>'
 at '2024-07-03T05:07:09Z'
 

--- a/testdata/script/branch_submit_remote_prompt.txt
+++ b/testdata/script/branch_submit_remote_prompt.txt
@@ -1,6 +1,8 @@
 # 'branch submit' after initializing without a remote
 # will ask for a remote to push to.
 
+[!unix] skip # pending github.com/creack/pty/pull/155
+
 as 'Test <test@example.com>'
 at '2024-04-05T16:40:32Z'
 
@@ -36,6 +38,7 @@ Contents of feature1
 await Please select a remote
 snapshot dialog
 feed \r
+await
 
 -- golden/prompt.txt --
 ### dialog ###

--- a/testdata/script/branch_submit_use_git_editor.txt
+++ b/testdata/script/branch_submit_use_git_editor.txt
@@ -1,6 +1,8 @@
 # branch submit uses the editor set by Git.
 # https://github.com/abhinav/git-spice/issues/274
 
+[!unix] skip # pending github.com/creack/pty/pull/155
+
 as 'Test <test@example.com>'
 at '2024-07-23T07:11:32Z'
 

--- a/testdata/script/commit_split.txt
+++ b/testdata/script/commit_split.txt
@@ -1,5 +1,7 @@
 # Basic 'commit split' usage.
 
+[!unix] skip # pending github.com/creack/pty/pull/155
+
 as 'Test <test@example.com>'
 at '2024-07-08T05:04:32Z'
 

--- a/testdata/script/commit_split_incomplete_rollback.txt
+++ b/testdata/script/commit_split_incomplete_rollback.txt
@@ -2,6 +2,8 @@
 #
 # https://github.com/abhinav/git-spice/issues/291
 
+[!unix] skip # pending github.com/creack/pty/pull/155
+
 as 'Test <test@example.com>'
 at '2024-08-23T17:08:32Z'
 

--- a/testdata/script/repo_init_prompt_multiple_local.txt
+++ b/testdata/script/repo_init_prompt_multiple_local.txt
@@ -1,6 +1,8 @@
 # 'gs repo init' with multiple local branches
 # prompts for a selection.
 
+[!unix] skip # pending github.com/creack/pty/pull/155
+
 # setup
 mkdir repo
 cd repo

--- a/testdata/script/repo_init_prompt_upstream.txt
+++ b/testdata/script/repo_init_prompt_upstream.txt
@@ -1,5 +1,7 @@
 # 'gs repo init' prefers upstream default branch.
 
+[!unix] skip # pending github.com/creack/pty/pull/155
+
 # set up an upstream
 mkdir upstream
 cd upstream

--- a/testdata/script/repo_init_remote_prompt.txt
+++ b/testdata/script/repo_init_remote_prompt.txt
@@ -1,6 +1,8 @@
 # 'gs repo init' prompts for a remote
 # if there are multiple remotes.
 
+[!unix] skip # pending github.com/creack/pty/pull/155
+
 as 'Test <test@example.com>'
 at '2024-03-30T14:59:32Z'
 

--- a/testdata/script/repo_sync_external_pr_head_mismatch.txt
+++ b/testdata/script/repo_sync_external_pr_head_mismatch.txt
@@ -2,6 +2,8 @@
 # if the heads mismatch and we're in interactive mode,
 # prompt the user for deletion.
 
+[!unix] skip # pending https://github.com/creack/pty/pull/155
+
 as 'Test <test@example.com>'
 at '2024-06-05T05:29:28Z'
 

--- a/testdata/script/top_multiple_prompt.txt
+++ b/testdata/script/top_multiple_prompt.txt
@@ -1,6 +1,8 @@
 # 'gs top' prompts for selection
 # if there are multiple top-level branches.
 
+[!unix] skip # pending github.com/creack/pty/pull/155
+
 as 'Test <test@example.com>'
 at '2024-03-30T14:59:32Z'
 

--- a/testdata/script/up_down_top_bottom_prompt.txt
+++ b/testdata/script/up_down_top_bottom_prompt.txt
@@ -1,5 +1,7 @@
 # Moving in a linear stack with gs up/bd/bt/bb.
 
+[!unix] skip # pending https://github.com/creack/pty/pull/155
+
 as 'Test <test@example.com>'
 at '2024-03-30T14:59:32Z'
 

--- a/testdata/script/up_multiple_prompt.txt
+++ b/testdata/script/up_multiple_prompt.txt
@@ -1,5 +1,7 @@
 # 'gs branch up' prompts to pick between multiple branches.
 
+[!unix] skip # pending https://github.com/creack/pty/pull/155
+
 as 'Test <test@example.com>'
 at '2024-03-30T14:59:32Z'
 


### PR DESCRIPTION
This adds support for using git-spice with Windows.
I'm pretty sure it already works, but testing it is a bit difficult,
especially since I don't have a Windows system to test on.

All terminal prompt use creack/pty to create a fake terminal.
Until creack/pty#155 is merged, these tests cannot be run on Windows.
We'll skip the prompt tests on Windows for the time being.