### PR TITLE
forge: Add MarshalChangeID/UnmarshalChangeID

### DIFF
--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -91,6 +91,12 @@ type Forge interface {
 	// it's possible to define change templates in the repository.
 	ChangeTemplatePaths() []string
 
+	// MarshalChangeID serializes the given change ID into a valid JSON blob.
+	MarshalChangeID(ChangeID) (json.RawMessage, error)
+
+	// UnmarshalChangeID deserializes the given JSON blob into a change ID.
+	UnmarshalChangeID(json.RawMessage) (ChangeID, error)
+
 	// MarshalChangeMetadata serializes the given change metadata
 	// into a valid JSON blob.
 	MarshalChangeMetadata(ChangeMetadata) (json.RawMessage, error)

--- a/internal/forge/forgetest/mocks.go
+++ b/internal/forge/forgetest/mocks.go
@@ -275,6 +275,45 @@ func (c *MockForgeLoadAuthenticationTokenCall) DoAndReturn(f func(secret.Stash) 
 	return c
 }
 
+// MarshalChangeID mocks base method.
+func (m *MockForge) MarshalChangeID(arg0 forge.ChangeID) (json.RawMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MarshalChangeID", arg0)
+	ret0, _ := ret[0].(json.RawMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MarshalChangeID indicates an expected call of MarshalChangeID.
+func (mr *MockForgeMockRecorder) MarshalChangeID(arg0 any) *MockForgeMarshalChangeIDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarshalChangeID", reflect.TypeOf((*MockForge)(nil).MarshalChangeID), arg0)
+	return &MockForgeMarshalChangeIDCall{Call: call}
+}
+
+// MockForgeMarshalChangeIDCall wrap *gomock.Call
+type MockForgeMarshalChangeIDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockForgeMarshalChangeIDCall) Return(arg0 json.RawMessage, arg1 error) *MockForgeMarshalChangeIDCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockForgeMarshalChangeIDCall) Do(f func(forge.ChangeID) (json.RawMessage, error)) *MockForgeMarshalChangeIDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockForgeMarshalChangeIDCall) DoAndReturn(f func(forge.ChangeID) (json.RawMessage, error)) *MockForgeMarshalChangeIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // MarshalChangeMetadata mocks base method.
 func (m *MockForge) MarshalChangeMetadata(arg0 forge.ChangeMetadata) (json.RawMessage, error) {
 	m.ctrl.T.Helper()
@@ -425,6 +464,45 @@ func (c *MockForgeSaveAuthenticationTokenCall) Do(f func(secret.Stash, forge.Aut
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockForgeSaveAuthenticationTokenCall) DoAndReturn(f func(secret.Stash, forge.AuthenticationToken) error) *MockForgeSaveAuthenticationTokenCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// UnmarshalChangeID mocks base method.
+func (m *MockForge) UnmarshalChangeID(arg0 json.RawMessage) (forge.ChangeID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UnmarshalChangeID", arg0)
+	ret0, _ := ret[0].(forge.ChangeID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UnmarshalChangeID indicates an expected call of UnmarshalChangeID.
+func (mr *MockForgeMockRecorder) UnmarshalChangeID(arg0 any) *MockForgeUnmarshalChangeIDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnmarshalChangeID", reflect.TypeOf((*MockForge)(nil).UnmarshalChangeID), arg0)
+	return &MockForgeUnmarshalChangeIDCall{Call: call}
+}
+
+// MockForgeUnmarshalChangeIDCall wrap *gomock.Call
+type MockForgeUnmarshalChangeIDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockForgeUnmarshalChangeIDCall) Return(arg0 forge.ChangeID, arg1 error) *MockForgeUnmarshalChangeIDCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockForgeUnmarshalChangeIDCall) Do(f func(json.RawMessage) (forge.ChangeID, error)) *MockForgeUnmarshalChangeIDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockForgeUnmarshalChangeIDCall) DoAndReturn(f func(json.RawMessage) (forge.ChangeID, error)) *MockForgeUnmarshalChangeIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/forge/github/change_meta.go
+++ b/internal/forge/github/change_meta.go
@@ -75,6 +75,20 @@ func (*Forge) UnmarshalChangeMetadata(data json.RawMessage) (forge.ChangeMetadat
 	return &md, nil
 }
 
+// MarshalChangeID serializes a PR into JSON.
+func (*Forge) MarshalChangeID(cid forge.ChangeID) (json.RawMessage, error) {
+	return json.Marshal(mustPR(cid))
+}
+
+// UnmarshalChangeID deserializes a PR from JSON.
+func (*Forge) UnmarshalChangeID(data json.RawMessage) (forge.ChangeID, error) {
+	var pr PR
+	if err := json.Unmarshal(data, &pr); err != nil {
+		return nil, fmt.Errorf("unmarshal PR: %w", err)
+	}
+	return &pr, nil
+}
+
 // PR uniquely identifies a PR in a GitHub repository.
 // It's a valid forge.ChangeID.
 type PR struct {

--- a/internal/forge/github/change_meta_test.go
+++ b/internal/forge/github/change_meta_test.go
@@ -30,6 +30,33 @@ func TestPRString(t *testing.T) {
 	}).String())
 }
 
