### PR TITLE
fix(gitlab): don't lose MR number for listed comments

### DIFF
--- a/internal/forge/gitlab/change_meta_test.go
+++ b/internal/forge/gitlab/change_meta_test.go
@@ -18,8 +18,14 @@ func TestMRMetadata(t *testing.T) {
 	assert.Equal(t, &MR{Number: 42}, md.ChangeID())
 	assert.Nil(t, md.NavigationCommentID())
 
-	md.SetNavigationCommentID(&MRComment{Number: 123})
-	assert.Equal(t, &MRComment{Number: 123}, md.NavigationCommentID())
+	md.SetNavigationCommentID(&MRComment{
+		Number:   123,
+		MRNumber: 42,
+	})
+	assert.Equal(t, &MRComment{
+		Number:   123,
+		MRNumber: 42,
+	}, md.NavigationCommentID())
 }
 
 func TestMustMR(t *testing.T) {

--- a/internal/forge/gitlab/integration_test.go
+++ b/internal/forge/gitlab/integration_test.go
@@ -449,7 +449,8 @@ func TestIntegration_Repository_ListChangeComments_simple(t *testing.T) {
 	assert.Equal(t, []*forge.ListChangeCommentItem{
 		{
 			ID: &gitlab.MRComment{
-				Number: 2225710594,
+				Number:   2225710594,
+				MRNumber: 4,
 			},
 			Body: "This change is part of the following stack:\n\n" +
 				"- !4 ◀\n\n" +


### PR DESCRIPTION
We list comments on a MR to find and associate navigation comments.
These need the MR number known when sending update requests.
Without it, the MR number is 0 for all comments,
so for MRs submitted with git-spice from a different machine,
we won't recover the navigation comments.

[skip changelog]: not released yet, part of the same feature