### PR TITLE
submit: list templates: allow configuring timeout

### DIFF
--- a/.changes/unreleased/Added-20241109-095515.yaml
+++ b/.changes/unreleased/Added-20241109-095515.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'submit: Add `spice.submit.listTemplatesTimeout` configuration option to change the timeout for template lookup operations.'
+time: 2024-11-09T09:55:15.926195-08:00

--- a/branch_submit_test.go
+++ b/branch_submit_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/logtest"
+)
+
+func TestBranchSubmit_listChangeTemplates(t *testing.T) {
+	t.Run("NoTimeout", func(t *testing.T) {
+		log := logtest.New(t)
+		ctx := context.Background()
+		tmpl := &forge.ChangeTemplate{}
+		svc := &spiceTemplateServiceStub{
+			ListChangeTemplatesF: func(ctx context.Context, _ string, _ forge.Repository) ([]*forge.ChangeTemplate, error) {
+				_, ok := ctx.Deadline()
+				require.False(t, ok, "context should not have a deadline")
+
+				return []*forge.ChangeTemplate{tmpl}, nil
+			},
+		}
+
+		got := (&branchSubmitCmd{}).listChangeTemplates(ctx, log, svc, "origin", nil)
+		if assert.Len(t, got, 1) {
+			assert.Same(t, tmpl, got[0])
+		}
+	})
+
+	t.Run("Timeout", func(t *testing.T) {
+		log := logtest.New(t)
+		ctx := context.Background()
+
+		svc := &spiceTemplateServiceStub{
+			ListChangeTemplatesF: func(ctx context.Context, _ string, _ forge.Repository) ([]*forge.ChangeTemplate, error) {
+				_, ok := ctx.Deadline()
+				require.True(t, ok, "context should have a deadline")
+				return nil, errors.New("great sadness")
+			},
+		}
+
+		got := (&branchSubmitCmd{
+			ListTemplatesTimeout: time.Second,
+		}).listChangeTemplates(ctx, log, svc, "origin", nil)
+		assert.Empty(t, got)
+	})
+}
+
+type spiceTemplateServiceStub struct {
+	ListChangeTemplatesF func(context.Context, string, forge.Repository) ([]*forge.ChangeTemplate, error)
+}
+
+func (s *spiceTemplateServiceStub) ListChangeTemplates(ctx context.Context, remoteName string, fr forge.Repository) ([]*forge.ChangeTemplate, error) {
+	return s.ListChangeTemplatesF(ctx, remoteName, fr)
+}

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -752,7 +752,7 @@ or --nav-comment=multiple to post those comments only if there are multiple CRs 
 * `--body=BODY`: Body of the change request
 * `--branch=NAME`: Branch to submit
 
-**Configuration**: [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.web](/cli/config.md#spicesubmitweb), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment)
+**Configuration**: [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.web](/cli/config.md#spicesubmitweb), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.listTemplatesTimeout](/cli/config.md#spicesubmitlisttemplatestimeout)
 
 ## Commit
 

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -79,6 +79,26 @@ instead of showing just the current stack.
 - `true`
 - `false` (default)
 
+### spice.submit.listTemplatesTimeout
+
+<!-- gs:version unreleased -->
+
+Maximum duration that $$gs branch submit$$ will wait
+to receive a list of available CR templates from the forge.
+If the timeout is reached, the command will proceed without a template.
+
+Value must be a duration string such as `5s`, `1m`, `1h`, etc.
+Defaults to `1s`.
+
+Bump this value if you see warnings like any of the following:
+
+```
+WRN Failed to cache templates err="cache templates: write object: hash-object: signal: killed"
+WRN Could not list change templates error="list templates: Post \"https://api.github.com/graphql\": context deadline exceeded"
+```
+
+Set to `0` to disable the timeout completely.
+
 ### spice.submit.navigationComment
 
 Specifies whether CR submission commands ($$gs branch submit$$ and friends)


### PR DESCRIPTION
The hard-coded timeout for looking up CR templates
was causing issues for users with slow connections.

```
WRN Could not list change templates error="list templates: Post \"https://api.github.com/graphql\": context deadline exceeded"
```

This adds a `spice.submit.listTemplatesTimeout` configuration
to configure this timeout.
Setting the timeout to 0 disables it completely.

Resolves #438