### PR TITLE
fix(branch submit): handle base branch renaming

### DIFF
--- a/.changes/unreleased/Fixed-20241102-094426.yaml
+++ b/.changes/unreleased/Fixed-20241102-094426.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'submit: Fix incorrect branch name used when a base branch of a submitted branch is renamed.'
+time: 2024-11-02T09:44:26.588392-07:00

--- a/testdata/script/branch_submit_rename_base.txt
+++ b/testdata/script/branch_submit_rename_base.txt
@@ -1,0 +1,163 @@
+# when a submitted base branch is renamed,
+# its upstacks still use the correct base branch.
+
+as 'Test <test@example.com>'
+at '2024-11-02T09:39:40Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# create a feat1 -> feat2 -> feat3 stack
+git add feat1.txt
+gs bc -m feat1 feature
+git add feat2.txt
+gs bc -m feat2
+git add feat3.txt
+gs bc -m feat3
+
+# submit the stack
+gs ss --fill
+
+shamhub dump changes
+cmpenvJSON stdout $WORK/golden/pulls-before.json
+gs ll
+cmp stderr $WORK/golden/ll-before.txt
+
+gs bottom
+gs branch rename feat1
+
+gs ss
+shamhub dump changes
+cmpenvJSON stdout $WORK/golden/pulls-after.json
+gs ll
+cmp stderr $WORK/golden/ll-after.txt
+
+-- repo/feat1.txt --
+feature 1
+-- repo/feat2.txt --
+feature 2
+-- repo/feat3.txt --
+feature 3
+-- golden/pulls-before.json --
+[
+  {
+    "number": 1,
+    "html_url": "$SHAMHUB_URL/alice/example/change/1",
+    "state": "open",
+    "title": "feat1",
+    "body": "",
+    "base": {
+      "ref": "main",
+      "sha": "c445405317004b13d3068a427db716dae6664429"
+    },
+    "head": {
+      "ref": "feature",
+      "sha": "3cf69453c8843285b64929602d476f9e8021b4f5"
+    }
+  },
+  {
+    "number": 2,
+    "html_url": "$SHAMHUB_URL/alice/example/change/2",
+    "state": "open",
+    "title": "feat2",
+    "body": "",
+    "base": {
+      "ref": "feature",
+      "sha": "3cf69453c8843285b64929602d476f9e8021b4f5"
+    },
+    "head": {
+      "ref": "feat2",
+      "sha": "3a0374269031eff114a8ab4ab23d25ec33674972"
+    }
+  },
+  {
+    "number": 3,
+    "html_url": "$SHAMHUB_URL/alice/example/change/3",
+    "state": "open",
+    "title": "feat3",
+    "body": "",
+    "base": {
+      "ref": "feat2",
+      "sha": "3a0374269031eff114a8ab4ab23d25ec33674972"
+    },
+    "head": {
+      "ref": "feat3",
+      "sha": "dc2b288e577cd1aaeaaf02ae3e14267e08908f54"
+    }
+  }
+]
+-- golden/ll-before.txt --
+    ┏━■ feat3 (#3) ◀
+    ┃   dc2b288 feat3 (now)
+  ┏━┻□ feat2 (#2)
+  ┃    3a03742 feat2 (now)
+┏━┻□ feature (#1)
+┃    3cf6945 feat1 (now)
+main
+-- golden/pulls-after.json --
+[
+  {
+    "number": 1,
+    "html_url": "$SHAMHUB_URL/alice/example/change/1",
+    "state": "open",
+    "title": "feat1",
+    "body": "",
+    "base": {
+      "ref": "main",
+      "sha": "c445405317004b13d3068a427db716dae6664429"
+    },
+    "head": {
+      "ref": "feature",
+      "sha": "3cf69453c8843285b64929602d476f9e8021b4f5"
+    }
+  },
+  {
+    "number": 2,
+    "html_url": "$SHAMHUB_URL/alice/example/change/2",
+    "state": "open",
+    "title": "feat2",
+    "body": "",
+    "base": {
+      "ref": "feature",
+      "sha": "3cf69453c8843285b64929602d476f9e8021b4f5"
+    },
+    "head": {
+      "ref": "feat2",
+      "sha": "3a0374269031eff114a8ab4ab23d25ec33674972"
+    }
+  },
+  {
+    "number": 3,
+    "html_url": "$SHAMHUB_URL/alice/example/change/3",
+    "state": "open",
+    "title": "feat3",
+    "body": "",
+    "base": {
+      "ref": "feat2",
+      "sha": "3a0374269031eff114a8ab4ab23d25ec33674972"
+    },
+    "head": {
+      "ref": "feat3",
+      "sha": "dc2b288e577cd1aaeaaf02ae3e14267e08908f54"
+    }
+  }
+]
+-- golden/ll-after.txt --
+    ┏━□ feat3 (#3)
+    ┃   dc2b288 feat3 (now)
+  ┏━┻□ feat2 (#2)
+  ┃    3a03742 feat2 (now)
+┏━┻■ feat1 (#1) ◀
+┃    3cf6945 feat1 (now)
+main


### PR DESCRIPTION
When submitting a branch, we already handle the case
where the local branch has been renamed since submitting.
The original upstream name is still used.

But we did not account for that change
when submitting branches based on top of the renamed branch.

This fixes that--just a matter of plumbing the right variables around.
