### PR TITLE
Add a --restack flag to repo sync

### DIFF
--- a/.changes/unreleased/Added-20241123-225228.yaml
+++ b/.changes/unreleased/Added-20241123-225228.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'repo sync: Add a --restack flag to automatically restack the current stack after syncing.'
+time: 2024-11-23T22:52:28.1537634Z

--- a/repo_sync.go
+++ b/repo_sync.go
@@ -19,7 +19,7 @@ import (
 
 type repoSyncCmd struct {
 	// TODO: flag to not delete merged branches?
-	// TODO: flag to auto-restack current stack
+	Restack bool `help:"Restack the current stack after syncing"`
 }
 
 func (*repoSyncCmd) Help() string {
@@ -223,7 +223,16 @@ func (cmd *repoSyncCmd) Run(
 		}
 	}
 
-	return cmd.deleteBranches(ctx, opts, log, repo, remote, branchesToDelete)
+	err = cmd.deleteBranches(ctx, opts, log, repo, remote, branchesToDelete)
+	if err != nil {
+		return err
+	}
+
+	if cmd.Restack {
+		return (&stackRestackCmd{}).Run(ctx, log, opts)
+	}
+
+	return nil
 }
 
 // findLocalMergedBranches finds branches that have been merged

--- a/testdata/script/repo_sync_restack.txt
+++ b/testdata/script/repo_sync_restack.txt
@@ -1,0 +1,67 @@
+# 'repo sync' with --restack flag restacks branches after syncing
+
+as 'Test <test@example.com>'
+at '2024-05-18T13:59:12Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# create a stack
+git add feature1.txt
+gs bc -m 'Add feature1' feature1
+
+git add feature2.txt
+gs bc -m 'Add feature2' feature2
+
+git add feature3.txt
+gs bc -m 'Add feature3' feature3
+
+# submit feature1
+gs bco feature1
+gs branch submit --fill
+stderr 'Created #'
+
+# merge the PR server side and sync with restack
+shamhub merge alice/example 1
+gs repo sync --restack
+stderr 'feature1: #1 was merged'
+
+# verify the stack was restacked after sync
+gs ls -a
+cmp stderr $WORK/golden/restacked.txt
+
+git graph --branches
+cmp stdout $WORK/golden/graph.txt
+
+-- repo/feature1.txt --
+Contents of feature1
+
+-- repo/feature2.txt --
+Contents of feature2
+
+-- repo/feature3.txt --
+Contents of feature3
+
+-- golden/restacked.txt --
+  ┏━□ feature3
+┏━┻□ feature2
+main ◀
+-- golden/graph.txt --
+* 935a1f6 (feature3) Add feature3
+* bd70ef4 (feature2) Add feature2
+*   614e5f2 (HEAD -> main, origin/main) Merge change #1
+|\  
+| * 9f1c9af Add feature1
+|/  
+* d90607e Initial commit


### PR DESCRIPTION
This change adds a --restack flag to `repo sync` which allows users to automatically restack their active stack after syncing the repo.

Fixes https://github.com/abhinav/git-spice/issues/384


---- 

Hi! Thanks for the useful tool. Also thanks for marking the issue as suitable for a first-time contributor. I hope the change is good, happy to take any feedback here!

I'm one of the maintainers of https://github.com/pulumi/pulumi-terraform-bridge and have recently started using git-spice and have found it very useful. See for example this currently active stack for an example of my usage: https://github.com/pulumi/pulumi-terraform-bridge/pull/2629 - It currently has 5 active PRs and 6 have already been merged.

I'm also interested in https://github.com/abhinav/git-spice/issues/314 and https://github.com/abhinav/git-spice/issues/331. If you have any thoughts for either of these, that'd be much appreciated - I'd like to pick up #331 next time I have some free time if that's OK!