### PR TITLE
submit: Generate unique remote name if branch name is taken

### DIFF
--- a/.changes/unreleased/Fixed-20241106-052308.yaml
+++ b/.changes/unreleased/Fixed-20241106-052308.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'submit: If a branch has already been pushed to the remote repository with `git push -u`, use that branch name when creating a CR.'
+time: 2024-11-06T05:23:08.585547-08:00

--- a/.changes/unreleased/Fixed-20241106-052308.yaml
+++ b/.changes/unreleased/Fixed-20241106-052308.yaml
@@ -1,3 +1,3 @@
-kind: Fixed
+kind: Changed
 body: 'submit: If a branch has already been pushed to the remote repository with `git push -u`, use that branch name when creating a CR.'
 time: 2024-11-06T05:23:08.585547-08:00

--- a/.changes/unreleased/Fixed-20241108-054719.yaml
+++ b/.changes/unreleased/Fixed-20241108-054719.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: >-
+  submit: If a branch name is already taken in the remote,
+  generate a unique name for the remote branch that is used to submit the CR.
+time: 2024-11-08T05:47:19.503116-08:00

--- a/.changes/unreleased/Fixed-20241108-055122.yaml
+++ b/.changes/unreleased/Fixed-20241108-055122.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'submit: When matching externally submitted CRs to a branch, reject matches where the names are equal but their HEADs are not.'
+time: 2024-11-08T05:51:22.431767-08:00

--- a/.changes/unreleased/Fixed-20241108-055122.yaml
+++ b/.changes/unreleased/Fixed-20241108-055122.yaml
@@ -1,3 +1,3 @@
-kind: Fixed
+kind: Changed
 body: 'submit: When matching externally submitted CRs to a branch, reject matches where the names are equal but their HEADs are not.'
 time: 2024-11-08T05:51:22.431767-08:00

--- a/branch_submit.go
+++ b/branch_submit.go
@@ -178,6 +178,8 @@ func (cmd *branchSubmitCmd) run(
 			// origin/branch -> branch
 			if b, ok := strings.CutPrefix(upstream, remote+"/"); ok {
 				upstreamBranch = b
+				log.Infof("%v: Using upstream name '%v'", cmd.Branch, upstreamBranch)
+				log.Infof("%v: If this is incorrect, cancel this operation and run 'git branch --unset-upstream %v'.", cmd.Branch, cmd.Branch)
 			}
 		}
 	}
@@ -227,6 +229,7 @@ func (cmd *branchSubmitCmd) run(
 				if change.HeadHash != commitHash {
 					log.Infof("%v: Ignoring CR %v with the same branch name: remote HEAD (%v) does not match local HEAD (%v)",
 						cmd.Branch, change.ID, change.HeadHash, commitHash)
+					log.Infof("%v: If this is incorrect, cancel this operation, 'git pull' the branch, and retry.", cmd.Branch)
 					break
 				}
 				upstreamBranch = cmd.Branch
@@ -344,7 +347,8 @@ func (cmd *branchSubmitCmd) run(
 			}
 
 			if unique != cmd.Branch {
-				log.Infof("%v: using upstream branch %v", cmd.Branch, unique)
+				log.Infof("%v: Branch name already in use in remote '%v'", cmd.Branch, remote)
+				log.Infof("%v: Using upstream name '%v' instead", cmd.Branch, unique)
 			}
 			upstreamBranch = unique
 		}

