### PR TITLE
navigation commands: -n/--dry-run and --detach

### DIFF
--- a/.changes/unreleased/Added-20241019-110354.yaml
+++ b/.changes/unreleased/Added-20241019-110354.yaml
@@ -1,0 +1,4 @@
+kind: Added
+body: >-
+  {trunk, branch checkout}: Add -n/--dry-run flag to print the target branch.
+time: 2024-10-19T11:03:54.694618-07:00

--- a/.changes/unreleased/Added-20241019-110430.yaml
+++ b/.changes/unreleased/Added-20241019-110430.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: '{up, down, top, bottom, branch checkout}: Add --detach flag to detach HEAD after checking out the target branch.'
+time: 2024-10-19T11:04:30.374611-07:00

--- a/bottom.go
+++ b/bottom.go
@@ -10,7 +10,7 @@ import (
 )
 
 type bottomCmd struct {
-	DryRun bool `short:"n" help:"Print the target branch without checking it out."`
+	checkoutOptions
 }
 
 func (*bottomCmd) Help() string {
@@ -41,10 +41,8 @@ func (cmd *bottomCmd) Run(ctx context.Context, log *log.Logger, opts *globalOpti
 		return fmt.Errorf("find bottom: %w", err)
 	}
 
-	if cmd.DryRun {
-		fmt.Println(bottom)
-		return nil
-	}
-
-	return (&branchCheckoutCmd{Branch: bottom}).Run(ctx, log, opts)
+	return (&branchCheckoutCmd{
+		checkoutOptions: cmd.checkoutOptions,
+		Branch:          bottom,
+	}).Run(ctx, log, opts)
 }

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -466,6 +466,8 @@ Use -u/--untracked to show untracked branches in the prompt.
 
 **Flags**
 
