### PR TITLE
branch create: no detached HEAD on aborted commit

### DIFF
--- a/.changes/unreleased/Fixed-20240912-045448.yaml
+++ b/.changes/unreleased/Fixed-20240912-045448.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'branch create: Fix bug where aborting a commit would leave the repository in a detached HEAD state.'
+time: 2024-09-12T04:54:48.790051-07:00

--- a/testdata/script/issue393_branch_create_commit_abort.txt
+++ b/testdata/script/issue393_branch_create_commit_abort.txt
@@ -1,0 +1,38 @@
+# aborting a commit during 'branch create'
+# should not leave the tree in a detached state.
+#
+# https://github.com/abhinav/git-spice/issues/393
+
+as 'Test <test@example.com>'
+at '2024-09-12T04:44:44Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git add feat1.txt
+
+git status --porcelain
+cmp stdout $WORK/golden/status.txt
+
+git branch
+cmp stdout $WORK/golden/branch.txt
+
+env EDITOR=mockedit MOCKEDIT_GIVE=$WORK/input/empty.txt
+! gs bc feat1
+stderr 'Aborting commit due to empty commit message'
+
+git status --porcelain
+cmp stdout $WORK/golden/status.txt
+
+git branch
+cmp stdout $WORK/golden/branch.txt
+
+-- repo/feat1.txt --
+feat 1
+-- input/empty.txt --
+-- golden/status.txt --
+A  feat1.txt
+-- golden/branch.txt --
+* main


### PR DESCRIPTION
When 'branch create' was fixed previously
to restore the working tree if the create fails for any reason,
it introduced a regression where aborting the commit
(e.g. by deleting the commit message)
would leave the repository in a detached HEAD state.

This fixes the regression.

Resolves #393