### PR TITLE
submit: Add -w/--web flag to open a browser

### DIFF
--- a/.changes/unreleased/Added-20241026-102334.yaml
+++ b/.changes/unreleased/Added-20241026-102334.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: >-
+  Add -w/--web to all submit commands to open a browser with the submitted CR.
+  Make this the default behavior with the `spice.submit.web` configuration option.
+time: 2024-10-26T10:23:34.749014-07:00

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -210,10 +210,11 @@ or --nav-comment=multiple to post those comments only if there are multiple CRs 
 * `-c`, `--fill`: Fill in the change title and body from the commit messages
 * `--[no-]draft`: Whether to mark change requests as drafts
 * `--[no-]publish` ([:material-wrench:{ .middle title="spice.submit.publish" }](/cli/config.md#spicesubmitpublish)): Whether to create CRs for pushed branches. Defaults to true.
+* `-w`, `--[no-]web` ([:material-wrench:{ .middle title="spice.submit.web" }](/cli/config.md#spicesubmitweb)): Open submitted changes in a web browser
 * `--nav-comment=true` ([:material-wrench:{ .middle title="spice.submit.navigationComment" }](/cli/config.md#spicesubmitnavigationcomment)): Whether to add a navigation comment to the change request. Must be one of: true, false, multiple.
 * `--force`: Force push, bypassing safety checks
 
-**Configuration**: [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment)
+**Configuration**: [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.web](/cli/config.md#spicesubmitweb), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment)
 
 ### gs stack restack
 
@@ -282,11 +283,12 @@ or --nav-comment=multiple to post those comments only if there are multiple CRs 
 * `-c`, `--fill`: Fill in the change title and body from the commit messages
 * `--[no-]draft`: Whether to mark change requests as drafts
 * `--[no-]publish` ([:material-wrench:{ .middle title="spice.submit.publish" }](/cli/config.md#spicesubmitpublish)): Whether to create CRs for pushed branches. Defaults to true.
+* `-w`, `--[no-]web` ([:material-wrench:{ .middle title="spice.submit.web" }](/cli/config.md#spicesubmitweb)): Open submitted changes in a web browser
 * `--nav-comment=true` ([:material-wrench:{ .middle title="spice.submit.navigationComment" }](/cli/config.md#spicesubmitnavigationcomment)): Whether to add a navigation comment to the change request. Must be one of: true, false, multiple.
 * `--force`: Force push, bypassing safety checks
 * `--branch=NAME`: Branch to start at
 
-**Configuration**: [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment)
+**Configuration**: [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.web](/cli/config.md#spicesubmitweb), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment)
 
 ### gs upstack restack
 
@@ -374,11 +376,12 @@ or --nav-comment=multiple to post those comments only if there are multiple CRs 
 * `-c`, `--fill`: Fill in the change title and body from the commit messages
 * `--[no-]draft`: Whether to mark change requests as drafts
 * `--[no-]publish` ([:material-wrench:{ .middle title="spice.submit.publish" }](/cli/config.md#spicesubmitpublish)): Whether to create CRs for pushed branches. Defaults to true.
+* `-w`, `--[no-]web` ([:material-wrench:{ .middle title="spice.submit.web" }](/cli/config.md#spicesubmitweb)): Open submitted changes in a web browser
 * `--nav-comment=true` ([:material-wrench:{ .middle title="spice.submit.navigationComment" }](/cli/config.md#spicesubmitnavigationcomment)): Whether to add a navigation comment to the change request. Must be one of: true, false, multiple.
 * `--force`: Force push, bypassing safety checks
 * `--branch=NAME`: Branch to start at
 
-**Configuration**: [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment)
+**Configuration**: [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.web](/cli/config.md#spicesubmitweb), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment)
 
 ### gs downstack edit
 
@@ -740,13 +743,14 @@ or --nav-comment=multiple to post those comments only if there are multiple CRs 
 * `-c`, `--fill`: Fill in the change title and body from the commit messages
 * `--[no-]draft`: Whether to mark change requests as drafts
 * `--[no-]publish` ([:material-wrench:{ .middle title="spice.submit.publish" }](/cli/config.md#spicesubmitpublish)): Whether to create CRs for pushed branches. Defaults to true.
+* `-w`, `--[no-]web` ([:material-wrench:{ .middle title="spice.submit.web" }](/cli/config.md#spicesubmitweb)): Open submitted changes in a web browser
 * `--nav-comment=true` ([:material-wrench:{ .middle title="spice.submit.navigationComment" }](/cli/config.md#spicesubmitnavigationcomment)): Whether to add a navigation comment to the change request. Must be one of: true, false, multiple.
 * `--force`: Force push, bypassing safety checks
 * `--title=TITLE`: Title of the change request
 * `--body=BODY`: Body of the change request
 * `--branch=NAME`: Branch to submit
 
-**Configuration**: [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment)
+**Configuration**: [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.web](/cli/config.md#spicesubmitweb), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment)
 
 ## Commit
 

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -107,3 +107,15 @@ on a case-by-case basis.
 
 - `true` (default)
 - `false`
+
+### spice.submit.web
+
+<!-- gs:version unreleased -->
+
+Whether submission commands ($$gs branch submit$$ and friends)
+should open a web browser with submitted CRs.
+
+**Accepted values:**
+
+- `true`
+- `false` (default)

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.1.1
 	github.com/charmbracelet/lipgloss v0.13.0
 	github.com/charmbracelet/log v0.4.0
+	github.com/cli/browser v1.3.0
 	github.com/creack/pty v1.1.23
 	github.com/dustin/go-humanize v1.0.1
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/charmbracelet/x/ansi v0.3.2 h1:wsEwgAN+C9U06l9dCVMX0/L3x7ptvY1qmjMwyf
 github.com/charmbracelet/x/ansi v0.3.2/go.mod h1:dk73KoMTT5AX5BsX0KrqhsTqAnhZZoCBjs7dGWp4Ktw=
 github.com/charmbracelet/x/term v0.2.0 h1:cNB9Ot9q8I711MyZ7myUR5HFWL/lc3OpU8jZ4hwm0x0=
 github.com/charmbracelet/x/term v0.2.0/go.mod h1:GVxgxAbjUrmpvIINHIQnJJKpMlHiZ4cktEQCN6GWyF0=
+github.com/cli/browser v1.3.0 h1:LejqCrpWr+1pRqmEPDGnTZOjsMe7sehifLynZJuqJpo=
+github.com/cli/browser v1.3.0/go.mod h1:HH8s+fOAxjhQoBUAsKuPCbqUuxZDhQ2/aD+SzsEfBTk=
 github.com/creack/pty v1.1.23 h1:4M6+isWdcStXEf15G/RbrMPOQj1dZ7HPZCGwE4kOeP0=
 github.com/creack/pty v1.1.23/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/danieljoos/wincred v1.2.2 h1:774zMFJrqaeYCK2W57BgAem/MLi6mtSE47MB6BOJ0i0=

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -1,0 +1,40 @@
+// Package browser provides a means of opening a URL
+// in the user's default web browser.
+package browser
+
+import (
+	"github.com/cli/browser"
+)
+
+// Launcher launches the web browser.
+type Launcher interface {
+	// OpenURL opens the specified URL.
+	OpenURL(url string) error
+}
+
+// Browser is a [Launcher] that opens URLs in a real web browser.
+//
+// Its zero value is a valid instance.
+type Browser struct {
+	openURL func(url string) error // to stub in tests
+}
+
+var _ Launcher = (*Browser)(nil)
+
+// OpenURL opens the URL in the user's default web browser.
+func (b *Browser) OpenURL(url string) error {
+	openURL := browser.OpenURL
+	if b.openURL != nil {
+		openURL = b.openURL
+	}
+	return openURL(url)
+}
+
+// Noop is a [Launcher] that does nothing.
+// Its zero value is a valid instance.
+type Noop struct{}
+
+var _ Launcher = (*Noop)(nil)
+
+// OpenURL does nothing.
+func (*Noop) OpenURL(string) error { return nil }

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -1,0 +1,27 @@
+package browser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBrowser_OpenURL(t *testing.T) {
+	var called bool
+	b := &Browser{
+		openURL: func(url string) error {
+			called = true
+			assert.Equal(t, "https://example.com", url)
+			return nil
+		},
+	}
+
+	require.NoError(t, b.OpenURL("https://example.com"))
+	assert.True(t, called)
+}
+
+func TestNoop_OpenURL(t *testing.T) {
+	var n Noop
+	require.NoError(t, n.OpenURL("https://example.com"))
+}

--- a/internal/browser/browsertest/recorder.go
+++ b/internal/browser/browsertest/recorder.go
@@ -1,0 +1,34 @@
+// Package browsertest provides test helpers
+// for browser support.
+package browsertest
+
+import (
+	"fmt"
+	"os"
+
+	"go.abhg.dev/gs/internal/browser"
+)
+
+// Recorder is a [Launcher] that records the URLs it is asked to open
+// into a file.
+type Recorder struct{ path string }
+
+var _ browser.Launcher = (*Recorder)(nil)
+
+// NewRecorder builds a [Recorder]
+// that records URLs to the specified path.
+func NewRecorder(path string) *Recorder {
+	return &Recorder{path}
+}
+
+// OpenURL records the URL to the file.
+func (r *Recorder) OpenURL(url string) error {
+	f, err := os.OpenFile(r.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	_, err = fmt.Fprintln(f, url)
+	return err
+}

--- a/internal/browser/browsertest/recorder_test.go
+++ b/internal/browser/browsertest/recorder_test.go
@@ -1,0 +1,37 @@
+package browsertest_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/browser/browsertest"
+)
+
+func TestRecorder(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "urls")
+	rec := browsertest.NewRecorder(path)
+
+	require.NoError(t, rec.OpenURL("https://example.com"))
+	require.NoError(t, rec.OpenURL("https://example.org"))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{
+		"https://example.com",
+		"https://example.org",
+	}, strings.Split(strings.TrimSpace(string(got)), "\n"))
+}
+
+func TestRecorder_openFileError(t *testing.T) {
+	rec := browsertest.NewRecorder(
+		filepath.Join(t.TempDir(), "nonexistent", "file"),
+	)
+
+	err := rec.OpenURL("https://example.com")
+	assert.Error(t, err)
+}

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/log"
 	"github.com/mattn/go-isatty"
+	"go.abhg.dev/gs/internal/browser"
 	"go.abhg.dev/gs/internal/cli/shorthand"
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/forge/github"
@@ -27,10 +28,15 @@ import (
 // Set by goreleaser at build time.
 var _version = "dev"
 
-// _secretStash is the secret stash used by the application.
-//
-// This is overridden in tests to use a memory stash.
-var _secretStash secret.Stash = new(secret.Keyring)
+var (
+	// _secretStash is the secret stash used by the application.
+	//
+	// This is overridden in tests to use a memory stash.
+	_secretStash secret.Stash = new(secret.Keyring)
+
+	// _browserLauncher opens URLs in the user's configured browser.
+	_browserLauncher browser.Launcher = new(browser.Browser)
+)
 
 var errNoPrompt = fmt.Errorf("not allowed to prompt for input")
 

--- a/testdata/script/branch_submit_web.txt
+++ b/testdata/script/branch_submit_web.txt
@@ -1,0 +1,44 @@
+# 'branch submit' supports the -w flag.
+
+as 'Test <test@example.com>'
+at '2024-10-26T10:26:00Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub register alice
+shamhub new origin alice/example.git
+git push origin main
+
+env BROWSER_RECORDER_FILE=$WORK/browser.txt
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# create a branch
+git add feature1.txt
+gs bc -m 'Add feature1' feature1
+gs branch submit --fill --web
+grep -count=1 $SHAMHUB_URL/alice/example/change/1 $WORK/browser.txt
+
+# re-submission should also open the browser
+cp $WORK/extra/feature1-new.txt feature1.txt
+git add feature1.txt
+gs cc -m 'Update feature1'
+gs branch submit --web
+grep -count=2 $SHAMHUB_URL/alice/example/change/1 $WORK/browser.txt
+
+# error in opening the browser is logged but doesn't fail
+env BROWSER_RECORDER_FILE=$WORK/non-existent-dir/browser.txt
+gs branch submit --web
+stderr 'Could not open browser'
+stderr $SHAMHUB_URL/alice/example/change/1
+
+-- repo/feature1.txt --
+Contents of feature1
+
+-- extra/feature1-new.txt --
+New contents of feature1

--- a/testdata/script/branch_submit_web_opt_out.txt
+++ b/testdata/script/branch_submit_web_opt_out.txt
@@ -1,0 +1,39 @@
+# If 'branch submit' is the default, --no-web opts out.
+
+as 'Test <test@example.com>'
+at '2024-10-26T10:32:00Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+git config spice.submit.web true
+
+# set up a fake GitHub remote
+shamhub init
+shamhub register alice
+shamhub new origin alice/example.git
+git push origin main
+
+env BROWSER_RECORDER_FILE=$WORK/browser.txt
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# create a branch
+git add feature1.txt
+gs bc -m 'Add feature1' feature1
+
+# no-publish won't open the browser
+gs branch submit --no-publish
+! exists $WORK/browser.txt
+
+# submit with --no-web won't open the browser
+gs branch submit --no-web --fill
+! exists $WORK/browser.txt
+
+# submit again will open the browser
+gs branch submit --fill
+grep -count=1 $SHAMHUB_URL/alice/example/change/1 $WORK/browser.txt
+
+-- repo/feature1.txt --
+Contents of feature1

--- a/testdata/script/stack_submit_web.txt
+++ b/testdata/script/stack_submit_web.txt
@@ -1,0 +1,41 @@
+# 'stack submit' supports the -w flag.
+
+as 'Test <test@example.com>'
+at '2024-10-26T10:38:00Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub register alice
+shamhub new origin alice/example.git
+git push origin main
+
+env BROWSER_RECORDER_FILE=$WORK/browser.txt
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+git add feat1.txt
+gs bc -m feat1
+git add feat2.txt
+gs bc -m feat2
+git add feat3.txt
+gs bc -m feat3
+
+gs trunk
+gs stack submit --fill --web
+cmpenv $WORK/browser.txt $WORK/golden/browser.txt
+
+-- repo/feat1.txt --
+This is feature 1
+-- repo/feat2.txt --
+This is feature 2
+-- repo/feat3.txt --
+This is feature 3
+-- golden/browser.txt --
+$SHAMHUB_URL/alice/example/change/1
+$SHAMHUB_URL/alice/example/change/2
+$SHAMHUB_URL/alice/example/change/3


### PR DESCRIPTION
If set, the `gs branch submit` and related commands
will open a web browser with the submitted CR.

This can be made the default by setting `spice.submit.web` to `true`.

Resolves #446