### PR TITLE
repo sync: Handle many merged, branch delete: support multiple

### DIFF
--- a/.changes/unreleased/Changed-20240928-162434.yaml
+++ b/.changes/unreleased/Changed-20240928-162434.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'branch delete: Accept multiple branches for deletion.'
+time: 2024-09-28T16:24:34.055862-07:00

--- a/.changes/unreleased/Fixed-20240928-162724.yaml
+++ b/.changes/unreleased/Fixed-20240928-162724.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'repo sync: Fix case when many branches from the same stack are merged, and order of deletion causes a restacking error or conflict.'
+time: 2024-09-28T16:27:24.379249-07:00

--- a/.changes/unreleased/Fixed-20240928-162826.yaml
+++ b/.changes/unreleased/Fixed-20240928-162826.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'repo sync: Reduce the number of redundant operations performed when processing multiple merged branches.'
+time: 2024-09-28T16:28:26.362279-07:00

--- a/branch.go
+++ b/branch.go
@@ -18,7 +18,7 @@ type branchCmd struct {
 
 	// Creation and destruction
 	Create branchCreateCmd `cmd:"" aliases:"c" help:"Create a new branch"`
-	Delete branchDeleteCmd `cmd:"" aliases:"d,rm" help:"Delete a branch"`
+	Delete branchDeleteCmd `cmd:"" aliases:"d,rm" help:"Delete branches"`
 	Fold   branchFoldCmd   `cmd:"" aliases:"fo" help:"Merge a branch into its base"`
 	Split  branchSplitCmd  `cmd:"" aliases:"sp" help:"Split a branch on commits"`
 

--- a/branch_delete.go
+++ b/branch_delete.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/must"
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
@@ -14,18 +17,17 @@ import (
 )
 
 type branchDeleteCmd struct {
-	Force  bool   `help:"Force deletion of the branch"`
-	Branch string `arg:"" optional:"" help:"Name of the branch to delete" predictor:"branches"`
+	Force    bool     `help:"Force deletion of the branch"`
+	Branches []string `arg:"" optional:"" help:"Names of the branches to delete" predictor:"branches"`
 }
 
 func (*branchDeleteCmd) Help() string {
 	return text.Dedent(`
-		The deleted branch and its commits are removed from the stack.
-		Branches above the deleted branch are rebased onto
-		the next branch downstack.
+		The deleted branches and their commits are removed from the stack.
+		Branches above the deleted branches are rebased onto
+		the next branches available downstack.
 
-		A prompt will allow selecting the target branch.
-		Provide a name as an argument to skip the prompt.
+		A prompt will allow selecting the target branch if none are provided.
 	`)
 }
 
@@ -35,7 +37,7 @@ func (cmd *branchDeleteCmd) Run(ctx context.Context, log *log.Logger, opts *glob
 		return err
 	}
 
-	if cmd.Branch == "" {
+	if len(cmd.Branches) == 0 {
 		// If a branch name is not given, prompt for one;
 		// assuming we're in interactive mode.
 		if !opts.Prompt {
@@ -47,7 +49,7 @@ func (cmd *branchDeleteCmd) Run(ctx context.Context, log *log.Logger, opts *glob
 			currentBranch = ""
 		}
 
-		cmd.Branch, err = (&branchPrompt{
+		branch, err := (&branchPrompt{
 			Disabled: func(b git.LocalBranch) bool {
 				return b.Name == store.Trunk()
 			},
@@ -57,37 +59,73 @@ func (cmd *branchDeleteCmd) Run(ctx context.Context, log *log.Logger, opts *glob
 		if err != nil {
 			return fmt.Errorf("select branch: %w", err)
 		}
+
+		cmd.Branches = []string{branch}
 	}
 
-	tracked, exists := true, true
-	var head git.Hash
-	base := store.Trunk()
-	if b, err := svc.LookupBranch(ctx, cmd.Branch); err != nil {
-		if delErr := new(spice.DeletedBranchError); errors.As(err, &delErr) {
-			exists = false
-			log.Info("branch has already been deleted", "branch", cmd.Branch)
-		} else if errors.Is(err, state.ErrNotExist) {
-			tracked = false
-			log.Debug("branch is not tracked", "error", err)
-			log.Info("branch is not tracked: deleting anyway", "branch", cmd.Branch)
+	type branchInfo struct {
+		Name string
+
+		Tracked bool
+		Base    string // base branch (may be unset if untracked)
+
+		Head   git.Hash // head hash (set only if exists)
+		Exists bool
+	}
+
+	// name to branch info
+	branchesToDelete := make(map[string]*branchInfo, len(cmd.Branches))
+	for _, branch := range cmd.Branches {
+		base := store.Trunk()
+		tracked, exists := true, true
+
+		var head git.Hash
+		if b, err := svc.LookupBranch(ctx, branch); err != nil {
+			if delErr := new(spice.DeletedBranchError); errors.As(err, &delErr) {
+				exists = false
+				base = delErr.Base
+				log.Info("branch has already been deleted", "branch", branch)
+			} else if errors.Is(err, state.ErrNotExist) {
+				tracked = false
+				log.Debug("branch is not tracked", "error", err)
+				log.Info("branch is not tracked: deleting anyway", "branch", branch)
+			} else {
+				return fmt.Errorf("lookup branch %v: %w", branch, err)
+			}
 		} else {
-			return fmt.Errorf("lookup branch %v: %w", cmd.Branch, err)
+			head = b.Head
+			base = b.Base
+			must.NotBeBlankf(base, "base branch for %v must be set", branch)
+			must.NotBeBlankf(head.String(), "head commit for %v must be set", branch)
 		}
-	} else {
-		head = b.Head
-		base = b.Base
-	}
 
-	if exists && head == "" {
-		hash, err := repo.PeelToCommit(ctx, cmd.Branch)
-		if err != nil {
-			return fmt.Errorf("peel to commit: %w", err)
+		// Branch is untracked, but exists.
+		if exists && head == "" {
+			hash, err := repo.PeelToCommit(ctx, branch)
+			if err != nil {
+				return fmt.Errorf("peel to commit: %w", err)
+			}
+			head = hash
 		}
-		head = hash
+
+		branchesToDelete[branch] = &branchInfo{
+			Name:    branch,
+			Head:    head,
+			Base:    base,
+			Tracked: tracked,
+			Exists:  exists,
+		}
 	}
 
 	// upstack restack changes the current branch.
-	// Restore the current branch (or its base) after the operation.
+	// checkoutTarget specifiest he branch we'll check out after deletion.
+	// The logic for this is as follows:
+	//
+	//  - if in detached HEAD state, use the current commit
+	//  - if the current branch is not being deleted, use that
+	//  - if the current branch is being deleted,
+	//     - if there are multiple branches, use trunk
+	//     - if there is only one branch, use its base
 	//
 	// TODO: Make an 'upstack restack' spice.Service method
 	// that won't leave us on the wrong branch.
@@ -97,50 +135,79 @@ func (cmd *branchDeleteCmd) Run(ctx context.Context, log *log.Logger, opts *glob
 			return fmt.Errorf("get current branch: %w", err)
 		}
 
-		// We still want to check out the original branch
-		// if we're in detached HEAD state.
 		head, err := repo.PeelToCommit(ctx, "HEAD")
 		if err != nil {
 			return fmt.Errorf("peel to commit: %w", err)
 		}
 
+		// In detached HEAD state, use the current commit.
 		checkoutTarget = head.String()
 	} else {
-		if cmd.Branch == currentBranch {
-			checkoutTarget = base
-		} else {
-			checkoutTarget = currentBranch
+		checkoutTarget = currentBranch
+
+		// Current branch is being deleted.
+		// If there are multiple branches, use trunk.
+		if slices.Contains(cmd.Branches, currentBranch) {
+			// If current branch is being deleted,
+			// pick a different branch to check out.
+			if len(branchesToDelete) == 1 {
+				info, ok := branchesToDelete[currentBranch]
+				must.Bef(ok, "current branch %v not found in branches to delete", currentBranch)
+				checkoutTarget = info.Base
+			} else {
+				// Multiple branches are being deleted.
+				// Use trunk.
+				checkoutTarget = store.Trunk()
+			}
 		}
 	}
 
-	// If this branch is tracked,
-	// move the the branches above this one to its base
-	// without including its own changes.
-	//
-	// Only then will we update internal state.
-	if tracked {
-		aboves, err := svc.ListAbove(ctx, cmd.Branch)
+	// For each branch under consideration,
+	// if it's a tracked branch, update the upstacks from it
+	// to point to its base, or the next branch downstack
+	// if the base is also being deleted.
+	for branch, info := range branchesToDelete {
+		if !info.Tracked {
+			continue
+		}
+
+		// Search through the bases to find one
+		// that isn't being deleted.
+		base := info.Base
+		baseInfo, deletingBase := branchesToDelete[base]
+		for base != store.Trunk() && deletingBase {
+			base = baseInfo.Base
+			baseInfo, deletingBase = branchesToDelete[base]
+		}
+
+		aboves, err := svc.ListAbove(ctx, branch)
 		if err != nil {
-			return fmt.Errorf("list above %v: %w", cmd.Branch, err)
+			return fmt.Errorf("list above %v: %w", branch, err)
 		}
 
 		for _, above := range aboves {
-			if err := (&upstackOntoCmd{
+			if _, ok := branchesToDelete[above]; ok {
+				// This upstack is also being deleted. Skip.
+				continue
+			}
+
+			if err := svc.BranchOnto(ctx, &spice.BranchOntoRequest{
 				Branch: above,
 				Onto:   base,
-			}).Run(ctx, log, opts); err != nil {
+			}); err != nil {
 				contCmd := []string{"branch", "delete"}
 				if cmd.Force {
 					contCmd = append(contCmd, "--force")
 				}
-				contCmd = append(contCmd, cmd.Branch)
+				contCmd = append(contCmd, cmd.Branches...)
 				return svc.RebaseRescue(ctx, spice.RebaseRescueRequest{
 					Err:     err,
 					Command: contCmd,
 					Branch:  checkoutTarget,
-					Message: fmt.Sprintf("interrupted: %v: branch deleted", cmd.Branch),
+					Message: fmt.Sprintf("interrupted: %v: deleting branch", branch),
 				})
 			}
+			log.Infof("%v: moved upstack onto %v", above, base)
 		}
 	}
 
@@ -148,43 +215,81 @@ func (cmd *branchDeleteCmd) Run(ctx context.Context, log *log.Logger, opts *glob
 		return fmt.Errorf("checkout %v: %w", checkoutTarget, err)
 	}
 
-	// If the branch exists, and is not reachable from HEAD,
-	// git will refuse to delete it.
-	// If we can prompt, ask the user to upgrade to a forceful deletion.
-	if exists && !cmd.Force && opts.Prompt && !repo.IsAncestor(ctx, head, "HEAD") {
-		log.Warnf("%v (%v) is not reachable from HEAD", cmd.Branch, head.Short())
-		prompt := ui.NewConfirm().
-			WithTitlef("Delete %v anyway?", cmd.Branch).
-			WithDescriptionf("%v has not been merged into HEAD. This may result in data loss.", cmd.Branch).
-			WithValue(&cmd.Force)
-		if err := ui.Run(prompt); err != nil {
-			return fmt.Errorf("run prompt: %w", err)
+	// Remaining branches may have relationships with each other.
+	// We'll need to delete them in topological order: leaf to root.
+	var (
+		deleteOrder []*branchInfo
+		visit       func(string)
+	)
+	visit = func(branch string) {
+		info := branchesToDelete[branch]
+		if info == nil {
+			return // already visited or not in the list
 		}
+
+		visit(info.Base)
+		deleteOrder = append(deleteOrder, info)
+		delete(branchesToDelete, branch)
+	}
+	for branch := range branchesToDelete {
+		visit(branch)
 	}
 
-	if exists {
-		opts := git.BranchDeleteOptions{Force: cmd.Force}
-		if err := repo.DeleteBranch(ctx, cmd.Branch, opts); err != nil {
-			// If the branch still exists,
-			// it's likely because it's not merged.
-			if _, peelErr := repo.PeelToCommit(ctx, cmd.Branch); peelErr == nil {
-				log.Error("git refused to delete the branch", "err", err)
-				log.Error("try re-running with --force")
-				return errors.New("branch not deleted")
+	// deleteOrder is now in [base, ..., leaf] order. Reverse it.
+	slices.Reverse(deleteOrder)
+
+	branchTx := store.BeginBranchTx()
+	var untrackedNames []string
+	for _, b := range deleteOrder {
+		branch, head := b.Name, b.Head
+		exists, tracked, force := b.Exists, b.Tracked, cmd.Force
+
+		// If the branch exists, and is not reachable from HEAD,
+		// git will refuse to delete it.
+		// If we can prompt, ask the user to upgrade to a forceful deletion.
+		if exists && !force && opts.Prompt && !repo.IsAncestor(ctx, head, "HEAD") {
+			log.Warnf("%v (%v) is not reachable from HEAD", branch, head.Short())
+			prompt := ui.NewConfirm().
+				WithTitlef("Delete %v anyway?", branch).
+				WithDescriptionf("%v has not been merged into HEAD. This may result in data loss.", branch).
+				WithValue(&force)
+			if err := ui.Run(prompt); err != nil {
+				return fmt.Errorf("run prompt: %w", err)
+			}
+		}
+
+		if exists {
+			opts := git.BranchDeleteOptions{Force: force}
+			if err := repo.DeleteBranch(ctx, branch, opts); err != nil {
+				// If the branch still exists,
+				// it's likely because it's not merged.
+				if _, peelErr := repo.PeelToCommit(ctx, branch); peelErr == nil {
+					log.Error("git refused to delete the branch", "err", err)
+					log.Error("try re-running with --force")
+					return errors.New("branch not deleted")
+				}
+
+				// If the branch doesn't exist,
+				// it may already have been deleted.
+				log.Warn("branch may already have been deleted", "err", err)
 			}
 
-			// If the branch doesn't exist,
-			// it may already have been deleted.
-			log.Warn("branch may already have been deleted", "err", err)
+			log.Infof("%v: deleted (was %v)", branch, head.Short())
 		}
 
-		log.Infof("%v: deleted (was %v)", cmd.Branch, head.Short())
+		if tracked {
+			if err := branchTx.Delete(ctx, branch); err != nil {
+				log.Warn("Unable to untrack branch", "branch", branch, "error", err)
+				log.Warn("Try manually untracking the branch with 'gs branch untrack'")
+			} else {
+				untrackedNames = append(untrackedNames, branch)
+			}
+		}
 	}
 
-	if tracked {
-		if err := svc.ForgetBranch(ctx, cmd.Branch); err != nil {
-			return fmt.Errorf("forget branch %v: %w", cmd.Branch, err)
-		}
+	msg := fmt.Sprintf("delete: %v", strings.Join(untrackedNames, ", "))
+	if err := branchTx.Commit(ctx, msg); err != nil {
+		return fmt.Errorf("update state: %w", err)
 	}
 
 	return nil

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -545,21 +545,20 @@ target (A) to the specified branch:
 ### gs branch delete
 
 ```
-gs branch (b) delete (d,rm) [<branch>] [flags]
+gs branch (b) delete (d,rm) [<branches> ...] [flags]
 ```
 
-Delete a branch
+Delete branches
 
-The deleted branch and its commits are removed from the stack.
-Branches above the deleted branch are rebased onto
-the next branch downstack.
+The deleted branches and their commits are removed from the stack.
+Branches above the deleted branches are rebased onto
+the next branches available downstack.
 
-A prompt will allow selecting the target branch.
-Provide a name as an argument to skip the prompt.
+A prompt will allow selecting the target branch if none are provided.
 
 **Arguments**
 
-* `branch`: Name of the branch to delete
+* `branches`: Names of the branches to delete
 
 **Flags**
 

--- a/internal/spice/branch.go
+++ b/internal/spice/branch.go
@@ -410,8 +410,8 @@ func (s *Service) LoadBranches(ctx context.Context) ([]LoadBranchItem, error) {
 		if base != origBase {
 			if err := tx.Upsert(ctx, state.UpsertRequest{
 				Name:     item.Name,
-				Base:     item.Base,
-				BaseHash: item.BaseHash,
+				Base:     base,
+				BaseHash: baseHash,
 			}); err != nil {
 				s.log.Warn("Could not update base of branch upstack from deleted branch",
 					"branch", item.Name,

--- a/testdata/script/issue398_repo_sync_many_merged.txt
+++ b/testdata/script/issue398_repo_sync_many_merged.txt
@@ -1,0 +1,162 @@
+# repo sync witha number of different merged branches
+# does not cause any issues.
+#
+# https://github.com/abhinav/git-spice/issues/398
+
+as 'Test <test@example.com>'
+at '2024-09-28T15:16:17Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+# feat1->feat2->feat3->feat4
+git add feat1.txt
+gs bc -m feat1
+git add feat2.txt
+gs bc -m feat2
+git add feat3.txt
+gs bc -m feat3
+git add feat4.txt
+gs bc -m feat4
+
+# add an extra branch off each feature branch
+gs bco feat1
+mv feat1.part2.txt feat1.txt
+git add feat1.txt
+gs bc -m feat1.part2 -t feat1
+
+gs bco feat2
+mv feat2.part2.txt feat2.txt
+git add feat2.txt
+gs bc -m feat2.part2 -t feat2
+
+gs bco feat3
+mv feat3.part2.txt feat3.txt
+git add feat3.txt
+gs bc -m feat3.part2 -t feat3
+
+gs bco feat4
+mv feat4.part2.txt feat4.txt
+git add feat4.txt
+gs bc -m feat4.part2 -t feat4
+
+# sanity check: branch state
+gs trunk
+gs ll -a
+cmp stderr $WORK/golden/ll.start.txt
+
+# We'll submit PRs for everything,
+# but since we want deterministic PR numbers,
+# we'll manually submit them in the order we want.
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+gs branch submit --branch feat1 --fill
+gs branch submit --branch feat2 --fill
+gs branch submit --branch feat3 --fill
+gs branch submit --branch feat4 --fill
+
+gs branch submit --branch feat1-part2 --fill
+gs branch submit --branch feat2-part2 --fill
+gs branch submit --branch feat3-part2 --fill
+gs branch submit --branch feat4-part2 --fill
+
+# sanity check: submitted
+gs trunk
+gs ls -a
+cmp stderr $WORK/golden/ls.submit.txt
+
+# merge 1-4 server-side
+shamhub merge alice/example 4
+shamhub merge alice/example 3
+shamhub merge alice/example 2
+shamhub merge alice/example 1
+
+# sync, and don't expect to move upstacks
+# of the merged branches; they should just be deleted.
+gs repo sync
+! stderr 'feat1: moved upstack'
+! stderr 'feat2: moved upstack'
+! stderr 'feat3: moved upstack'
+! stderr 'feat4: moved upstack'
+
+git graph --branches
+cmp stdout $WORK/golden/graph.txt
+
+-- repo/feat1.txt --
+feat1
+-- repo/feat2.txt --
+feat2
+-- repo/feat3.txt --
+feat3
+-- repo/feat4.txt --
+feat4
+-- repo/feat1.part2.txt --
+feat1 part2
+-- repo/feat2.part2.txt --
+feat2 part2
+-- repo/feat3.part2.txt --
+feat3 part2
+-- repo/feat4.part2.txt --
+feat4 part2
+-- golden/ll.start.txt --
+  ┏━□ feat1-part2
+  ┃   3b90c1c feat1.part2 (now)
+  ┃ ┏━□ feat2-part2
+  ┃ ┃   a252f85 feat2.part2 (now)
+  ┃ ┃ ┏━□ feat3-part2
+  ┃ ┃ ┃   9a90907 feat3.part2 (now)
+  ┃ ┃ ┃ ┏━□ feat4-part2
+  ┃ ┃ ┃ ┃   d568d96 feat4.part2 (now)
+  ┃ ┃ ┣━┻□ feat4
+  ┃ ┃ ┃    267a7ec feat4 (now)
+  ┃ ┣━┻□ feat3
+  ┃ ┃    fcb4332 feat3 (now)
+  ┣━┻□ feat2
+  ┃    aee78bc feat2 (now)
+┏━┻□ feat1
+┃    fc49b37 feat1 (now)
+main ◀
+-- golden/ls.submit.txt --
+  ┏━□ feat1-part2 (#5)
+  ┃ ┏━□ feat2-part2 (#6)
+  ┃ ┃ ┏━□ feat3-part2 (#7)
+  ┃ ┃ ┃ ┏━□ feat4-part2 (#8)
+  ┃ ┃ ┣━┻□ feat4 (#4)
+  ┃ ┣━┻□ feat3 (#3)
+  ┣━┻□ feat2 (#2)
+┏━┻□ feat1 (#1)
+main ◀
+-- golden/graph.txt --
+* ab3dc43 (feat1-part2) feat1.part2
+| * 9bffe4e (feat2-part2) feat2.part2
+|/  
+| * f27faaa (feat3-part2) feat3.part2
+|/  
+| * 43f356c (feat4-part2) feat4.part2
+|/  
+*   d744bd8 (HEAD -> main, origin/main) Merge change #1
+|\  
+| *   a2aa887 Merge change #2
+| |\  
+| | *   0e75bc3 Merge change #3
+| | |\  
+| | | *   50c346f Merge change #4
+| | | |\  
+| | | | * 267a7ec feat4
+| | | |/  
+| | | * fcb4332 feat3
+| | |/  
+| | * aee78bc feat2
+| |/  
+| * fc49b37 feat1
+|/  
+* f6036b5 Initial commit


### PR DESCRIPTION
Previously, `repo sync` would invoke `branch delete`
for each merged branch in an indeterminate order,
which would first move the upstacks of that branch to its base,
then delete the branch.

When multiple branches are merged, this has issues:

- repeated work of constantly moving the same branches
- log noise
- in some corner cases, (e.g. #398), the order of deletion matters
  and it causes the command to fail

The fix for this is multi-fold:

- `branch delete`: now accepts multiple branches
  instead of just one branch.
- `branch delete`: delete branches in reverse topological order.
  This will ensure that branches that have no dependents are deleted
  before branches that depend on them.
- `branch delete`: when multiple branches are being deleted,
  redirect the base of the upstacks to the next available branch,
  not just the immediate base.
- `repo sync`: use the multi-delete to delete merged branches

Resolves #398