### PR TITLE
ci: update to use `go-version-file` rather than `go-version`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.23.x
   GOLANGCI_LINT_VERSION: v1.60.1
 
 jobs:
@@ -26,7 +25,7 @@ jobs:
     - uses: actions/setup-go@v5
       name: Set up Go
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: go.mod
     - uses: golangci/golangci-lint-action@v6
       name: Install golangci-lint
       with:
@@ -52,7 +51,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: go.mod
 
     # TODO: extract into separate action
     - name: Determine Git cache directory

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23
+          go-version-file: go.mod
 
       # This will handle installing Python and Python dependencies.
       - name: Install uv

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23.x
+        go-version-file: go.mod
 
     - name: Query changie
       if: inputs.version == ''


### PR DESCRIPTION
using go-version-file would ease the go version management, which takes go.mod as source of truth. 