--- a/internal/git/remote_test.go
+++ b/internal/git/remote_test.go
@@ -1,0 +1,102 @@
+package git_test
+
+import (
+	"context"
+	"io"
+	"os/exec"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/sliceutil"
+	"go.uber.org/mock/gomock"
+)
+
+func TestRepositoryListRemoteRefs(t *testing.T) {
+	mockExecer := git.NewMockExecer(gomock.NewController(t))
+	repo := git.NewTestRepository(t, "", mockExecer)
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	mockExecer.EXPECT().
+		Start(gomock.Any()).
+		Do(func(cmd *exec.Cmd) error {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				_, _ = io.WriteString(cmd.Stdout, "abc123\trefs/heads/main\n")
+				_, _ = io.WriteString(cmd.Stdout, "malformed entry is ignored\n")
+				_, _ = io.WriteString(cmd.Stdout, "def456\trefs/heads/feature\n")
+				assert.NoError(t, cmd.Stdout.(io.Closer).Close())
+			}()
+			return nil
+		})
+	mockExecer.EXPECT().
+		Wait(gomock.Any()).
+		Return(nil)
+
+	got, err := sliceutil.CollectErr(repo.ListRemoteRefs(ctx, "origin", nil))
+	require.NoError(t, err)
+
+	assert.Equal(t, []git.RemoteRef{
+		{
+			Name: "refs/heads/main",
+			Hash: "abc123",
+		},
+		{
+			Name: "refs/heads/feature",
+			Hash: "def456",
+		},
+	}, got)
+}
+
+func TestRepositoryListRemoteRefsOptions(t *testing.T) {
+	mockExecer := git.NewMockExecer(gomock.NewController(t))
+	repo := git.NewTestRepository(t, "", mockExecer)
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	mockExecer.EXPECT().
+		Start(gomock.Any()).
+		Do(func(cmd *exec.Cmd) error {
+			assert.Equal(t, []string{
+				"ls-remote", "--quiet",
+				"--heads", "origin", "refs/heads/feat*",
+			}, cmd.Args[1:])
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				_, _ = io.WriteString(cmd.Stdout, "abc123\trefs/heads/feat1\n")
+				_, _ = io.WriteString(cmd.Stdout, "def456\trefs/heads/feat2\n")
+				_, _ = io.WriteString(cmd.Stdout, "ghi789\trefs/heads/feat3\n")
+				assert.NoError(t, cmd.Stdout.(io.Closer).Close())
+			}()
+			return nil
+		})
+	mockExecer.EXPECT().
+		Kill(gomock.Any()).
+		Return(nil)
+
+	opts := git.ListRemoteRefsOptions{
+		Heads:    true,
+		Patterns: []string{"refs/heads/feat*"},
+	}
+
+	for ref, err := range repo.ListRemoteRefs(ctx, "origin", &opts) {
+		require.NoError(t, err)
+		assert.Equal(t, git.RemoteRef{
+			Name: "refs/heads/feat1",
+			Hash: "abc123",
+		}, ref)
+		break
+	}
+}

--- a/internal/spice/mock_service_test.go
+++ b/internal/spice/mock_service_test.go
@@ -11,6 +11,7 @@ package spice
 
 import (
 	context "context"
+	iter "iter"
 	reflect "reflect"
 
 	git "go.abhg.dev/gs/internal/git"
@@ -113,6 +114,20 @@ func (m *MockGitRepository) IsAncestor(ctx context.Context, a, b git.Hash) bool 
 func (mr *MockGitRepositoryMockRecorder) IsAncestor(ctx, a, b any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAncestor", reflect.TypeOf((*MockGitRepository)(nil).IsAncestor), ctx, a, b)
+}
+
+// ListRemoteRefs mocks base method.
+func (m *MockGitRepository) ListRemoteRefs(ctx context.Context, remote string, opts *git.ListRemoteRefsOptions) iter.Seq2[git.RemoteRef, error] {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRemoteRefs", ctx, remote, opts)
+	ret0, _ := ret[0].(iter.Seq2[git.RemoteRef, error])
+	return ret0
+}
+
+// ListRemoteRefs indicates an expected call of ListRemoteRefs.
+func (mr *MockGitRepositoryMockRecorder) ListRemoteRefs(ctx, remote, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRemoteRefs", reflect.TypeOf((*MockGitRepository)(nil).ListRemoteRefs), ctx, remote, opts)
 }
 
 // ListRemotes mocks base method.

--- a/internal/spice/remote.go
+++ b/internal/spice/remote.go
@@ -1,0 +1,51 @@
+package spice
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"go.abhg.dev/gs/internal/git"
+)
+
+// UnusedBranchName returns a branch name that is not in use in the given remote,
+// based on the given branch name.
+func (s *Service) UnusedBranchName(ctx context.Context, remote, branch string) (string, error) {
+	// ListRemoteRefs makes a network call, so we lookups in batches.
+	const batchSize = 5
+
+	candidates := make([]string, 0, batchSize)
+	sawBranches := make(map[string]struct{})
+	for batchStart := 1; ; batchStart += batchSize {
+		candidates = candidates[:0]
+		clear(sawBranches)
+
+		for i := batchStart; i < batchStart+batchSize; i++ {
+			name := branch
+			if i > 1 {
+				name += fmt.Sprintf("-%d", i)
+			}
+			candidates = append(candidates, name)
+		}
+
+		opts := git.ListRemoteRefsOptions{
+			Heads:    true,
+			Patterns: candidates,
+		}
+
+		for remoteRef, err := range s.repo.ListRemoteRefs(ctx, remote, &opts) {
+			if err != nil {
+				return "", fmt.Errorf("list remote refs: %w", err)
+			}
+
+			name := strings.TrimPrefix(remoteRef.Name, "refs/heads/")
+			sawBranches[name] = struct{}{}
+		}
+
+		for _, name := range candidates {
+			if _, ok := sawBranches[name]; !ok {
+				return name, nil
+			}
+		}
+	}
+}

