### PR TITLE
gitlab: Reduce OAuth scope to just "api"

### DIFF
--- a/internal/forge/gitlab/auth.go
+++ b/internal/forge/gitlab/auth.go
@@ -197,11 +197,7 @@ var _authenticationMethods = []struct {
 			return &DeviceFlowAuthenticator{
 				ClientID: _oauthAppID,
 				Endpoint: a.Endpoint,
-				Scopes: []string{
-					"api",
-					"read_user",
-					"write_repository",
-				},
+				Scopes:   []string{"api"},
 			}
 		},
 	},


### PR DESCRIPTION
Verified that it still works with just this.

[skip changelog]: feature not yet released