### PR TITLE
repo sync/downstack history: Don't nuke merged branch history

### DIFF
--- a/internal/forge/shamhub/merge.go
+++ b/internal/forge/shamhub/merge.go
@@ -44,7 +44,7 @@ func (sh *ShamHub) handleAreMerged(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sh.mu.RLock()
-	merged := make([]bool, len(sh.changes))
+	merged := make([]bool, len(changeNumToIdx))
 	for _, c := range sh.changes {
 		if c.Owner == owner && c.Repo == repo {
 			idx, ok := changeNumToIdx[c.Number]


### PR DESCRIPTION
When bubbling up downstack history,
don't nuke the history of a merged branch until it's deleted.
If this branch fails to be deleted/untracked for any reason,
we'll still have this history to work with.