### PR TITLE
forge/github: Recognize ssh://git@ssh.github.com:443 URLs

### DIFF
--- a/.changes/unreleased/Fixed-20240928-110233.yaml
+++ b/.changes/unreleased/Fixed-20240928-110233.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'github: Recognize remote URLs in the form `ssh://git@ssh.github.com:443/org/repo`.'
+time: 2024-09-28T11:02:33.331213-07:00

--- a/internal/forge/github/forge_test.go
+++ b/internal/forge/github/forge_test.go
@@ -111,6 +111,20 @@ func TestExtractRepoInfo(t *testing.T) {
 			wantOwner: "example",
 			wantRepo:  "repo",
 		},
+		{
+			// https://github.com/abhinav/git-spice/issues/425
+			name:      "ssh protocol with port",
+			give:      "ssh://git@ssh.github.com:443/mycompany/myrepo.git",
+			wantOwner: "mycompany",
+			wantRepo:  "myrepo",
+		},
+		{
+			name:      "ssh protocol with custom port",
+			githubURL: "ssh://git@ssh.mygithub.example.com:1443",
+			give:      "ssh://git@ssh.mygithub.example.com:1443/mycompany/myrepo",
+			wantOwner: "mycompany",
+			wantRepo:  "myrepo",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
ssh://git@ssh.github.com:443/foo/bar.git is a valid GitHub URL.
Add handling for this: strip the port if it's a default port
*and* the base URL doesn't specify a port.

Resolves #425