### PR TITLE
branch split: prompt for CR reassignment

### DIFF
--- a/.changes/unreleased/Changed-20241102-095155.yaml
+++ b/.changes/unreleased/Changed-20241102-095155.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'branch split: If the branch being split has been submitted, allow attachind the CR to one of the split branches.'
+time: 2024-11-02T09:51:55.847657-07:00

--- a/branch_submit.go
+++ b/branch_submit.go
@@ -279,7 +279,7 @@ func (cmd *branchSubmitCmd) run(
 				Name:           cmd.Branch,
 				ChangeForge:    md.ForgeID(),
 				ChangeMetadata: changeMeta,
-				UpstreamBranch: upstreamBranch,
+				UpstreamBranch: &upstreamBranch,
 			}); err != nil {
 				return fmt.Errorf("%s: %w", msg, err)
 			}
@@ -422,7 +422,7 @@ func (cmd *branchSubmitCmd) run(
 		// with the recorded name.
 		upsert := state.UpsertRequest{
 			Name:           cmd.Branch,
-			UpstreamBranch: upstreamBranch,
+			UpstreamBranch: &upstreamBranch,
 		}
 		defer func() {
 			msg := fmt.Sprintf("branch submit %s", cmd.Branch)

--- a/doc/includes/captures/README.txt
+++ b/doc/includes/captures/README.txt
@@ -1,0 +1,24 @@
+This directory contains captured output from git-spice interactions.
+To generate one:
+
+1. Start capturing:
+
+        script foo.txt
+
+2. Use git-spice like you normally would.
+   Type 'exit' to stop capturing.
+
+        gs branch submit
+        exit
+
+3. Trim the resulting output in a text editor,
+   removing unnecessary lines and commands.
+
+4. Rename the file to something descriptive and place it in this directory.
+
+5. Include these in the documentation under a 'freeze' block
+   with language 'ansi':
+
+        ```freeze language="ansi"
+        --8<-- "captures/foo.txt"
+        ```

--- a/doc/includes/captures/branch-split-reassociate.txt
+++ b/doc/includes/captures/branch-split-reassociate.txt
@@ -1,0 +1,8 @@
+[1;92mAssign CR #123 to branch[0m: 
+
+  aardvark
+  pangolin
+▶ [93mpenguin[0m
+
+[2;90mBranch being split has an open CR assigned to it.[0m
+[2;90mSelect which branch should take over the CR.[0m

--- a/doc/src/guide/branch.md
+++ b/doc/src/guide/branch.md
@@ -402,6 +402,15 @@ it will prompt you for a name for each new branch.
     to safely and easily manipulate the commits in the branch
     before splitting it into multiple branches.
 
+<!-- gs:version unreleased -->
+If you split a branch after submitting it for review,
+git-spice will prompt you to assign the submitted CR
+to one of the branches.
+
+```freeze language="ansi"
+--8<-- "captures/branch-split-reassociate.txt"
+```
+
 ### Splitting non-interactively
 
 ```freeze language="terminal" float="right"
@@ -423,6 +432,10 @@ The option takes the form:
 
 Where `COMMIT` is a reference to a commit in the branch's history,
 and `NAME` is the name of the new branch.
+
+If running in non-interactive mode
+and the branch has already been submitted for review,
+it will be left assigned to the original branch.
 
 ## Moving branches around
 

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -223,15 +223,21 @@ func (r *Repository) BranchUpstream(ctx context.Context, branch string) (string,
 
 // SetBranchUpstream sets the upstream ref for a local branch.
 // The upstream must be in the form "remote/branch".
+//
+// If upstream is empty, the upstream is unset.
 func (r *Repository) SetBranchUpstream(
 	ctx context.Context,
 	branch, upstream string,
 ) error {
-	if err := r.gitCmd(ctx,
-		"branch",
-		"--set-upstream-to="+upstream,
-		branch,
-	).Run(r.exec); err != nil {
+	args := []string{"branch"}
+	if upstream == "" {
+		args = append(args, "--unset-upstream")
+	} else {
+		args = append(args, "--set-upstream-to="+upstream)
+	}
+	args = append(args, branch)
+
+	if err := r.gitCmd(ctx, args...).Run(r.exec); err != nil {
 		return fmt.Errorf("git branch: %w", err)
 	}
 	return nil

--- a/internal/git/branch_test.go
+++ b/internal/git/branch_test.go
@@ -264,6 +264,18 @@ func TestIntegrationRemoteBranches(t *testing.T) {
 		assert.Equal(t, "origin/feature1", upstream)
 	})
 
+	t.Run("unset upstream", func(t *testing.T) {
+		require.NoError(t,
+			repo.SetBranchUpstream(ctx, "feature1", ""))
+
+		_, err := repo.BranchUpstream(ctx, "feature1")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, git.ErrNotExist)
+	})
+
+	require.NoError(t,
+		repo.SetBranchUpstream(ctx, "feature1", "origin/feature1"))
+
 	t.Run("delete upstream", func(t *testing.T) {
 		require.NoError(t,
 			repo.DeleteBranch(ctx, "origin/feature1", git.BranchDeleteOptions{

--- a/internal/spice/branch.go
+++ b/internal/spice/branch.go
@@ -282,7 +282,7 @@ func (s *Service) RenameBranch(ctx context.Context, oldName, newName string) err
 		BaseHash:       oldBranch.BaseHash,
 		ChangeForge:    changeForge,
 		ChangeMetadata: changeMetadata,
-		UpstreamBranch: oldBranch.UpstreamBranch,
+		UpstreamBranch: &oldBranch.UpstreamBranch,
 	}); err != nil {
 		return fmt.Errorf("create branch with name %v: %w", newName, err)
 	}

--- a/internal/spice/state/store_test.go
+++ b/internal/spice/state/store_test.go
@@ -105,12 +105,13 @@ func TestStore(t *testing.T) {
 	})
 
 	t.Run("upstream branch", func(t *testing.T) {
+		upstream := "remoteBranch"
 		err := state.UpdateBranch(ctx, store, &state.UpdateRequest{
 			Upserts: []state.UpsertRequest{{
 				Name:           "localBranch",
 				Base:           "main",
 				BaseHash:       "abcdef",
-				UpstreamBranch: "remoteBranch",
+				UpstreamBranch: &upstream,
 			}},
 		})
 		require.NoError(t, err)

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -202,6 +202,10 @@ func (f *Form) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case acceptFieldMsg:
+		if f.focused >= len(f.fields) {
+			return f, tea.Quit
+		}
+
 		// When a field is accepted, freeze its current view.
 		var acceptedView strings.Builder
 		f.renderField(&acceptedView, f.fields[f.focused], true)

--- a/main.go
+++ b/main.go
@@ -40,6 +40,8 @@ var (
 
 var errNoPrompt = fmt.Errorf("not allowed to prompt for input")
 
+var _highlightStyle = ui.NewStyle().Foreground(ui.Cyan).Bold(true)
+
 func main() {
 	logger := log.NewWithOptions(os.Stderr, log.Options{
 		Level: log.InfoLevel,

--- a/testdata/script/branch_split_reassign_submitted.txt
+++ b/testdata/script/branch_split_reassign_submitted.txt
@@ -1,0 +1,177 @@
+# branch split supports reassigning submitted CRs
+# to a different branch.
+
+[!unix] skip # pending https://github.com/creack/pty/pull/155
+
+as 'Test <test@example.com>'
+at '2024-10-26T17:30:31Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+shamhub init
+shamhub register alice
+shamhub new origin alice/example.git
+git push origin main
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# setup: one branch with three commits
+git add feat1.txt
+gs bc -m feat1 features
+git add feat2.txt
+gs cc -m feat2
+git add feat3.txt
+gs cc -m feat3
+
+# sanity check
+gs ll -a
+cmp stderr $WORK/golden/ll-before.txt
+
+# setup: submit the branch
+gs bs --fill
+
+# splitting the branch prompts for reassignment
+with-term -final exit $WORK/input/prompt.txt -- gs branch split --at HEAD~2:feat1 --at HEAD^:feat2
+cmp stdout $WORK/golden/prompt.txt
+
+gs ll -a
+cmp stderr $WORK/golden/ll-split.txt
+
+# modify the branch that owns the CR
+gs bottom
+cp $WORK/extra/feat1-new.txt feat1.txt
+git add feat1.txt
+gs cc -m 'new feat 1'
+
+gs ll -a
+cmp stderr $WORK/golden/ll-commit-feat1.txt
+
+# submit the entire stack
+gs stack submit --fill
+shamhub dump changes
+cmpenvJSON stdout $WORK/golden/pulls.json
+
+gs ll -a
+cmp stderr $WORK/golden/ll-final.txt
+
+-- repo/feat1.txt --
+feat 1
+-- repo/feat2.txt --
+feat 2
+-- repo/feat3.txt --
+feat 3
+-- extra/feat1-new.txt --
+new feat 1
+-- golden/ll-before.txt --
+┏━■ features ◀
+┃   f460550 feat3 (now)
+┃   f9c1263 feat2 (now)
+┃   1578492 feat1 (now)
+main
+-- input/prompt.txt --
+await Assign CR #1 to branch
+snapshot init
+feed feat1
+await
+snapshot search
+feed \r
+-- golden/prompt.txt --
+### init ###
+Assign CR #1 to branch:
+
+  feat1
+  feat2
+▶ features
+
+Branch being split has an open CR assigned to it.
+Select which branch should take over the CR.
+### search ###
+Assign CR #1 to branch:
+
+▶ feat1
+
+Branch being split has an open CR assigned to it.
+Select which branch should take over the CR.
+### exit ###
+Assign CR #1 to branch: feat1
+INF features: Upstream branch 'features' transferred to 'feat1'
+WRN features: If you push this branch with 'git push' instead of 'gs branch submit',
+WRN features: remember to use a different upstream branch name with the command:
+    git push -u origin features:<new name>
+-- golden/ll-split.txt --
+    ┏━■ features ◀
+    ┃   f460550 feat3 (now)
+  ┏━┻□ feat2
+  ┃    f9c1263 feat2 (now)
+┏━┻□ feat1 (#1)
+┃    1578492 feat1 (now)
+main
+-- golden/ll-commit-feat1.txt --
+    ┏━□ features
+    ┃   d543265 feat3 (now)
+  ┏━┻□ feat2
+  ┃    4432c24 feat2 (now)
+┏━┻■ feat1 (#1) ◀
+┃    215a01b new feat 1 (now)
+┃    1578492 feat1 (now)
+main
+-- golden/ll-final.txt --
+    ┏━□ features (#3)
+    ┃   d543265 feat3 (now)
+  ┏━┻□ feat2 (#2)
+  ┃    4432c24 feat2 (now)
+┏━┻■ feat1 (#1) ◀
+┃    215a01b new feat 1 (now)
+┃    1578492 feat1 (now)
+main
+-- golden/pulls.json --
+[
+  {
+    "number": 1,
+    "html_url": "$SHAMHUB_URL/alice/example/change/1",
+    "state": "open",
+    "title": "feat1",
+    "body": "feat1\n\nfeat2\n\nfeat3",
+    "base": {
+      "ref": "main",
+      "sha": "5142f7714f22cf4dcf062504922f0cb20dd7ba00"
+    },
+    "head": {
+      "ref": "features",
+      "sha": "215a01b45667f154f7d8cbc15ac81ceeba837124"
+    }
+  },
+  {
+    "number": 2,
+    "html_url": "$SHAMHUB_URL/alice/example/change/2",
+    "state": "open",
+    "title": "feat2",
+    "body": "",
+    "base": {
+      "ref": "features",
+      "sha": "215a01b45667f154f7d8cbc15ac81ceeba837124"
+    },
+    "head": {
+      "ref": "feat2",
+      "sha": "4432c24dc64b97751d795163fbb8c2c71b20dedd"
+    }
+  },
+  {
+    "number": 3,
+    "html_url": "$SHAMHUB_URL/alice/example/change/3",
+    "state": "open",
+    "title": "feat3",
+    "body": "",
+    "base": {
+      "ref": "feat2",
+      "sha": "4432c24dc64b97751d795163fbb8c2c71b20dedd"
+    },
+    "head": {
+      "ref": "features-2",
+      "sha": "d543265b0dc321aaae88c652f0d7937fc8fea257"
+    }
+  }
+]


### PR DESCRIPTION
When splitting a branch that has already been submitted,
prompt the user to reassign the CR to one of the branches
(defaulting to the original branch).

![bsp-reassoc](https://github.com/user-attachments/assets/36a42664-88f3-4f68-826e-296291ccc3c3)


Resolves #410