### PR TITLE
repo sync: Gracefully handle unsupported forges

### DIFF
--- a/.changes/unreleased/Changed-20240914-175829.yaml
+++ b/.changes/unreleased/Changed-20240914-175829.yaml
@@ -1,0 +1,8 @@
+kind: Changed
+body: >-
+  repo sync:
+  Don't fail while attempting to make API requests
+  if the Git remote points to an unsupported hosting service.
+  This provides a more graceful degradation of functionality
+  when git-spice is used with non-GitHub remotes.
+time: 2024-09-14T17:58:29.581188-07:00

--- a/remote.go
+++ b/remote.go
@@ -11,9 +11,28 @@ import (
 	"go.abhg.dev/gs/internal/secret"
 )
 
-func openRemoteRepository(
+type unsupportedForgeError struct{ RemoteURL string }
+
+func (e *unsupportedForgeError) Error() string {
+	return fmt.Sprintf("unsupported Git remote URL: %s", e.RemoteURL)
+}
+
+type notLoggedInError struct{ Forge forge.Forge }
+
+func (e *notLoggedInError) Error() string {
+	return fmt.Sprintf("not logged in to %s", e.Forge.ID())
+}
+
+// Attempts to open the forge.Repository associated with the given Git remote.
+//
+// Does not print any error messages to the user.
+// Instead, returns one of the following errors:
+//
+//   - unsupportedForgeError if the remote URL does not match
+//     any any known forges.
+//   - notLoggedInError if the user is not authenticated with the forge.
+func openRemoteRepositorySilent(
 	ctx context.Context,
-	log *log.Logger,
 	stash secret.Stash,
 	gitRepo *git.Repository,
 	remote string,
@@ -25,20 +44,46 @@ func openRemoteRepository(
 
 	f, ok := forge.MatchForgeURL(remoteURL)
 	if !ok {
-		log.Error("Could not guess repository from remote URL", "url", remoteURL)
-		log.Error("Are you sure the remote identifies a supported Git host?")
-		return nil, errors.New("unsupported Git remote URL")
+		return nil, &unsupportedForgeError{remoteURL}
 	}
 
 	tok, err := f.LoadAuthenticationToken(stash)
 	if err != nil {
 		if errors.Is(err, secret.ErrNotFound) {
-			log.Errorf("No authentication token found for %s.", f.ID())
-			log.Errorf("Try running `gs auth login %s`", f.ID())
-			return nil, errors.New("not logged in")
+			return nil, &notLoggedInError{f}
 		}
 		return nil, fmt.Errorf("load authentication token: %w", err)
 	}
 
 	return f.OpenURL(ctx, tok, remoteURL)
+}
+
+func openRemoteRepository(
+	ctx context.Context,
+	log *log.Logger,
+	stash secret.Stash,
+	gitRepo *git.Repository,
+	remote string,
+) (forge.Repository, error) {
+	forgeRepo, err := openRemoteRepositorySilent(ctx, stash, gitRepo, remote)
+
+	var (
+		unsupportedErr *unsupportedForgeError
+		notLoggedInErr *notLoggedInError
+	)
+	switch {
+	case errors.As(err, &unsupportedErr):
+		log.Error("Could not guess repository from remote URL", "url", unsupportedErr.RemoteURL)
+		log.Error("Are you sure the remote identifies a supported Git host?")
+		return nil, err
+
+	case errors.As(err, &notLoggedInErr):
+		f := notLoggedInErr.Forge
+		log.Errorf("No authentication token found for %s.", f.ID())
+		log.Errorf("Try running `gs auth login --forge=%s`", f.ID())
+		return nil, err
+
+	default:
+		return forgeRepo, err
+	}
 }

--- a/repo_sync.go
+++ b/repo_sync.go
@@ -187,8 +187,18 @@ func (cmd *repoSyncCmd) Run(
 		}
 	}
 
-	remoteRepo, err := openRemoteRepository(ctx, log, secretStash, repo, remote)
+	remoteRepo, err := openRemoteRepositorySilent(ctx, secretStash, repo, remote)
 	if err != nil {
+		var unsupported *unsupportedForgeError
+		if errors.As(err, &unsupported) {
+			// TODO: Detect merged branches by checking whether
+			// commits of branches are reachable.
+			// This won't handle squash/rebase merges,
+			// but it's better than nothing.
+			log.Warn("Skipping branch deletion: unsupported Git host", "url", unsupported.RemoteURL)
+			return nil
+		}
+
 		return err
 	}
 

--- a/testdata/script/issue391_repo_sync_pull_unsupported_forge.txt
+++ b/testdata/script/issue391_repo_sync_pull_unsupported_forge.txt
@@ -1,0 +1,61 @@
+# 'repo sync' is able to pull main from unsupported forges.
+#
+# https://github.com/abhinav/git-spice/issues/391
+
+as 'Test <test@example.com>'
+at '2024-09-14T11:35:36Z'
+
+# setup an upstream repository
+mkdir upstream
+cd upstream
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# receive updates to the current branch
+git config receive.denyCurrentBranch updateInstead
+
+# setup the git-spice managed repository
+cd ..
+git clone upstream repo
+cd repo
+gs repo init
+
+# Don't attempt to publish PRs for the unsupported forge
+git config spice.submit.publish false
+
+# set up a stack: feat1 -> feat2
+mv $WORK/extra/feat1.txt feat1.txt
+git add feat1.txt
+gs bc -m feat1
+mv $WORK/extra/feat2.txt feat2.txt
+git add feat2.txt
+gs bc -m feat2
+gs stack submit
+
+# merge the PR server-side with a merge-commit
+cd ../upstream
+git branch
+cmp stdout $WORK/golden/upstream-branches.txt
+git merge feat1
+git branch -d feat1
+
+# repo sync
+cd ../repo
+gs repo sync
+git graph --branches
+cmp stdout $WORK/golden/repo-sync-graph.txt
+
+# TODO: detect the merge commit and delete feat1
+
+-- extra/feat1.txt --
+feature 1
+-- extra/feat2.txt --
+feature 2
+-- golden/upstream-branches.txt --
+  feat1
+  feat2
+* main
+-- golden/repo-sync-graph.txt --
+* b3ed169 (HEAD -> feat2, origin/feat2) feat2
+* 1993921 (origin/main, origin/feat1, origin/HEAD, main, feat1) feat1
+* 8b0535b Initial commit


### PR DESCRIPTION
When `repo sync` is run on a repository with a remote
that is not a known forge (e.g. GitLab),
instead of failing with an error because we can't detect merged PRs,
just log a warning and skip the branch deletion step.

This is only a partial fix for #391.
It'll still leave the merged branches around,
and worse, the upstack branches will still point to merged branches
as their bases.
Since we can easily detect merged branches that used a merge commit,
we will do that instead of a warning in a follow-up PR.