### PR TITLE
feat: Add OAuth Client ID configuration option for GitLab forge

### DIFF
--- a/.changes/unreleased/Added-20241125-222348.yaml
+++ b/.changes/unreleased/Added-20241125-222348.yaml
@@ -1,3 +1,5 @@
 kind: Added
-body: Add OAuth Client ID configuration option for GitLab forge.
+body: >-
+  Add 'spice.forge.gitlab.oauth.clientID' configuration option
+  to change the OAuth2 client ID used by the GitLab forge.
 time: 2024-11-25T22:23:48.313974+01:00

--- a/.changes/unreleased/Added-20241125-222348.yaml
+++ b/.changes/unreleased/Added-20241125-222348.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add OAuth Client ID configuration option for GitLab forge.
+time: 2024-11-25T22:23:48.313974+01:00

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -12,7 +12,7 @@ gs (git-spice) is a command line tool for stacking Git branches.
 * `-C`, `--dir=DIR`: Change to DIR before doing anything
 * `--[no-]prompt`: Whether to prompt for missing information
 
-**Configuration**: [spice.forge.github.url](/cli/config.md#spiceforgegithuburl), [spice.forge.github.apiUrl](/cli/config.md#spiceforgegithubapiurl), [spice.forge.gitlab.url](/cli/config.md#spiceforgegitlaburl)
+**Configuration**: [spice.forge.github.url](/cli/config.md#spiceforgegithuburl), [spice.forge.github.apiUrl](/cli/config.md#spiceforgegithubapiurl), [spice.forge.gitlab.url](/cli/config.md#spiceforgegitlaburl), [spice.forge.gitlab.oauth.clientID](/cli/config.md#spiceforgegitlaboauthclientid)
 
 ## Shell
 
@@ -130,7 +130,7 @@ and untrack all branches.
 ### gs repo sync
 
 ```
-gs repo (r) sync (s)
+gs repo (r) sync (s) [flags]
 ```
 
 Pull latest changes from the remote
@@ -141,6 +141,10 @@ will be deleted after syncing.
 The repository must have a remote associated for syncing.
 A prompt will ask for one if the repository
 was not initialized with a remote.
+
+**Flags**
+
+* `--restack`: Restack the current stack after syncing
 
 ## Log
 

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -76,6 +76,14 @@ See also: [GitHub Enterprise](../setup/auth.md#github-enterprise).
 URL of the GitLab instance used for GitLab requests.
 Defaults to `$GITLAB_URL` if set, or `https://gitlab.com` otherwise.
 
+### spice.forge.gitlab.oauth.clientID
+
+<!-- gs:version unreleased -->
+
+Client ID for OAuth authentication with GitLab.
+Default to git-spice's built-in Client ID in https://gitlab.com. 
+It should be set to a custom value if you are running your own GitLab Self-Managed instance.
+
 ### spice.log.all
 
 Whether $$gs log short$$ and $$gs log long$$ should show all stacks by default,

--- a/internal/forge/gitlab/forge.go
+++ b/internal/forge/gitlab/forge.go
@@ -31,6 +31,10 @@ type Options struct {
 	// Token is a fixed token used to authenticate with GitLab.
 	// This may be used to skip the login flow.
 	Token string `name:"gitlab-token" hidden:"" env:"GITLAB_TOKEN" help:"GitLab API token"`
+
+	// ClientID is the OAuth client ID for GitLab OAuth device flow.
+	// This should be used if the GitLab instance is Self Managed.
+	ClientID string `name:"gitlab-oauth-client-id" hidden:"" config:"forge.gitlab.oauth.clientID" help:"GitLab OAuth client ID"`
 }
 
 // Forge builds a GitLab Forge.


### PR DESCRIPTION
his pull request introduces a new configuration option for specifying the OAuth Client ID when using GitLab as the forge. This allows users to configure the client ID for their GitLab Self Managed instance, enabling proper OAuth authentication.