--- a/internal/spice/remote_test.go
+++ b/internal/spice/remote_test.go
@@ -1,0 +1,123 @@
+package spice
+
+import (
+	"context"
+	"iter"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/logtest"
+	gomock "go.uber.org/mock/gomock"
+)
+
+func TestUnusedBranchName(t *testing.T) {
+	log := logtest.New(t)
+
+	type listRemoteRefsCall struct {
+		want []string
+		give []string
+	}
+
+	tests := []struct {
+		name string
+
+		branch     string
+		calls      []listRemoteRefsCall
+		wantBranch string
+	}{
+		{
+			name:   "NoExistingBranches",
+			branch: "feature",
+			calls: []listRemoteRefsCall{
+				{
+					want: []string{"feature", "feature-2", "feature-3", "feature-4", "feature-5"},
+				},
+			},
+			wantBranch: "feature",
+		},
+		{
+			name:   "OriginalNameTaken",
+			branch: "feature",
+			calls: []listRemoteRefsCall{
+				{
+					want: []string{"feature", "feature-2", "feature-3", "feature-4", "feature-5"},
+					give: []string{"feature"},
+				},
+			},
+			wantBranch: "feature-2",
+		},
+		{
+			name:   "SecondBatch",
+			branch: "feature",
+			calls: []listRemoteRefsCall{
+				{
+					want: []string{"feature", "feature-2", "feature-3", "feature-4", "feature-5"},
+					give: []string{"feature", "feature-2", "feature-3", "feature-4", "feature-5"},
+				},
+				{
+					want: []string{"feature-6", "feature-7", "feature-8", "feature-9", "feature-10"},
+					give: []string{"feature-6", "feature-7", "feature-8", "feature-9"},
+				},
+			},
+			wantBranch: "feature-10",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			repo := NewMockGitRepository(mockCtrl)
+			svc := NewTestService(repo, NewMockStore(mockCtrl), nil, log)
+
+			var lastCall *gomock.Call
+			for _, call := range tt.calls {
+				currCall := repo.EXPECT().
+					ListRemoteRefs(gomock.Any(), "origin", &git.ListRemoteRefsOptions{
+						Heads:    true,
+						Patterns: call.want,
+					}).
+					Return(iterRefs(call.give...))
+				if lastCall != nil {
+					currCall.After(lastCall)
+				}
+				lastCall = currCall
+			}
+
+			got, err := svc.UnusedBranchName(context.Background(), "origin", tt.branch)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantBranch, got)
+		})
+	}
+}
+
+func TestUnusedBranchName_listError(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	repo := NewMockGitRepository(mockCtrl)
+	svc := NewTestService(repo, NewMockStore(mockCtrl), nil, logtest.New(t))
+
+	repo.EXPECT().
+		ListRemoteRefs(gomock.Any(), "origin", gomock.Any()).
+		Return(func(yield func(git.RemoteRef, error) bool) {
+			yield(git.RemoteRef{}, assert.AnError)
+		})
+
+	_, err := svc.UnusedBranchName(context.Background(), "origin", "feature")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, assert.AnError)
+}
+
+func iterRefs(branchNames ...string) iter.Seq2[git.RemoteRef, error] {
+	return func(yield func(git.RemoteRef, error) bool) {
+		for _, name := range branchNames {
+			ref := git.RemoteRef{
+				Name: "refs/heads/" + name,
+				Hash: "abc123",
+			}
+			if !yield(ref, nil) {
+				return
+			}
+		}
+	}
+}

