### PR TITLE
repo sync: Delete merged branches for unknown forges

### DIFF
--- a/.changes/unreleased/Changed-20240914-175829.yaml
+++ b/.changes/unreleased/Changed-20240914-175829.yaml
@@ -1,8 +1,9 @@
 kind: Changed
 body: >-
   repo sync:
-  Don't fail while attempting to make API requests
-  if the Git remote points to an unsupported hosting service.
-  This provides a more graceful degradation of functionality
-  when git-spice is used with non-GitHub remotes.
+  Gracefully degrade for unsupported Git hosting services
+  by looking for merged branches locally
+  instead of attempting to make API requests and failing.
+  This only works for merge commits and fast-forwards,
+  but it makes it easier to use git-spice with non-GitHub remotes.
 time: 2024-09-14T17:58:29.581188-07:00

--- a/doc/src/faq.md
+++ b/doc/src/faq.md
@@ -71,3 +71,21 @@ while still using git-spice to navigate the stack and submit PRs.
 If you run a git-spice restack operation,
 it will automatically detect that the branches are already properly stacked,
 and leave them as-is.
+
+## Will git-spice add support for other Git hosting services?
+
+git-spice is designed with room for other Git hosting services.
+Most of the code is Git hosting service-agnostic,
+The internal abstractions isolate GitHub-specific functionality into the
+[`internal/forge/github` package](https://github.com/abhinav/git-spice/tree/340b95dd7028a2af6e34d041d7dd596d42ac61c9/internal/forge/github).
+It is possible to add support for other Git hosting services
+by implementing a similar integration satisfying the same interfaces.
+In fact, most integration tests for git-spice run against a local-only,
+fake Git service developed alongside the GitHub integration.
+
+While we do not have plans to work on new integrations at this time,
+we are willing to accept contributions that add such functionality.
+If you're serious about contributing a new integration,
+feel free to reach out to us on the issue tracker.
+We will be happy to provide guidance
+and work with you to get the contribution merged.

--- a/doc/src/guide/pr.md
+++ b/doc/src/guide/pr.md
@@ -7,6 +7,17 @@ description: >-
 
 # Working with Pull Requests
 
+!!! note
+
+    This page assumes you're using git-spice with GitHub.
+    If you're using a different Git hosting service,
+    you can still use git-spice, but some features may not be available.
+
+    See:
+
+    - [:material-tooltip-check: Recipes > Working with non-GitHub remotes](../recipes.md#working-with-non-github-remotes)
+    - [:material-frequently-asked-questions: FAQ > Will git-spice add support for other Git hosting services](../faq.md#will-git-spice-add-support-for-other-git-hosting-services)
+
 ## Submitting pull requests
 
 When your local changes are ready,

--- a/doc/src/recipes.md
+++ b/doc/src/recipes.md
@@ -42,6 +42,28 @@ and then work on them, you can use the following to adjust the workflow:
     gs branch create my-branch --commit
     ```
 
+### Working with non-GitHub remotes
+
+<!-- gs:version unreleased -->
+
+If you're using a Git hosting service that is not GitHub
+(e.g. GitLab, Bitbucket, etc.),
+you can use git-spice to manage your branches locally without any issues.
+However, when it comes to pushing branches to the remote,
+there are some options that can help your workflow.
+
+- Stop git-spice from trying to create GitHub Pull Requests
+  by setting $$spice.submit.publish$$ to false.
+
+    ```bash
+    git config spice.submit.publish false
+    ```
+
+- $$gs repo sync$$ will detect branches that were merged
+  with merge commits or fast-forwards, and delete them locally.
+  For branches that were merged by rebasing or squashing,
+  you'll need to manually delete merged branches with $$gs branch delete$$.
+
 ## Tasks
 
 ### Import a Pull Request from GitHub

--- a/testdata/script/issue391_repo_sync_pull_unsupported_forge.txt
+++ b/testdata/script/issue391_repo_sync_pull_unsupported_forge.txt
@@ -42,10 +42,27 @@ git branch -d feat1
 # repo sync
 cd ../repo
 gs repo sync
+stderr 'Unsupported remote "origin"'
+stderr 'feat1: deleted'
 git graph --branches
 cmp stdout $WORK/golden/repo-sync-graph.txt
 
-# TODO: detect the merge commit and delete feat1
+gs ll -a
+cmp stderr $WORK/golden/repo-sync-ll.txt
+
+# merge feat2
+cd ../upstream
+git merge feat2
+git branch -d feat2
+
+# repo sync
+cd ../repo
+gs repo sync
+# Don't log the message if all tracked branches are deleted
+! stderr 'Unsupported remote "origin"'
+stderr 'feat2: deleted'
+git graph --branches
+cmp stdout $WORK/golden/repo-sync-graph-2.txt
 
 -- extra/feat1.txt --
 feature 1
@@ -57,5 +74,13 @@ feature 2
 * main
 -- golden/repo-sync-graph.txt --
 * b3ed169 (HEAD -> feat2, origin/feat2) feat2
-* 1993921 (origin/main, origin/feat1, origin/HEAD, main, feat1) feat1
+* 1993921 (origin/main, origin/HEAD, main) feat1
+* 8b0535b Initial commit
+-- golden/repo-sync-ll.txt --
+┏━■ feat2 ◀
+┃   b3ed169 feat2 (now)
+main
+-- golden/repo-sync-graph-2.txt --
+* b3ed169 (HEAD -> main, origin/main, origin/HEAD) feat2
+* 1993921 feat1
 * 8b0535b Initial commit


### PR DESCRIPTION
Follow up to #404.
Previously, we just skipped branch deletion for unknown forges.
This degrades more gracefully by doing a best-effort check
for merged branches by looking at what's reachable from the trunk.

This will not handle squashes or rebases,
but it's good enough in lieu of official support for the forge.

Resolves #391