### PR TITLE
ci: On release, bump Homebrew formula

### DIFF
--- a/.github/workflows/bump-homebrew-formula.yml
+++ b/.github/workflows/bump-homebrew-formula.yml
@@ -1,0 +1,19 @@
+on:
+  release:
+    types: [released]
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    name: Bump Homebrew Formula
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Update Homebrew Formula
+        uses: dawidd6/action-homebrew-bump-formula@v3.11.0
+        with:
+          token: ${{ secrets.PAT }}
+          user_name: Abhinav Gupta
+          user_email: "41730+abhinav@users.noreply.github.com"
+          formula: git-spice


### PR DESCRIPTION
git-spice is now in homebrew-core,
so update it automatically on release.