### PR TITLE
ui: New terminal prompting API

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,10 +76,14 @@ make cover
 
 ### Test scripts
 
-Tests for the project make heavy use of the
-[testscript package](https://pkg.go.dev/github.com/rogpeppe/go-internal/testscript).
+Tests for the project make heavy use of the go-internal/testscript package.
+Read more about the test script language at [testscript package](https://pkg.go.dev/github.com/rogpeppe/go-internal/testscript).
+
 Tests scripts are stored inside the testdata/script directory.
-Read more about the test script format in the documentation of the package.
+On top of the base functionality of testscript,
+we add a bunch of custom commands and infrastructure to make testing easier.
+
+Read more about these in the [test scripts README](testdata/script/README.md).
 
 ## Releasing a new version
 

--- a/auth.go
+++ b/auth.go
@@ -29,9 +29,9 @@ func (c *authCmd) AfterApply(
 	ctx context.Context,
 	kctx *kong.Context,
 	log *log.Logger,
-	globals *globalOptions,
+	view ui.View,
 ) error {
-	f, err := resolveForge(ctx, log, globals, c.Forge)
+	f, err := resolveForge(ctx, log, view, c.Forge)
 	if err != nil {
 		return err
 	}
@@ -45,7 +45,7 @@ func (c *authCmd) AfterApply(
 // repository's remote URL.
 // If the forge cannot be guessed, it will prompt the user to select one
 // if we're in interactive mode.
-func resolveForge(ctx context.Context, log *log.Logger, globals *globalOptions, forgeID string) (forge.Forge, error) {
+func resolveForge(ctx context.Context, log *log.Logger, view ui.View, forgeID string) (forge.Forge, error) {
 	if forgeID != "" {
 		f, ok := forge.Lookup(forgeID)
 		if !ok {
@@ -82,7 +82,7 @@ func resolveForge(ctx context.Context, log *log.Logger, globals *globalOptions, 
 		return opts[0].Value, nil
 	}
 
-	if !globals.Prompt {
+	if !ui.Interactive(view) {
 		log.Error("No Forge specified, and could not guess one from the repository", "error", err)
 		return nil, fmt.Errorf("%w: please use the --forge flag", errNoPrompt)
 	}
@@ -91,7 +91,7 @@ func resolveForge(ctx context.Context, log *log.Logger, globals *globalOptions, 
 		WithTitle("Select a Forge").
 		WithOptions(opts...).
 		WithValue(&f)
-	err = ui.Run(field)
+	err = ui.Run(view, field)
 	return f, err
 }
 

--- a/auth_login.go
+++ b/auth_login.go
@@ -8,6 +8,7 @@ import (
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/secret"
 	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 type authLoginCmd struct {
@@ -33,7 +34,7 @@ func (cmd *authLoginCmd) Run(
 	ctx context.Context,
 	stash secret.Stash,
 	log *log.Logger,
-	globals *globalOptions,
+	view ui.View,
 	f forge.Forge,
 ) error {
 	if _, err := f.LoadAuthenticationToken(stash); err == nil && !cmd.Refresh {
@@ -41,7 +42,7 @@ func (cmd *authLoginCmd) Run(
 		return fmt.Errorf("%s: already logged in", f.ID())
 	}
 
-	secret, err := f.AuthenticationFlow(ctx)
+	secret, err := f.AuthenticationFlow(ctx, view)
 	if err != nil {
 		return err
 	}

--- a/auth_logout.go
+++ b/auth_logout.go
@@ -24,7 +24,6 @@ func (cmd *authLogoutCmd) Run(
 	ctx context.Context,
 	stash secret.Stash,
 	log *log.Logger,
-	globals *globalOptions,
 	f forge.Forge,
 ) error {
 	if err := f.ClearAuthenticationToken(stash); err != nil {

--- a/auth_status.go
+++ b/auth_status.go
@@ -20,7 +20,6 @@ func (cmd *authStatusCmd) Run(
 	ctx context.Context,
 	stash secret.Stash,
 	log *log.Logger,
-	globals *globalOptions,
 	f forge.Forge,
 ) error {
 	if _, err := f.LoadAuthenticationToken(stash); err != nil {

--- a/bottom.go
+++ b/bottom.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 type bottomCmd struct {
@@ -20,8 +21,8 @@ func (*bottomCmd) Help() string {
 	`)
 }
 
-func (cmd *bottomCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
-	repo, store, svc, err := openRepo(ctx, log, opts)
+func (cmd *bottomCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
+	repo, store, svc, err := openRepo(ctx, log, view)
 	if err != nil {
 		return err
 	}
@@ -44,5 +45,5 @@ func (cmd *bottomCmd) Run(ctx context.Context, log *log.Logger, opts *globalOpti
 	return (&branchCheckoutCmd{
 		checkoutOptions: cmd.checkoutOptions,
 		Branch:          bottom,
-	}).Run(ctx, log, opts)
+	}).Run(ctx, log, view)
 }

--- a/branch.go
+++ b/branch.go
@@ -52,7 +52,12 @@ type branchPrompt struct {
 	Description string
 }
 
-func (p *branchPrompt) Run(ctx context.Context, repo *git.Repository, store *state.Store) (string, error) {
+func (p *branchPrompt) Run(
+	ctx context.Context,
+	view ui.View,
+	repo *git.Repository,
+	store *state.Store,
+) (string, error) {
 	disabled := func(git.LocalBranch) bool { return false }
 	if p.Disabled != nil {
 		disabled = p.Disabled
@@ -112,7 +117,7 @@ func (p *branchPrompt) Run(ctx context.Context, repo *git.Repository, store *sta
 		WithValue(&value).
 		WithItems(items...).
 		WithDescription(p.Description)
-	if err := ui.Run(prompt); err != nil {
+	if err := ui.Run(view, prompt); err != nil {
 		return "", fmt.Errorf("select branch: %w", err)
 	}
 

--- a/branch_create.go
+++ b/branch_create.go
@@ -9,6 +9,7 @@ import (
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 type branchCreateCmd struct {
@@ -77,12 +78,12 @@ func (*branchCreateCmd) Help() string {
 	`)
 }
 
-func (cmd *branchCreateCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) (err error) {
+func (cmd *branchCreateCmd) Run(ctx context.Context, log *log.Logger, view ui.View) (err error) {
 	if cmd.Name == "" && !cmd.Commit {
 		return fmt.Errorf("a branch name is required with --no-commit")
 	}
 
-	repo, store, svc, err := openRepo(ctx, log, opts)
+	repo, store, svc, err := openRepo(ctx, log, view)
 	if err != nil {
 		return err
 	}
@@ -251,7 +252,7 @@ func (cmd *branchCreateCmd) Run(ctx context.Context, log *log.Logger, opts *glob
 	}
 
 	if cmd.Below || cmd.Insert {
-		return (&upstackRestackCmd{}).Run(ctx, log, opts)
+		return (&upstackRestackCmd{}).Run(ctx, log, view)
 	}
 
 	return nil

--- a/branch_edit.go
+++ b/branch_edit.go
@@ -10,6 +10,7 @@ import (
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 type branchEditCmd struct{}
@@ -23,8 +24,8 @@ func (*branchEditCmd) Help() string {
 	`)
 }
 
-func (*branchEditCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
-	repo, _, svc, err := openRepo(ctx, log, opts)
+func (*branchEditCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
+	repo, _, svc, err := openRepo(ctx, log, view)
 	if err != nil {
 		return err
 	}
@@ -58,5 +59,5 @@ func (*branchEditCmd) Run(ctx context.Context, log *log.Logger, opts *globalOpti
 		})
 	}
 
-	return (&upstackRestackCmd{}).Run(ctx, log, opts)
+	return (&upstackRestackCmd{}).Run(ctx, log, view)
 }

--- a/branch_fold.go
+++ b/branch_fold.go
@@ -10,6 +10,7 @@ import (
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 type branchFoldCmd struct {
@@ -26,8 +27,8 @@ func (*branchFoldCmd) Help() string {
 	`)
 }
 
-func (cmd *branchFoldCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
-	repo, store, svc, err := openRepo(ctx, log, opts)
+func (cmd *branchFoldCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
+	repo, store, svc, err := openRepo(ctx, log, view)
 	if err != nil {
 		return err
 	}
@@ -102,7 +103,7 @@ func (cmd *branchFoldCmd) Run(ctx context.Context, log *log.Logger, opts *global
 	}
 
 	// Check out base and delete the branch we are folding.
-	if err := (&branchCheckoutCmd{Branch: b.Base}).Run(ctx, log, opts); err != nil {
+	if err := (&branchCheckoutCmd{Branch: b.Base}).Run(ctx, log, view); err != nil {
 		return fmt.Errorf("checkout base: %w", err)
 	}
 

--- a/branch_rename.go
+++ b/branch_rename.go
@@ -35,8 +35,8 @@ func (*branchRenameCmd) Help() string {
 	`)
 }
 
-func (cmd *branchRenameCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) (err error) {
-	repo, _, svc, err := openRepo(ctx, log, opts)
+func (cmd *branchRenameCmd) Run(ctx context.Context, log *log.Logger, view ui.View) (err error) {
+	repo, _, svc, err := openRepo(ctx, log, view)
 	if err != nil {
 		return err
 	}
@@ -67,7 +67,7 @@ func (cmd *branchRenameCmd) Run(ctx context.Context, log *log.Logger, opts *glob
 				return nil
 			})
 
-		if err := ui.Run(prompt); err != nil {
+		if err := ui.Run(view, prompt); err != nil {
 			return fmt.Errorf("prompt: %w", err)
 		}
 	}

--- a/branch_restack.go
+++ b/branch_restack.go
@@ -10,6 +10,7 @@ import (
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 type branchRestackCmd struct {
@@ -24,8 +25,8 @@ func (*branchRestackCmd) Help() string {
 	`)
 }
 
-func (cmd *branchRestackCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
-	repo, _, svc, err := openRepo(ctx, log, opts)
+func (cmd *branchRestackCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
+	repo, _, svc, err := openRepo(ctx, log, view)
 	if err != nil {
 		return err
 	}

--- a/branch_track.go
+++ b/branch_track.go
@@ -10,6 +10,7 @@ import (
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 type branchTrackCmd struct {
@@ -27,8 +28,8 @@ func (*branchTrackCmd) Help() string {
 	`)
 }
 
-func (cmd *branchTrackCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
-	repo, store, svc, err := openRepo(ctx, log, opts)
+func (cmd *branchTrackCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
+	repo, store, svc, err := openRepo(ctx, log, view)
 	if err != nil {
 		return err
 	}

--- a/branch_untrack.go
+++ b/branch_untrack.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 type branchUntrackCmd struct {
@@ -26,8 +27,8 @@ func (*branchUntrackCmd) Help() string {
 	`)
 }
 
-func (cmd *branchUntrackCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
-	repo, _, svc, err := openRepo(ctx, log, opts)
+func (cmd *branchUntrackCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
+	repo, _, svc, err := openRepo(ctx, log, view)
 	if err != nil {
 		return err
 	}

--- a/codecov.yml
+++ b/codecov.yml
@@ -26,3 +26,4 @@ ignore:
   - internal/secret/secrettest
   - internal/stub
   - internal/termtest
+  - internal/ui/uitest

--- a/commit_amend.go
+++ b/commit_amend.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 type commitAmendCmd struct {
@@ -25,7 +26,7 @@ func (*commitAmendCmd) Help() string {
 	`)
 }
 
-func (cmd *commitAmendCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
+func (cmd *commitAmendCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
 	repo, err := git.Open(ctx, ".", git.OpenOptions{
 		Log: log,
 	})
@@ -60,5 +61,5 @@ func (cmd *commitAmendCmd) Run(ctx context.Context, log *log.Logger, opts *globa
 	return (&upstackRestackCmd{
 		Branch:    currentBranch,
 		SkipStart: true,
-	}).Run(ctx, log, opts)
+	}).Run(ctx, log, view)
 }

--- a/commit_create.go
+++ b/commit_create.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 type commitCreateCmd struct {
@@ -24,7 +25,7 @@ func (*commitCreateCmd) Help() string {
 	`)
 }
 
-func (cmd *commitCreateCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
+func (cmd *commitCreateCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
 	repo, err := git.Open(ctx, ".", git.OpenOptions{
 		Log: log,
 	})
@@ -57,5 +58,5 @@ func (cmd *commitCreateCmd) Run(ctx context.Context, log *log.Logger, opts *glob
 	return (&upstackRestackCmd{
 		Branch:    currentBranch,
 		SkipStart: true,
-	}).Run(ctx, log, opts)
+	}).Run(ctx, log, view)
 }

--- a/commit_split.go
+++ b/commit_split.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 type commitSplitCmd struct {
@@ -22,7 +23,7 @@ func (*commitSplitCmd) Help() string {
 	`)
 }
 
-func (cmd *commitSplitCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) (err error) {
+func (cmd *commitSplitCmd) Run(ctx context.Context, log *log.Logger, view ui.View) (err error) {
 	repo, err := git.Open(ctx, ".", git.OpenOptions{
 		Log: log,
 	})
@@ -102,5 +103,5 @@ func (cmd *commitSplitCmd) Run(ctx context.Context, log *log.Logger, opts *globa
 	return (&upstackRestackCmd{
 		Branch:    currentBranch,
 		SkipStart: true,
-	}).Run(ctx, log, opts)
+	}).Run(ctx, log, view)
 }

--- a/down.go
+++ b/down.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 type downCmd struct {
@@ -23,8 +24,8 @@ func (*downCmd) Help() string {
 	`)
 }
 
-func (cmd *downCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
-	repo, store, svc, err := openRepo(ctx, log, opts)
+func (cmd *downCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
+	repo, store, svc, err := openRepo(ctx, log, view)
 	if err != nil {
 		return err
 	}
@@ -69,5 +70,5 @@ outer:
 	return (&branchCheckoutCmd{
 		checkoutOptions: cmd.checkoutOptions,
 		Branch:          below,
-	}).Run(ctx, log, opts)
+	}).Run(ctx, log, view)
 }

--- a/downstack_edit.go
+++ b/downstack_edit.go
@@ -10,6 +10,7 @@ import (
 	"go.abhg.dev/gs/internal/must"
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 type downstackEditCmd struct {
@@ -33,8 +34,8 @@ func (*downstackEditCmd) Help() string {
 	`)
 }
 
-func (cmd *downstackEditCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
-	repo, store, svc, err := openRepo(ctx, log, opts)
+func (cmd *downstackEditCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
+	repo, store, svc, err := openRepo(ctx, log, view)
 	if err != nil {
 		return err
 	}
@@ -87,5 +88,5 @@ func (cmd *downstackEditCmd) Run(ctx context.Context, log *log.Logger, opts *glo
 
 	return (&branchCheckoutCmd{
 		Branch: res.Stack[len(res.Stack)-1],
-	}).Run(ctx, log, opts)
+	}).Run(ctx, log, view)
 }

--- a/downstack_submit.go
+++ b/downstack_submit.go
@@ -10,6 +10,7 @@ import (
 	"go.abhg.dev/gs/internal/must"
 	"go.abhg.dev/gs/internal/secret"
 	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 type downstackSubmitCmd struct {
@@ -30,9 +31,9 @@ func (cmd *downstackSubmitCmd) Run(
 	ctx context.Context,
 	secretStash secret.Stash,
 	log *log.Logger,
-	opts *globalOptions,
+	view ui.View,
 ) error {
-	repo, store, svc, err := openRepo(ctx, log, opts)
+	repo, store, svc, err := openRepo(ctx, log, view)
 	if err != nil {
 		return err
 	}
@@ -59,12 +60,12 @@ func (cmd *downstackSubmitCmd) Run(
 	// TODO: generalize into a service-level method
 	// TODO: separate preparation of the stack from submission
 
-	session := newSubmitSession(repo, store, secretStash, opts, log)
+	session := newSubmitSession(repo, store, secretStash, view, log)
 	for _, downstack := range downstacks {
 		err := (&branchSubmitCmd{
 			submitOptions: cmd.submitOptions,
 			Branch:        downstack,
-		}).run(ctx, session, repo, store, svc, log, opts)
+		}).run(ctx, session, repo, store, svc, log, view)
 		if err != nil {
 			return fmt.Errorf("submit %v: %w", downstack, err)
 		}

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -16,6 +16,7 @@ import (
 
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/secret"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 var _forgeRegistry sync.Map
@@ -103,7 +104,7 @@ type Forge interface {
 	//
 	// The implementation should return a secret that the Forge
 	// can serialize and store for future use.
-	AuthenticationFlow(ctx context.Context) (AuthenticationToken, error)
+	AuthenticationFlow(ctx context.Context, view ui.View) (AuthenticationToken, error)
 
 	// SaveAuthenticationToken saves the given authentication token
 	// to the secret stash.

--- a/internal/forge/forgetest/mocks.go
+++ b/internal/forge/forgetest/mocks.go
@@ -17,6 +17,7 @@ import (
 
 	forge "go.abhg.dev/gs/internal/forge"
 	secret "go.abhg.dev/gs/internal/secret"
+	ui "go.abhg.dev/gs/internal/ui"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -45,18 +46,18 @@ func (m *MockForge) EXPECT() *MockForgeMockRecorder {
 }
 
 // AuthenticationFlow mocks base method.
-func (m *MockForge) AuthenticationFlow(ctx context.Context) (forge.AuthenticationToken, error) {
+func (m *MockForge) AuthenticationFlow(ctx context.Context, view ui.View) (forge.AuthenticationToken, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AuthenticationFlow", ctx)
+	ret := m.ctrl.Call(m, "AuthenticationFlow", ctx, view)
 	ret0, _ := ret[0].(forge.AuthenticationToken)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AuthenticationFlow indicates an expected call of AuthenticationFlow.
-func (mr *MockForgeMockRecorder) AuthenticationFlow(ctx any) *MockForgeAuthenticationFlowCall {
+func (mr *MockForgeMockRecorder) AuthenticationFlow(ctx, view any) *MockForgeAuthenticationFlowCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthenticationFlow", reflect.TypeOf((*MockForge)(nil).AuthenticationFlow), ctx)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthenticationFlow", reflect.TypeOf((*MockForge)(nil).AuthenticationFlow), ctx, view)
 	return &MockForgeAuthenticationFlowCall{Call: call}
 }
 
@@ -72,13 +73,13 @@ func (c *MockForgeAuthenticationFlowCall) Return(arg0 forge.AuthenticationToken,
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockForgeAuthenticationFlowCall) Do(f func(context.Context) (forge.AuthenticationToken, error)) *MockForgeAuthenticationFlowCall {
+func (c *MockForgeAuthenticationFlowCall) Do(f func(context.Context, ui.View) (forge.AuthenticationToken, error)) *MockForgeAuthenticationFlowCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockForgeAuthenticationFlowCall) DoAndReturn(f func(context.Context) (forge.AuthenticationToken, error)) *MockForgeAuthenticationFlowCall {
+func (c *MockForgeAuthenticationFlowCall) DoAndReturn(f func(context.Context, ui.View) (forge.AuthenticationToken, error)) *MockForgeAuthenticationFlowCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/forge/github/auth_test.go
+++ b/internal/forge/github/auth_test.go
@@ -20,6 +20,7 @@ import (
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/secret"
 	"go.abhg.dev/gs/internal/termtest"
+	"go.abhg.dev/gs/internal/ui"
 	"golang.org/x/oauth2"
 )
 
@@ -75,9 +76,10 @@ func TestAuthHasGitHubToken(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	view := &ui.FileView{W: io.Discard}
 
 	t.Run("AuthenticationFlow", func(t *testing.T) {
-		_, err := f.AuthenticationFlow(ctx)
+		_, err := f.AuthenticationFlow(ctx, view)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "already authenticated")
 		assert.Contains(t, logBuffer.String(), "Already authenticated")
@@ -175,12 +177,11 @@ func TestDeviceFlowAuthenticator(t *testing.T) {
 	tok, err := (&DeviceFlowAuthenticator{
 		ClientID: "client-id",
 		Scopes:   []string{"scope"},
-		Stderr:   io.Discard,
 		Endpoint: oauth2.Endpoint{
 			DeviceAuthURL: srv.URL + "/device/code",
 			TokenURL:      srv.URL + "/oauth/access_token",
 		},
-	}).Authenticate(context.Background())
+	}).Authenticate(context.Background(), &ui.FileView{W: io.Discard})
 	require.NoError(t, err)
 
 	assert.Equal(t, "my-token", tok.AccessToken)
@@ -195,6 +196,10 @@ func TestSelectAuthenticator(t *testing.T) {
 	}()
 
 	term := midterm.NewAutoResizingTerminal()
+	view := &ui.TerminalView{
+		R: stdin,
+		W: term,
+	}
 
 	type result struct {
 		auth authenticator
@@ -204,9 +209,7 @@ func TestSelectAuthenticator(t *testing.T) {
 	go func() {
 		defer close(resultc)
 
-		got, err := selectAuthenticator(authenticatorOptions{
-			Stdin:    stdin,
-			Stderr:   term,
+		got, err := selectAuthenticator(view, authenticatorOptions{
 			Endpoint: oauth2.Endpoint{},
 		})
 		resultc <- result{got, err}
@@ -248,6 +251,10 @@ func TestPATAuthenticator(t *testing.T) {
 	}()
 
 	term := midterm.NewAutoResizingTerminal()
+	view := &ui.TerminalView{
+		R: stdin,
+		W: term,
+	}
 
 	type result struct {
 		tok forge.AuthenticationToken
@@ -257,10 +264,7 @@ func TestPATAuthenticator(t *testing.T) {
 	go func() {
 		defer close(resultc)
 
-		got, err := (&PATAuthenticator{
-			Stdin:  stdin,
-			Stderr: term,
-		}).Authenticate(context.Background())
+		got, err := (&PATAuthenticator{}).Authenticate(context.Background(), view)
 		resultc <- result{got, err}
 	}()
 
@@ -290,13 +294,15 @@ func TestPATAuthenticator(t *testing.T) {
 }
 
 func TestAuthCLI(t *testing.T) {
+	discardView := &ui.FileView{W: io.Discard}
+
 	t.Run("success", func(t *testing.T) {
 		tok, err := (&CLIAuthenticator{
 			GH: "gh",
 			runCmd: func(*exec.Cmd) error {
 				return nil
 			},
-		}).Authenticate(context.Background())
+		}).Authenticate(context.Background(), discardView)
 		require.NoError(t, err)
 
 		f := Forge{
@@ -321,7 +327,7 @@ func TestAuthCLI(t *testing.T) {
 					Stderr: []byte("great sadness"),
 				}
 			},
-		}).Authenticate(context.Background())
+		}).Authenticate(context.Background(), discardView)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "not authenticated")
 		assert.ErrorContains(t, err, "great sadness")
@@ -333,7 +339,7 @@ func TestAuthCLI(t *testing.T) {
 			runCmd: func(*exec.Cmd) error {
 				return errors.New("gh not found")
 			},
-		}).Authenticate(context.Background())
+		}).Authenticate(context.Background(), discardView)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "gh not found")
 	})

--- a/internal/forge/shamhub/auth.go
+++ b/internal/forge/shamhub/auth.go
@@ -13,6 +13,7 @@ import (
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/must"
 	"go.abhg.dev/gs/internal/secret"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 type loginRequest struct {
@@ -94,7 +95,7 @@ type AuthenticationToken struct {
 // before attempting to authenticate.
 // The flow will fail if these variables are not set.
 // The flow will also fail if the user is already authenticated.
-func (f *Forge) AuthenticationFlow(ctx context.Context) (forge.AuthenticationToken, error) {
+func (f *Forge) AuthenticationFlow(ctx context.Context, _ ui.View) (forge.AuthenticationToken, error) {
 	must.NotBeBlankf(f.APIURL, "API URL is required")
 
 	username := os.Getenv("SHAMHUB_USERNAME")

--- a/internal/ui/confirm.go
+++ b/internal/ui/confirm.go
@@ -81,6 +81,11 @@ func (c *Confirm) Value() bool {
 	return *c.value
 }
 
+// UnmarshalValue reads a boolean value from the given unmarshal function.
+func (c *Confirm) UnmarshalValue(unmarshal func(any) error) error {
+	return unmarshal(c.value)
+}
+
 // WithTitle sets the title for the confirm field.
 func (c *Confirm) WithTitle(title string) *Confirm {
 	c.title = title

--- a/internal/ui/defer.go
+++ b/internal/ui/defer.go
@@ -1,6 +1,10 @@
 package ui
 
-import tea "github.com/charmbracelet/bubbletea"
+import (
+	"errors"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
 
 // Deferred is a field that is not constructed
 // until initialization time.
@@ -35,6 +39,14 @@ func (d *Deferred) Title() string {
 		return ""
 	}
 	return d.f.Title()
+}
+
+// UnmarshalValue unmarshals the value of the deferred field.
+func (d *Deferred) UnmarshalValue(unmarshal func(any) error) error {
+	if d.f == nil {
+		return errors.New("value provided for uninitialized deferred field")
+	}
+	return d.f.UnmarshalValue(unmarshal)
 }
 
 // Description returns the description of the deferred field.

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -75,9 +75,21 @@ type Field interface {
 	// Init initializes the field.
 	// This is called right before the field is first rendered,
 	// not when the form is initialized.
+	//
+	// If this returns [SkipField], the field will be skipped.
 	Init() tea.Cmd
 	Update(msg tea.Msg) tea.Cmd
 	Render(Writer)
+
+	// UnmarshalValue unmarshals the field's value
+	// using the given unmarshal function.
+	//
+	// The unmarhal function should be called with a pointer to a value
+	// and it will attempt to decode the underlying raw value into it,
+	// behaving similarly to encoding/json.Unmarshal.
+	//
+	// This function is used in tests to simulate user input.
+	UnmarshalValue(unmarshal func(any) error) error
 
 	// Err reports any errors for the field at render time.
 	// These will be rendered in red below the field.

--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -61,6 +61,11 @@ func (i *Input) WithValue(value *string) *Input {
 	return i
 }
 
+// UnmarshalValue reads a string value for the input field.
+func (i *Input) UnmarshalValue(unmarshal func(any) error) error {
+	return unmarshal(i.value)
+}
+
 // WithTitle sets the title of the input field.
 func (i *Input) WithTitle(title string) *Input {
 	i.title = title

--- a/internal/ui/list.go
+++ b/internal/ui/list.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"fmt"
+
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -89,6 +91,34 @@ func (l *List[T]) WithValue(value *T) *List[T] {
 // Value retrieevs the selected item's value.
 func (l *List[T]) Value() *T {
 	return l.value
+}
+
+// UnmarshalValue reads a value from the given unmarshal function.
+// It expects an index of the selected item, or the title of the selected item.
+func (l *List[T]) UnmarshalValue(unmarshal func(any) error) error {
+	var title string
+	if err := unmarshal(&title); err == nil {
+		for i, item := range l.items {
+			if item.Title == title {
+				*l.value = l.items[i].Value
+				return nil
+			}
+		}
+
+		return fmt.Errorf("item with title %q not found", title)
+	}
+
+	var idx int
+	if err := unmarshal(&idx); err != nil {
+		return err
+	}
+
+	if idx < 0 || idx >= len(l.items) {
+		return fmt.Errorf("index %d is out of bounds [0, %d]", idx, len(l.items)-1)
+	}
+
+	*l.value = l.items[idx].Value
+	return nil
 }
 
 // WithTitle sets the title of the [List].

--- a/internal/ui/multi_select.go
+++ b/internal/ui/multi_select.go
@@ -110,6 +110,21 @@ func (s *MultiSelect[T]) Value() []T {
 	return items
 }
 
+// UnmarshalValue unmarshals the result of the field from the given function.
+// The input source must be a list of indexes, not []T.
+func (s *MultiSelect[T]) UnmarshalValue(unmarshal func(any) error) error {
+	var selected []int
+	if err := unmarshal(&selected); err != nil {
+		return err
+	}
+
+	for i := range s.options {
+		s.options[i].Selected = slices.Contains(selected, i)
+	}
+
+	return nil
+}
+
 // MultiSelectOption is an option for a multi-select field.
 type MultiSelectOption[T any] struct {
 	// Value of the option.

--- a/internal/ui/open_editor.go
+++ b/internal/ui/open_editor.go
@@ -118,6 +118,46 @@ func (a *OpenEditor) WithValue(value *string) *OpenEditor {
 	return a
 }
 
+// UnmarshalValue reads the value for the field from simulated input.
+// It accepts one of the following types:
+//
+//	string
+//	  conents of the string will be used as-is
+//
+//	{
+//	    // If set, the initial value is expected to be this value.
+//	    want: string?,
+//
+//	    // If set, the value will be set to this value.
+//	    // Otherwise it'll be left unchanged.
+//	    give: string?,
+//	}
+func (a *OpenEditor) UnmarshalValue(unmarshal func(any) error) error {
+	var give string
+	if err := unmarshal(&give); err == nil {
+		*a.value = give
+		return nil
+	}
+
+	var value struct {
+		Want *string `json:"want"`
+		Give *string `json:"give"`
+	}
+	if err := unmarshal(&value); err != nil {
+		return err
+	}
+
+	if value.Want != nil && *value.Want != *a.value {
+		return fmt.Errorf("expected value %q, got %q", *value.Want, *a.value)
+	}
+
+	if value.Give != nil {
+		*a.value = *value.Give
+	}
+
+	return nil
+}
+
 // WithTitle sets the title for the field.
 func (a *OpenEditor) WithTitle(title string) *OpenEditor {
 	a.title = title

--- a/internal/ui/select.go
+++ b/internal/ui/select.go
@@ -111,6 +111,24 @@ func (s *Select[T]) Value() T {
 	return *s.value
 }
 
+// UnmarshalValue unmarshals the value of the select field
+// using the provided unmarshal function.
+func (s *Select[T]) UnmarshalValue(unmarshal func(any) error) error {
+	var selectLabel string
+	if err := unmarshal(&selectLabel); err != nil {
+		return err
+	}
+
+	for _, opt := range s.options {
+		if opt.Label == selectLabel {
+			*s.value = opt.Value
+			return nil
+		}
+	}
+
+	return fmt.Errorf("no option with label: %v", selectLabel)
+}
+
 // With runs the given function with the select field.
 func (s *Select[T]) With(f func(*Select[T])) *Select[T] {
 	f(s)

--- a/internal/ui/uitest/doc.go
+++ b/internal/ui/uitest/doc.go
@@ -1,0 +1,2 @@
+// Package uitest provides means of testing UI interactions.
+package uitest

--- a/internal/ui/uitest/robot.go
+++ b/internal/ui/uitest/robot.go
@@ -1,0 +1,451 @@
+package uitest
+
+import (
+	"bufio"
+	"bytes"
+	"cmp"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/ui"
+)
+
+const (
+	// DefaultWidth is the default terminal width.
+	DefaultWidth = 80
+
+	// DefaultHeight is the default terminal height.
+	DefaultHeight = 24
+)
+
+var (
+	_commentPrefix = []byte(">")
+	_separator     = []byte("===")
+)
+
+// RobotView is an [ui.InteractiveView] that simulates user input in tests.
+//
+// It is backed by a fixture file that contains the inputs.
+// The file is divided into sections by a line containing only `===`.
+// Each section corresponds to a prompt and contains JSON-encoded input
+// for that prompt.
+//
+//	===
+//	"Alice"
+//	===
+//	["branch1", "branch2"]
+//
+// For convenience, the first "===" is optional.
+// The JSON input is fed into the corresponding field's UnmarshalValue method.
+//
+// ">"-prefixed lines before the JSON-encoded input are treated as comments.
+//
+//	> This is a comment
+//	> across multiple lines
+//	"Alice"
+//
+// If an output file is provided, the fixture is reproduced to it,
+// along with a comment containing each prompt's rendered form.
+// This allows comparing the resulting prompts with the prompts that the input
+// was written for.
+//
+//	===
+//	> Enter a name:
+//	"Alice"
+//	===
+//	> Pick branches:
+//	>  - branch1
+//	>  - branch2
+//	>  - branch3
+//	["branch1", "branch2"]
+//
+// Non-prompt output from the application is also written to the output file.
+//
+// The current position in the fixture file is recorded in a separate file
+// to allow resuming from where the test left off.
+// This allows reusing the same fixture file across multiple executions.
+type RobotView struct {
+	fixtureFile  string
+	positionFile string
+	logger       *log.Logger
+	w, h         int
+
+	// outputBuffer holds non-prompt output until the next prompt.
+	// This will be made part of the comment that is generated for the prompt.
+	outputBuffer bytes.Buffer
+	outputWriter outputFileWriter
+}
+
+// RobotViewOptions customizes a [RobotView].
+type RobotViewOptions struct {
+	// OutputFile is the file to write the output to.
+	//
+	// This will contain all the original inputs from the fixture file,
+	// alongside rendered prompts for those inputs.
+	//
+	// If unset, the output is discarded.
+	OutputFile string
+
+	// LogOutput is the writer to log messages to.
+	//
+	// If unset, messages are discarded.
+	LogOutput io.Writer
+
+	// Size of the terminal window.
+	//
+	// Defaults to DefaultWidth and DefaultHeight.
+	Width, Height int
+}
+
+// NewRobotView creates a new [RobotView] that reads from the given
+// fixture file and writes to the given output file.
+// If outputFile is empty, output is discarded.
+//
+// The returned RobotView must be closed once you're done with it.
+func NewRobotView(fixtureFile string, opts *RobotViewOptions) (*RobotView, error) {
+	opts = cmp.Or(opts, &RobotViewOptions{})
+
+	var of outputFileWriter = &nopOutputFile{}
+	if opts.OutputFile != "" {
+		file, err := os.OpenFile(opts.OutputFile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+		if err != nil {
+			return nil, fmt.Errorf("create output file: %w", err)
+		}
+
+		of = file
+	}
+
+	logOutput := opts.LogOutput
+	if logOutput == nil {
+		logOutput = io.Discard
+	}
+	logger := log.NewWithOptions(logOutput, log.Options{
+		Level: log.DebugLevel,
+	})
+
+	return &RobotView{
+		fixtureFile:  fixtureFile,
+		positionFile: fixtureFile + ".pos",
+		outputWriter: of,
+		logger:       logger,
+		w:            cmp.Or(opts.Width, DefaultWidth),
+		h:            cmp.Or(opts.Height, DefaultHeight),
+	}, nil
+}
+
+var _ ui.InteractiveView = (*RobotView)(nil)
+
+// Write writes non-prompt output.
+//
+// This is buffered in-memory until the next prompt,
+// or until the view is closed.
+func (s *RobotView) Write(bs []byte) (n int, err error) {
+	return s.outputBuffer.Write(bs)
+}
+
+// Close flushes the output buffer to the output file.
+func (s *RobotView) Close() error {
+	if s.outputBuffer.Len() > 0 {
+		fixture := robotFixture{Comment: s.outputBuffer.String()}
+		if err := s.appendOutputFixture(fixture); err != nil {
+			return fmt.Errorf("append output fixture: %w", err)
+		}
+		s.outputBuffer.Reset()
+	}
+
+	return s.outputWriter.Close()
+}
+
+// Prompt runs the given fields as prompts,
+// reading the remaining input values from the fixture file.
+// If the fixture file is exhausted, an error is returned.
+func (s *RobotView) Prompt(fields ...ui.Field) error {
+	log := s.logger
+
+	var inputFixtures robotFixtureFile
+	if err := inputFixtures.ReadFile(s.fixtureFile); err != nil {
+		return fmt.Errorf("read fixture: %w", err)
+	}
+
+fieldLoop:
+	for fieldIdx, field := range fields {
+		cmd := tea.Sequence(
+			field.Init(),
+			field.Update(tea.WindowSizeMsg{
+				Width:  s.w,
+				Height: s.h,
+			}),
+		)
+		msgs := []tea.Msg{cmd()}
+		for len(msgs) > 0 {
+			var msg tea.Msg
+			msg, msgs = msgs[0], msgs[1:]
+
+			switch msg := msg.(type) {
+			case tea.Cmd:
+				if msg != nil {
+					msgs = append(msgs, msg())
+				}
+
+			case tea.BatchMsg:
+				for _, cmd := range msg {
+					msgs = append(msgs, cmd())
+				}
+
+			default:
+				// HACK:
+				// tea.sequenceMsg is private, but it's a slice.
+				if v := reflect.ValueOf(msg); v.IsValid() && v.Kind() == reflect.Slice {
+					for i := range v.Len() {
+						msgs = append(msgs, v.Index(i).Interface())
+					}
+
+					continue
+				}
+
+				switch msg {
+				case ui.SkipField():
+					continue fieldLoop
+
+				case tea.QuitMsg{}:
+					return nil
+				}
+			}
+		}
+
+		var fieldView strings.Builder
+		fieldView.Write(s.outputBuffer.Bytes())
+		s.outputBuffer.Reset()
+		if title := field.Title(); title != "" {
+			fieldView.WriteString(field.Title())
+			fieldView.WriteString(": ")
+		}
+		field.Render(&fieldView)
+		if desc := field.Description(); desc != "" {
+			fieldView.WriteString("\n")
+			fieldView.WriteString(desc)
+		}
+		if err := field.Err(); err != nil {
+			return fmt.Errorf("field [%d]: %w", fieldIdx, err)
+		}
+
+		var fixture robotFixture
+		for {
+			pos, err := s.nextPos()
+			if err != nil {
+				return fmt.Errorf("field [%d]: next pos: %w", fieldIdx, err)
+			}
+
+			if pos >= len(inputFixtures) {
+				log.Error("Unexpected prompt",
+					"prompt", fieldView.String())
+				return fmt.Errorf("field [%d]: no more fixtures", fieldIdx)
+			}
+
+			f := inputFixtures[pos]
+			if strings.TrimSpace(f.Value) == "" {
+				// Skip fixtures that only contain comments.
+				continue
+			}
+
+			fixture = f
+			break
+		}
+
+		err := field.UnmarshalValue(func(dst any) error {
+			dec := json.NewDecoder(strings.NewReader(fixture.Value))
+			dec.DisallowUnknownFields()
+			return dec.Decode(dst)
+		})
+		if err != nil {
+			log.Error("Error unmarshalling value into field",
+				"field", strings.Trim(fieldView.String(), "\n"),
+				"value", fixture.Value,
+				"error", err,
+			)
+			return fmt.Errorf("field [%d]: bad input: %w", fieldIdx, err)
+		}
+
+		fixture.Comment = fieldView.String()
+		if err := s.appendOutputFixture(fixture); err != nil {
+			return fmt.Errorf("append output fixture: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// nextPos returns the next position in the position file,
+// and increments the value for the next call.
+//
+// If there's no file, it will be created.
+func (s *RobotView) nextPos() (int, error) {
+	var pos int
+	if bs, err := os.ReadFile(s.positionFile); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return 0, err
+		}
+
+		pos = 0
+	} else {
+		pos, err = strconv.Atoi(string(bs))
+		if err != nil {
+			return 0, fmt.Errorf("parse position: %w", err)
+		}
+	}
+
+	newBs := []byte(strconv.Itoa(pos + 1))
+	if err := os.WriteFile(s.positionFile, newBs, 0o644); err != nil {
+		return 0, fmt.Errorf("write position: %w", err)
+	}
+
+	return pos, nil
+}
+
+func (s *RobotView) appendOutputFixture(fixture robotFixture) error {
+	p := printer{w: s.outputWriter}
+	fixture.Print(&p)
+	if err := p.Err(); err != nil {
+		return fmt.Errorf("write output fixture: %w", err)
+	}
+
+	return nil
+}
+
+type robotFixtureFile []robotFixture
+
+func (sf *robotFixtureFile) ReadFile(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	return sf.Read(f)
+}
+
+func (sf *robotFixtureFile) Read(r io.Reader) error {
+	scan := bufio.NewScanner(r)
+	var (
+		comment strings.Builder
+		jsonBuf strings.Builder
+	)
+
+	flush := func() {
+		if jsonBuf.Len() == 0 && comment.Len() == 0 {
+			return
+		}
+
+		*sf = append(*sf, robotFixture{
+			Comment: strings.Trim(comment.String(), "\n"),
+			Value:   jsonBuf.String(),
+		})
+
+		comment.Reset()
+		jsonBuf.Reset()
+	}
+
+	for scan.Scan() {
+		line := scan.Bytes()
+
+		if bytes.Equal(line, _separator) {
+			flush()
+			continue
+		}
+
+		if bytes.HasPrefix(line, _commentPrefix) {
+			line := line[len(_commentPrefix):]
+			if len(line) > 0 && line[0] == ' ' {
+				line = line[1:] // skip space after ">"
+			}
+
+			comment.Write(line)
+			comment.WriteByte('\n')
+			continue
+		}
+
+		jsonBuf.Write(line)
+		jsonBuf.WriteByte('\n')
+	}
+
+	flush()
+	return scan.Err()
+}
+
+func (sf robotFixtureFile) Write(w io.Writer) error {
+	p := printer{w: w}
+	for _, fixture := range sf {
+		fixture.Print(&p)
+	}
+	return p.Err()
+}
+
+type robotFixture struct {
+	Comment string
+	Value   string // JSON
+}
+
+func (sf *robotFixture) Print(p *printer) {
+	p.Write(_separator)
+	p.WriteString("\n")
+
+	comment := strings.Trim(sf.Comment, "\n") // strip extraneous newlines
+	for _, cl := range strings.Split(comment, "\n") {
+		p.Write(_commentPrefix)
+		if len(cl) > 0 {
+			p.WriteString(" ")
+			p.WriteString(cl)
+		}
+		p.WriteString("\n")
+	}
+
+	p.WriteString(sf.Value)
+	if len(sf.Value) > 0 && sf.Value[len(sf.Value)-1] != '\n' {
+		p.WriteString("\n")
+	}
+}
+
+type printer struct {
+	w   io.Writer
+	err error
+}
+
+func (p *printer) Write(bs []byte) {
+	if p.err == nil {
+		_, p.err = p.w.Write(bs)
+	}
+}
+
+func (p *printer) WriteString(s string) {
+	if p.err == nil {
+		_, p.err = io.WriteString(p.w, s)
+	}
+}
+
+func (p *printer) Err() error {
+	return p.err
+}
+
+type outputFileWriter interface {
+	io.WriteCloser
+
+	Sync() error
+}
+
+type nopOutputFile struct{}
+
+var _ outputFileWriter = (*nopOutputFile)(nil)
+
+func (nopOutputFile) Write(bs []byte) (int, error) { return len(bs), nil }
+
+func (nopOutputFile) Close() error { return nil }
+
+func (nopOutputFile) Sync() error { return nil }

--- a/internal/ui/uitest/robot_test.go
+++ b/internal/ui/uitest/robot_test.go
@@ -1,0 +1,329 @@
+package uitest
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
+)
+
+func TestRobotView_simple(t *testing.T) {
+	dir := t.TempDir()
+	inputFile := filepath.Join(dir, "input")
+	outputFile := filepath.Join(dir, "output")
+
+	require.NoError(t, os.WriteFile(inputFile, []byte(text.Dedent(`
+		"foo"
+		===
+		"bar"
+	`)), 0o644))
+
+	view, err := NewRobotView(inputFile, &RobotViewOptions{
+		OutputFile: outputFile,
+	})
+	require.NoError(t, err)
+
+	field1 := &fakeField{View: "Who are you?"}
+	field2 := &fakeField{View: "Where are you going?"}
+
+	_, err = io.WriteString(view, "Title: ")
+	require.NoError(t, err)
+	require.NoError(t, view.Prompt(field1, field2))
+	assert.Equal(t, "foo", field1.GotValue)
+	assert.Equal(t, "bar", field2.GotValue)
+
+	require.NoError(t, view.Close())
+
+	got, err := os.ReadFile(outputFile)
+	require.NoError(t, err)
+
+	assert.Equal(t, text.Dedent(`
+		===
+		> Title: Who are you?
+		"foo"
+		===
+		> Where are you going?
+		"bar"
+
+	`), string(got))
+}
+
+func TestRobotView_persistsState(t *testing.T) {
+	dir := t.TempDir()
+	inputFile := filepath.Join(dir, "input")
+	outputFile := filepath.Join(dir, "output")
+
+	require.NoError(t, os.WriteFile(inputFile, []byte(text.Dedent(`
+		"foo"
+		===
+		"bar"
+	`)), 0o644))
+
+	field1 := &fakeField{View: "Who are you?"}
+	field2 := &fakeField{View: "Where are you going?"}
+
+	{
+		view1, err := NewRobotView(inputFile, &RobotViewOptions{
+			OutputFile: outputFile,
+		})
+		require.NoError(t, err)
+
+		_, err = io.WriteString(view1, "INFO: something happened\n")
+		require.NoError(t, err)
+
+		require.NoError(t, view1.Prompt(field1))
+		require.NoError(t, view1.Close())
+	}
+
+	{
+		view2, err := NewRobotView(inputFile, &RobotViewOptions{
+			OutputFile: outputFile,
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, view2.Prompt(field2))
+
+		_, err = io.WriteString(view2, "INFO: something else\n")
+		require.NoError(t, err)
+
+		require.NoError(t, view2.Close())
+	}
+
+	assert.Equal(t, "foo", field1.GotValue)
+	assert.Equal(t, "bar", field2.GotValue)
+
+	got, err := os.ReadFile(outputFile)
+	require.NoError(t, err)
+
+	assert.Equal(t, text.Dedent(`
+		===
+		> INFO: something happened
+		> Who are you?
+		"foo"
+		===
+		> Where are you going?
+		"bar"
+		===
+		> INFO: something else
+
+	`), string(got))
+}
+
+type fakeField struct {
+	GotValue any
+	View     string
+}
+
+var _ ui.Field = (*fakeField)(nil)
+
+func (f *fakeField) Init() tea.Cmd { return nil }
+func (f *fakeField) Err() error    { return nil }
+
+func (f *fakeField) Description() string { return "" }
+func (f *fakeField) Title() string       { return "" }
+
+func (f *fakeField) Update(msg tea.Msg) tea.Cmd { return nil }
+
+func (f *fakeField) Render(w ui.Writer) {
+	_, _ = w.WriteString(f.View)
+}
+
+func (f *fakeField) UnmarshalValue(unmarshal func(any) error) error {
+	return unmarshal(&f.GotValue)
+}
+
+func TestRobotFile(t *testing.T) {
+	tests := []struct {
+		name string
+		give string
+		want robotFixtureFile
+	}{
+		{name: "Empty"},
+		{
+			name: "Single",
+			give: text.Dedent(`
+				> foo
+				"bar"
+			`),
+			want: robotFixtureFile{
+				{
+					Comment: "foo",
+					Value:   `"bar"` + "\n",
+				},
+			},
+		},
+		{
+			name: "SingleCommentOnlySection",
+			give: text.Dedent(`
+				> foo
+			`),
+			want: robotFixtureFile{
+				{
+					Comment: "foo",
+				},
+			},
+		},
+		{
+			name: "Multiple",
+			give: text.Dedent(`
+				> foo
+				> another
+				"bar"
+				===
+				> baz
+				"qux"
+			`),
+			want: robotFixtureFile{
+				{
+					Comment: "foo\nanother",
+					Value:   `"bar"` + "\n",
+				},
+				{
+					Comment: "baz",
+					Value:   `"qux"` + "\n",
+				},
+			},
+		},
+		{
+			name: "MultipleWithCommentOnly",
+			give: text.Dedent(`
+				> foo
+				"bar"
+				===
+				> baz
+				===
+				"qux"
+			`),
+			want: robotFixtureFile{
+				{
+					Comment: "foo",
+					Value:   `"bar"` + "\n",
+				},
+				{
+					Comment: "baz",
+				},
+				{
+					Value: `"qux"` + "\n",
+				},
+			},
+		},
+		{
+			name: "EmptyLineInComment",
+			give: text.Dedent(`
+				> foo
+				>
+				> bar
+				"baz"
+			`),
+			want: robotFixtureFile{
+				{
+					Comment: "foo\n\nbar",
+					Value:   `"baz"` + "\n",
+				},
+			},
+		},
+		{
+			name: "NoComment",
+			give: text.Dedent(`
+				"foo"
+			`),
+			want: robotFixtureFile{
+				{
+					Value: `"foo"` + "\n",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got robotFixtureFile
+			require.NoError(t, got.Read(strings.NewReader(tt.give)))
+			require.Equal(t, tt.want, got)
+
+			t.Run("RoundTrip", func(t *testing.T) {
+				var b strings.Builder
+				require.NoError(t, got.Write(&b))
+
+				var got2 robotFixtureFile
+				require.NoError(t, got2.Read(strings.NewReader(b.String())))
+
+				assert.Equal(t, got, got2,
+					"round trip failed:\ngave: %q\ngot: %q", tt.give, b.String())
+			})
+		})
+	}
+}
+
+func FuzzRobotFile_Read(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte(text.Dedent(`
+		> foo
+		"bar"
+	`)))
+	f.Add([]byte(text.Dedent(`
+		> foo
+		"bar"
+		===
+		> baz
+		"qux"
+	`)))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var sf robotFixtureFile
+		_ = sf.Read(bytes.NewReader(data))
+		// Just make sure it doesn't panic or infinite loop.
+	})
+}
+
+func FuzzRobotFile_roundTrip(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte(text.Dedent(`
+		> foo
+		"bar"
+	`)))
+	f.Add([]byte(text.Dedent(`
+		> foo
+		"bar"
+		===
+		> baz
+		"qux"
+	`)))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var give robotFixtureFile
+		if err := give.Read(bytes.NewReader(data)); err != nil {
+			t.Skip("invalid input")
+		}
+
+		for i, f := range give {
+			var body any
+			if err := json.Unmarshal([]byte(f.Value), &body); err != nil {
+				t.Skip("invalid input")
+			}
+
+			bs, err := json.Marshal(body)
+			require.NoError(t, err)
+
+			f.Value = string(bs) + "\n"
+			give[i] = f
+		}
+
+		var b bytes.Buffer
+		require.NoError(t, give.Write(&b))
+
+		var got robotFixtureFile
+		require.NoError(t, got.Read(&b))
+
+		assert.Equal(t, give, got)
+	})
+}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -60,12 +60,11 @@ type TerminalView struct {
 
 var _ InteractiveView = (*TerminalView)(nil)
 
-func (iv *TerminalView) Write(p []byte) (int, error) {
-	return iv.W.Write(p)
+func (tv *TerminalView) Write(p []byte) (int, error) {
+	return tv.W.Write(p)
 }
 
 // Prompt prompts the user for input with the given interactive fields.
-func (iv *TerminalView) Prompt(fields ...Field) error {
-	// TODO: replace top-level Run with View argument.
-	return NewForm(fields...).Run(WithInput(iv.R), WithOutput(iv.W))
+func (tv *TerminalView) Prompt(fields ...Field) error {
+	return NewForm(fields...).Run(tv)
 }

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -1,0 +1,71 @@
+package ui
+
+import (
+	"errors"
+	"io"
+)
+
+// ErrPrompt indicates that we're not running in interactive mode.
+var ErrPrompt = errors.New("not allowed to prompt for input")
+
+// View provides access to the UI,
+// allowing the application to send messages to the user,
+// and in interactive mode, prompt for input.
+type View interface {
+	// Write posts messages to the user.
+	//
+	// These are typically rendered to Stderr
+	// to allow piping Stdout to other processes.
+	io.Writer
+}
+
+// InteractiveView is a view that allows prompting the user for input.
+//
+// Views don't have to implement this interface, but if they do,
+// they can prompt the user for input.
+type InteractiveView interface {
+	View
+
+	// Prompt prompts the user for input with the given interactive fields.
+	Prompt(...Field) error
+}
+
+// Interactive reports whether the given view is interactive.
+func Interactive(v View) bool {
+	_, ok := v.(InteractiveView)
+	return ok
+}
+
+// FileView is a non-interactive view that posts messages
+// to the given file.
+type FileView struct {
+	W io.Writer // required
+}
+
+var _ View = (*FileView)(nil)
+
+func (fv *FileView) Write(p []byte) (int, error) {
+	return fv.W.Write(p)
+}
+
+// TerminalView is a view that posts messages to the user's terminal
+// and allows prompting for input.
+type TerminalView struct {
+	// R is the input stream to read from.
+	R io.Reader // required
+
+	// W is the output stream to write to.
+	W io.Writer // required
+}
+
+var _ InteractiveView = (*TerminalView)(nil)
+
+func (iv *TerminalView) Write(p []byte) (int, error) {
+	return iv.W.Write(p)
+}
+
+// Prompt prompts the user for input with the given interactive fields.
+func (iv *TerminalView) Prompt(fields ...Field) error {
+	// TODO: replace top-level Run with View argument.
+	return NewForm(fields...).Run(WithInput(iv.R), WithOutput(iv.W))
+}

--- a/internal/ui/widget/branch_select.go
+++ b/internal/ui/widget/branch_select.go
@@ -142,6 +142,25 @@ func (b *BranchTreeSelect) WithValue(value *string) *BranchTreeSelect {
 	return b
 }
 
+// UnmarshalValue unmarshals the value of the field
+// using the given unmarshal function.
+func (b *BranchTreeSelect) UnmarshalValue(unmarshal func(interface{}) error) error {
+	var got string
+	if err := unmarshal(&got); err != nil {
+		return err
+	}
+
+	for _, bi := range b.all {
+		if bi.Branch == got && !bi.Disabled {
+			*b.value = got
+			b.accepted = true
+			return nil
+		}
+	}
+
+	return fmt.Errorf("unknown branch: %s", got)
+}
+
 // Init initializes the widget.
 func (b *BranchTreeSelect) Init() tea.Cmd {
 	rootSet := make(map[int]struct{})

--- a/log.go
+++ b/log.go
@@ -53,14 +53,13 @@ type branchLogCmd struct {
 type branchLogOptions struct {
 	Commits bool
 
-	Log     *log.Logger
-	Globals *globalOptions
+	Log *log.Logger
 }
 
-func (cmd *branchLogCmd) run(ctx context.Context, opts *branchLogOptions) (err error) {
+func (cmd *branchLogCmd) run(ctx context.Context, view ui.View, opts *branchLogOptions) (err error) {
 	log := opts.Log
 
-	repo, store, svc, err := openRepo(ctx, log, opts.Globals)
+	repo, store, svc, err := openRepo(ctx, log, view)
 	if err != nil {
 		return err
 	}

--- a/log_long.go
+++ b/log_long.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 type logLongCmd struct {
@@ -19,10 +20,9 @@ func (*logLongCmd) Help() string {
 	`)
 }
 
-func (cmd *logLongCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) (err error) {
-	return cmd.run(ctx, &branchLogOptions{
+func (cmd *logLongCmd) Run(ctx context.Context, log *log.Logger, view ui.View) (err error) {
+	return cmd.run(ctx, view, &branchLogOptions{
 		Log:     log,
 		Commits: true,
-		Globals: opts,
 	})
 }

--- a/log_short.go
+++ b/log_short.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 type logShortCmd struct {
@@ -19,9 +20,8 @@ func (*logShortCmd) Help() string {
 	`)
 }
 
-func (cmd *logShortCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) (err error) {
-	return cmd.run(ctx, &branchLogOptions{
-		Log:     log,
-		Globals: opts,
+func (cmd *logShortCmd) Run(ctx context.Context, log *log.Logger, view ui.View) (err error) {
+	return cmd.run(ctx, view, &branchLogOptions{
+		Log: log,
 	})
 }

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -117,7 +118,7 @@ func main() {
 		kong.Name(cmdName),
 		kong.Description("gs (git-spice) is a command line tool for stacking Git branches."),
 		kong.Resolvers(spiceConfig),
-		kong.Bind(logger, &cmd.globalOptions),
+		kong.Bind(logger),
 		kong.BindTo(ctx, (*context.Context)(nil)),
 		kong.BindTo(secretStash, (*secret.Stash)(nil)),
 		kong.Vars{
@@ -204,21 +205,17 @@ func main() {
 	}
 }
 
-type globalOptions struct {
-	// Flags that are not accessed directly by command implementations:
-
-	Version versionFlag        `help:"Print version information and quit"`
-	Verbose bool               `short:"v" help:"Enable verbose output" env:"GIT_SPICE_VERBOSE"`
-	Dir     kong.ChangeDirFlag `short:"C" placeholder:"DIR" help:"Change to DIR before doing anything" predictor:"dirs"`
-
-	// Flags that are accessed directly:
-
-	Prompt bool `name:"prompt" negatable:"" default:"${defaultPrompt}" help:"Whether to prompt for missing information"`
-}
-
 type mainCmd struct {
 	kong.Plugins
-	globalOptions `group:"globals"`
+
+	// Global options that are never accessed directly by subcommands.
+	Globals struct {
+		// Flags with built-in side effects.
+		Version versionFlag        `help:"Print version information and quit"`
+		Verbose bool               `short:"v" help:"Enable verbose output" env:"GIT_SPICE_VERBOSE"`
+		Dir     kong.ChangeDirFlag `short:"C" placeholder:"DIR" help:"Change to DIR before doing anything" predictor:"dirs"`
+		Prompt  bool               `name:"prompt" negatable:"" default:"${defaultPrompt}" help:"Whether to prompt for missing information"`
+	} `embed:"" group:"globals"`
 
 	Shell shellCmd `cmd:"" group:"Shell"`
 	Auth  authCmd  `cmd:"" group:"Authentication"`
@@ -247,9 +244,25 @@ type mainCmd struct {
 }
 
 func (cmd *mainCmd) AfterApply(kctx *kong.Context, logger *log.Logger) error {
-	if cmd.Verbose {
+	if cmd.Globals.Verbose {
 		logger.SetLevel(log.DebugLevel)
 	}
 
+	view, err := _buildView(os.Stdin, kctx.Stderr, cmd.Globals.Prompt)
+	if err != nil {
+		return fmt.Errorf("build view: %w", err)
+	}
+	kctx.BindTo(view, (*ui.View)(nil))
+
 	return nil
+}
+
+var _buildView = func(stdin io.Reader, stderr io.Writer, interactive bool) (ui.View, error) {
+	if interactive {
+		return &ui.TerminalView{
+			R: stdin,
+			W: stderr,
+		}, nil
+	}
+	return &ui.FileView{W: stderr}, nil
 }

--- a/rebase_abort.go
+++ b/rebase_abort.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 type rebaseAbortCmd struct{}
@@ -26,7 +27,7 @@ func (*rebaseAbortCmd) Help() string {
 	`)
 }
 
-func (cmd *rebaseAbortCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
+func (cmd *rebaseAbortCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
 	repo, err := git.Open(ctx, ".", git.OpenOptions{
 		Log: log,
 	})
@@ -34,7 +35,7 @@ func (cmd *rebaseAbortCmd) Run(ctx context.Context, log *log.Logger, opts *globa
 		return fmt.Errorf("open repository: %w", err)
 	}
 
-	store, err := ensureStore(ctx, repo, log, opts)
+	store, err := ensureStore(ctx, repo, log, view)
 	if err != nil {
 		return err
 	}

--- a/rebase_continue.go
+++ b/rebase_continue.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 type rebaseContinueCmd struct{}
@@ -31,7 +32,7 @@ func (*rebaseContinueCmd) Help() string {
 func (cmd *rebaseContinueCmd) Run(
 	ctx context.Context,
 	log *log.Logger,
-	opts *globalOptions,
+	view ui.View,
 	parser *kong.Kong,
 ) error {
 	repo, err := git.Open(ctx, ".", git.OpenOptions{
@@ -41,7 +42,7 @@ func (cmd *rebaseContinueCmd) Run(
 		return fmt.Errorf("open repository: %w", err)
 	}
 
-	store, err := ensureStore(ctx, repo, log, opts)
+	store, err := ensureStore(ctx, repo, log, view)
 	if err != nil {
 		return err
 	}

--- a/repo_sync.go
+++ b/repo_sync.go
@@ -37,14 +37,14 @@ func (cmd *repoSyncCmd) Run(
 	ctx context.Context,
 	secretStash secret.Stash,
 	log *log.Logger,
-	opts *globalOptions,
+	view ui.View,
 ) error {
-	repo, store, svc, err := openRepo(ctx, log, opts)
+	repo, store, svc, err := openRepo(ctx, log, view)
 	if err != nil {
 		return err
 	}
 
-	remote, err := ensureRemote(ctx, repo, store, log, opts)
+	remote, err := ensureRemote(ctx, repo, store, log, view)
 	// TODO: move ensure remote to Service
 	if err != nil {
 		return err
@@ -217,19 +217,17 @@ func (cmd *repoSyncCmd) Run(
 		}
 	} else {
 		// Supported forge. Check for merged CRs and upstream branches.
-		branchesToDelete, err = cmd.findForgeMergedBranches(ctx, log, repo, remoteRepo, candidates, opts)
+		branchesToDelete, err = cmd.findForgeMergedBranches(ctx, log, repo, remoteRepo, candidates, view)
 		if err != nil {
 			return fmt.Errorf("find merged CRs: %w", err)
 		}
 	}
-
-	err = cmd.deleteBranches(ctx, opts, log, repo, remote, branchesToDelete)
-	if err != nil {
+	if err := cmd.deleteBranches(ctx, view, log, repo, remote, branchesToDelete); err != nil {
 		return err
 	}
 
 	if cmd.Restack {
-		return (&stackRestackCmd{}).Run(ctx, log, opts)
+		return (&stackRestackCmd{}).Run(ctx, log, view)
 	}
 
 	return nil
@@ -269,7 +267,7 @@ func (cmd *repoSyncCmd) findForgeMergedBranches(
 	repo *git.Repository,
 	remoteRepo forge.Repository,
 	knownBranches []spice.LoadBranchItem,
-	opts *globalOptions,
+	view ui.View,
 ) ([]branchDeletion, error) {
 	type submittedBranch struct {
 		Name   string
@@ -435,7 +433,7 @@ func (cmd *repoSyncCmd) findForgeMergedBranches(
 		// If the remote head SHA doesn't match the local head SHA,
 		// there may be local commits that haven't been pushed yet.
 		// Prompt for deletion if we have the option of prompting.
-		if !opts.Prompt {
+		if !ui.Interactive(view) {
 			log.Warnf("%v: %v. Skipping...", branch.Name, mismatchMsg)
 			continue
 		}
@@ -445,7 +443,7 @@ func (cmd *repoSyncCmd) findForgeMergedBranches(
 			WithTitle(fmt.Sprintf("Delete %v?", branch.Name)).
 			WithDescription(mismatchMsg).
 			WithValue(&shouldDelete)
-		if err := ui.Run(prompt); err != nil {
+		if err := ui.Run(view, prompt); err != nil {
 			log.Warn("Skipping branch", "branch", branch.Name, "error", err)
 			continue
 		}
@@ -468,7 +466,7 @@ type branchDeletion struct {
 
 func (cmd *repoSyncCmd) deleteBranches(
 	ctx context.Context,
-	opts *globalOptions,
+	view ui.View,
 	log *log.Logger,
 	repo *git.Repository,
 	remote string,
@@ -486,7 +484,7 @@ func (cmd *repoSyncCmd) deleteBranches(
 	err := (&branchDeleteCmd{
 		Branches: branchNames,
 		Force:    true,
-	}).Run(ctx, log, opts)
+	}).Run(ctx, log, view)
 	if err != nil {
 		return fmt.Errorf("delete merged branches: %w", err)
 	}

--- a/stack_edit.go
+++ b/stack_edit.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 type stackEditCmd struct {
@@ -33,8 +34,8 @@ func (*stackEditCmd) Help() string {
 	`)
 }
 
-func (cmd *stackEditCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
-	repo, store, svc, err := openRepo(ctx, log, opts)
+func (cmd *stackEditCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
+	repo, store, svc, err := openRepo(ctx, log, view)
 	if err != nil {
 		return err
 	}
@@ -90,5 +91,5 @@ func (cmd *stackEditCmd) Run(ctx context.Context, log *log.Logger, opts *globalO
 		return fmt.Errorf("edit downstack: %w", err)
 	}
 
-	return (&branchCheckoutCmd{Branch: cmd.Branch}).Run(ctx, log, opts)
+	return (&branchCheckoutCmd{Branch: cmd.Branch}).Run(ctx, log, view)
 }

--- a/stack_restack.go
+++ b/stack_restack.go
@@ -9,6 +9,7 @@ import (
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 type stackRestackCmd struct{}
@@ -20,8 +21,8 @@ func (*stackRestackCmd) Help() string {
 	`)
 }
 
-func (*stackRestackCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
-	repo, store, svc, err := openRepo(ctx, log, opts)
+func (*stackRestackCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
+	repo, store, svc, err := openRepo(ctx, log, view)
 	if err != nil {
 		return err
 	}

--- a/stack_submit.go
+++ b/stack_submit.go
@@ -7,6 +7,7 @@ import (
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/secret"
 	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 type stackSubmitCmd struct {
@@ -24,9 +25,9 @@ func (cmd *stackSubmitCmd) Run(
 	ctx context.Context,
 	secretStash secret.Stash,
 	log *log.Logger,
-	opts *globalOptions,
+	view ui.View,
 ) error {
-	repo, store, svc, err := openRepo(ctx, log, opts)
+	repo, store, svc, err := openRepo(ctx, log, view)
 	if err != nil {
 		return err
 	}
@@ -44,7 +45,7 @@ func (cmd *stackSubmitCmd) Run(
 	// TODO: generalize into a service-level method
 	// TODO: separate preparation of the stack from submission
 
-	session := newSubmitSession(repo, store, secretStash, opts, log)
+	session := newSubmitSession(repo, store, secretStash, view, log)
 	for _, branch := range stack {
 		if branch == store.Trunk() {
 			continue
@@ -53,7 +54,7 @@ func (cmd *stackSubmitCmd) Run(
 		err := (&branchSubmitCmd{
 			submitOptions: cmd.submitOptions,
 			Branch:        branch,
-		}).run(ctx, session, repo, store, svc, log, opts)
+		}).run(ctx, session, repo, store, svc, log, view)
 		if err != nil {
 			return fmt.Errorf("submit %v: %w", branch, err)
 		}

--- a/submit.go
+++ b/submit.go
@@ -15,6 +15,7 @@ import (
 	"go.abhg.dev/gs/internal/secret"
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 // submitSession is a single session of submitting branches.
@@ -35,12 +36,12 @@ func newSubmitSession(
 	repo *git.Repository,
 	store *state.Store,
 	stash secret.Stash,
-	globals *globalOptions,
+	view ui.View,
 	log *log.Logger,
 ) *submitSession {
 	var s submitSession
 	s.Remote.get = func(ctx context.Context) (string, error) {
-		return ensureRemote(ctx, repo, store, log, globals)
+		return ensureRemote(ctx, repo, store, log, view)
 	}
 
 	s.RemoteRepo.get = func(ctx context.Context) (forge.Repository, error) {

--- a/top.go
+++ b/top.go
@@ -24,8 +24,8 @@ func (*topCmd) Help() string {
 	`)
 }
 
-func (cmd *topCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
-	repo, _, svc, err := openRepo(ctx, log, opts)
+func (cmd *topCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
+	repo, _, svc, err := openRepo(ctx, log, view)
 	if err != nil {
 		return err
 	}
@@ -45,7 +45,7 @@ func (cmd *topCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions
 	branch := tops[0]
 	if len(tops) > 1 {
 		desc := "There are multiple top-level branches reachable from the current branch."
-		if !opts.Prompt {
+		if !ui.Interactive(view) {
 			log.Error(desc)
 			return errNoPrompt
 		}
@@ -65,7 +65,7 @@ func (cmd *topCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions
 			WithItems(items...).
 			WithTitle("Pick a branch").
 			WithDescription(desc)
-		if err := ui.Run(prompt); err != nil {
+		if err := ui.Run(view, prompt); err != nil {
 			return fmt.Errorf("a branch is required: %w", err)
 		}
 	}
@@ -78,5 +78,5 @@ func (cmd *topCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions
 	return (&branchCheckoutCmd{
 		checkoutOptions: cmd.checkoutOptions,
 		Branch:          branch,
-	}).Run(ctx, log, opts)
+	}).Run(ctx, log, view)
 }

--- a/trunk.go
+++ b/trunk.go
@@ -6,13 +6,14 @@ import (
 
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 type trunkCmd struct {
 	checkoutOptions
 }
 
-func (cmd *trunkCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
+func (cmd *trunkCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
 	repo, err := git.Open(ctx, ".", git.OpenOptions{
 		Log: log,
 	})
@@ -20,7 +21,7 @@ func (cmd *trunkCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptio
 		return fmt.Errorf("open repository: %w", err)
 	}
 
-	store, err := ensureStore(ctx, repo, log, opts)
+	store, err := ensureStore(ctx, repo, log, view)
 	if err != nil {
 		return err
 	}
@@ -29,5 +30,5 @@ func (cmd *trunkCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptio
 	return (&branchCheckoutCmd{
 		checkoutOptions: cmd.checkoutOptions,
 		Branch:          trunk,
-	}).Run(ctx, log, opts)
+	}).Run(ctx, log, view)
 }

--- a/up.go
+++ b/up.go
@@ -25,8 +25,8 @@ func (*upCmd) Help() string {
 	`)
 }
 
-func (cmd *upCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
-	repo, _, svc, err := openRepo(ctx, log, opts)
+func (cmd *upCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
+	repo, _, svc, err := openRepo(ctx, log, view)
 	if err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ outer:
 			branch = aboves[0]
 		default:
 			desc := "There are multiple branches above the current branch."
-			if !opts.Prompt {
+			if !ui.Interactive(view) {
 				log.Error(desc)
 				return errNoPrompt
 			}
@@ -76,7 +76,7 @@ outer:
 				WithItems(items...).
 				WithTitle("Pick a branch").
 				WithDescription(desc)
-			if err := ui.Run(prompt); err != nil {
+			if err := ui.Run(view, prompt); err != nil {
 				return fmt.Errorf("a branch is required: %w", err)
 			}
 		}
@@ -87,5 +87,5 @@ outer:
 	return (&branchCheckoutCmd{
 		checkoutOptions: cmd.checkoutOptions,
 		Branch:          branch,
-	}).Run(ctx, log, opts)
+	}).Run(ctx, log, view)
 }

--- a/upstack_onto.go
+++ b/upstack_onto.go
@@ -10,6 +10,7 @@ import (
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 type upstackOntoCmd struct {
@@ -38,8 +39,8 @@ func (*upstackOntoCmd) Help() string {
 	`)
 }
 
-func (cmd *upstackOntoCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
-	repo, store, svc, err := openRepo(ctx, log, opts)
+func (cmd *upstackOntoCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
+	repo, store, svc, err := openRepo(ctx, log, view)
 	if err != nil {
 		return err
 	}
@@ -64,7 +65,7 @@ func (cmd *upstackOntoCmd) Run(ctx context.Context, log *log.Logger, opts *globa
 	}
 
 	if cmd.Onto == "" {
-		if !opts.Prompt {
+		if !ui.Interactive(view) {
 			return fmt.Errorf("cannot proceed without a destination branch: %w", errNoPrompt)
 		}
 
@@ -76,7 +77,7 @@ func (cmd *upstackOntoCmd) Run(ctx context.Context, log *log.Logger, opts *globa
 			Default:     branch.Base,
 			Title:       "Select a branch to move onto",
 			Description: fmt.Sprintf("Moving the upstack of %s onto another branch", cmd.Branch),
-		}).Run(ctx, repo, store)
+		}).Run(ctx, view, repo, store)
 		if err != nil {
 			return fmt.Errorf("select branch: %w", err)
 		}
@@ -105,5 +106,5 @@ func (cmd *upstackOntoCmd) Run(ctx context.Context, log *log.Logger, opts *globa
 
 	return (&upstackRestackCmd{
 		SkipStart: true, // we've already moved the current branch
-	}).Run(ctx, log, opts)
+	}).Run(ctx, log, view)
 }

--- a/upstack_restack.go
+++ b/upstack_restack.go
@@ -9,6 +9,7 @@ import (
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 type upstackRestackCmd struct {
@@ -31,8 +32,8 @@ func (*upstackRestackCmd) Help() string {
 	`)
 }
 
-func (cmd *upstackRestackCmd) Run(ctx context.Context, log *log.Logger, opts *globalOptions) error {
-	repo, store, svc, err := openRepo(ctx, log, opts)
+func (cmd *upstackRestackCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
+	repo, store, svc, err := openRepo(ctx, log, view)
 	if err != nil {
 		return err
 	}

--- a/upstack_submit.go
+++ b/upstack_submit.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/secret"
 	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 type upstackSubmitCmd struct {
@@ -30,9 +31,9 @@ func (cmd *upstackSubmitCmd) Run(
 	ctx context.Context,
 	secretStash secret.Stash,
 	log *log.Logger,
-	opts *globalOptions,
+	view ui.View,
 ) error {
-	repo, store, svc, err := openRepo(ctx, log, opts)
+	repo, store, svc, err := openRepo(ctx, log, view)
 	if err != nil {
 		return err
 	}
@@ -77,12 +78,12 @@ func (cmd *upstackSubmitCmd) Run(
 
 	// TODO: generalize into a service-level method
 	// TODO: separate preparation of the stack from submission
-	session := newSubmitSession(repo, store, secretStash, opts, log)
+	session := newSubmitSession(repo, store, secretStash, view, log)
 	for _, b := range upstacks {
 		err := (&branchSubmitCmd{
 			submitOptions: cmd.submitOptions,
 			Branch:        b,
-		}).run(ctx, session, repo, store, svc, log, opts)
+		}).run(ctx, session, repo, store, svc, log, view)
 		if err != nil {
 			return fmt.Errorf("submit %v: %w", b, err)
 		}


### PR DESCRIPTION
We currently emulate a full terminal with mideterm in test scripts.
This gets a bit finicky when things break because test scripts
have limited control flow.
Those tests also don't run on Windows because the pty library
does not yet have support for Windows consoles.
Furthermore, the terminal tests aren't used at all for unit testing
the terminal widget implementations because they're too high-level.

This change attempts to start addressing these issues by refactoring
how we render to the terminal and test it.

To start with, a new `View` interface is introduced
that provides write-only access to the terminal.
It's just an `io.Writer` at this level.

The key is the new `InteractiveView` interface
that provides a request-response style method
for prompting the user for input with a few `ui.Field`s.
A given `View` can be upgraded to `InteractiveView`
if the application is currently running in interactive mode.

`InteractiveView` is implemented by the `TerminalView` struct which runs
the current normal rendering logic.

`InteractiveView` is also implemented by a new `uitest.RobotView`
which answers prompts with values from a fixture file
and renders the widgets back into the fixture file for testing.
So the idea is that in script tests, when we expect to be prompted,
we'll provide a fixture file that contains inputs to those prompts.
The `RobotView` prints a copy of the input fixture file
and a rendering of each prompt to an output file.
The script test will be able to compare the output file
with the original input file to verify that the prompts were rendered
correctly.

This new design has a few nice properties:

- It will likely speed up script tests because we are doing less.
  There won't be any need to sleep until something is rendered,
  for example.
- It will make script tests that need to prompt much easier to write.
- Code that writes to the terminal will now be more explicit
  because it must now have a `View` argument instead of just using
  `os.Stderr` will-nilly.
- Script tests will drop the dependency on creack/pty so all prompt
  tests will be able to run on Windows too.

While the script tests won't use midterm terminal emulation anymore,
that will still be used for unit testing terminal widgets directly.
