### PR TITLE
repo sync: Don't complain about deleted remote branches

### DIFF
--- a/.changes/unreleased/Fixed-20240912-051752.yaml
+++ b/.changes/unreleased/Fixed-20240912-051752.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'repo sync: Don''t warn about missing remote tracking branch if it was already deleted by a ''git fetch --prune'' or similar operation.'
+time: 2024-09-12T05:17:52.115595-07:00

--- a/repo_sync.go
+++ b/repo_sync.go
@@ -398,12 +398,15 @@ func (cmd *repoSyncCmd) deleteMergedBranches(
 			return fmt.Errorf("delete branch %v: %w", branch, err)
 		}
 
-		// Also delete the remote tracking branch for this branch.
+		// Also delete the remote tracking branch for this branch
+		// if it still exists.
 		remoteBranch := remote + "/" + branch
-		if err := repo.DeleteBranch(ctx, remoteBranch, git.BranchDeleteOptions{
-			Remote: true,
-		}); err != nil {
-			log.Warn("Unable to delete remote tracking branch", "branch", remoteBranch, "error", err)
+		if _, err := repo.PeelToCommit(ctx, remoteBranch); err == nil {
+			if err := repo.DeleteBranch(ctx, remoteBranch, git.BranchDeleteOptions{
+				Remote: true,
+			}); err != nil {
+				log.Warn("Unable to delete remote tracking branch", "branch", remoteBranch, "error", err)
+			}
 		}
 	}
 

--- a/testdata/script/repo_sync_merged_pr.txt
+++ b/testdata/script/repo_sync_merged_pr.txt
@@ -34,6 +34,9 @@ shamhub merge alice/example 1
 gs repo sync
 stderr 'feature1: #1 was merged'
 
+git branch -r
+cmp stdout $WORK/golden/merged-branches.txt
+
 # we should now be on main,
 # feature1 branch should be gone,
 # and feature2 should be restacked.
@@ -50,6 +53,8 @@ Contents of feature1
 -- repo/feature2.txt --
 Contents of feature2
 
+-- golden/merged-branches.txt --
+  origin/main
 -- golden/pull.json --
 {
   "number": 1,

--- a/testdata/script/repo_sync_remote_already_deleted.txt
+++ b/testdata/script/repo_sync_remote_already_deleted.txt
@@ -1,0 +1,45 @@
+# 'repo sync' doesn't complain about a missing tracking branch
+# if it's been deleted manually with a git pull.
+
+as 'Test <test@example.com>'
+at '2024-09-12T05:04:03Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# submit a PR and merge it
+git add feature.txt
+gs bc -m 'Add feature' feature
+gs branch submit --fill
+stderr 'Created #'
+shamhub merge -prune alice/example 1
+
+# Pull the merged changes
+git checkout main
+git fetch --prune origin
+git pull origin main
+
+# sanity check: the tracking branch is gone
+git branch -r
+cmp stdout $WORK/golden/branch-gone.txt
+
+gs repo sync
+stderr 'feature: #\d was merged'
+stderr 'feature: deleted'
+! stderr 'Unable to delete remote tracking branch'
+
+-- repo/feature.txt --
+Contents of feature
+-- golden/branch-gone.txt --
+  origin/main


### PR DESCRIPTION
Right now, if you run `git pull` or `git fetch` with `--prune`
before calling `repo sync`,
it will complain that the remote tracking branch is missing.
It's only an error, not a warning, but it can still be confusing.

This makes `repo sync` check if the remote tracking branch exists
before trying to delete it,
making it a no-op if the branch has already been deleted.