+* `-n`, `--dry-run`: Print the target branch without checking it out
+* `--detach`: Detach HEAD after checking out
 * `-u`, `--untracked` ([:material-wrench:{ .middle title="spice.branchCheckout.showUntracked" }](/cli/config.md#spicebranchcheckoutshowuntracked)): Show untracked branches if one isn't supplied
 
 **Configuration**: [spice.branchCheckout.showUntracked](/cli/config.md#spicebranchcheckoutshowuntracked)
@@ -862,7 +864,8 @@ Use the -n flag to print the branch without checking it out.
 
 **Flags**
 
-* `-n`, `--dry-run`: Print the target branch without checking it out.
+* `-n`, `--dry-run`: Print the target branch without checking it out
+* `--detach`: Detach HEAD after checking out
 
 ### gs down
 
@@ -883,7 +886,8 @@ Use the -n flag to print the branch without checking it out.
 
 **Flags**
 
-* `-n`, `--dry-run`: Print the target branch without checking it out.
+* `-n`, `--dry-run`: Print the target branch without checking it out
+* `--detach`: Detach HEAD after checking out
 
 ### gs top
 
@@ -900,7 +904,8 @@ Use the -n flag to print the branch without checking it out.
 
 **Flags**
 
-* `-n`, `--dry-run`: Print the target branch without checking it out.
+* `-n`, `--dry-run`: Print the target branch without checking it out
+* `--detach`: Detach HEAD after checking out
 
 ### gs bottom
 
@@ -915,7 +920,8 @@ Use the -n flag to print the branch without checking it out.
 
 **Flags**
 
-* `-n`, `--dry-run`: Print the target branch without checking it out.
+* `-n`, `--dry-run`: Print the target branch without checking it out
+* `--detach`: Detach HEAD after checking out
 
 ### gs trunk
 
@@ -924,4 +930,9 @@ gs trunk [flags]
 ```
 
 Move to the trunk branch
+
+**Flags**
+
+* `-n`, `--dry-run`: Print the target branch without checking it out
+* `--detach`: Detach HEAD after checking out
 

--- a/down.go
+++ b/down.go
@@ -9,9 +9,9 @@ import (
 )
 
 type downCmd struct {
-	N int `arg:"" optional:"" help:"Number of branches to move up." default:"1"`
+	checkoutOptions
 
-	DryRun bool `short:"n" help:"Print the target branch without checking it out."`
+	N int `arg:"" optional:"" help:"Number of branches to move up." default:"1"`
 }
 
 func (*downCmd) Help() string {
@@ -66,10 +66,8 @@ outer:
 		current = below
 	}
 
-	if cmd.DryRun {
-		fmt.Println(below)
-		return nil
-	}
-
-	return (&branchCheckoutCmd{Branch: below}).Run(ctx, log, opts)
+	return (&branchCheckoutCmd{
+		checkoutOptions: cmd.checkoutOptions,
+		Branch:          below,
+	}).Run(ctx, log, opts)
 }

--- a/testdata/script/nav_detach_dry_run.txt
+++ b/testdata/script/nav_detach_dry_run.txt
@@ -1,0 +1,99 @@
+# up, down, top, bottom, and bco support dry run and detach.
+
+as 'Test <test@example.com>'
+at '2024-10-26T09:22:23Z'
+
+# main with initial commit
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+gs bc -m feat1
+gs bc -m feat2
+gs bc -m feat3
+gs bc -m feat4
+gs bc -m feat5
+
+gs bottom -n
+stdout '^feat1$'
+
+gs trunk -n
+stdout '^main$'
+
+# nothing above feat5
+! gs up -n
+
+git graph --branches
+cmp stdout $WORK/golden/feat5_graph.txt
+
+gs down --detach
+git branch
+cmp stdout $WORK/golden/feat4_branch.txt
+
+# TODO: maybe we can match detached head to branch in the future.
+! gs up
+stderr 'in detached HEAD state'
+
+gs bco feat1 -n
+stdout '^feat1$'
+gs bco feat1 --detach
+git branch
+cmp stdout $WORK/golden/feat1_branch.txt
+
+gs bco feat2
+gs up -n
+stdout '^feat3$'
+gs down -n
+stdout '^feat1$'
+
+gs top -n
+stdout '^feat5$'
+gs top --detach
+git branch
+cmp stdout $WORK/golden/feat5_branch.txt
+
+gs trunk --detach
+git branch
+cmp stdout $WORK/golden/trunk_branch.txt
+
+-- golden/feat5_graph.txt --
+* 372d1de (HEAD -> feat5) feat5
+* d3ab99d (feat4) feat4
+* 4eac2b9 (feat3) feat3
+* dc8887b (feat2) feat2
+* dcda5c3 (feat1) feat1
+* ff53bfb (main) Initial commit
+-- golden/feat4_branch.txt --
+* (HEAD detached at refs/heads/feat4)
+  feat1
+  feat2
+  feat3
+  feat4
+  feat5
+  main
+-- golden/feat1_branch.txt --
+* (HEAD detached at refs/heads/feat1)
+  feat1
+  feat2
+  feat3
+  feat4
+  feat5
+  main
+-- golden/feat5_branch.txt --
+* (HEAD detached at refs/heads/feat5)
+  feat1
+  feat2
+  feat3
+  feat4
+  feat5
+  main
+-- golden/trunk_branch.txt --
+* (HEAD detached at refs/heads/main)
+  feat1
+  feat2
+  feat3
+  feat4
+  feat5
+  main

--- a/top.go
+++ b/top.go
@@ -12,7 +12,7 @@ import (
 )
 
 type topCmd struct {
-	DryRun bool `short:"n" help:"Print the target branch without checking it out."`
+	checkoutOptions
 }
 
 func (*topCmd) Help() string {
@@ -70,15 +70,13 @@ func (cmd *topCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions
 		}
 	}
 
-	if cmd.DryRun {
-		fmt.Println(branch)
-		return nil
-	}
-
-	if branch == current {
+	if branch == current && !cmd.DryRun {
 		log.Info("Already on the top-most branch in this stack")
 		return nil
 	}
 
-	return (&branchCheckoutCmd{Branch: branch}).Run(ctx, log, opts)
+	return (&branchCheckoutCmd{
+		checkoutOptions: cmd.checkoutOptions,
+		Branch:          branch,
+	}).Run(ctx, log, opts)
 }

--- a/trunk.go
+++ b/trunk.go
@@ -8,9 +8,11 @@ import (
 	"go.abhg.dev/gs/internal/git"
 )
 
-type trunkCmd struct{}
+type trunkCmd struct {
+	checkoutOptions
+}
 
-func (*trunkCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
+func (cmd *trunkCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
 	repo, err := git.Open(ctx, ".", git.OpenOptions{
 		Log: log,
 	})
@@ -24,5 +26,8 @@ func (*trunkCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) 
 	}
 
 	trunk := store.Trunk()
-	return (&branchCheckoutCmd{Branch: trunk}).Run(ctx, log, opts)
+	return (&branchCheckoutCmd{
+		checkoutOptions: cmd.checkoutOptions,
+		Branch:          trunk,
+	}).Run(ctx, log, opts)
 }

--- a/up.go
+++ b/up.go
@@ -11,9 +11,9 @@ import (
 )
 
 type upCmd struct {
-	N int `arg:"" optional:"" help:"Number of branches to move up." default:"1"`
+	checkoutOptions
 
-	DryRun bool `short:"n" help:"Print the target branch without checking it out."`
+	N int `arg:"" optional:"" help:"Number of branches to move up." default:"1"`
 }
 
 func (*upCmd) Help() string {
@@ -84,10 +84,8 @@ outer:
 		current = branch
 	}
 
-	if cmd.DryRun {
-		fmt.Println(branch)
-		return nil
-	}
-
-	return (&branchCheckoutCmd{Branch: branch}).Run(ctx, log, opts)
+	return (&branchCheckoutCmd{
+		checkoutOptions: cmd.checkoutOptions,
+		Branch:          branch,
+	}).Run(ctx, log, opts)
 }


### PR DESCRIPTION
All commands that check out branches (up, down, top, bottom, trunk, bco)
now support -n/--dry-run to print the target branch,
and --detach to check that branch out in a detached HEAD state.
