### PR TITLE
commit amend: deprecate -n in favor of --no-edit

### DIFF
--- a/.changes/unreleased/Changed-20241129-120946.yaml
+++ b/.changes/unreleased/Changed-20241129-120946.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'commit amend: Deprecate ''-n'' form of ''--no-edit''. This will be removed in a future version.'
+time: 2024-11-29T12:09:46.681512-08:00

--- a/commit_amend.go
+++ b/commit_amend.go
@@ -14,7 +14,12 @@ import (
 type commitAmendCmd struct {
 	All     bool   `short:"a" help:"Stage all changes before committing."`
 	Message string `short:"m" placeholder:"MSG" help:"Use the given message as the commit message."`
-	NoEdit  bool   `short:"n" help:"Don't edit the commit message"`
+
+	NoEdit bool `help:"Don't edit the commit message"`
+
+	// TODO:
+	// Remove this short form and put it on NoVerify.
+	NoEditDeprecated bool `hidden:"true" short:"n" help:"Don't edit the commit message"`
 }
 
 func (*commitAmendCmd) Help() string {
@@ -27,6 +32,11 @@ func (*commitAmendCmd) Help() string {
 }
 
 func (cmd *commitAmendCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
+	if cmd.NoEditDeprecated {
+		cmd.NoEdit = true
+		log.Warn("flag '-n' is deprecated; use '--no-edit' instead")
+	}
+
 	repo, err := git.Open(ctx, ".", git.OpenOptions{
 		Log: log,
 	})

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -796,7 +796,7 @@ followed by 'gs upstack restack'.
 
 * `-a`, `--all`: Stage all changes before committing.
 * `-m`, `--message=MSG`: Use the given message as the commit message.
-* `-n`, `--no-edit`: Don't edit the commit message
+* `--no-edit`: Don't edit the commit message
 
 ### gs commit split
 

--- a/testdata/script/branch_submit_config_no_publish.txt
+++ b/testdata/script/branch_submit_config_no_publish.txt
@@ -41,7 +41,7 @@ cmp stdout $WORK/golden/no-pulls.txt
 # publish
 cp feature1-v3.txt feature1.txt
 git add feature1.txt
-gs ca -n -m 'feature1 v3'
+gs ca --no-edit -m 'feature1 v3'
 gs branch submit --publish --fill
 
 gs ll

--- a/testdata/script/commit_amend_deprecated_short_form.txt
+++ b/testdata/script/commit_amend_deprecated_short_form.txt
@@ -1,0 +1,31 @@
+# commit amend warns when -n flag is used.
+# TODO: Delete this test when -n is removed from commit amend
+
+as 'Test <test@example.com>'
+at '2024-11-29T12:13:14Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git add feat.txt
+gs bc -m feat
+
+mv feat-new.txt feat.txt
+gs ca -n
+stderr 'flag .-n. is deprecated; use .--no-edit. instead'
+
+git graph --branches
+cmp stdout $WORK/graph.golden
+
+-- repo/feat.txt --
+feature
+
+-- repo/feat-new.txt --
+rest of feature
+
+-- graph.golden --
+* 8a02d9e (HEAD -> feat) feat
+* af5877c (main) Initial commit

--- a/testdata/script/commit_amend_rebase.txt
+++ b/testdata/script/commit_amend_rebase.txt
@@ -32,7 +32,7 @@ stdout 94ce19e
 # amend the feature 1 commit
 mv $WORK/extra/feature1-part2.txt feature1-part2.txt
 git add feature1-part2.txt
-gs commit amend -n
+gs commit amend --no-edit
 
 git rev-parse HEAD
 stdout 95044b5
@@ -40,7 +40,7 @@ git rebase --continue
 
 # amend the feature 2 commit with -a flag
 mv $WORK/extra/new-feature2.txt feature2.txt
-gs commit amend -a -n
+gs commit amend -a --no-edit
 
 git rev-parse HEAD
 stdout ad5037b


### PR DESCRIPTION
`git commit --no-edit` does not have a `-n` short form
so we shouldn't either.

In the interest of not breaking anyone, just deprecate the flag first.
We'll warn users when they use the short form for now.

Refs https://github.com/abhinav/git-spice/issues/380#issuecomment-2508558831