### PR TITLE
repo init: Update --help per recent changes

### DIFF
--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -112,8 +112,14 @@ For operations that push or pull commits, a remote is required.
 A prompt will ask for one during initialization
 if not provided with --remote.
 
-Re-run the command to change the trunk or remote.
-Re-run with --reset to discard all stored information.
+Re-run the command on an already initialized repository
+to change the trunk or remote.
+If the trunk branch is changed on re-initialization,
+existing branches stacked on the old trunk
+will be updated to point to the new trunk.
+
+Re-run with --reset to discard all stored information
+and untrack all branches.
 
 **Flags**
 

--- a/repo_init.go
+++ b/repo_init.go
@@ -34,8 +34,14 @@ func (*repoInitCmd) Help() string {
 		A prompt will ask for one during initialization
 		if not provided with --remote.
 
-		Re-run the command to change the trunk or remote.
-		Re-run with --reset to discard all stored information.
+		Re-run the command on an already initialized repository
+		to change the trunk or remote.
+		If the trunk branch is changed on re-initialization,
+		existing branches stacked on the old trunk
+		will be updated to point to the new trunk.
+
+		Re-run with --reset to discard all stored information
+		and untrack all branches.
 	`)
 }
 


### PR DESCRIPTION
#419 made the behavior for re-initializing a repository more explicit,
especially with regards to handling branches stacked on the trunk.
We no longer leave them pointing to the old untracked trunk,
but update them to point to the new trunk.

This updates the `repo init --help` output to reflect this change.

[skip changelog]: no user facing changes