### PR TITLE
fix: correct navigation comment selection

### DIFF
--- a/.changes/unreleased/Fixed-20241025-231804.yaml
+++ b/.changes/unreleased/Fixed-20241025-231804.yaml
@@ -1,3 +1,5 @@
 kind: Fixed
-body: Fixes a bug which selected incorrect navigation comment
+body: >-
+  branch submit: Fix bug when importing externally created PRs,
+  where the first comment in the PR would be hijacked as the navigation comment.
 time: 2024-10-25T23:18:04.61755+05:30

--- a/.changes/unreleased/Fixed-20241025-231804.yaml
+++ b/.changes/unreleased/Fixed-20241025-231804.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fixes a bug which selected incorrect navigation comment
+time: 2024-10-25T23:18:04.61755+05:30

--- a/internal/forge/github/comment.go
+++ b/internal/forge/github/comment.go
@@ -205,10 +205,15 @@ func (f *Repository) ListChangeComments(
 			}
 
 			for _, node := range q.Node.PullRequest.Comments.Nodes {
+				isNavigationComment := true
 				for _, filter := range filters {
 					if !filter(node) {
-						continue
+						isNavigationComment = false
+						break
 					}
+				}
+				if !isNavigationComment {
+					continue
 				}
 
 				item := &forge.ListChangeCommentItem{

--- a/internal/forge/github/comment.go
+++ b/internal/forge/github/comment.go
@@ -205,14 +205,14 @@ func (f *Repository) ListChangeComments(
 			}
 
 			for _, node := range q.Node.PullRequest.Comments.Nodes {
-				isNavigationComment := true
+				match := true
 				for _, filter := range filters {
 					if !filter(node) {
-						isNavigationComment = false
+						match = false
 						break
 					}
 				}
-				if !isNavigationComment {
+				if !match {
 					continue
 				}
 

--- a/internal/forge/github/comment_test.go
+++ b/internal/forge/github/comment_test.go
@@ -1,15 +1,151 @@
 package github
 
-import "testing"
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/shurcooL/githubv4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/logtest"
+	"go.abhg.dev/testing/stub"
+)
 
 // SetListChangeCommentsPageSize changes the page size
 // used for listing change comments.
 //
 // It restores the old value after the test finishes.
 func SetListChangeCommentsPageSize(t testing.TB, pageSize int) {
-	old := _listChangeCommentsPageSize
-	_listChangeCommentsPageSize = pageSize
-	t.Cleanup(func() {
-		_listChangeCommentsPageSize = old
-	})
+	t.Cleanup(stub.Value(&_listChangeCommentsPageSize, pageSize))
+}
+
+func TestListChangeComments(t *testing.T) {
+	type commentRes struct {
+		ID   string `json:"id"`
+		Body string `json:"body"`
+		URL  string `json:"url"`
+
+		ViewerCanUpdate bool `json:"viewerCanUpdate"`
+		ViewerDidAuthor bool `json:"viewerDidAuthor"`
+
+		CreatedAt time.Time `json:"createdAt"`
+		UpdatedAt time.Time `json:"updatedAt"`
+	}
+
+	tests := []struct {
+		name string
+		give []commentRes
+		opts *forge.ListChangeCommentsOptions
+
+		wantBodies []string
+	}{
+		{
+			name: "NoFilter",
+			give: []commentRes{
+				{
+					ID:   "abc",
+					Body: "hello",
+					URL:  "https://example.com/comment/abc",
+				},
+				{
+					ID:   "def",
+					Body: "world",
+					URL:  "https://example.com/comment/def",
+				},
+			},
+			wantBodies: []string{"hello", "world"},
+		},
+		{
+			name: "BodyMatchesAll",
+			give: []commentRes{
+				{
+					ID:   "abc",
+					Body: "hello",
+					URL:  "https://example.com/comment/abc",
+				},
+				{
+					ID:   "def",
+					Body: "world",
+					URL:  "https://example.com/comment/def",
+				},
+			},
+			opts: &forge.ListChangeCommentsOptions{
+				BodyMatchesAll: []*regexp.Regexp{
+					regexp.MustCompile(`d$`),
+				},
+			},
+			wantBodies: []string{"world"},
+		},
+		{
+			name: "CanUpdate",
+			give: []commentRes{
+				{
+					ID:              "abc",
+					Body:            "hello",
+					URL:             "https://example.com/comment/abc",
+					ViewerCanUpdate: true,
+				},
+				{
+					ID:              "def",
+					Body:            "world",
+					URL:             "https://example.com/comment/def",
+					ViewerCanUpdate: false,
+				},
+			},
+			opts: &forge.ListChangeCommentsOptions{
+				CanUpdate: true,
+			},
+			wantBodies: []string{"hello"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response := map[string]any{
+				"data": map[string]any{
+					"node": map[string]any{
+						"comments": map[string]any{
+							"pageInfo": map[string]any{
+								"hasNextPage": false,
+							},
+							"nodes": tt.give,
+						},
+					},
+				},
+			}
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				enc := json.NewEncoder(w)
+				enc.SetIndent("", "  ")
+				assert.NoError(t, enc.Encode(response))
+			}))
+			defer srv.Close()
+
+			repo, err := newRepository(
+				context.Background(), new(Forge),
+				"owner", "repo",
+				logtest.New(t),
+				githubv4.NewEnterpriseClient(srv.URL, nil),
+				"repoID",
+			)
+			require.NoError(t, err)
+
+			prID := PR{Number: 1, GQLID: "prID"}
+
+			ctx := context.Background()
+			var bodies []string
+			for comment, err := range repo.ListChangeComments(ctx, &prID, tt.opts) {
+				require.NoError(t, err)
+				bodies = append(bodies, comment.Body)
+			}
+
+			assert.Equal(t, tt.wantBodies, bodies)
+		})
+	}
 }


### PR DESCRIPTION
This PR fixes a bug in the loop where we always select the first comment and don't filter anything due to a misplaced `continue`.

fixes #447 