--- a/internal/spice/service.go
+++ b/internal/spice/service.go
@@ -3,6 +3,7 @@ package spice
 
 import (
 	"context"
+	"iter"
 
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/forge"
@@ -41,6 +42,12 @@ type GitRepository interface {
 	// ListRemotes returns the names of all known remotes.
 	ListRemotes(ctx context.Context) ([]string, error)
 	RemoteURL(ctx context.Context, remote string) (string, error)
+
+	// ListRemoteRefs returns an iterator over references in a remote
+	// Git repository that match the given options.
+	ListRemoteRefs(
+		ctx context.Context, remote string, opts *git.ListRemoteRefsOptions,
+	) iter.Seq2[git.RemoteRef, error]
 
 	Rebase(context.Context, git.RebaseRequest) error
 	RenameBranch(context.Context, git.RenameBranchRequest) error
@@ -100,10 +107,19 @@ func NewService(ctx context.Context, repo GitRepository, store Store, log *log.L
 		}
 	}
 
+	return newService(repo, store, forg, log)
+}
+
+func newService(
+	repo GitRepository,
+	store Store,
+	forge forge.Forge,
+	log *log.Logger,
+) *Service {
 	return &Service{
 		repo:  repo,
 		store: store,
+		forge: forge,
 		log:   log,
-		forge: forg,
 	}
 }

--- a/internal/spice/service_test.go
+++ b/internal/spice/service_test.go
@@ -1,0 +1,24 @@
+package spice
+
+import (
+	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/forge/shamhub"
+)
+
+// NewTestService creates a new Service for testing.
+// If forge is nil, it uses the ShamHub forge.
+func NewTestService(
+	repo GitRepository,
+	store Store,
+	forge forge.Forge,
+	log *log.Logger,
+) *Service {
+	if forge == nil {
+		forge = &shamhub.Forge{
+			Log: log,
+		}
+	}
+
+	return newService(repo, store, forge, log)
+}

--- a/testdata/script/branch_submit_detect_existing_conflict.txt
+++ b/testdata/script/branch_submit_detect_existing_conflict.txt
@@ -38,7 +38,9 @@ gs bc feature -m 'Add feature 2'
 gs branch submit --fill
 stderr 'Ignoring CR #\d+ with the same branch name'
 stderr 'remote HEAD .+? does not match local HEAD'
-stderr 'using upstream branch feature-2'
+stderr 'If this is incorrect, cancel this operation.*git pull.*and retry'
+stderr 'Branch name already in use in remote ''origin'''
+stderr 'Using upstream name ''feature-2'''
 
 git rev-parse --abbrev-ref feature@{upstream}
 stdout 'origin/feature-2'

--- a/testdata/script/branch_submit_detect_existing_conflict.txt
+++ b/testdata/script/branch_submit_detect_existing_conflict.txt
@@ -1,0 +1,50 @@
+# When looking for existing CRs,
+# 'branch submit' will disregard CRs that don't match HEAD.
+
+as 'Test <test@example.com>'
+at '2024-11-06T05:31:32Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub register alice
+shamhub new origin alice/example.git
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# create a CR with the name "feature"
+git add feat1.txt
+gs bc -m feat1
+git push -u origin feat1:feature
+gs bs --fill
+
+# go back to trunk, forget all state,
+# create a new branch with a different file.
+gs trunk
+gs repo init --reset --trunk=main --remote=origin
+git add feat2.txt
+gs bc feature -m 'Add feature 2'
+
+# Since we don't have an upstream branch associated,
+# gs will want to use 'feature' as the branch name.
+# This will fail, because 'feature' is already taken
+# by the CR we created earlier.
+gs branch submit --fill
+stderr 'Ignoring CR #\d+ with the same branch name'
+stderr 'remote HEAD .+? does not match local HEAD'
+stderr 'using upstream branch feature-2'
+
+git rev-parse --abbrev-ref feature@{upstream}
+stdout 'origin/feature-2'
+
+-- repo/feat1.txt --
+feature 1
+
+-- repo/feat2.txt --
+feature 2

