### PR TITLE
branch create: Don't create or commit if store would reject

### DIFF
--- a/.changes/unreleased/Fixed-20240927-074731.yaml
+++ b/.changes/unreleased/Fixed-20240927-074731.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'branch create: Don''t commit staged changes if git-spice is unable to save the branch to its internal storage.'
+time: 2024-09-27T07:47:31.749911-07:00

--- a/testdata/script/branch_create_over_untracked.txt
+++ b/testdata/script/branch_create_over_untracked.txt
@@ -17,7 +17,18 @@ git commit -m 'Add feature 1'
 git add feat2.txt
 ! gs bc feat2 -m 'Add feature 2'
 
+git graph --branches
+cmp stdout $WORK/golden/branch-graph.txt
+
+git status --porcelain
+cmp stdout $WORK/golden/status.txt
+
 -- repo/feat1.txt --
 feature 1
 -- repo/feat2.txt --
 feature 2
+-- golden/branch-graph.txt --
+* b6be74c (HEAD -> feat1) Add feature 1
+* 7cee8ef (main) Initial commit
+-- golden/status.txt --
+A  feat2.txt


### PR DESCRIPTION
By using the new BranchTx API,
we're able to check whether the store will accept the change
before we actually create the branch.

So, we now first prepare the transaction with the new branch state,
and only if that succeeds do we actually create the branch.

This way, if the store would reject the change
because the base branch is untracked or something similar,
we'll roll back to the original target branch and staged changes.