+func TestPRMarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		give PR
+		want string
+	}{
+		{
+			name: "NumberOnly",
+			give: PR{Number: 42},
+			want: `{"number": 42}`,
+		},
+		{
+			name: "NumberAndGQLID",
+			give: PR{Number: 42, GQLID: "foo"},
+			want: `{"number": 42, "gqlID": "foo"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := new(Forge).MarshalChangeID(&tt.give)
+			require.NoError(t, err)
+			assert.JSONEq(t, tt.want, string(got))
+		})
+	}
+}
+
 func TestPRUnmarshal(t *testing.T) {
 	tests := []struct {
 		name string
@@ -57,8 +84,7 @@ func TestPRUnmarshal(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var pr PR
-			err := json.Unmarshal([]byte(tt.give), &pr)
+			pr, err := new(Forge).UnmarshalChangeID(json.RawMessage(tt.give))
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.ErrorContains(t, err, tt.wantErr)
@@ -66,7 +92,7 @@ func TestPRUnmarshal(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			assert.Equal(t, tt.want, pr)
+			assert.Equal(t, &tt.want, pr)
 		})
 	}
 }

--- a/internal/forge/gitlab/change_meta.go
+++ b/internal/forge/gitlab/change_meta.go
@@ -68,6 +68,20 @@ func (*Forge) UnmarshalChangeMetadata(data json.RawMessage) (forge.ChangeMetadat
 	return &md, nil
 }
 
+// MarshalChangeID serializes a MR into JSON.
+func (*Forge) MarshalChangeID(id forge.ChangeID) (json.RawMessage, error) {
+	return json.Marshal(mustMR(id))
+}
+
+// UnmarshalChangeID deserializes a MR from JSON.
+func (*Forge) UnmarshalChangeID(data json.RawMessage) (forge.ChangeID, error) {
+	var id MR
+	if err := json.Unmarshal(data, &id); err != nil {
+		return nil, fmt.Errorf("unmarshal MR ID: %w", err)
+	}
+	return &id, nil
+}
+
 // MR uniquely identifies a Merge Request in GitLab.
 // It's a valid forge.ChangeID.
 type MR struct {

--- a/internal/forge/gitlab/change_meta_test.go
+++ b/internal/forge/gitlab/change_meta_test.go
@@ -48,6 +48,28 @@ func TestMRString(t *testing.T) {
 	}).String())
 }
 
+func TestMRMarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		give MR
+		want string
+	}{
+		{
+			name: "NumberOnly",
+			give: MR{Number: 42},
+			want: `{"number": 42}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := new(Forge).MarshalChangeID(&tt.give)
+			require.NoError(t, err)
+			assert.JSONEq(t, tt.want, string(got))
+		})
+	}
+}
+
 func TestMRUnmarshal(t *testing.T) {
 	tests := []struct {
 		name string
@@ -70,8 +92,7 @@ func TestMRUnmarshal(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var pr MR
-			err := json.Unmarshal([]byte(tt.give), &pr)
+			pr, err := new(Forge).UnmarshalChangeID(json.RawMessage(tt.give))
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.ErrorContains(t, err, tt.wantErr)
@@ -79,7 +100,7 @@ func TestMRUnmarshal(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			assert.Equal(t, tt.want, pr)
+			assert.Equal(t, &tt.want, pr)
 		})
 	}
 }

--- a/internal/forge/shamhub/change_meta.go
+++ b/internal/forge/shamhub/change_meta.go
@@ -63,3 +63,17 @@ func (f *Forge) UnmarshalChangeMetadata(data json.RawMessage) (forge.ChangeMetad
 	}
 	return &md, nil
 }
+
+// MarshalChangeID marshals the given change ID to JSON.
+func (f *Forge) MarshalChangeID(id forge.ChangeID) (json.RawMessage, error) {
+	return json.Marshal(id.(ChangeID))
+}
+
+// UnmarshalChangeID unmarshals the given JSON data to change ID.
+func (f *Forge) UnmarshalChangeID(data json.RawMessage) (forge.ChangeID, error) {
+	var id ChangeID
+	if err := json.Unmarshal(data, &id); err != nil {
+		return nil, fmt.Errorf("unmarshal change ID: %w", err)
+	}
+	return id, nil
+}


### PR DESCRIPTION
Add a means for forges to serialize and deserialize just their ChangeIDs
without any other change metadata.

This will be used by #508.