--- a/testdata/script/branch_submit_detect_existing_upstream_name.txt
+++ b/testdata/script/branch_submit_detect_existing_upstream_name.txt
@@ -1,0 +1,58 @@
+# 'branch submit' should detect a PR created
+# outside of the 'branch submit' command
+# even if it used a different name with `--set-upstream`.
+
+as 'Test <test@example.com>'
+at '2024-11-06T05:26:00Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub register alice
+shamhub new origin alice/example.git
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# create a new branch and submit it
+git add feat1.txt
+gs bc -m feat1
+git push --set-upstream origin feat1:feature1
+gs bs --fill
+stderr 'Created #'
+git cat-file blob refs/spice/data:branches/feat1
+cmp stdout $WORK/golden/feat1-state.txt
+
+# forget all state, re-track the branch
+gs repo init --reset --trunk=main --remote=origin
+gs branch track --base=main feat1
+# re-submitting should detect that the PR already exists
+
+gs branch submit
+stderr 'feat1: Found existing CR #1'
+stderr 'feat1: Found existing navigation comment'
+stderr 'CR #\d+ is up-to-date'
+
+-- repo/feat1.txt --
+feature 1
+-- golden/feat1-state.txt --
+{
+  "base": {
+    "name": "main",
+    "hash": "2ff547329e55465505b962b0615d398764bea3de"
+  },
+  "upstream": {
+    "branch": "feature1"
+  },
+  "change": {
+    "shamhub": {
+      "number": 1,
+      "nav_comment": 1
+    }
+  }
+}

