### PR TITLE
branch submit: Fix draft status --dry-run log

### DIFF
--- a/.changes/unreleased/Fixed-20241002-052319.yaml
+++ b/.changes/unreleased/Fixed-20241002-052319.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'branch submit: Fix bad log statement in --dry-run mode.'
+time: 2024-10-02T05:23:19.718591-07:00

--- a/branch_submit.go
+++ b/branch_submit.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -406,7 +407,7 @@ func (cmd *branchSubmitCmd) run(
 			updates = append(updates, "set base to "+branch.Base)
 		}
 		if cmd.Draft != nil && pull.Draft != *cmd.Draft {
-			updates = append(updates, "set draft to "+fmt.Sprint(cmd.Draft))
+			updates = append(updates, "set draft to "+strconv.FormatBool(*cmd.Draft))
 		}
 
 		if len(updates) == 0 {

--- a/testdata/script/stack_submit_update_leave_draft.txt
+++ b/testdata/script/stack_submit_update_leave_draft.txt
@@ -41,6 +41,11 @@ gs stack submit --dry-run
 cmpenv stderr $WORK/golden/submit-dry-run.txt
 ! stderr 'draft' # draft status should not be changed
 
+# dry-run: verify --dry-run *would* change draft status
+gs stack submit --no-draft --dry-run
+stderr 'WOULD update'
+stderr 'set draft to false'
+
 shamhub dump changes
 cmpenvJSON stdout $WORK/golden/start.json
 


### PR DESCRIPTION
cmd.Draft is a pointer, so "set draft to"
was printing a memory address instead of true/false.

Resolves #433