### PR TITLE
state: Lazy branch graph load, incremental changes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,6 @@
 *.txt text eol=lf
 
 *.png filter=lfs diff=lfs merge=lfs -text
+
+# pgregory.net/rapid should be considered generated code to reduce noise.
+**/testdata/rapid/**/*.fail linguist-generated

--- a/internal/spice/state/branch.go
+++ b/internal/spice/state/branch.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"iter"
 	"path"
 	"slices"
 	"sort"
@@ -14,6 +15,7 @@ import (
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/maputil"
 	"go.abhg.dev/gs/internal/must"
+	"go.abhg.dev/gs/internal/sliceutil"
 	"go.abhg.dev/gs/internal/spice/state/storage"
 )
 
@@ -121,10 +123,13 @@ func (s *Store) LookupBranch(ctx context.Context, name string) (*LookupResponse,
 	return res, nil
 }
 
-func (s *Store) lookupBranchState(ctx context.Context, name string) (*branchState, error) {
+// lookupBranchState loads the state of the given branch from the store.
+// Returns [ErrNotExist] if the branch does not exist in the store.
+// Trunk branch never exists in the store.
+func (s *Store) lookupBranchState(ctx context.Context, branch string) (*branchState, error) {
 	var state branchState
-	if err := s.db.Get(ctx, branchKey(name), &state); err != nil {
-		return nil, fmt.Errorf("get branch state: %w", err)
+	if err := s.db.Get(ctx, branchKey(branch), &state); err != nil {
+		return nil, fmt.Errorf("load branch %q: %w", branch, err)
 	}
 	return &state, nil
 }
@@ -132,12 +137,30 @@ func (s *Store) lookupBranchState(ctx context.Context, name string) (*branchStat
 // ListBranches reports the names of all tracked branches.
 // The list is sorted in lexicographic order.
 func (s *Store) ListBranches(ctx context.Context) ([]string, error) {
-	branches, err := s.db.Keys(ctx, _branchesDir)
+	branches, err := sliceutil.CollectErr(s.listBranches(ctx))
 	if err != nil {
-		return nil, fmt.Errorf("list branches: %w", err)
+		return nil, err
 	}
 	sort.Strings(branches)
 	return branches, nil
+}
+
+// listBranches returns the names of all branches in the store.
+// The list is in no particular order.
+func (s *Store) listBranches(ctx context.Context) iter.Seq2[string, error] {
+	return func(yield func(string, error) bool) {
+		branches, err := s.db.Keys(ctx, _branchesDir)
+		if err != nil {
+			yield("", err)
+			return
+		}
+
+		for _, branch := range branches {
+			if !yield(branch, nil) {
+				return
+			}
+		}
+	}
 }
 
 // UpdateRequest is a request to add, update, or delete information about branches.
@@ -151,6 +174,50 @@ type UpdateRequest struct {
 	// Message is a message specifying the reason for the update.
 	// This will be persisted in the Git commit message.
 	Message string
+}
+
+// UpdateBranch upates the store with the parameters in the request.
+func (s *Store) UpdateBranch(ctx context.Context, req *UpdateRequest) error {
+	// TODO: delete this in favor of BeginBranchTx
+	tx := s.BeginBranchTx()
+	for idx, upsert := range req.Upserts {
+		if err := tx.Upsert(ctx, upsert); err != nil {
+			return fmt.Errorf("upsert [%d] %q: %w", idx, upsert.Name, err)
+		}
+	}
+
+	for idx, name := range req.Deletes {
+		if err := tx.Delete(ctx, name); err != nil {
+			return fmt.Errorf("delete [%d] %q: %w", idx, name, err)
+		}
+	}
+
+	if err := tx.Commit(ctx, req.Message); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+
+	return nil
+}
+
+// BranchTx is an ongoing change to the branch graph.
+// Changes made to it are not persisted until Commit is called.
+// However, in-flight changes are visible to the transaction,
+// so it can use them to prevent cycles and other issues.
+type BranchTx struct {
+	store *Store
+
+	sets map[string]*branchState // branches modified or added
+	dels map[string]struct{}     // branches to delete
+}
+
+// BeginBranchTx starts a new transaction for updating the branch graph.
+// Changes are not persisted until Commit is called.
+func (s *Store) BeginBranchTx() *BranchTx {
+	return &BranchTx{
+		store: s,
+		sets:  make(map[string]*branchState),
+		dels:  make(map[string]struct{}),
+	}
 }
 
 // UpsertRequest is a request to add or update information about a branch.
@@ -185,272 +252,276 @@ type UpsertRequest struct {
 	UpstreamBranch string
 }
 
-// branchGraph is an acyclic directed graph of branches.
-// Edges describe branch->base relationships.
-type branchGraph struct {
-	byName map[string]int
+// Upsert adds or updates information about a branch.
+// If the branch is not known, it will be added.
+// For new branches, a base MUST be provided.
+func (tx *BranchTx) Upsert(ctx context.Context, req UpsertRequest) error {
+	if req.Name == "" {
+		return errors.New("branch name is required")
+	}
 
-	trunk  string         // name of trunk
-	names  []string       // name of branch[i]
-	bases  []int          // index of branch[i].Base
-	states []*branchState // state of branch[i]
-	aboves [][]int        // branches with branch[i] as base, sorted
-}
+	if req.Name == tx.store.trunk {
+		return ErrTrunk
+	}
 
-func loadGraph(ctx context.Context, s *Store) (*branchGraph, error) {
-	names, err := s.ListBranches(ctx)
+	state, err := tx.state(ctx, req.Name)
 	if err != nil {
-		return nil, fmt.Errorf("list branches: %w", err)
-	}
-	// Always put trunk in the front.
-	names = slices.Insert(names, 0, s.trunk)
-
-	byName := make(map[string]int, len(names))
-	states := make([]*branchState, len(names))
-	for i, name := range names {
-		if i == 0 {
-			// no state for trunk
-			byName[name] = i
-			continue
+		if !errors.Is(err, ErrNotExist) {
+			return err
 		}
 
-		state, err := s.lookupBranchState(ctx, name)
-		if err != nil {
-			return nil, fmt.Errorf("get branch %q: %w", name, err)
-		}
-
-		byName[name] = i
-		states[i] = state
+		must.NotBeBlankf(req.Base, "new branch %q must have a base", req.Name)
+		state = &branchState{Base: branchStateBase{Name: req.Base}}
+		tx.sets[req.Name] = state
 	}
 
-	bases := make([]int, len(names))
-	aboves := make([][]int, len(names))
-	for i, state := range states {
-		if i == 0 {
-			// no base for trunk
-			bases[i] = -1
-			continue
-		}
-
-		base := state.Base.Name
-		must.NotBeBlankf(base, "branch %q has no base", names[i])
-
-		baseIdx, ok := byName[base]
-		if !ok {
-			return nil, fmt.Errorf("branch %q has untracked base %q", names[i], base)
-		}
-
-		bases[i] = baseIdx
-		aboves[baseIdx] = append(aboves[baseIdx], i)
-	}
-	for _, above := range aboves {
-		sort.Ints(above)
-	}
-
-	return &branchGraph{
-		byName: byName,
-		names:  names,
-		bases:  bases,
-		states: states,
-		aboves: aboves,
-		trunk:  s.trunk,
-	}, nil
-}
-
-// Path returns the path from 'from' to 'to' in the branch graph,
-// or nil if there is no path.
-//
-// If the returned path is non-nil,
-// the first element will always be 'from'
-// and the last element will always be 'to'.
-func (g *branchGraph) path(from, to int) []int {
-	if from == 0 {
-		// There will never be a path from trunk to any other branch.
-		return nil
-	}
-
-	var p []int
-	for cur := from; cur != to; cur = g.bases[cur] {
-		if cur == -1 {
-			return nil
-		}
-		p = append(p, cur)
-	}
-	return append(p, to)
-}
-
-// State returns the state of the branch with the given name
-// or nil if the branch does not exist.
-func (g *branchGraph) State(name string) *branchState {
-	must.NotBeEqualf(name, g.trunk, "trunk has no state")
-	idx, ok := g.byName[name]
-	if !ok {
-		return nil
-	}
-	return g.states[idx]
-}
-
-func (g *branchGraph) NewBranch(name string) *branchState {
-	must.NotBeEqualf(name, g.trunk, "trunk has no state")
-	idx, ok := g.byName[name]
-	must.Bef(!ok || idx == -1, "branch %q already exists", name)
-
-	idx = len(g.names)
-	state := &branchState{}
-	g.names = append(g.names, name)
-	g.bases = append(g.bases, -1)
-	g.states = append(g.states, state)
-	g.aboves = append(g.aboves, nil)
-	g.byName[name] = idx
-	return state
-}
-
-func (g *branchGraph) SetBase(name, base string) error {
-	// Base must already exist for name->base to be valid.
-	baseIdx, ok := g.byName[base]
-	if !ok || baseIdx == -1 {
-		return &branchUntrackedError{Name: base}
-	}
-
-	nameIdx, ok := g.byName[name]
-	if !ok || baseIdx == -1 {
-		return fmt.Errorf("branch %q does not exist", name)
-	}
-
-	// Adding a name->base edge will not create a cycle
-	// only if there's no existing path from base to name.
-	if p := g.path(baseIdx, nameIdx); len(p) > 0 {
-		path := make([]string, len(p))
-		for i, idx := range p {
-			path[i] = g.names[idx]
-		}
-		return newBranchCycleError(path)
-	}
-
-	if oldBaseIdx := g.bases[nameIdx]; oldBaseIdx != -1 && oldBaseIdx != baseIdx {
-		// If the old base is not the same,
-		// remove name from the old base's aboves.
-		aboves := g.aboves[oldBaseIdx]
-		if idx, ok := slices.BinarySearch(aboves, nameIdx); ok {
-			aboves = slices.Delete(aboves, idx, idx+1)
-			g.aboves[oldBaseIdx] = aboves
-		}
-	}
-
-	g.bases[nameIdx] = baseIdx
-	g.aboves[baseIdx] = append(g.aboves[baseIdx], nameIdx)
-	return nil
-}
-
-func (g *branchGraph) DeleteBranch(name string) error {
-	must.NotBeEqualf(name, g.trunk, "trunk cannot be deleted")
-
-	idx, ok := g.byName[name]
-	if !ok || idx == -1 {
-		return fmt.Errorf("branch %q does not exist", name)
-	}
-
-	// Deletion will not cause a broken path
-	// only if the branch is not a base for any other branch.
-	if aboves := g.aboves[idx]; len(aboves) > 0 {
-		var sb strings.Builder
-		for i, idx := range aboves {
-			if i > 0 {
-				sb.WriteString(", ")
+	if req.Base != "" {
+		if req.Base != tx.store.trunk {
+			// Base must already be tracked for name->base to be valid.
+			if _, err := tx.state(ctx, req.Base); err != nil {
+				if errors.Is(err, ErrNotExist) {
+					return &branchUntrackedError{Name: req.Base}
+				}
+				return fmt.Errorf("load base %q: %w", req.Base, err)
 			}
-			sb.WriteString(g.names[idx])
+
+			// Adding name->base will not create a cycle
+			// only if there's no existing path from base to name.
+			if path, err := tx.path(ctx, req.Base, req.Name); err != nil {
+				return fmt.Errorf("find path from trunk to %q: %w", req.Name, err)
+			} else if len(path) > 0 {
+				return newBranchCycleError(path)
+			}
+
 		}
-		return fmt.Errorf("branch %v is needed by %v", name, sb.String())
+		state.Base.Name = req.Base
 	}
 
-	// So as not to break existing indexes,
-	// just invalidate all information about the branch.
-	g.byName[name] = -1
-	g.names[idx] = ""
-	g.bases[idx] = -1
-	g.states[idx] = nil
-	g.aboves[idx] = nil
+	if req.BaseHash != "" {
+		state.Base.Hash = req.BaseHash.String()
+	}
+
+	if len(req.ChangeMetadata) > 0 {
+		must.NotBeBlankf(req.ChangeForge, "change forge is required when change metadata is set")
+		state.Change = &branchChangeState{
+			Forge:  req.ChangeForge,
+			Change: req.ChangeMetadata,
+		}
+	}
+
+	if req.UpstreamBranch != "" {
+		state.Upstream = &branchUpstreamState{
+			Branch: req.UpstreamBranch,
+		}
+	}
+
+	tx.sets[req.Name] = state
 	return nil
 }
 
-// UpdateBranch upates the store with the parameters in the request.
-func (s *Store) UpdateBranch(ctx context.Context, req *UpdateRequest) error {
+// Delete removes information about a branch from the store.
+//
+// The branch must not be a base for any other branch,
+// or an error will be returned.
+func (tx *BranchTx) Delete(ctx context.Context, name string) error {
+	if name == tx.store.trunk {
+		return ErrTrunk
+	}
+
+	aboves, err := sliceutil.CollectErr(tx.aboves(ctx, name))
+	if err != nil {
+		return fmt.Errorf("list branches above %v: %w", name, err)
+	}
+	if len(aboves) > 0 {
+		return fmt.Errorf("branch %v is needed by %v", name, strings.Join(aboves, ", "))
+	}
+
+	tx.dels[name] = struct{}{}
+	delete(tx.sets, name)
+	return nil
+}
+
+// Commit persists all planned changes to the store.
+// If there are no changes, this is a no-op.
+func (tx *BranchTx) Commit(ctx context.Context, msg string) error {
+	req := updateBranchesRequest{
+		Sets:    make([]setBranchStateRequest, 0, len(tx.sets)),
+		Deletes: make([]string, 0, len(tx.dels)),
+		Message: msg,
+	}
+
+	for branch, state := range tx.sets {
+		req.Sets = append(req.Sets, setBranchStateRequest{
+			Branch: branch,
+			State:  state,
+		})
+	}
+
+	for branch := range tx.dels {
+		req.Deletes = append(req.Deletes, branch)
+	}
+
+	if err := tx.store.updateBranches(ctx, req); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+
+	clear(tx.sets)
+	clear(tx.dels)
+	return nil
+}
+
+func (tx *BranchTx) state(ctx context.Context, branch string) (*branchState, error) {
+	if _, ok := tx.dels[branch]; ok {
+		return nil, ErrNotExist
+	}
+
+	if state, ok := tx.sets[branch]; ok {
+		return state, nil
+	}
+
+	state, err := tx.store.lookupBranchState(ctx, branch)
+	if err != nil {
+		return nil, err
+	}
+	newState := *state
+	return &newState, nil
+}
+
+func (tx *BranchTx) listBranches(ctx context.Context) iter.Seq2[string, error] {
+	return func(yield func(string, error) bool) {
+		// seen prevents underlying branches from being listed twice.
+		seen := make(map[string]struct{})
+
+		// Entries in tx.sets take precedence unless they are deleted.
+		for branch := range tx.sets {
+			if _, ok := tx.dels[branch]; ok {
+				continue
+			}
+
+			if !yield(branch, nil) {
+				return
+			}
+			seen[branch] = struct{}{}
+		}
+
+		// List underlying branches.
+		for branch, err := range tx.store.listBranches(ctx) {
+			if err != nil {
+				yield("", fmt.Errorf("list branches: %w", err))
+				return
+			}
+
+			_, overridden := seen[branch]
+			_, deleted := tx.dels[branch]
+			if overridden || deleted {
+				continue
+			}
+
+			if !yield(branch, err) {
+				return
+			}
+			seen[branch] = struct{}{}
+		}
+	}
+}
+
+func (tx *BranchTx) aboves(ctx context.Context, branch string) iter.Seq2[string, error] {
+	return func(yield func(string, error) bool) {
+		for branchName, err := range tx.listBranches(ctx) {
+			if err != nil {
+				yield("", err)
+				return
+			}
+
+			state, err := tx.state(ctx, branchName)
+			if err != nil {
+				yield("", fmt.Errorf("load branch %q: %w", branchName, err))
+				return
+			}
+
+			if state.Base.Name == branch {
+				if !yield(branchName, nil) {
+					return
+				}
+			}
+		}
+	}
+}
+
+func (tx *BranchTx) path(ctx context.Context, from, to string) ([]string, error) {
+	seen := make(map[string]struct{})
+	var p []string
+	for cur := from; cur != to; {
+		if cur == tx.store.trunk {
+			// There can never be a path from trunk to any other branch.
+			return nil, nil
+		}
+
+		// We avoid state corruption by checking for cycles at add time.
+		// If we see a cycle here, the state is already corrupt.
+		// This is a bug and not recoverable.
+		if _, ok := seen[cur]; ok {
+			panic(fmt.Sprintf("corrupt store: cycle detected in branch graph: %v", append(p, cur)))
+		}
+		seen[cur] = struct{}{}
+
+		state, err := tx.state(ctx, cur)
+		if err != nil {
+			return nil, fmt.Errorf("load branch %q: %w", cur, err)
+		}
+
+		p = append(p, cur)
+		must.NotBeBlankf(state.Base.Name, "branch %q has no base", cur)
+		cur = state.Base.Name
+	}
+
+	return append(p, to), nil
+}
+
+// setBranchStateRequest is a request to set the state of a branch.
+type setBranchStateRequest struct {
+	Branch string
+	State  *branchState
+}
+
+// updateBranchesRequest is a request to update the state of multiple branches.
+// The request can set the state of branches, delete branches, or both.
+// A message is recorded with the update.
+type updateBranchesRequest struct {
+	Sets    []setBranchStateRequest
+	Deletes []string
+	Message string // required
+}
+
+// updateBranches atomically updates the state of multiple branches in the store.
+func (s *Store) updateBranches(ctx context.Context, req updateBranchesRequest) error {
+	if len(req.Sets) == 0 && len(req.Deletes) == 0 {
+		return nil
+	}
+
 	if req.Message == "" {
 		req.Message = fmt.Sprintf("update at %s", time.Now().Format(time.RFC3339))
 	}
 
-	graph, err := loadGraph(ctx, s)
-	if err != nil {
-		return fmt.Errorf("load branch graph: %w", err)
+	sets := make([]storage.SetRequest, len(req.Sets))
+	for idx, set := range req.Sets {
+		sets[idx] = storage.SetRequest{
+			Key:   branchKey(set.Branch),
+			Value: set.State,
+		}
 	}
 
-	sets := make([]storage.SetRequest, 0, len(req.Upserts))
-	for i, req := range req.Upserts {
-		if req.Name == "" {
-			return fmt.Errorf("upsert [%d]: branch name is required", i)
-		}
-		if req.Name == s.trunk {
-			return fmt.Errorf("upsert [%d] (%q): %w", i, req.Name, ErrTrunk)
-		}
-
-		b := graph.State(req.Name)
-		if b == nil {
-			b = graph.NewBranch(req.Name)
-		}
-
-		if req.Base != "" {
-			if err := graph.SetBase(req.Name, req.Base); err != nil {
-				return fmt.Errorf("add branch %v with base %v: %w", req.Name, req.Base, err)
-			}
-			b.Base.Name = req.Base
-		}
-		if req.BaseHash != "" {
-			b.Base.Hash = req.BaseHash.String()
-		}
-
-		if len(req.ChangeMetadata) > 0 {
-			must.NotBeBlankf(req.ChangeForge, "change forge is required when change metadata is set")
-			b.Change = &branchChangeState{
-				Forge:  req.ChangeForge,
-				Change: req.ChangeMetadata,
-			}
-		}
-
-		if req.UpstreamBranch != "" {
-			b.Upstream = &branchUpstreamState{
-				Branch: req.UpstreamBranch,
-			}
-		}
-
-		if b.Base.Name == "" {
-			return fmt.Errorf("branch %q would have no base", req.Name)
-		}
-
-		sets = append(sets, storage.SetRequest{
-			Key:   branchKey(req.Name),
-			Value: b,
-		})
+	dels := make([]string, len(req.Deletes))
+	for idx, del := range req.Deletes {
+		dels[idx] = branchKey(del)
 	}
 
-	deletes := make([]string, len(req.Deletes))
-	for i, name := range req.Deletes {
-		if name == s.trunk {
-			return fmt.Errorf("delete [%d] (%q): %w", i, name, ErrTrunk)
-		}
-
-		if err := graph.DeleteBranch(name); err != nil {
-			return fmt.Errorf("delete branch %v: %w", name, err)
-		}
-
-		deletes[i] = branchKey(name)
-	}
-
-	err = s.db.Update(ctx, storage.UpdateRequest{
+	updReq := storage.UpdateRequest{
 		Sets:    sets,
-		Deletes: deletes,
+		Deletes: dels,
 		Message: req.Message,
-	})
-	if err != nil {
+	}
+	if err := s.db.Update(ctx, updReq); err != nil {
 		return fmt.Errorf("update: %w", err)
 	}
 

--- a/internal/spice/state/store_test.go
+++ b/internal/spice/state/store_test.go
@@ -103,4 +103,23 @@ func TestStore(t *testing.T) {
 		assert.Equal(t, "shamhub", res.ChangeForge)
 		assert.JSONEq(t, `{"id": 44}`, string(res.ChangeMetadata))
 	})
+
+	t.Run("upstream branch", func(t *testing.T) {
+		err := store.UpdateBranch(ctx, &state.UpdateRequest{
+			Upserts: []state.UpsertRequest{{
+				Name:           "localBranch",
+				Base:           "main",
+				BaseHash:       "abcdef",
+				UpstreamBranch: "remoteBranch",
+			}},
+		})
+		require.NoError(t, err)
+
+		res, err := store.LookupBranch(ctx, "localBranch")
+		require.NoError(t, err)
+
+		assert.Equal(t, "main", res.Base)
+		assert.Equal(t, "abcdef", string(res.BaseHash))
+		assert.Equal(t, "remoteBranch", res.UpstreamBranch)
+	})
 }

--- a/internal/spice/state/testdata/rapid/TestBranchStateUncorruptible/TestBranchStateUncorruptible-20240924203849-74162.fail
+++ b/internal/spice/state/testdata/rapid/TestBranchStateUncorruptible/TestBranchStateUncorruptible-20240924203849-74162.fail
@@ -1,0 +1,609 @@
+# 2024/09/24 20:38:49.377389 [TestBranchStateUncorruptible] [rapid] draw trunk: "mr"
+# 2024/09/24 20:38:49.377411 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunk"
+# 2024/09/24 20:38:49.377413 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "as"
+# 2024/09/24 20:38:49.377423 [TestBranchStateUncorruptible] changed trunk to "as"
+# 2024/09/24 20:38:49.377428 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunkToKnownBranchFails"
+# 2024/09/24 20:38:49.377430 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "as"
+# 2024/09/24 20:38:49.377431 [TestBranchStateUncorruptible] new trunk is the same as the current trunk
+# 2024/09/24 20:38:49.377433 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunkToKnownBranchFails"
+# 2024/09/24 20:38:49.377435 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "as"
+# 2024/09/24 20:38:49.377437 [TestBranchStateUncorruptible] new trunk is the same as the current trunk
+# 2024/09/24 20:38:49.377439 [TestBranchStateUncorruptible] [rapid] draw action: "DeleteOne"
+# 2024/09/24 20:38:49.377440 [TestBranchStateUncorruptible] [rapid] draw branchToDelete: "g"
+# 2024/09/24 20:38:49.377441 [TestBranchStateUncorruptible] try update: delete random branch
+# 2024/09/24 20:38:49.377442 [TestBranchStateUncorruptible] delete branch: name=g
+# 2024/09/24 20:38:49.377447 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunkToKnownBranchFails"
+# 2024/09/24 20:38:49.377448 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "as"
+# 2024/09/24 20:38:49.377449 [TestBranchStateUncorruptible] new trunk is the same as the current trunk
+# 2024/09/24 20:38:49.377451 [TestBranchStateUncorruptible] [rapid] draw action: "UpsertAlwaysSuccess"
+# 2024/09/24 20:38:49.377453 [TestBranchStateUncorruptible] [rapid] draw branch: "z"
+# 2024/09/24 20:38:49.377454 [TestBranchStateUncorruptible] [rapid] draw base: "as"
+# 2024/09/24 20:38:49.377455 [TestBranchStateUncorruptible] try update: upsert branch with known base
+# 2024/09/24 20:38:49.377458 [TestBranchStateUncorruptible] upsert branch: name=z base=as
+# 2024/09/24 20:38:49.377464 [TestBranchStateUncorruptible] [rapid] draw action: "DeleteOne"
+# 2024/09/24 20:38:49.377465 [TestBranchStateUncorruptible] [rapid] draw branchToDelete: "h"
+# 2024/09/24 20:38:49.377466 [TestBranchStateUncorruptible] try update: delete random branch
+# 2024/09/24 20:38:49.377467 [TestBranchStateUncorruptible] delete branch: name=h
+# 2024/09/24 20:38:49.377473 [TestBranchStateUncorruptible] [rapid] draw action: "UpsertAlwaysSuccess"
+# 2024/09/24 20:38:49.377474 [TestBranchStateUncorruptible] [rapid] draw branch: "u"
+# 2024/09/24 20:38:49.377476 [TestBranchStateUncorruptible] [rapid] draw base: "z"
+# 2024/09/24 20:38:49.377476 [TestBranchStateUncorruptible] try update: upsert branch with known base
+# 2024/09/24 20:38:49.377479 [TestBranchStateUncorruptible] upsert branch: name=u base=z
+# 2024/09/24 20:38:49.377486 [TestBranchStateUncorruptible] [rapid] draw action: "DeleteOne"
+# 2024/09/24 20:38:49.377487 [TestBranchStateUncorruptible] [rapid] draw branchToDelete: "z"
+# 2024/09/24 20:38:49.377488 [TestBranchStateUncorruptible] try update: delete random branch
+# 2024/09/24 20:38:49.377494 [TestBranchStateUncorruptible] failed to delete branch: name=z: delete [0] "z": branch z is needed by u
+# 2024/09/24 20:38:49.377502 [TestBranchStateUncorruptible] [rapid] draw action: "UpsertAlwaysSuccess"
+# 2024/09/24 20:38:49.377504 [TestBranchStateUncorruptible] [rapid] draw branch: "c"
+# 2024/09/24 20:38:49.377505 [TestBranchStateUncorruptible] [rapid] draw base: "z"
+# 2024/09/24 20:38:49.377505 [TestBranchStateUncorruptible] try update: upsert branch with known base
+# 2024/09/24 20:38:49.377509 [TestBranchStateUncorruptible] upsert branch: name=c base=z
+# 2024/09/24 20:38:49.377517 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunk"
+# 2024/09/24 20:38:49.377519 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "e"
+# 2024/09/24 20:38:49.377533 [TestBranchStateUncorruptible] changed trunk to "e"
+# 2024/09/24 20:38:49.377546 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunk"
+# 2024/09/24 20:38:49.377548 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "p"
+# 2024/09/24 20:38:49.377562 [TestBranchStateUncorruptible] changed trunk to "p"
+# 2024/09/24 20:38:49.377582 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunkToKnownBranchFails"
+# 2024/09/24 20:38:49.377584 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "z"
+# 2024/09/24 20:38:49.377603 [TestBranchStateUncorruptible] [rapid] draw action: "DeleteOne"
+# 2024/09/24 20:38:49.377605 [TestBranchStateUncorruptible] [rapid] draw branchToDelete: "br"
+# 2024/09/24 20:38:49.377605 [TestBranchStateUncorruptible] try update: delete random branch
+# 2024/09/24 20:38:49.377607 [TestBranchStateUncorruptible] delete branch: name=br
+# 2024/09/24 20:38:49.377616 [TestBranchStateUncorruptible] [rapid] draw action: "DeleteOne"
+# 2024/09/24 20:38:49.377617 [TestBranchStateUncorruptible] [rapid] draw branchToDelete: "b"
+# 2024/09/24 20:38:49.377618 [TestBranchStateUncorruptible] try update: delete random branch
+# 2024/09/24 20:38:49.377619 [TestBranchStateUncorruptible] delete branch: name=b
+# 2024/09/24 20:38:49.377627 [TestBranchStateUncorruptible] [rapid] draw action: "DeleteOne"
+# 2024/09/24 20:38:49.377628 [TestBranchStateUncorruptible] [rapid] draw branchToDelete: "a"
+# 2024/09/24 20:38:49.377629 [TestBranchStateUncorruptible] try update: delete random branch
+# 2024/09/24 20:38:49.377630 [TestBranchStateUncorruptible] delete branch: name=a
+# 2024/09/24 20:38:49.377638 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunkToKnownBranchFails"
+# 2024/09/24 20:38:49.377640 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "c"
+# 2024/09/24 20:38:49.377675 [TestBranchStateUncorruptible] [rapid] draw action: "UpsertOne"
+# 2024/09/24 20:38:49.377677 [TestBranchStateUncorruptible] [rapid] draw branch: "b"
+# 2024/09/24 20:38:49.377678 [TestBranchStateUncorruptible] [rapid] draw base: "c"
+# 2024/09/24 20:38:49.377679 [TestBranchStateUncorruptible] try update: upsert random branch
+# 2024/09/24 20:38:49.377685 [TestBranchStateUncorruptible] upsert branch: name=b base=c
+# 2024/09/24 20:38:49.377717 [TestBranchStateUncorruptible] [rapid] draw action: "UpsertAlwaysSuccess"
+# 2024/09/24 20:38:49.377726 [TestBranchStateUncorruptible] [rapid] draw branch: "a"
+# 2024/09/24 20:38:49.377728 [TestBranchStateUncorruptible] [rapid] draw base: "c"
+# 2024/09/24 20:38:49.377729 [TestBranchStateUncorruptible] try update: upsert branch with known base
+# 2024/09/24 20:38:49.377734 [TestBranchStateUncorruptible] upsert branch: name=a base=c
+# 2024/09/24 20:38:49.377753 [TestBranchStateUncorruptible] [rapid] draw action: "UpsertAlwaysSuccess"
+# 2024/09/24 20:38:49.377755 [TestBranchStateUncorruptible] [rapid] draw branch: "fc"
+# 2024/09/24 20:38:49.377757 [TestBranchStateUncorruptible] [rapid] draw base: "b"
+# 2024/09/24 20:38:49.377757 [TestBranchStateUncorruptible] try update: upsert branch with known base
+# 2024/09/24 20:38:49.377762 [TestBranchStateUncorruptible] upsert branch: name=fc base=b
+# 2024/09/24 20:38:49.377778 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunk"
+# 2024/09/24 20:38:49.377780 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "ow"
+# 2024/09/24 20:38:49.377799 [TestBranchStateUncorruptible] changed trunk to "ow"
+# 2024/09/24 20:38:49.377827 [TestBranchStateUncorruptible] [rapid] draw action: "UpsertAndDeleteMany"
+# 2024/09/24 20:38:49.377837 [TestBranchStateUncorruptible] [rapid] draw upserts: []state.UpsertRequest{state.UpsertRequest{Name:"b", Base:"x", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"l", Base:"a", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"p", Base:"m", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"b", Base:"e", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"a", Base:"f", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"yp", Base:"o", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}}
+# 2024/09/24 20:38:49.377859 [TestBranchStateUncorruptible] [rapid] draw deletes: []string{"p", "f", "pq", "ma", "aw", "e", "c", "ec", "w"}
+# 2024/09/24 20:38:49.377861 [TestBranchStateUncorruptible] try update: upsert and delete random branches
+# 2024/09/24 20:38:49.377864 [TestBranchStateUncorruptible] failed to upsert branch: name=b base=x: upsert [0] "b": branch x is not tracked
+# 2024/09/24 20:38:49.377865 [TestBranchStateUncorruptible] failed to upsert branch: name=l base=a: upsert [0] "b": branch x is not tracked
+# 2024/09/24 20:38:49.377866 [TestBranchStateUncorruptible] failed to upsert branch: name=p base=m: upsert [0] "b": branch x is not tracked
+# 2024/09/24 20:38:49.377866 [TestBranchStateUncorruptible] failed to upsert branch: name=b base=e: upsert [0] "b": branch x is not tracked
+# 2024/09/24 20:38:49.377867 [TestBranchStateUncorruptible] failed to upsert branch: name=a base=f: upsert [0] "b": branch x is not tracked
+# 2024/09/24 20:38:49.377868 [TestBranchStateUncorruptible] failed to upsert branch: name=yp base=o: upsert [0] "b": branch x is not tracked
+# 2024/09/24 20:38:49.377868 [TestBranchStateUncorruptible] failed to delete branch: name=p: upsert [0] "b": branch x is not tracked
+# 2024/09/24 20:38:49.377869 [TestBranchStateUncorruptible] failed to delete branch: name=f: upsert [0] "b": branch x is not tracked
+# 2024/09/24 20:38:49.377869 [TestBranchStateUncorruptible] failed to delete branch: name=pq: upsert [0] "b": branch x is not tracked
+# 2024/09/24 20:38:49.377870 [TestBranchStateUncorruptible] failed to delete branch: name=ma: upsert [0] "b": branch x is not tracked
+# 2024/09/24 20:38:49.377870 [TestBranchStateUncorruptible] failed to delete branch: name=aw: upsert [0] "b": branch x is not tracked
+# 2024/09/24 20:38:49.377871 [TestBranchStateUncorruptible] failed to delete branch: name=e: upsert [0] "b": branch x is not tracked
+# 2024/09/24 20:38:49.377872 [TestBranchStateUncorruptible] failed to delete branch: name=c: upsert [0] "b": branch x is not tracked
+# 2024/09/24 20:38:49.377872 [TestBranchStateUncorruptible] failed to delete branch: name=ec: upsert [0] "b": branch x is not tracked
+# 2024/09/24 20:38:49.377873 [TestBranchStateUncorruptible] failed to delete branch: name=w: upsert [0] "b": branch x is not tracked
+# 2024/09/24 20:38:49.377890 [TestBranchStateUncorruptible] [rapid] draw action: "DeleteOne"
+# 2024/09/24 20:38:49.377892 [TestBranchStateUncorruptible] [rapid] draw branchToDelete: "v"
+# 2024/09/24 20:38:49.377892 [TestBranchStateUncorruptible] try update: delete random branch
+# 2024/09/24 20:38:49.377895 [TestBranchStateUncorruptible] delete branch: name=v
+# 2024/09/24 20:38:49.377910 [TestBranchStateUncorruptible] [rapid] draw action: "UpsertAlwaysSuccess"
+# 2024/09/24 20:38:49.377911 [TestBranchStateUncorruptible] [rapid] draw branch: "s"
+# 2024/09/24 20:38:49.377913 [TestBranchStateUncorruptible] [rapid] draw base: "c"
+# 2024/09/24 20:38:49.377913 [TestBranchStateUncorruptible] try update: upsert branch with known base
+# 2024/09/24 20:38:49.377917 [TestBranchStateUncorruptible] upsert branch: name=s base=c
+# 2024/09/24 20:38:49.377934 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunk"
+# 2024/09/24 20:38:49.377936 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "g"
+# 2024/09/24 20:38:49.377961 [TestBranchStateUncorruptible] changed trunk to "g"
+# 2024/09/24 20:38:49.377988 [TestBranchStateUncorruptible] [rapid] draw action: "DeleteOne"
+# 2024/09/24 20:38:49.377990 [TestBranchStateUncorruptible] [rapid] draw branchToDelete: "cu"
+# 2024/09/24 20:38:49.377991 [TestBranchStateUncorruptible] try update: delete random branch
+# 2024/09/24 20:38:49.377993 [TestBranchStateUncorruptible] delete branch: name=cu
+# 2024/09/24 20:38:49.378011 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunkToKnownBranchFails"
+# 2024/09/24 20:38:49.378014 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "s"
+# 2024/09/24 20:38:49.378036 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunk"
+# 2024/09/24 20:38:49.378038 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "y"
+# 2024/09/24 20:38:49.378057 [TestBranchStateUncorruptible] changed trunk to "y"
+# 2024/09/24 20:38:49.378089 [TestBranchStateUncorruptible] [rapid] draw action: "UpsertAlwaysSuccess"
+# 2024/09/24 20:38:49.378091 [TestBranchStateUncorruptible] [rapid] draw branch: "b"
+# 2024/09/24 20:38:49.378093 [TestBranchStateUncorruptible] [rapid] draw base: "a"
+# 2024/09/24 20:38:49.378093 [TestBranchStateUncorruptible] try update: upsert branch with known base
+# 2024/09/24 20:38:49.378096 [TestBranchStateUncorruptible] upsert branch: name=b base=a
+# 2024/09/24 20:38:49.378118 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunkToKnownBranchFails"
+# 2024/09/24 20:38:49.378121 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "b"
+# 2024/09/24 20:38:49.378154 [TestBranchStateUncorruptible] [rapid] draw action: "UpsertAndDeleteMany"
+# 2024/09/24 20:38:49.378158 [TestBranchStateUncorruptible] [rapid] draw upserts: []state.UpsertRequest{state.UpsertRequest{Name:"a", Base:"c", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"ua", Base:"u", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}}
+# 2024/09/24 20:38:49.378163 [TestBranchStateUncorruptible] [rapid] draw deletes: []string{"u"}
+# 2024/09/24 20:38:49.378164 [TestBranchStateUncorruptible] try update: upsert and delete random branches
+# 2024/09/24 20:38:49.378199 [TestBranchStateUncorruptible] upsert branch: name=a base=c
+# 2024/09/24 20:38:49.378200 [TestBranchStateUncorruptible] upsert branch: name=ua base=u
+# 2024/09/24 20:38:49.378201 [TestBranchStateUncorruptible] delete branch: name=u
+# 2024/09/24 20:38:49.378250 [TestBranchStateUncorruptible] 
+# 	Error Trace:	/Users/abg/src/git-spice/internal/spice/state/branch_test.go:213
+# 	            				/Users/abg/src/git-spice/internal/spice/state/branch_test.go:204
+# 	            				/Users/abg/go/pkg/mod/pgregory.net/rapid@v1.1.0/statemachine.go:63
+# 	            				/Users/abg/src/git-spice/internal/spice/state/branch_test.go:166
+# 	            				/Users/abg/go/pkg/mod/pgregory.net/rapid@v1.1.0/engine.go:368
+# 	            				/Users/abg/go/pkg/mod/pgregory.net/rapid@v1.1.0/engine.go:377
+# 	            				/Users/abg/go/pkg/mod/pgregory.net/rapid@v1.1.0/engine.go:203
+# 	            				/Users/abg/go/pkg/mod/pgregory.net/rapid@v1.1.0/engine.go:118
+# 	            				/Users/abg/src/git-spice/internal/spice/state/branch_test.go:127
+# 	Error:      	Received unexpected error:
+# 	            	load branch "u": does not exist in store
+# 	Test:       	TestBranchStateUncorruptible
+# 	Messages:   	lookup branch "u" (path: [ua u])
+# 
+v0.4.8#11336813700940197908
+0x142dc22cf74cc5
+0x0
+0x1550d26b08894d
+0xc
+0x1d844c648639d3
+0x0
+0x1dff75dd10ffda
+0x11
+0x6ad733a493684
+0x86ec24f294a94
+0x691f74e72cbda
+0x0
+0x113cea90c77d1d
+0x0
+0x1df80a1b2a676
+0x0
+0x1989118752d18e
+0x0
+0x1b4a87d13e8b8a
+0x1a
+0x12
+0x3524238bf5eb5
+0x1995544e7b017b
+0x122649017a42dc
+0x1
+0x17aa2cba163767
+0x0
+0x1343da5eee7303
+0xc9e5e5bccb999
+0x7
+0x1
+0x15b5064ca6c174
+0x0
+0x9a17ffb0b5537
+0x186b7bf3d6f5ec
+0x2
+0x19682d625aff31
+0x0
+0x755460eca366c
+0x6
+0xfa102ef8eb1a5
+0x4893cca081738
+0xa1c874333c1d4
+0x6
+0x1
+0x13c757084a97be
+0x0
+0x1909addf87e370
+0x1ce9f5da7d678e
+0x3
+0x138f1ca43dc4b4
+0x0
+0x1e2d6157febb06
+0x19
+0xd798d1c95d88
+0x5086b446ccd0b
+0x0
+0x6d30878cfb9f3
+0xca55c6df3730c
+0x2
+0x11ce96135f8e9
+0x0
+0x12b4f43af6866e
+0x7
+0xdbeb6120d3fe0
+0x3cf1a4641e99e
+0x140a64648ca15f
+0x3
+0xb3efe08c86e25
+0x0
+0x1099b598314771
+0x14
+0x10a74e9b9e5d3a
+0x110845ee554acf
+0x0
+0xb7272e1fd97b6
+0x1c1c0bd67321f8
+0x2
+0x15d87534fafa6d
+0x0
+0xd121882e7742c
+0x19
+0xcb73ba34e7e58
+0xfaee64b4df081
+0x1c295780ec7d20
+0x3
+0x15f81a47337c55
+0x0
+0x3bdcdfe356034
+0x2
+0x783e108bcaa91
+0x1381357f3879bd
+0x0
+0xab860706d2f3c
+0xbf724359359f9
+0x0
+0xbe7368bd37476
+0x0
+0x82feed643cd43
+0x4
+0xcc07c2d99dd3e
+0x49f27592f42d8
+0x152014e935d229
+0x0
+0xc09c3acb9b31f
+0x0
+0xc528b0c150d83
+0xf
+0xd10c4df68f698
+0x9699dd7465556
+0x1ef51232c12e31
+0x1
+0x1b3f576604e3fe
+0x0
+0x107f4efd52d4c8
+0x56a7396cd9f54
+0x2
+0x14814a445a8f75
+0x0
+0x1a552f42de6e63
+0x1
+0x169d60f56eb00a
+0x0
+0x12dea149394907
+0x11
+0x163e9ecc9258a3
+0xc0cd2f572f6e1
+0x4287c52504774
+0x2
+0xd9e33fbce7e35
+0x0
+0x45b78e65f3bf0
+0x1
+0xaeffd300f7271
+0xa2e60b9959b36
+0xc76b88691cd01
+0x6
+0x2
+0x1340ee1937bb67
+0x0
+0xafa69f6178a21
+0x0
+0x8cced487c39f4
+0x15283c0186ce56
+0x18f4d9dea896f1
+0x1
+0x1cefa870ac6515
+0x3
+0x2
+0x8593d15d48019
+0x82e847a705bf2
+0x5
+0xac3eafb83cfab
+0x0
+0xdbd0cb641bad4
+0x1
+0x14bf43cd6da897
+0x1118d0fb491211
+0x0
+0x7740491582aa2
+0x2
+0x34d514b4f5969
+0xb63683eb05989
+0xd7731c07bc019
+0x3
+0x16918e6f539116
+0x0
+0x1daa580c8160d3
+0x0
+0x50cf06789189e
+0x1b4f452f79bad0
+0x2
+0x1646fa155238b4
+0x7f0fdce50569e
+0x3
+0x715cc64466915
+0x0
+0x19d15c3be8a1b6
+0x1b
+0x5
+0x173dcfb25d8974
+0x0
+0x1305278c1098b0
+0x2
+0x82d8f8eaf6baf
+0x19f41d3ead1243
+0x2
+0x1494af946e5d47
+0x170470bbe4d049
+0x0
+0xb086767f5d62b
+0x0
+0x9a333570c8f41
+0xe
+0x1cb9882cd616e0
+0x0
+0x171f587e669f9e
+0x16
+0x1c8b3dbb381bb2
+0x66a6a5dd885cb
+0x1076e60c5f8802
+0x4
+0x1b2661428262d9
+0x11452ab5fb3c0d
+0x0
+0xfaa3acfaf975d
+0x1
+0x136c5f6a0a81a3
+0xa5010106ce526
+0x0
+0x19235c2c3d8aeb
+0x17
+0x89844719455a1
+0x15c6176ed7cec5
+0x1d3d9e0efb3f14
+0x0
+0x1badb978bd53ce
+0x1d
+0x1e
+0xb
+0x11dfe6637541d6
+0xdbb461082f20f
+0x0
+0x1b7a512bae9d8
+0x0
+0xc2d3c5c72c71d
+0x18558b471c3722
+0x5c65efd8cef97
+0x0
+0xec2a0d70a3f78
+0x1b
+0xf
+0x1524e63cc10a44
+0x157a2970d353b9
+0x0
+0xd8ba7f87c6013
+0xc
+0x8db21eaa63c83
+0x1ce42ef3bee4e1
+0x45f6c48e1029b
+0x0
+0xd166883646a4
+0x1
+0x228a794dde399
+0x9ba65137d82d
+0x0
+0x1dbe9f0ed6eb96
+0x4
+0xcc7c240b2ffca
+0x114e5251517d26
+0x2e9513735c164
+0x0
+0xdeb764e37d95a
+0x1b
+0x0
+0x41e982e28611
+0x160c21e01fede6
+0x0
+0xea5439dfc44a3
+0x1a
+0x1a
+0x5
+0xb7c50c81bbabf
+0x1ed674dd57c52d
+0x1e951a5175fc36
+0x0
+0x147d13eb80e873
+0x18
+0x1d4e95383f5382
+0x0
+0xe236090b2b2cb
+0xf
+0xa90bcd8884f15
+0xedc7449e40330
+0x0
+0x18f0d940c016c7
+0xe
+0x125dba43754179
+0x258afdbeb3abd
+0xf79289ca251d8
+0xf0da393487af2
+0x0
+0x128b3b67641e3d
+0xf
+0x314ec17a626b
+0xc33f5650da092
+0xface429e587
+0x0
+0x1e5cb437c6bde7
+0x5
+0x321c34c78100d
+0x9cc67b4733703
+0x1ec890d99e1488
+0x0
+0x1658c5720b3c33
+0xf
+0x1d7f7d1b327ac0
+0x0
+0x15614f32e18834
+0x10
+0xba439c45c17ee
+0xce37fbf0a7efb
+0xd3df62bf1a5dc
+0x0
+0xa274aca0a57db
+0xc
+0x1c2b5dccf33842
+0x0
+0xcbaf496349826
+0x0
+0xa269fb6836850
+0x120b25fb0c7803
+0xd51c4fc64794d
+0x0
+0x3feeb9515e48d
+0x0
+0x1a0ba3a57a42fc
+0x0
+0x1594ecb6eaad10
+0x16
+0x14853d3684760e
+0xc9e827e65adc2
+0xcba6da51edf9a
+0x0
+0x1cc01412839ab6
+0x4
+0x145200952f79ae
+0x12439dbbb38d54
+0x67d67c406903d
+0x0
+0x40004b349fc3f
+0x2
+0xe41efd3778a46
+0x1603fbc1aa0b37
+0x7d7204c185117
+0x0
+0xa47273a46d173
+0x4
+0x1f572baa1ffe12
+0x0
+0x63649588aa8fa
+0x2
+0x15e2f0c9bc9f51
+0x12d7180729baf6
+0x4ad5aa3430aaf
+0x0
+0x15b545712d2cb4
+0x1e
+0x16
+0x76d49054ea429
+0xf821ca703bb7
+0x16a9b5c2f3f53c
+0x1b3e53a888686f
+0x6
+0x7
+0x2
+0x14820ee36a146c
+0x0
+0x1ba0a00c5a9093
+0x15
+0x5802a7b09b8f4
+0x1f2ee9cd75f600
+0x5e13752228ee4
+0x3
+0xe22735c5b5513
+0x0
+0x17a5ce63487359
+0x12
+0xc02fa05361605
+0x8dabad572d22a
+0x5
+0x19bc9b88185b92
+0x69c48ba2ae82f
+0x0
+0x1aa6590170ffdf
+0x0
+0x1a0296ff2c1fe3
+0x6
+0x14990f5fabf006
+0x167ed0c020d7db
+0x69317d88f5da3
+0x2
+0x1372a60d6e5090
+0x0
+0x182ae36780e23c
+0x1f
+0x2
+0x15a3764ae43607
+0x0
+0x1d1f83c14916b6
+0x1f
+0x14
+0x1357ae0ab046ae
+0x1d03b5c5cdcc42
+0xbdb915d652d66
+0x1
+0x83d4564d70bb6
+0x0
+0xb6b4ff90b1218
+0x138e9cdbe28c29
+0x6
+0x0
+0x145a3ae048eac0
+0x0
+0x1576b3198b8331
+0x18
+0x6cd6aaaae763c
+0x823175e7719cd
+0x99b837e0a2245
+0x3
+0x18c14c899152ea
+0x0
+0x13fd7d8323b44
+0x1
+0x9af0249789286
+0x820e37f7186
+0x0
+0x17e230db7d28c8
+0x13d76ad8966c4e
+0x1
+0x10f8ace94fb540
+0x0
+0xf5f9098883b68
+0x1d6a9e2341e60c
+0x4
+0x12021ceffc59ca
+0x8838faaa70aec
+0x0
+0x390294b33228b
+0x0
+0x4cc9f68704606
+0x121081efac4b9f
+0x0
+0x987c12e7fe537
+0x2
+0xeb8990134980f
+0x1307268bd45b6a
+0x1313446f26c1a9
+0x0
+0x10baf8b317ef23
+0x14
+0x15c019dc70b6af
+0x0
+0x2bc1e152e1446
+0x0
+0xd5977fcad936b
+0x15b0e688757315
+0x0
+0xe8dfc1641b782
+0x14
+0xd06c43ae27c4c
+0x36b96cf1cce9a
+0x16c9623326d85d
+0x5cbb929ed60ae
+0x0
+0x169f7c83c6c476
+0x14
+0x1331c9ed746201
+0x518872c242249

--- a/internal/spice/state/testdata/rapid/TestBranchStateUncorruptible/TestBranchStateUncorruptible-20240924204020-75460.fail
+++ b/internal/spice/state/testdata/rapid/TestBranchStateUncorruptible/TestBranchStateUncorruptible-20240924204020-75460.fail
@@ -1,0 +1,1343 @@
+# 2024/09/24 20:40:20.938281 [TestBranchStateUncorruptible] [rapid] draw trunk: "dc"
+# 2024/09/24 20:40:20.938308 [TestBranchStateUncorruptible] [rapid] draw action: "UpsertAlwaysSuccess"
+# 2024/09/24 20:40:20.938311 [TestBranchStateUncorruptible] [rapid] draw branch: "a"
+# 2024/09/24 20:40:20.938313 [TestBranchStateUncorruptible] [rapid] draw base: "dc"
+# 2024/09/24 20:40:20.938313 [TestBranchStateUncorruptible] try update: upsert branch with known base
+# 2024/09/24 20:40:20.938318 [TestBranchStateUncorruptible] upsert branch: name=a base=dc
+# 2024/09/24 20:40:20.938325 [TestBranchStateUncorruptible] [rapid] draw action: "DeleteOne"
+# 2024/09/24 20:40:20.938327 [TestBranchStateUncorruptible] [rapid] draw branchToDelete: "k"
+# 2024/09/24 20:40:20.938327 [TestBranchStateUncorruptible] try update: delete random branch
+# 2024/09/24 20:40:20.938331 [TestBranchStateUncorruptible] delete branch: name=k
+# 2024/09/24 20:40:20.938337 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunkToKnownBranchFails"
+# 2024/09/24 20:40:20.938339 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "a"
+# 2024/09/24 20:40:20.938354 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunkToKnownBranchFails"
+# 2024/09/24 20:40:20.938356 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "a"
+# 2024/09/24 20:40:20.938369 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunkToKnownBranchFails"
+# 2024/09/24 20:40:20.938371 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "a"
+# 2024/09/24 20:40:20.938384 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunkToKnownBranchFails"
+# 2024/09/24 20:40:20.938387 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "a"
+# 2024/09/24 20:40:20.938399 [TestBranchStateUncorruptible] [rapid] draw action: "UpsertOne"
+# 2024/09/24 20:40:20.938402 [TestBranchStateUncorruptible] [rapid] draw branch: "po"
+# 2024/09/24 20:40:20.938403 [TestBranchStateUncorruptible] [rapid] draw base: "g"
+# 2024/09/24 20:40:20.938404 [TestBranchStateUncorruptible] try update: upsert random branch
+# 2024/09/24 20:40:20.938407 [TestBranchStateUncorruptible] failed to upsert branch: name=po base=g: upsert [0] "po": branch g is not tracked
+# 2024/09/24 20:40:20.938415 [TestBranchStateUncorruptible] [rapid] draw action: "UpsertOne"
+# 2024/09/24 20:40:20.938417 [TestBranchStateUncorruptible] [rapid] draw branch: "c"
+# 2024/09/24 20:40:20.938418 [TestBranchStateUncorruptible] [rapid] draw base: "g"
+# 2024/09/24 20:40:20.938419 [TestBranchStateUncorruptible] try update: upsert random branch
+# 2024/09/24 20:40:20.938422 [TestBranchStateUncorruptible] failed to upsert branch: name=c base=g: upsert [0] "c": branch g is not tracked
+# 2024/09/24 20:40:20.938428 [TestBranchStateUncorruptible] [rapid] draw action: "UpsertAlwaysSuccess"
+# 2024/09/24 20:40:20.938430 [TestBranchStateUncorruptible] [rapid] draw branch: "m"
+# 2024/09/24 20:40:20.938431 [TestBranchStateUncorruptible] [rapid] draw base: "a"
+# 2024/09/24 20:40:20.938432 [TestBranchStateUncorruptible] try update: upsert branch with known base
+# 2024/09/24 20:40:20.938435 [TestBranchStateUncorruptible] upsert branch: name=m base=a
+# 2024/09/24 20:40:20.938445 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunk"
+# 2024/09/24 20:40:20.938447 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "f"
+# 2024/09/24 20:40:20.938459 [TestBranchStateUncorruptible] changed trunk to "f"
+# 2024/09/24 20:40:20.938471 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunk"
+# 2024/09/24 20:40:20.938474 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "ha"
+# 2024/09/24 20:40:20.938487 [TestBranchStateUncorruptible] changed trunk to "ha"
+# 2024/09/24 20:40:20.938499 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunk"
+# 2024/09/24 20:40:20.938501 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "ze"
+# 2024/09/24 20:40:20.938512 [TestBranchStateUncorruptible] changed trunk to "ze"
+# 2024/09/24 20:40:20.938524 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunkToKnownBranchFails"
+# 2024/09/24 20:40:20.938527 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "m"
+# 2024/09/24 20:40:20.938541 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunkToKnownBranchFails"
+# 2024/09/24 20:40:20.938544 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "a"
+# 2024/09/24 20:40:20.938559 [TestBranchStateUncorruptible] [rapid] draw action: "UpsertOne"
+# 2024/09/24 20:40:20.938561 [TestBranchStateUncorruptible] [rapid] draw branch: "ha"
+# 2024/09/24 20:40:20.938563 [TestBranchStateUncorruptible] [rapid] draw base: "eu"
+# 2024/09/24 20:40:20.938563 [TestBranchStateUncorruptible] try update: upsert random branch
+# 2024/09/24 20:40:20.938566 [TestBranchStateUncorruptible] failed to upsert branch: name=ha base=eu: upsert [0] "ha": branch eu is not tracked
+# 2024/09/24 20:40:20.938575 [TestBranchStateUncorruptible] [rapid] draw action: "UpsertOne"
+# 2024/09/24 20:40:20.938576 [TestBranchStateUncorruptible] [rapid] draw branch: "cc"
+# 2024/09/24 20:40:20.938578 [TestBranchStateUncorruptible] [rapid] draw base: "h"
+# 2024/09/24 20:40:20.938578 [TestBranchStateUncorruptible] try update: upsert random branch
+# 2024/09/24 20:40:20.938582 [TestBranchStateUncorruptible] failed to upsert branch: name=cc base=h: upsert [0] "cc": branch h is not tracked
+# 2024/09/24 20:40:20.938589 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunkToKnownBranchFails"
+# 2024/09/24 20:40:20.938591 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "a"
+# 2024/09/24 20:40:20.938606 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunk"
+# 2024/09/24 20:40:20.938608 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "az"
+# 2024/09/24 20:40:20.938619 [TestBranchStateUncorruptible] changed trunk to "az"
+# 2024/09/24 20:40:20.938631 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunkToKnownBranchFails"
+# 2024/09/24 20:40:20.938633 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "a"
+# 2024/09/24 20:40:20.938647 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunkToKnownBranchFails"
+# 2024/09/24 20:40:20.938649 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "m"
+# 2024/09/24 20:40:20.938679 [TestBranchStateUncorruptible] [rapid] draw action: "UpsertAndDeleteMany"
+# 2024/09/24 20:40:20.938699 [TestBranchStateUncorruptible] [rapid] draw upserts: []state.UpsertRequest{state.UpsertRequest{Name:"i", Base:"v", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"ca", Base:"b", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"w", Base:"kv", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"o", Base:"o", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"d", Base:"zj", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"va", Base:"n", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"ak", Base:"ak", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"wj", Base:"fb", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"d", Base:"dp", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"l", Base:"z", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"o", Base:"vv", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}}
+# 2024/09/24 20:40:20.938726 [TestBranchStateUncorruptible] [rapid] draw deletes: []string{"pb", "n", "f", "b"}
+# 2024/09/24 20:40:20.938728 [TestBranchStateUncorruptible] try update: upsert and delete random branches
+# 2024/09/24 20:40:20.938731 [TestBranchStateUncorruptible] failed to upsert branch: name=i base=v: upsert [0] "i": branch v is not tracked
+# 2024/09/24 20:40:20.938732 [TestBranchStateUncorruptible] failed to upsert branch: name=ca base=b: upsert [0] "i": branch v is not tracked
+# 2024/09/24 20:40:20.938733 [TestBranchStateUncorruptible] failed to upsert branch: name=w base=kv: upsert [0] "i": branch v is not tracked
+# 2024/09/24 20:40:20.938734 [TestBranchStateUncorruptible] failed to upsert branch: name=o base=o: upsert [0] "i": branch v is not tracked
+# 2024/09/24 20:40:20.938734 [TestBranchStateUncorruptible] failed to upsert branch: name=d base=zj: upsert [0] "i": branch v is not tracked
+# 2024/09/24 20:40:20.938735 [TestBranchStateUncorruptible] failed to upsert branch: name=va base=n: upsert [0] "i": branch v is not tracked
+# 2024/09/24 20:40:20.938736 [TestBranchStateUncorruptible] failed to upsert branch: name=ak base=ak: upsert [0] "i": branch v is not tracked
+# 2024/09/24 20:40:20.938736 [TestBranchStateUncorruptible] failed to upsert branch: name=wj base=fb: upsert [0] "i": branch v is not tracked
+# 2024/09/24 20:40:20.938737 [TestBranchStateUncorruptible] failed to upsert branch: name=d base=dp: upsert [0] "i": branch v is not tracked
+# 2024/09/24 20:40:20.938738 [TestBranchStateUncorruptible] failed to upsert branch: name=l base=z: upsert [0] "i": branch v is not tracked
+# 2024/09/24 20:40:20.938739 [TestBranchStateUncorruptible] failed to upsert branch: name=o base=vv: upsert [0] "i": branch v is not tracked
+# 2024/09/24 20:40:20.938739 [TestBranchStateUncorruptible] failed to delete branch: name=pb: upsert [0] "i": branch v is not tracked
+# 2024/09/24 20:40:20.938740 [TestBranchStateUncorruptible] failed to delete branch: name=n: upsert [0] "i": branch v is not tracked
+# 2024/09/24 20:40:20.938741 [TestBranchStateUncorruptible] failed to delete branch: name=f: upsert [0] "i": branch v is not tracked
+# 2024/09/24 20:40:20.938741 [TestBranchStateUncorruptible] failed to delete branch: name=b: upsert [0] "i": branch v is not tracked
+# 2024/09/24 20:40:20.938749 [TestBranchStateUncorruptible] [rapid] draw action: "UpsertOne"
+# 2024/09/24 20:40:20.938751 [TestBranchStateUncorruptible] [rapid] draw branch: "f"
+# 2024/09/24 20:40:20.938752 [TestBranchStateUncorruptible] [rapid] draw base: "dg"
+# 2024/09/24 20:40:20.938753 [TestBranchStateUncorruptible] try update: upsert random branch
+# 2024/09/24 20:40:20.938756 [TestBranchStateUncorruptible] failed to upsert branch: name=f base=dg: upsert [0] "f": branch dg is not tracked
+# 2024/09/24 20:40:20.938764 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunk"
+# 2024/09/24 20:40:20.938766 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "m"
+# 2024/09/24 20:40:20.938774 [TestBranchStateUncorruptible] failed to change trunk to "m": trunk branch ("m") is tracked by gs; use --reset to clear
+# 2024/09/24 20:40:20.938782 [TestBranchStateUncorruptible] [rapid] draw action: "UpsertAndDeleteMany"
+# 2024/09/24 20:40:20.938801 [TestBranchStateUncorruptible] [rapid] draw upserts: []state.UpsertRequest{state.UpsertRequest{Name:"ho", Base:"b", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"dx", Base:"z", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"l", Base:"m", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"of", Base:"l", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"b", Base:"ca", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"b", Base:"d", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"ha", Base:"hj", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"d", Base:"c", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"a", Base:"a", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"yw", Base:"c", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"v", Base:"a", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}}
+# 2024/09/24 20:40:20.938900 [TestBranchStateUncorruptible] [rapid] draw deletes: []string{"t", "m"}
+# 2024/09/24 20:40:20.938901 [TestBranchStateUncorruptible] try update: upsert and delete random branches
+# 2024/09/24 20:40:20.938905 [TestBranchStateUncorruptible] failed to upsert branch: name=ho base=b: upsert [0] "ho": branch b is not tracked
+# 2024/09/24 20:40:20.938906 [TestBranchStateUncorruptible] failed to upsert branch: name=dx base=z: upsert [0] "ho": branch b is not tracked
+# 2024/09/24 20:40:20.938906 [TestBranchStateUncorruptible] failed to upsert branch: name=l base=m: upsert [0] "ho": branch b is not tracked
+# 2024/09/24 20:40:20.938907 [TestBranchStateUncorruptible] failed to upsert branch: name=of base=l: upsert [0] "ho": branch b is not tracked
+# 2024/09/24 20:40:20.938908 [TestBranchStateUncorruptible] failed to upsert branch: name=b base=ca: upsert [0] "ho": branch b is not tracked
+# 2024/09/24 20:40:20.938909 [TestBranchStateUncorruptible] failed to upsert branch: name=b base=d: upsert [0] "ho": branch b is not tracked
+# 2024/09/24 20:40:20.938909 [TestBranchStateUncorruptible] failed to upsert branch: name=ha base=hj: upsert [0] "ho": branch b is not tracked
+# 2024/09/24 20:40:20.938910 [TestBranchStateUncorruptible] failed to upsert branch: name=d base=c: upsert [0] "ho": branch b is not tracked
+# 2024/09/24 20:40:20.938911 [TestBranchStateUncorruptible] failed to upsert branch: name=a base=a: upsert [0] "ho": branch b is not tracked
+# 2024/09/24 20:40:20.938911 [TestBranchStateUncorruptible] failed to upsert branch: name=yw base=c: upsert [0] "ho": branch b is not tracked
+# 2024/09/24 20:40:20.938912 [TestBranchStateUncorruptible] failed to upsert branch: name=v base=a: upsert [0] "ho": branch b is not tracked
+# 2024/09/24 20:40:20.938913 [TestBranchStateUncorruptible] failed to delete branch: name=t: upsert [0] "ho": branch b is not tracked
+# 2024/09/24 20:40:20.938913 [TestBranchStateUncorruptible] failed to delete branch: name=m: upsert [0] "ho": branch b is not tracked
+# 2024/09/24 20:40:20.938923 [TestBranchStateUncorruptible] [rapid] draw action: "DeleteOne"
+# 2024/09/24 20:40:20.938925 [TestBranchStateUncorruptible] [rapid] draw branchToDelete: "z"
+# 2024/09/24 20:40:20.938926 [TestBranchStateUncorruptible] try update: delete random branch
+# 2024/09/24 20:40:20.938928 [TestBranchStateUncorruptible] delete branch: name=z
+# 2024/09/24 20:40:20.938936 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunk"
+# 2024/09/24 20:40:20.938937 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "e"
+# 2024/09/24 20:40:20.938950 [TestBranchStateUncorruptible] changed trunk to "e"
+# 2024/09/24 20:40:20.938961 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunkToKnownBranchFails"
+# 2024/09/24 20:40:20.938964 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "m"
+# 2024/09/24 20:40:20.938978 [TestBranchStateUncorruptible] [rapid] draw action: "UpsertOne"
+# 2024/09/24 20:40:20.938980 [TestBranchStateUncorruptible] [rapid] draw branch: "l"
+# 2024/09/24 20:40:20.938981 [TestBranchStateUncorruptible] [rapid] draw base: "b"
+# 2024/09/24 20:40:20.938982 [TestBranchStateUncorruptible] try update: upsert random branch
+# 2024/09/24 20:40:20.938985 [TestBranchStateUncorruptible] failed to upsert branch: name=l base=b: upsert [0] "l": branch b is not tracked
+# 2024/09/24 20:40:20.938994 [TestBranchStateUncorruptible] [rapid] draw action: "DeleteOne"
+# 2024/09/24 20:40:20.938996 [TestBranchStateUncorruptible] [rapid] draw branchToDelete: "a"
+# 2024/09/24 20:40:20.938996 [TestBranchStateUncorruptible] try update: delete random branch
+# 2024/09/24 20:40:20.938999 [TestBranchStateUncorruptible] failed to delete branch: name=a: delete [0] "a": branch a is needed by m
+# 2024/09/24 20:40:20.939006 [TestBranchStateUncorruptible] [rapid] draw action: "UpsertAndDeleteMany"
+# 2024/09/24 20:40:20.939025 [TestBranchStateUncorruptible] [rapid] draw upserts: []state.UpsertRequest{state.UpsertRequest{Name:"b", Base:"kk", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"gq", Base:"n", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"a", Base:"c", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"a", Base:"g", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"ej", Base:"io", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"p", Base:"b", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"i", Base:"k", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"e", Base:"si", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"fy", Base:"na", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"y", Base:"dq", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"a", Base:"h", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}}
+# 2024/09/24 20:40:20.939061 [TestBranchStateUncorruptible] [rapid] draw deletes: []string{"a", "bc", "cl", "hc", "f", "a", "bv", "f", "a", "g", "z", "sy", "e", "i", "a", "a", "n", "ba", "bb", "c", "a", "aa", "e", "xx", "w", "w", "e", "d", "p"}
+# 2024/09/24 20:40:20.939066 [TestBranchStateUncorruptible] try update: upsert and delete random branches
+# 2024/09/24 20:40:20.939070 [TestBranchStateUncorruptible] failed to upsert branch: name=b base=kk: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939070 [TestBranchStateUncorruptible] failed to upsert branch: name=gq base=n: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939071 [TestBranchStateUncorruptible] failed to upsert branch: name=a base=c: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939072 [TestBranchStateUncorruptible] failed to upsert branch: name=a base=g: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939073 [TestBranchStateUncorruptible] failed to upsert branch: name=ej base=io: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939073 [TestBranchStateUncorruptible] failed to upsert branch: name=p base=b: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939074 [TestBranchStateUncorruptible] failed to upsert branch: name=i base=k: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939075 [TestBranchStateUncorruptible] failed to upsert branch: name=e base=si: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939075 [TestBranchStateUncorruptible] failed to upsert branch: name=fy base=na: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939076 [TestBranchStateUncorruptible] failed to upsert branch: name=y base=dq: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939077 [TestBranchStateUncorruptible] failed to upsert branch: name=a base=h: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939078 [TestBranchStateUncorruptible] failed to delete branch: name=a: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939078 [TestBranchStateUncorruptible] failed to delete branch: name=bc: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939079 [TestBranchStateUncorruptible] failed to delete branch: name=cl: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939079 [TestBranchStateUncorruptible] failed to delete branch: name=hc: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939080 [TestBranchStateUncorruptible] failed to delete branch: name=f: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939081 [TestBranchStateUncorruptible] failed to delete branch: name=a: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939081 [TestBranchStateUncorruptible] failed to delete branch: name=bv: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939082 [TestBranchStateUncorruptible] failed to delete branch: name=f: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939083 [TestBranchStateUncorruptible] failed to delete branch: name=a: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939083 [TestBranchStateUncorruptible] failed to delete branch: name=g: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939084 [TestBranchStateUncorruptible] failed to delete branch: name=z: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939084 [TestBranchStateUncorruptible] failed to delete branch: name=sy: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939085 [TestBranchStateUncorruptible] failed to delete branch: name=e: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939086 [TestBranchStateUncorruptible] failed to delete branch: name=i: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939086 [TestBranchStateUncorruptible] failed to delete branch: name=a: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939087 [TestBranchStateUncorruptible] failed to delete branch: name=a: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939087 [TestBranchStateUncorruptible] failed to delete branch: name=n: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939088 [TestBranchStateUncorruptible] failed to delete branch: name=ba: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939089 [TestBranchStateUncorruptible] failed to delete branch: name=bb: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939089 [TestBranchStateUncorruptible] failed to delete branch: name=c: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939090 [TestBranchStateUncorruptible] failed to delete branch: name=a: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939090 [TestBranchStateUncorruptible] failed to delete branch: name=aa: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939091 [TestBranchStateUncorruptible] failed to delete branch: name=e: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939092 [TestBranchStateUncorruptible] failed to delete branch: name=xx: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939092 [TestBranchStateUncorruptible] failed to delete branch: name=w: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939093 [TestBranchStateUncorruptible] failed to delete branch: name=w: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939093 [TestBranchStateUncorruptible] failed to delete branch: name=e: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939094 [TestBranchStateUncorruptible] failed to delete branch: name=d: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939094 [TestBranchStateUncorruptible] failed to delete branch: name=p: upsert [0] "b": branch kk is not tracked
+# 2024/09/24 20:40:20.939103 [TestBranchStateUncorruptible] [rapid] draw action: "UpsertOne"
+# 2024/09/24 20:40:20.939105 [TestBranchStateUncorruptible] [rapid] draw branch: "al"
+# 2024/09/24 20:40:20.939106 [TestBranchStateUncorruptible] [rapid] draw base: "e"
+# 2024/09/24 20:40:20.939107 [TestBranchStateUncorruptible] try update: upsert random branch
+# 2024/09/24 20:40:20.939110 [TestBranchStateUncorruptible] upsert branch: name=al base=e
+# 2024/09/24 20:40:20.939120 [TestBranchStateUncorruptible] [rapid] draw action: "DeleteOne"
+# 2024/09/24 20:40:20.939121 [TestBranchStateUncorruptible] [rapid] draw branchToDelete: "f"
+# 2024/09/24 20:40:20.939122 [TestBranchStateUncorruptible] try update: delete random branch
+# 2024/09/24 20:40:20.939124 [TestBranchStateUncorruptible] delete branch: name=f
+# 2024/09/24 20:40:20.939133 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunkToKnownBranchFails"
+# 2024/09/24 20:40:20.939135 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "m"
+# 2024/09/24 20:40:20.939152 [TestBranchStateUncorruptible] [rapid] draw action: "DeleteOne"
+# 2024/09/24 20:40:20.939154 [TestBranchStateUncorruptible] [rapid] draw branchToDelete: "io"
+# 2024/09/24 20:40:20.939154 [TestBranchStateUncorruptible] try update: delete random branch
+# 2024/09/24 20:40:20.939160 [TestBranchStateUncorruptible] delete branch: name=io
+# 2024/09/24 20:40:20.939169 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunkToKnownBranchFails"
+# 2024/09/24 20:40:20.939171 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "al"
+# 2024/09/24 20:40:20.939187 [TestBranchStateUncorruptible] [rapid] draw action: "UpsertAndDeleteMany"
+# 2024/09/24 20:40:20.939193 [TestBranchStateUncorruptible] [rapid] draw upserts: []state.UpsertRequest{state.UpsertRequest{Name:"ay", Base:"m", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}, state.UpsertRequest{Name:"f", Base:"i", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}}
+# 2024/09/24 20:40:20.939199 [TestBranchStateUncorruptible] [rapid] draw deletes: []string{"cm"}
+# 2024/09/24 20:40:20.939200 [TestBranchStateUncorruptible] try update: upsert and delete random branches
+# 2024/09/24 20:40:20.939205 [TestBranchStateUncorruptible] failed to upsert branch: name=ay base=m: upsert [1] "f": branch i is not tracked
+# 2024/09/24 20:40:20.939206 [TestBranchStateUncorruptible] failed to upsert branch: name=f base=i: upsert [1] "f": branch i is not tracked
+# 2024/09/24 20:40:20.939207 [TestBranchStateUncorruptible] failed to delete branch: name=cm: upsert [1] "f": branch i is not tracked
+# 2024/09/24 20:40:20.939216 [TestBranchStateUncorruptible] [rapid] draw action: "UpsertAlwaysSuccess"
+# 2024/09/24 20:40:20.939218 [TestBranchStateUncorruptible] [rapid] draw branch: "ab"
+# 2024/09/24 20:40:20.939220 [TestBranchStateUncorruptible] [rapid] draw base: "al"
+# 2024/09/24 20:40:20.939221 [TestBranchStateUncorruptible] try update: upsert branch with known base
+# 2024/09/24 20:40:20.939225 [TestBranchStateUncorruptible] upsert branch: name=ab base=al
+# 2024/09/24 20:40:20.939293 [TestBranchStateUncorruptible] 
+# 	Error Trace:	/Users/abg/src/git-spice/internal/spice/state/branch_test.go:191
+# 	            				/Users/abg/go/pkg/mod/pgregory.net/rapid@v1.1.0/statemachine.go:63
+# 	            				/Users/abg/src/git-spice/internal/spice/state/branch_test.go:166
+# 	            				/Users/abg/go/pkg/mod/pgregory.net/rapid@v1.1.0/engine.go:368
+# 	            				/Users/abg/go/pkg/mod/pgregory.net/rapid@v1.1.0/engine.go:377
+# 	            				/Users/abg/go/pkg/mod/pgregory.net/rapid@v1.1.0/engine.go:203
+# 	            				/Users/abg/go/pkg/mod/pgregory.net/rapid@v1.1.0/engine.go:118
+# 	            				/Users/abg/src/git-spice/internal/spice/state/branch_test.go:127
+# 	Error:      	Not equal: 
+# 	            	expected: []string{"a", "ab", "al", "m"}
+# 	            	actual  : []string{"a", "ab", "al", "ay", "m"}
+# 	            	
+# 	            	Diff:
+# 	            	--- Expected
+# 	            	+++ Actual
+# 	            	@@ -1,2 +1,2 @@
+# 	            	-([]string) (len=4) {
+# 	            	+([]string) (len=5) {
+# 	            	  (string) (len=1) "a",
+# 	            	@@ -4,2 +4,3 @@
+# 	            	  (string) (len=2) "al",
+# 	            	+ (string) (len=2) "ay",
+# 	            	  (string) (len=1) "m"
+# 	Test:       	TestBranchStateUncorruptible
+# 	Messages:   	known branches does not match listed branches
+# 
+v0.4.8#15845916697181367193
+0x146a9b802e447b
+0x0
+0xa3521bf53a710
+0x3
+0x1fd4f09de2e4e6
+0x0
+0x1da13b70e68813
+0x2
+0x169559972645b8
+0xdeea6b55bcf7e
+0x11491246197c66
+0x3
+0x7ec0093cb42aa
+0x0
+0x2be944ad9fc5a
+0x0
+0xe56fab4599a64
+0xd7b3f9402578a
+0x0
+0xce14ad6c01f7c
+0x4d8cdc212ff10
+0x2
+0xdf7bfa8faabc3
+0x0
+0x1f24c595cb0879
+0xa
+0xf157f29e357f8
+0xb3bb1e81a2fb7
+0x8a58f66680008
+0x1
+0x116a20bb1a6c10
+0x0
+0x10e8b4e9338277
+0x3531395b8b1e6
+0x1
+0x589ad74207c49
+0x0
+0x1dc79a3cd8bb01
+0x39531ed8b5b49
+0x1
+0xec96e6ef9455a
+0x0
+0xc115db6034c13
+0xf73bf0297b7d0
+0x1
+0xb87b4ffe0b8cd
+0x0
+0x712b98b187c71
+0x1fd6fcc9120e04
+0xffffffffffffffff
+0x19aeb47a381995
+0x0
+0xb2d19976ef7e8
+0xf
+0x1b5e8bf71e39e2
+0x0
+0x1a965071bea0a2
+0xe
+0xfe6d2412eed78
+0x14b9df0dfd2f05
+0x0
+0x1674a2cd7e4987
+0x6
+0xb096e50354ccf
+0x1e7bfc9f0e2e3e
+0x18926b46c1e0f3
+0x5
+0xe7c06c370192c
+0x0
+0x12c8ac8787cfda
+0x2
+0xab76da3a2edc0
+0xdf95d5cd508f2
+0x0
+0x8901de4fc70ca
+0x6
+0x9bb87b149d462
+0x34f4adcfd6f1c
+0x1821f3a8d96ab9
+0x3
+0x7b300cb51f157
+0x0
+0x13456ce39f5960
+0xc
+0x785ee58c59178
+0x57b0c5f2ab405
+0x0
+0x19604f1c004f21
+0x918a82692a1ab
+0x7
+0x0
+0x13d97d34f29f5
+0x0
+0x11348b1b152dec
+0x5
+0xf332ec3e6085a
+0x642a62bfa1eb2
+0x2aef291189f2e
+0x0
+0x13b5408f84c18c
+0x0
+0xc44b72ac273e4
+0x7
+0x18987ff495dba2
+0x0
+0x13642cd46da55
+0x0
+0xf5ed61a06e35
+0x47660435d4a92
+0xf474d0b718b5f
+0x0
+0x181ac49376d52c
+0x0
+0x1f78367fc45725
+0xffffffffffffffff
+0x1e4f16d1f1a593
+0x0
+0xf79e5d6b1c355
+0x4
+0x137e625f0f2222
+0xf3e7869e4bb62
+0xa2e5878e6ceac
+0x1
+0x18b9ffa3b57e01
+0x1
+0x1866031d0eea71
+0xcdad6d876037f
+0x1
+0x15eeb836007689
+0x1
+0x140394f7f622d4
+0x1d45fe1021aee8
+0x5
+0x1306e732a92075
+0x0
+0xd6ce26a86700a
+0x1e
+0x7
+0x196b6402ec02fa
+0x0
+0x2c60bcd423525
+0x0
+0x1d03964a08ef96
+0x1ad42e2e98c251
+0x0
+0x1ee30ef1c61ae4
+0x4
+0x188a15dc647d3c
+0x0
+0xe45e862b693b4
+0x14
+0x110560220cb437
+0x16b98db5b6cf2b
+0x1f502bb4973289
+0xffffffffffffffff
+0x1b305613a41999
+0x0
+0x1a10a0813f3c32
+0x2
+0x1ec397d465ff25
+0x0
+0x42a564b503c12
+0x2
+0xf85fcbacc9d02
+0x162ae3df1d3a
+0x0
+0x94a035e73a37a
+0x7
+0x144e4341ab83e8
+0xe2e47f6788685
+0x19799ef84d45c1
+0x1
+0x828625747fb7e
+0x0
+0x1ae603228ad750
+0x1523bc55f8d287
+0x7
+0x0
+0x1e61e82d8d95ba
+0x0
+0x58975b3aab195
+0x0
+0x1d39548fa3f9b5
+0x0
+0x1993c76d1dc7ae
+0x1b
+0x1e
+0x19
+0x83c7b19de699
+0xcb1320a4c4195
+0x9d4afb3a14bdf
+0x1
+0x7ae72eb7987ed
+0x0
+0xe0a3e13d735d1
+0x7758b09a660ee
+0x6
+0x1
+0xf5d8ead249887
+0x1
+0xc9970c0603064
+0x82881b056723c
+0x4
+0x1434daf9dfc7e5
+0x136a1debc426dd
+0x0
+0x149766b63f1f3e
+0x8
+0x16411dca48b45
+0x11a9fbcf4af079
+0x0
+0x1ddc83e1a050b8
+0x15
+0x11d482653cead4
+0x1ade2a5fda7382
+0xc6e1c537634b3
+0x0
+0x733d2282202ef
+0x2
+0x1fa1349fb502cc
+0x0
+0x18732a649d5ca7
+0x0
+0xed5e24a18da9
+0x15fbc0b2d6f42a
+0x0
+0x186e49cc57a37
+0x1
+0xc60cf16dadd81
+0x1682d5e5defe0f
+0x10d3b202c02b4d
+0x0
+0x13c2b9a378c6b4
+0x16
+0xbcd716fc3665
+0x48dc7c9ac6142
+0x0
+0xc1ed5de01da05
+0x1c
+0xa
+0x1bf99c8f4e34b8
+0x0
+0x148166fea49684
+0x15
+0x893bf2027b92f
+0x19597759a9190a
+0x199565ed8bed99
+0x0
+0x168cd067760421
+0x1a
+0xe
+0x1036b68217a1cc
+0x153e12e747cb64
+0x0
+0x17a4743eded184
+0xe
+0x12ebf08717a7df
+0x1193d708412e67
+0xb5e077535860
+0x0
+0xbc65aeef013a7
+0x3
+0x3e16777f2087f
+0xdf3dc6afb23c
+0x0
+0x1fe21846f9f70b
+0xffffffffffffffff
+0x1ec90d8ea19a3f
+0x0
+0xf273a29baf70e
+0x9
+0x72c9a7bfa884
+0x1b0159acd0f19a
+0x41a46d4d02a09
+0x0
+0x108cc0fe8d3166
+0x15
+0x1ca56a11633025
+0x0
+0x199f9b2ea839d1
+0x0
+0xf91dd076b9209
+0x9486c35a0a06b
+0x0
+0x1dcdf31de21acf
+0x1c
+0x1c
+0xd
+0x109dbd89407d32
+0x904e7d1ce3d5d
+0x212a46cb74924
+0x0
+0x151e80ce560419
+0x0
+0x1e6f4909bd11e7
+0x0
+0x16f8a89f98fdd6
+0xa
+0xbe27bb60b4dd7
+0x299a64edcf069
+0x0
+0x7c925ab535dd5
+0x0
+0x1672515bac0643
+0x0
+0x16bfc3cdcc7dc8
+0x1d
+0x1c
+0xa
+0x12e709c8aab538
+0x11d02507928d86
+0x1d6aa5dd5e7498
+0x0
+0x1e8f705abe81a6
+0x16
+0x1b73039dd46c73
+0x0
+0xd04d56751d481
+0x9
+0x1ac67ed57996f6
+0x668f23f4d782b
+0x0
+0x84110a3c5f200
+0x5
+0x1b5078c94098f7
+0x0
+0x238a074ca5c1b
+0x1
+0x14f25cd081b856
+0x19c20aae3fd5b1
+0x6d4b5296b916a
+0x0
+0x397a6f126762d
+0x3
+0xc6e7c58df909d
+0x433af40533116
+0x0
+0x8dfc30e3a2115
+0x3
+0x1884e6454ceae5
+0x0
+0xeb4eab93bc624
+0xf
+0x1202a3b914cac9
+0x1683a68658dd42
+0x1c90865b42f659
+0x0
+0xb9454e45b5691
+0xb
+0x11f9e276e31227
+0x8ed4307fc6928
+0x0
+0x1f5df27f00cf23
+0xffffffffffffffff
+0x149736e6db0cc4
+0x1afafa834591f3
+0x1e71f5ee42b9d8
+0x0
+0xc764237b76a46
+0xe
+0xc2795e49cb642
+0x23ab97b5496ec
+0x0
+0x1b1a814850cedc
+0x15
+0x16a98bffb0dc52
+0x0
+0x1988d30adb6eb0
+0x15
+0x19be826c60ef95
+0x2ab9fdbfb7bb6
+0xe74051576ce7b
+0x1f7806f1f0767c
+0x0
+0x1afc6b223b9ca6
+0xf
+0x1ee8385ddfec92
+0x0
+0x9057653474b85
+0x1
+0xbca3793e2d210
+0xbc6b23274e7ea
+0x1ef3f7335a3c34
+0x0
+0xcc6d3c149d73f
+0xd
+0xe82e60746895c
+0x1855e4bd1c4ef1
+0x10ddf9cfd152dd
+0x0
+0x75ddf4cea043a
+0x5
+0x3d798ff14a235
+0xd7559fe5d7b9b
+0x12d61dc0852d6d
+0x0
+0x418f5497432d6
+0x1
+0x5c979358bb2ae
+0x3a8569b5430a9
+0xb2068d23c0695
+0x1a700d6e63e49c
+0x5
+0x813ec97c70ae
+0x0
+0x76b195030aede
+0x5
+0x38376558bdb41
+0x123f906a858347
+0x0
+0xad2bc5596e0df
+0x3
+0x1d701170fff808
+0x0
+0x84a40c716f808
+0x6
+0xb676984958d4f
+0xf22d406e33ecd
+0x72f7a63b76c5
+0x0
+0x1faf10f4fa7492
+0x0
+0x15c093bc7f2513
+0xc
+0x71362c6ac6a81
+0x1510f3968f6ad2
+0x1566b3d4e17626
+0x4
+0xa54324d0ea1c6
+0x18a4920c219c1c
+0x0
+0xab549344ba662
+0x7
+0x16dce2621e221c
+0x0
+0x1d061c03d75dac
+0xe
+0x1ac78eb71e32b1
+0x630cf6d59cb6
+0x0
+0x9fa96d17f92fd
+0x1
+0xa3ab05cb85d2b
+0x1f583407a205b2
+0x16cf9553983f9e
+0x0
+0x1d0b5ffaeb10e6
+0x3
+0x1c09930d439d37
+0x0
+0x1ce7ef74d0f45d
+0x1c
+0x17
+0x877826f651626
+0x1d03ba799f7afe
+0x0
+0xcacac99cff111
+0x19
+0x86ef058f47b19
+0x167ee9552a135b
+0x1ba1c10009a0a5
+0x0
+0x17ea68f2d59e2b
+0xb
+0x8a6a0b71e241f
+0xa278eb66bdff0
+0x0
+0x18a2fdf103411f
+0xc
+0xe8f137e3ed082
+0x11773eb64b910d
+0x14adcf85c400d2
+0x0
+0x17869bd397ddd4
+0xe
+0x1ce98ff7207d23
+0x0
+0xa5b45f5c26f99
+0x5
+0x2b32718d840df
+0x9b8a1eb1d9c2a
+0x0
+0x1c510d849faae8
+0x1d
+0xb
+0x51baeb4cac195
+0x196a6ddbc7dba3
+0x6164b7074235a
+0x0
+0x5d769a3d4b83
+0x1
+0xf24e4f24fb69d
+0x61b844717ed28
+0x0
+0x41e4c654fddc9
+0x2
+0x155fc62d73b7b8
+0x0
+0x2c9818d35b5ef
+0x0
+0x1e3c67208cc73d
+0x13abbf3f170a5d
+0x1a2bc8eac28d8d
+0x0
+0x1ad05b806d2ff
+0x1
+0xc9e123f1e970c
+0x1dd6ea0e41a464
+0x0
+0x3bc39f0f9771c
+0x3
+0xf2faadeb7b61
+0x7f615c0dcd2ad
+0x412eef45c2c78
+0x0
+0xb60eb793889a8
+0x7
+0x1741ba0efde0c9
+0x0
+0x26e9ae959914
+0x0
+0x156dfd699fa36e
+0xa908f00863bad
+0x0
+0x1d0658fc3da977
+0x7
+0x1e4cbedf689ca5
+0x0
+0xd41794322d00e
+0x9
+0x27d246716c602
+0x1022d9189419a9
+0x1701fbb6104197
+0x0
+0x5230e20b9996a
+0x3
+0x1459d143550416
+0x55c9ac03f17ce
+0x0
+0x509e760693a9e
+0x2
+0x87898e3b5a20b
+0x86e85b9635d58
+0x1631bd6a4dabdd
+0x0
+0x73f007591ad4c
+0x0
+0x434a08e2118c9
+0xe48c6f82d5000
+0x0
+0x425e2ada5bef6
+0x0
+0x1051a6cdf16e47
+0x1bad66ae634226
+0xfd73a43d69f0d
+0x0
+0x16f7acf054e55a
+0x18
+0x1868d85cc5f26d
+0x0
+0x13d5519e9e007b
+0x16
+0x196a3950f01394
+0x14498c852161eb
+0x0
+0x863a5e3e900c7
+0x2
+0xdd0c3894f1af8
+0x11061954f37d1b
+0x1e5786e84910ac
+0x0
+0xce2eb32d7dbe1
+0x15
+0xde511c68710c3
+0x1c46a5eecdeaca
+0x0
+0x19af6495582081
+0x0
+0x85e58cd60230d
+0x4ae51679ffb7e
+0x692cb44e8142f
+0x1994bd8d605b86
+0x0
+0xd7c383a6e280f
+0x13
+0xab6d58e6512a3
+0x1be8e6e29f1aad
+0x149a1b8fb59653
+0x0
+0x14f2f57b165b9d
+0xc
+0x823fa23088f09
+0x26a73f09aa1d
+0x13855f0a7b448b
+0x129771cfa52aad
+0x6
+0x2
+0x1dca6d2f5d96d2
+0x0
+0x1a23362c8528ce
+0x19
+0x34d05924d8b1f
+0x10491f05daeac4
+0xd94d0a23f0486
+0x0
+0xecd526f80a177
+0x0
+0x9b4bda56a0140
+0x4
+0x1283fe5e55d330
+0x3c2cfac532ae6
+0x272d467fb34
+0x1
+0x1ae6f270c37ab5
+0x1
+0x1795993a0cae5
+0x172ff4f4090f63
+0x5
+0xbb30d542e4b1b
+0x0
+0xcee7ed09be2f6
+0xb
+0x104ea0d2b7adce
+0x8c10151701ce9
+0x0
+0x14d50c59b657a0
+0x1
+0xcb95e2f3b18c
+0x1d96911f55b18d
+0xbcc61e26b9b53
+0x2
+0x7ab6d6b794b9a
+0x0
+0x4b8f7c056e2f9
+0x0
+0xabb170a2ae7ee
+0x164ef54bcc229b
+0x1ef9f091e0ae7c
+0x4
+0xbb158a218d61f
+0x15f91c88f0a347
+0x0
+0x4375fe3ad6ea7
+0x1
+0x771c7bb73e78e
+0x1bb8ea5ffb47cb
+0x0
+0x1d891a5b531d9d
+0xa
+0x17c9fcc63e0cfc
+0x0
+0x161ac23173fa18
+0xa
+0x1971c07f4dcb52
+0x19b94d6f499d06
+0x10ab8e9fe9d0d1
+0x0
+0x902ffb561dc8c
+0x6
+0x16e8cae9ed5f26
+0x0
+0x1d7a21bc07a292
+0x10
+0xbffc8cf383999
+0x1753f9efba3307
+0x0
+0x19d4c406ef7cd0
+0xd
+0x1059111e67d477
+0x1d3c8f06bf1f0e
+0x2093f2c10135e
+0x0
+0x130fbbd9e650b3
+0x0
+0x125850ab3f7b02
+0x172f40bb7c02ea
+0x0
+0x60a6575a3d2f3
+0x2
+0xe4f05bf7168db
+0x1279c2a82aab3a
+0x11ce11b4e60064
+0x0
+0x18a99a95f718e7
+0x0
+0xcd825899637a0
+0x7a66710c64c9c
+0x0
+0xbab06f43dec35
+0x6
+0x10945be5628e99
+0x1cf9d333e760cf
+0x2e1b74e44b83d
+0x0
+0x100d3fc468edf6
+0x4
+0x1fe8a9709afa8a
+0x0
+0x12759fc1583307
+0x9
+0x1bbed51026dae3
+0x117bdf380dce76
+0x0
+0xf42517ec90a57
+0x8
+0x1922f15bdd16e5
+0x0
+0x1b4e9450c726c1
+0x1b
+0xe
+0x140e1520c47279
+0x18882026c7c910
+0x1cf079a888b89d
+0x0
+0xcf72ac42d6dc6
+0x1b
+0xf
+0x4286379e9c450
+0x1dd852c7f16a8a
+0x0
+0x473f2cc816388
+0x1
+0xad8604f011378
+0x16324fd5edca52
+0x1d79b1077e7ae4
+0x0
+0x1768b5e9807b42
+0x8
+0xf0cbc7606ec39
+0xed731223180ca
+0x0
+0xe81947dbd0233
+0xa
+0xce73f2815008a
+0x13089e6887a13a
+0x1a6881825b467a
+0x0
+0x7f11ebf893430
+0x4
+0x1532be9ffe5c68
+0x55bff3989ef51
+0x0
+0xd9e1db5463c8a
+0x12
+0x15da1c56037261
+0x0
+0x9f72375732aa0
+0x8
+0x75344e2bc415e
+0x122a7a42660984
+0x1eaef5ebb7860f
+0x0
+0x1a50cbd986192c
+0x5
+0x1f3a94a453cefe
+0x0
+0x1dff838888657d
+0x18
+0x212b07246e856
+0xbea7cb36735ee
+0x0
+0x149b490dca16ee
+0xd
+0x17840d9b97f0af
+0x0
+0x3ef637fc85d1c
+0x0
+0x1f70e0b4c89896
+0x174582cd07e863
+0x11229a59b9b1f9
+0x0
+0x14f038a67a562a
+0x18
+0x10eb16047d0fb1
+0x155cd3376da937
+0x0
+0x7665eb330edaa
+0x3
+0x18828dcd6e7fd6
+0x0
+0x1bcbe3138c23a6
+0x10
+0xd19b0067b213a
+0x17db47eaaee842
+0x1f900f073c160a
+0x0
+0x4737b82a2d5ef
+0x0
+0x11f7069b2f1bdc
+0xfe7c70bfa77c8
+0x0
+0x153a639c5438f9
+0x7
+0x7a08cc841a858
+0xd44384459e1
+0xe6d3ee75ffc4a
+0xa548b71d6336b
+0x0
+0x72addee6af485
+0x0
+0xc621ac0b6093b
+0x9655e2064aa26
+0x1e31baec2e019c
+0x0
+0x36d72f93a61d1
+0x1
+0x1cee826123d48e
+0x0
+0x7bdd64b5fce72
+0x2
+0xb04ec49dc369e
+0x1c4fe91125454b
+0x1f9287efdb855b
+0x0
+0x45c03ecc1311d
+0x2
+0x1fb77f66631554
+0x0
+0xa8516729aa3d9
+0xb
+0x17d17015a078a2
+0x13b7e3577ae733
+0x4ead83451d30f
+0x0
+0x18fa85d52bf878
+0x7
+0x1b12667bc8f20f
+0x0
+0xb8aa9983a20fc
+0x2
+0x12e2ea7a706f22
+0xb0004382bd396
+0x441cbbb938359
+0x0
+0x1b51d849af933d
+0x5
+0xe0f1dbf4f0f81
+0x1a5d221dd9750d
+0x18cdb285f8d722
+0x0
+0x54cdcd2af7180
+0x0
+0x10824b7ccb28aa
+0x18d1bf676685d8
+0x148ae4eae8c356
+0x0
+0x2246b7381c7ab
+0x1
+0x19725c9bc9e458
+0x0
+0x156eaccf498ab5
+0x15
+0x19aeaaea6dc7a0
+0x1955798496e471
+0x15b3768386038f
+0x0
+0x10ba1bc2f50797
+0x5
+0x13b4c9ee8e8956
+0x15f18874289180
+0x1e7fdec8ae9b2
+0x0
+0x675762aca3e32
+0x0
+0x9226844de4ba5
+0x13d27002c8fea1
+0xd883627678fd7
+0x0
+0xbea3ca85e7787
+0x6
+0xa945550eee111
+0x10b9111309116d
+0x2aa59298afe32
+0x0
+0x1fb22b7ff7e94a
+0xffffffffffffffff
+0x62368ecee411b
+0x1494a17b85d46c
+0xb881dce60977e
+0x0
+0x1b336160f3ebda
+0x12
+0x16672634fed13e
+0x0
+0xf9bf61594209b
+0x18
+0x117635eb384435
+0x7f92d4e6c0d7d
+0x151d0532c8917a
+0x0
+0x6f6623e01c3a3
+0x4
+0x35c4090a22c21
+0x13f4b4996583ab
+0x18b5ff21994b48
+0x0
+0x1e94b80111f61d
+0x8
+0x1231c8466e4af4
+0x7cb9f2c8611b7
+0xfe552537e05f3
+0x0
+0x3d6c512daf693
+0x0
+0xb25eb12feb7cf
+0xa577a8464ff9e
+0x15ac1b40a9e6f2
+0x0
+0x1203699632d2a
+0x0
+0x8a260d997e91c
+0xe7c25bb8f2ae9
+0x4e1fab756ac47
+0x0
+0xbc91d8eefc930
+0xd
+0x13ba16c91d4f8a
+0xcdc3b638b3a2c
+0x13d3d57dd71145
+0x0
+0x167986d71707a
+0x1
+0x1c85551304c861
+0x0
+0x633de6794558e
+0x0
+0x1d89453a62c774
+0x1093156592ac05
+0x11a2b4e12bda01
+0x0
+0x3f4b676efd337
+0x1
+0x1f53b893ec478d
+0x0
+0xe9762d19e1c0
+0x1
+0x1e7512714b113d
+0x16865bc7a15484
+0x38c28df35999d
+0x0
+0x6eff1a658f6cc
+0x2
+0xbcbc1e615e315
+0x1838d0c5129699
+0xe06cadb92147f
+0x0
+0x552d8becfd69
+0x0
+0xa61fc717684fd
+0x11806f2cd462cf
+0xaf7b3b1fc6d3e
+0x0
+0x1d8b41b241f3d4
+0x0
+0x16c5bfed911462
+0x0
+0x1b4f5db0f2fa00
+0x1e
+0x1b
+0x0
+0x1cd43c94e06814
+0x13dc2d10b7a355
+0x18a7f323275278
+0x0
+0x107372f128eae4
+0x4
+0x9d7a6600a50b7
+0x1ae0f8e7401166
+0x13b2b73beb93ca
+0x0
+0xee9d61c1fd55a
+0x17
+0x16339fcce5c9e7
+0x0
+0x1173ba9f5df1a3
+0x17
+0x5220924da5131
+0x1c284b2b61e6bf
+0x10ac8fe53e3bd
+0x0
+0x1c829c70881e32
+0x16
+0xa8c8e7ecc5ef2
+0x1936e3a15392f7
+0x1cf7b453b83a2a
+0x0
+0x13ebe6a9c4b2aa
+0x16
+0x155205dd9f5823
+0xb1aa9db919416
+0xcc6953bb1aa0
+0x0
+0xab111487e8cb3
+0x4
+0x279590591c135
+0x6fd2bb45b7a48
+0x143edba9c8b6e9
+0x0
+0x6546aa251fa3a
+0x3
+0x1448fab5cbc2cb
+0x1791d07cff121e
+0xd37e84eeeeebc
+0x0
+0x1bc7f86d54a093
+0xf
+0x133dbee44cc4e4
+0x28c47ed207341
+0x78a1c95fb21d3
+0x1692c56e8ab7e3
+0x5
+0x80588b37457f5
+0x0
+0xc6ebcaaaee2cb
+0x0
+0x1b5452695878dd
+0x0
+0xf5368428caab5
+0xb
+0x1644e9eba3d78d
+0x23de4ecee8075
+0x0
+0x1c794886bf97ff
+0x4
+0xe4e4cbc23843c
+0xff721c8552d5d
+0x5cb909ea47ab7
+0x2
+0x1201481e6ca2c8
+0x0
+0xb143f2790f81c
+0x5
+0x1527857fb0fc46
+0x45eba46ccaee8
+0x254bd8d479165
+0x1
+0xe64372b9e6a49
+0x3
+0x3
+0x1
+0x12f4d400c3897e
+0x184cf3f21eefaf
+0x2
+0x3807334c5aa0f
+0x0
+0x1e7b65e2b3cd21
+0x8
+0x1cc41eab893b99
+0x0
+0x19b2d090c5cdca
+0x1c
+0xe
+0x1c44fe1d0370d
+0xba5fc41f55bed
+0x38ed253b8509d
+0x1
+0xc893b45df10ae
+0x2
+0x13a03fcb63fb57
+0x1daface200bc24
+0x4
+0x130beeed9649c6
+0x1673168403dac0
+0x0
+0xc4eb42cfdde4
+0x0
+0x1df3c38c514b85
+0x0
+0x1c245ce162ee73
+0x18
+0x11f09714fc25f
+0x1313abdf5c977f
+0x0
+0x1c35bafd81623f
+0x1d
+0xc
+0x2c9d66de91cad
+0x1ea7f77d7178a6
+0xa92743c091e40
+0x0
+0x9586a254d0068
+0x5
+0xe3c5d522d57fa
+0xb84d0a9430b38
+0x0
+0x16e93d4ba82c61
+0x8
+0x13e39cb3119e07
+0x1ebcad56cb3c6
+0x978b4a692a74f
+0x162e54eb936c74
+0x0
+0x1928243b23f316
+0x2
+0x1f51a0355919f1
+0x0
+0x11a23bc7dd8c9b
+0x1f
+0xc
+0xf78b41a215d1a
+0x2d01a9332c8cd
+0x5ae8810f325c3
+0x1b7d6c21423f87
+0x3
+0x5f7db1cc903be
+0x0
+0x1eac2cc80e5b5b
+0x0
+0x19b2a43c0c7b80
+0x0
+0x3f33a105b193f
+0x1
+0x1bc65005b17c11
+0xa4bd6df49cebe
+0x2

--- a/internal/spice/state/testdata/rapid/TestBranchStateUncorruptible/TestBranchStateUncorruptible-20240927055400-19887.fail
+++ b/internal/spice/state/testdata/rapid/TestBranchStateUncorruptible/TestBranchStateUncorruptible-20240927055400-19887.fail
@@ -1,0 +1,115 @@
+# 2024/09/27 05:54:00.641364 [TestBranchStateUncorruptible] [rapid] draw trunk: "a"
+# 2024/09/27 05:54:00.641374 [TestBranchStateUncorruptible] [rapid] draw action: "ChangeTrunk"
+# 2024/09/27 05:54:00.641375 [TestBranchStateUncorruptible] [rapid] draw newTrunk: "d"
+# 2024/09/27 05:54:00.641378 [TestBranchStateUncorruptible] changed trunk to "d"
+# 2024/09/27 05:54:00.641380 [TestBranchStateUncorruptible] [rapid] draw action: "UpsertAlwaysSuccess"
+# 2024/09/27 05:54:00.641381 [TestBranchStateUncorruptible] [rapid] draw branch: "a"
+# 2024/09/27 05:54:00.641381 [TestBranchStateUncorruptible] [rapid] draw base: "d"
+# 2024/09/27 05:54:00.641381 [TestBranchStateUncorruptible] try update: upsert branch with known base
+# 2024/09/27 05:54:00.641383 [TestBranchStateUncorruptible] upsert branch: name=a base=d
+# 2024/09/27 05:54:00.641386 [TestBranchStateUncorruptible] [rapid] draw action: "UpsertAndDeleteManyTx"
+# 2024/09/27 05:54:00.641387 [TestBranchStateUncorruptible] [rapid] draw operations: 3
+# 2024/09/27 05:54:00.641387 [TestBranchStateUncorruptible] [rapid] draw operation: "delete"
+# 2024/09/27 05:54:00.641387 [TestBranchStateUncorruptible] [rapid] draw branchToDelete: "a"
+# 2024/09/27 05:54:00.641388 [TestBranchStateUncorruptible] deleted branch "a"
+# 2024/09/27 05:54:00.641389 [TestBranchStateUncorruptible] [rapid] draw operation: "delete"
+# 2024/09/27 05:54:00.641389 [TestBranchStateUncorruptible] [rapid] draw branchToDelete: "a"
+# 2024/09/27 05:54:00.641389 [TestBranchStateUncorruptible] failed to delete branch "a": does not exist in store
+# 2024/09/27 05:54:00.641390 [TestBranchStateUncorruptible] [rapid] draw operation: "upsert"
+# 2024/09/27 05:54:00.641390 [TestBranchStateUncorruptible] [rapid] draw upsert: state.UpsertRequest{Name:"a", Base:"d", BaseHash:"", ChangeMetadata:json.RawMessage(nil), ChangeForge:"", UpstreamBranch:""}
+# 2024/09/27 05:54:00.641394 [TestBranchStateUncorruptible] upserted branch "a" with base "d"
+# 2024/09/27 05:54:00.641417 [TestBranchStateUncorruptible] 
+# 	Error Trace:	/Users/abg/src/git-spice/internal/spice/state/branch_test.go:366
+# 	            				/Users/abg/go/pkg/mod/pgregory.net/rapid@v1.1.0/statemachine.go:63
+# 	            				/Users/abg/src/git-spice/internal/spice/state/branch_test.go:341
+# 	            				/Users/abg/go/pkg/mod/pgregory.net/rapid@v1.1.0/engine.go:368
+# 	            				/Users/abg/go/pkg/mod/pgregory.net/rapid@v1.1.0/engine.go:377
+# 	            				/Users/abg/go/pkg/mod/pgregory.net/rapid@v1.1.0/engine.go:203
+# 	            				/Users/abg/go/pkg/mod/pgregory.net/rapid@v1.1.0/engine.go:118
+# 	            				/Users/abg/src/git-spice/internal/spice/state/branch_test.go:302
+# 	Error:      	Not equal: 
+# 	            	expected: []string{"a"}
+# 	            	actual  : []string(nil)
+# 	            	
+# 	            	Diff:
+# 	            	--- Expected
+# 	            	+++ Actual
+# 	            	@@ -1,4 +1,2 @@
+# 	            	-([]string) (len=1) {
+# 	            	- (string) (len=1) "a"
+# 	            	-}
+# 	            	+([]string) <nil>
+# 	            	 
+# 	Test:       	TestBranchStateUncorruptible
+# 	Messages:   	known branches does not match listed branches
+# 2024/09/27 05:54:00.641436 [TestBranchStateUncorruptible] 
+# 	Error Trace:	/Users/abg/src/git-spice/internal/spice/state/branch_test.go:388
+# 	            				/Users/abg/src/git-spice/internal/spice/state/branch_test.go:379
+# 	            				/Users/abg/go/pkg/mod/pgregory.net/rapid@v1.1.0/statemachine.go:63
+# 	            				/Users/abg/src/git-spice/internal/spice/state/branch_test.go:341
+# 	            				/Users/abg/go/pkg/mod/pgregory.net/rapid@v1.1.0/engine.go:368
+# 	            				/Users/abg/go/pkg/mod/pgregory.net/rapid@v1.1.0/engine.go:377
+# 	            				/Users/abg/go/pkg/mod/pgregory.net/rapid@v1.1.0/engine.go:203
+# 	            				/Users/abg/go/pkg/mod/pgregory.net/rapid@v1.1.0/engine.go:118
+# 	            				/Users/abg/src/git-spice/internal/spice/state/branch_test.go:302
+# 	Error:      	Received unexpected error:
+# 	            	load branch "a": does not exist in store
+# 	Test:       	TestBranchStateUncorruptible
+# 	Messages:   	lookup branch "a" (path: [a])
+# 
+v0.4.8#3918114873337884568
+0x0
+0x0
+0x0
+0x0
+0x0
+0x1084210842108
+0x0
+0x0
+0x0
+0x0
+0x38e38e38e38e4
+0x3
+0x0
+0x1084210842108
+0x6b74f03291620
+0x4
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x1084210842108
+0x6b74f03291620
+0x6
+0x0
+0x38e38e38e38e4
+0x3
+0x0
+0x1
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x1
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x0
+0x38e38e38e38e4
+0x3
+0x0


### PR DESCRIPTION
Instead of building and discarding the branch graph for UpdateBranch,
provide a BranchTx API to prepare changes to the branch state.

Required state will be loaded lazily as needed for the underlying checks.
Changes will be accumulated in the BranchTx until Commit is called.

For now, the old UpdateBranch method just wraps BranchTx.
We'll delete it in the future and use BranchTx directly everywhere.

[skip changelog]: No user facing changes.J ust a better version of #419.