### PR TITLE
commit create: Add --fixup flag

### DIFF
--- a/.changes/unreleased/Added-20241127-125953.yaml
+++ b/.changes/unreleased/Added-20241127-125953.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'commit create: Added a --fixup flag to allow adding a fixup commit.'
+time: 2024-11-27T12:59:53.626214-08:00

--- a/commit_create.go
+++ b/commit_create.go
@@ -13,6 +13,7 @@ import (
 
 type commitCreateCmd struct {
 	All     bool   `short:"a" help:"Stage all changes before committing."`
+	Fixup   string `help:"Create a fixup commit."`
 	Message string `short:"m" help:"Use the given message as the commit message."`
 }
 
@@ -36,6 +37,7 @@ func (cmd *commitCreateCmd) Run(ctx context.Context, log *log.Logger, view ui.Vi
 	if err := repo.Commit(ctx, git.CommitRequest{
 		Message: cmd.Message,
 		All:     cmd.All,
+		Fixup:   cmd.Fixup,
 	}); err != nil {
 		return fmt.Errorf("commit: %w", err)
 	}

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -776,6 +776,7 @@ followed by 'gs upstack restack'.
 **Flags**
 
 * `-a`, `--all`: Stage all changes before committing.
+* `--fixup=STRING`: Create a fixup commit.
 * `-m`, `--message=STRING`: Use the given message as the commit message.
 
 ### gs commit amend

--- a/internal/git/commit.go
+++ b/internal/git/commit.go
@@ -120,6 +120,9 @@ type CommitRequest struct {
 
 	// AllowEmpty allows a commit with no changes.
 	AllowEmpty bool
+
+	// Create a new commit which "fixes up" the commit at the given commitish.
+	Fixup string
 }
 
 // Commit runs the 'git commit' command,
@@ -143,6 +146,9 @@ func (r *Repository) Commit(ctx context.Context, req CommitRequest) error {
 	}
 	if req.ReuseMessage != "" {
 		args = append(args, "-C", req.ReuseMessage)
+	}
+	if req.Fixup != "" {
+		args = append(args, "--fixup", req.Fixup)
 	}
 
 	err := r.gitCmd(ctx, args...).

--- a/testdata/script/commit_create_fixup.txt
+++ b/testdata/script/commit_create_fixup.txt
@@ -1,0 +1,60 @@
+# Commit create usage with --fixup option.
+
+as 'Test <test@example.com>'
+at '2024-03-30T14:59:32Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git checkout -b feature
+gs branch track --base main
+
+# create a couple commits
+git add foo.txt
+gs cc -m 'Add foo'
+mv $WORK/extra/bar.txt bar.txt
+git add bar.txt
+gs cc -m 'Add bar'
+mv $WORK/extra/new_foo.txt foo.txt
+gs cc -a --fixup :/foo
+
+# verify the output
+git log
+cmp stdout $WORK/golden/log.1.txt
+
+-- repo/foo.txt --
+Contents of foo.
+
+-- extra/new_foo.txt --
+New contents of foo.
+
+-- extra/bar.txt --
+Contents of bar.txt
+
+-- golden/log.1.txt --
+commit 09309bfe664697b2e69d883ccd6ab7cbef505d0d
+Author: Test <test@example.com>
+Date:   Sat Mar 30 14:59:32 2024 +0000
+
+    fixup! Add foo
+
+commit 6295ed5efe1d126f9b26c33d699b971e15589a0b
+Author: Test <test@example.com>
+Date:   Sat Mar 30 14:59:32 2024 +0000
+
+    Add bar
+
+commit 91582344149997d5a513acf7b4d56a03452e23cd
+Author: Test <test@example.com>
+Date:   Sat Mar 30 14:59:32 2024 +0000
+
+    Add foo
+
+commit 9bad92b764fe1d56cb99b394f373a71cdefd8e86
+Author: Test <test@example.com>
+Date:   Sat Mar 30 14:59:32 2024 +0000
+
+    Initial commit


### PR DESCRIPTION
This adds a new --fixup flag for allowing you to create fixup commits.

--fixup takes a commitish which targets where the fixup will be applied.
--fixup also takes the search :/<text> to target the subject of a commit
message to target the correct commit.

Using gs branch edit with the autosquash option set in git allows us to
automatically fixup our commits.

Resolves #492