### PR TITLE
repo sync: Use ChangesAreMerged to batch check submitted branches

### DIFF
--- a/.changes/unreleased/Changed-20240913-185002.yaml
+++ b/.changes/unreleased/Changed-20240913-185002.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'repo sync: Reduce the number of network requests made to check status of submitted branches.'
+time: 2024-09-13T18:50:02.036293-07:00


### PR DESCRIPTION
Make use of the ChangesAreMerged to make a single network request
for all submitted branches, rather than one per branch.

We still need to make one request per tracked branch for now.