--- a/testdata/script/branch_submit_many_upstream_names_taken.txt
+++ b/testdata/script/branch_submit_many_upstream_names_taken.txt
@@ -1,0 +1,75 @@
+# 'branch submit' correctly handles the case when a bunch of $name-$number
+# branch names are taken.
+
+as 'Test <test@example.com>'
+at '2024-11-08T05:38:39Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub register alice
+shamhub new origin alice/example.git
+git push origin main
+gs repo init
+
+# take feature, feature-2, and so on until feature-9.
+git branch feature
+git branch feature-2
+git branch feature-3
+git branch feature-4
+git branch feature-5
+git branch feature-6
+git branch feature-7
+git branch feature-8
+git branch feature-9
+git push origin feature feature-2 feature-3 feature-4 feature-5 feature-6 feature-7 feature-8 feature-9
+
+# free up 'feature' for local use.
+git branch -D feature
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# create a CR with the name "feature"
+git add feat1.txt
+gs bc -m 'add feature' feature
+gs bs --fill
+stderr 'feature: using upstream branch feature-10'
+
+git rev-parse --abbrev-ref feature@{upstream}
+stdout 'origin/feature-10'
+
+gs ll
+cmp stderr $WORK/golden/ll.txt
+
+shamhub dump changes
+cmpenvJSON stdout $WORK/golden/changes.json
+
+-- repo/feat1.txt --
+feature 1
+-- golden/ll.txt --
+┏━■ feature (#1) ◀
+┃   4af1d44 add feature (now)
+main
+-- golden/changes.json --
+[
+  {
+    "number": 1,
+    "html_url": "$SHAMHUB_URL/alice/example/change/1",
+    "state": "open",
+    "title": "add feature",
+    "body": "",
+    "base": {
+      "ref": "main",
+      "sha": "27316d3a0e4f2410c3b0215fb5153bfe5b4e2b9a"
+    },
+    "head": {
+      "ref": "feature-10",
+      "sha": "4af1d441e9ebd2a2abd75de1d969a90c3f25fb6f"
+    }
+  }
+]

--- a/testdata/script/branch_submit_many_upstream_names_taken.txt
+++ b/testdata/script/branch_submit_many_upstream_names_taken.txt
@@ -38,7 +38,7 @@ gs auth login
 git add feat1.txt
 gs bc -m 'add feature' feature
 gs bs --fill
-stderr 'Branch name alread in use in remote ''origin'''
+stderr 'Branch name already in use in remote ''origin'''
 stderr 'Using upstream name ''feature-10'''
 
 git rev-parse --abbrev-ref feature@{upstream}

--- a/testdata/script/branch_submit_many_upstream_names_taken.txt
+++ b/testdata/script/branch_submit_many_upstream_names_taken.txt
@@ -38,7 +38,8 @@ gs auth login
 git add feat1.txt
 gs bc -m 'add feature' feature
 gs bs --fill
-stderr 'feature: using upstream branch feature-10'
+stderr 'Branch name alread in use in remote ''origin'''
+stderr 'Using upstream name ''feature-10'''
 
 git rev-parse --abbrev-ref feature@{upstream}
 stdout 'origin/feature-10'

--- a/testdata/script/branch_submit_upstream_name.txt
+++ b/testdata/script/branch_submit_upstream_name.txt
@@ -27,6 +27,9 @@ git add feat1.txt
 git commit -m 'update feature 1'
 
 gs branch submit --fill
+stderr 'feat1: Using upstream name ''feature1'''
+stderr 'If this is incorrect, cancel this operation'
+stderr 'git branch --unset-upstream feat1'
 
 gs ll
 cmp stderr $WORK/golden/ll.txt

--- a/testdata/script/branch_submit_upstream_name.txt
+++ b/testdata/script/branch_submit_upstream_name.txt
@@ -1,0 +1,65 @@
+# If the branch has already been pushed with '--set-upstream',
+# that name is preferred over the branch name.
+
+as 'Test <test@example.com>'
+at '2024-11-06T05:06:07Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+git add feat1.txt
+gs bc feat1 -m 'Add feature 1'
+git push --set-upstream origin feat1:feature1
+
+cp $WORK/extra/feat1-new.txt feat1.txt
+git add feat1.txt
+git commit -m 'update feature 1'
+
+gs branch submit --fill
+
+gs ll
+cmp stderr $WORK/golden/ll.txt
+
+shamhub dump changes
+cmpenvJSON stdout $WORK/golden/pulls.json
+
+-- repo/feat1.txt --
+feature 1
+
+-- extra/feat1-new.txt --
+feature 1 new
+
+-- golden/ll.txt --
+┏━■ feat1 (#1) ◀
+┃   b7f8335 update feature 1 (now)
+┃   6731361 Add feature 1 (now)
+main
+-- golden/pulls.json --
+[
+  {
+    "number": 1,
+    "html_url": "$SHAMHUB_URL/alice/example/change/1",
+    "state": "open",
+    "title": "Add feature 1",
+    "body": "Add feature 1\n\nupdate feature 1",
+    "base": {
+      "ref": "main",
+      "sha": "c8486fbc58e9e6ee1058aac1a82e5f14fe50fc7c"
+    },
+    "head": {
+      "ref": "feature1",
+      "sha": "b7f833587ec8e8e0deab17f6e222861e302a18ce"
+    }
+  }
+]

--- a/testdata/script/branch_submit_upstream_name_wrong_remote.txt
+++ b/testdata/script/branch_submit_upstream_name_wrong_remote.txt
@@ -1,0 +1,64 @@
+# If the branch has alreday been pushed with '--set-upstream',
+# but to a different remote, don't use that branch name.
+
+as 'Test <test@example.com>'
+at '2024-11-06T05:18:19Z'
+
+# setup
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+cd ..
+git clone repo fork
+cd fork
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new upstream alice/example.git
+shamhub register alice
+git push upstream main
+
+env SHAMHUB_USERNAME=alice
+gs repo init --remote=upstream
+gs auth login
+
+cp $WORK/extra/feat1.txt feat1.txt
+git add feat1.txt
+gs bc feat1 -m 'Add feature 1'
+
+git push --set-upstream origin feat1:feature1
+gs branch submit --fill
+
+gs ll
+cmp stderr $WORK/golden/ll.txt
+
+shamhub dump changes
+cmpenvJSON stdout $WORK/golden/pulls.json
+
+
+-- extra/feat1.txt --
+feature 1
+-- golden/ll.txt --
+┏━■ feat1 (#1) ◀
+┃   aa30b56 Add feature 1 (now)
+main
+-- golden/pulls.json --
+[
+  {
+    "number": 1,
+    "html_url": "$SHAMHUB_URL/alice/example/change/1",
+    "state": "open",
+    "title": "Add feature 1",
+    "body": "",
+    "base": {
+      "ref": "main",
+      "sha": "bb59b1128830316c4a7939f3c97d31579793376f"
+    },
+    "head": {
+      "ref": "feat1",
+      "sha": "aa30b568f30e13394f834da24a76ca42e5bf9400"
+    }
+  }
+]


### PR DESCRIPTION
When submitting a branch `$name`,
it's possible that someone else has already taken that name.
For example, the local branch name might be something generic
like 'feature', and someone else may already have taken that name.

To handle this case, gs will now query the remote with `git ls-remote`,
and generate a unique name for the branch if the original name is taken.
New names start at `$name-2`, and keep incrementing the number
until a free name is found.

Making this change results in a couple other changes:

- If the branch has an upstream associated with it,
  e.g. with `git push -u origin foo:bar`, we'll prefer that name
  since the user has already pushed the branch and chosen it.
  This makes sense: I pushed the branch, and associated the upstream
  with the branch, so that's what should be used.
- When matching externally submitted CRs to the branch,
  just matching on the branch name is no longer sufficient.
  If we're handling conflicting names, we have to account for the case
  where someone else submitted a CR with the conflicting branch name.
  Therefore, CR matching now also requires that the HEADs match.

Resolves #408
