### PR TITLE
forge: ChangeIsMerged -> ChangesAreMerged

### DIFF
--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -133,7 +133,7 @@ type Repository interface {
 	EditChange(ctx context.Context, id ChangeID, opts EditChangeOptions) error
 	FindChangesByBranch(ctx context.Context, branch string, opts FindChangesOptions) ([]*FindChangeItem, error)
 	FindChangeByID(ctx context.Context, id ChangeID) (*FindChangeItem, error)
-	ChangeIsMerged(ctx context.Context, id ChangeID) (bool, error)
+	ChangesAreMerged(ctx context.Context, ids []ChangeID) ([]bool, error)
 
 	// Post and update comments on changes.
 	PostChangeComment(context.Context, ChangeID, string) (ChangeCommentID, error)

--- a/internal/forge/github/testdata/fixtures/TestIntegration_Repository_ChangesAreMerged.yaml
+++ b/internal/forge/github/testdata/fixtures/TestIntegration_Repository_ChangesAreMerged.yaml
@@ -1,0 +1,37 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 187
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"query":"query($ids:[ID!]!){nodes(ids: $ids){... on PullRequest{merged}}}","variables":{"ids":["PR_kwDOJ2BQKs5ylEYu","PR_kwDOJ2BQKs56wX01","PR_kwDOJ2BQKs5xNeqO","PR_kwDOMVd0xs51N_9r"]}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"nodes":[{"merged":true},{"merged":false},{"merged":true},{"merged":false}]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 269.167291ms

--- a/repo_sync.go
+++ b/repo_sync.go
@@ -272,13 +272,13 @@ func (cmd *repoSyncCmd) deleteMergedBranches(
 
 					// TODO: Once we're recording GraphQL IDs in the store,
 					// we can combine all submitted PRs into one query.
-					merged, err := remoteRepo.ChangeIsMerged(ctx, b.Change)
+					merged, err := remoteRepo.ChangesAreMerged(ctx, []forge.ChangeID{b.Change})
 					if err != nil {
 						log.Error("Failed to query CR status", "change", b.Change, "error", err)
 						continue
 					}
 
-					b.Merged = merged
+					b.Merged = merged[0]
 
 				case b, ok := <-trachedch:
 					if !ok {


### PR DESCRIPTION
Replace ChangeIsMerged with a bulk ChangesAreMerged API
that takes a list of ChangeIDs and returns a list of booleans
in the same order.

With this in place, we can change 'repo sync'
to make a single request for all submitted branches
instead of one request per branch.

[skip changelog]: No user facing changes in this branch.