### PR TITLE
cli: use Kong to inject repo, store, spice service

### DIFF
--- a/.changes/unreleased/Fixed-20241221-151600.yaml
+++ b/.changes/unreleased/Fixed-20241221-151600.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Reduce repeated work between git-spice commands that invoke each other.
+time: 2024-12-21T15:16:00.059639-05:00

--- a/auth_logout.go
+++ b/auth_logout.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"context"
-
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/secret"
@@ -21,7 +19,6 @@ func (*authLogoutCmd) Help() string {
 }
 
 func (cmd *authLogoutCmd) Run(
-	ctx context.Context,
 	stash secret.Stash,
 	log *log.Logger,
 	f forge.Forge,

--- a/auth_status.go
+++ b/auth_status.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
@@ -17,7 +16,6 @@ func (*authStatusCmd) Help() string {
 }
 
 func (cmd *authStatusCmd) Run(
-	ctx context.Context,
 	stash secret.Stash,
 	log *log.Logger,
 	f forge.Forge,

--- a/bottom.go
+++ b/bottom.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
 	"go.abhg.dev/gs/internal/ui"
 )
@@ -21,12 +24,14 @@ func (*bottomCmd) Help() string {
 	`)
 }
 
-func (cmd *bottomCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
-	repo, store, svc, err := openRepo(ctx, log, view)
-	if err != nil {
-		return err
-	}
-
+func (cmd *bottomCmd) Run(
+	ctx context.Context,
+	log *log.Logger,
+	view ui.View,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
+) error {
 	current, err := repo.CurrentBranch(ctx)
 	if err != nil {
 		// TODO: handle not a branch
@@ -45,5 +50,5 @@ func (cmd *bottomCmd) Run(ctx context.Context, log *log.Logger, view ui.View) er
 	return (&branchCheckoutCmd{
 		checkoutOptions: cmd.checkoutOptions,
 		Branch:          bottom,
-	}).Run(ctx, log, view)
+	}).Run(ctx, log, view, repo, store, svc)
 }

--- a/branch_checkout.go
+++ b/branch_checkout.go
@@ -33,12 +33,14 @@ func (*branchCheckoutCmd) Help() string {
 	`)
 }
 
-func (cmd *branchCheckoutCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
-	repo, store, svc, err := openRepo(ctx, log, view)
-	if err != nil {
-		return err
-	}
-
+func (cmd *branchCheckoutCmd) Run(
+	ctx context.Context,
+	log *log.Logger,
+	view ui.View,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
+) error {
 	if cmd.Branch == "" {
 		if !ui.Interactive(view) {
 			return fmt.Errorf("cannot proceed without a branch name: %w", errNoPrompt)
@@ -88,7 +90,7 @@ func (cmd *branchCheckoutCmd) Run(ctx context.Context, log *log.Logger, view ui.
 				if track {
 					err := (&branchTrackCmd{
 						Branch: cmd.Branch,
-					}).Run(ctx, log, view)
+					}).Run(ctx, log, repo, store, svc)
 					if err != nil {
 						return fmt.Errorf("track branch: %w", err)
 					}

--- a/branch_create.go
+++ b/branch_create.go
@@ -10,7 +10,6 @@ import (
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
-	"go.abhg.dev/gs/internal/ui"
 )
 
 type branchCreateCmd struct {
@@ -81,15 +80,17 @@ func (*branchCreateCmd) Help() string {
 	`)
 }
 
-func (cmd *branchCreateCmd) Run(ctx context.Context, log *log.Logger, view ui.View) (err error) {
+func (cmd *branchCreateCmd) Run(
+	ctx context.Context,
+	log *log.Logger,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
+) (err error) {
 	if cmd.Name == "" && !cmd.Commit {
 		return fmt.Errorf("a branch name is required with --no-commit")
 	}
 
-	repo, store, svc, err := openRepo(ctx, log, view)
-	if err != nil {
-		return err
-	}
 	trunk := store.Trunk()
 
 	if cmd.Target == "" {
@@ -272,7 +273,9 @@ func (cmd *branchCreateCmd) Run(ctx context.Context, log *log.Logger, view ui.Vi
 	}
 
 	if cmd.Below || cmd.Insert {
-		return (&upstackRestackCmd{}).Run(ctx, log, view)
+		return (&upstackRestackCmd{}).Run(
+			ctx, log, repo, store, svc,
+		)
 	}
 
 	return nil

--- a/branch_delete.go
+++ b/branch_delete.go
@@ -33,12 +33,14 @@ func (*branchDeleteCmd) Help() string {
 	`)
 }
 
-func (cmd *branchDeleteCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
-	repo, store, svc, err := openRepo(ctx, log, view)
-	if err != nil {
-		return err
-	}
-
+func (cmd *branchDeleteCmd) Run(
+	ctx context.Context,
+	log *log.Logger,
+	view ui.View,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
+) error {
 	if len(cmd.Branches) == 0 {
 		// If a branch name is not given, prompt for one;
 		// assuming we're in interactive mode.

--- a/branch_edit.go
+++ b/branch_edit.go
@@ -10,7 +10,6 @@ import (
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
-	"go.abhg.dev/gs/internal/ui"
 )
 
 type branchEditCmd struct{}
@@ -24,12 +23,13 @@ func (*branchEditCmd) Help() string {
 	`)
 }
 
-func (*branchEditCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
-	repo, _, svc, err := openRepo(ctx, log, view)
-	if err != nil {
-		return err
-	}
-
+func (*branchEditCmd) Run(
+	ctx context.Context,
+	log *log.Logger,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
+) error {
 	currentBranch, err := repo.CurrentBranch(ctx)
 	if err != nil {
 		return fmt.Errorf("get current branch: %w", err)
@@ -59,5 +59,5 @@ func (*branchEditCmd) Run(ctx context.Context, log *log.Logger, view ui.View) er
 		})
 	}
 
-	return (&upstackRestackCmd{}).Run(ctx, log, view)
+	return (&upstackRestackCmd{}).Run(ctx, log, repo, store, svc)
 }

--- a/branch_fold.go
+++ b/branch_fold.go
@@ -27,12 +27,14 @@ func (*branchFoldCmd) Help() string {
 	`)
 }
 
-func (cmd *branchFoldCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
-	repo, store, svc, err := openRepo(ctx, log, view)
-	if err != nil {
-		return err
-	}
-
+func (cmd *branchFoldCmd) Run(
+	ctx context.Context,
+	log *log.Logger,
+	view ui.View,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
+) error {
 	if cmd.Branch == "" {
 		currentBranch, err := repo.CurrentBranch(ctx)
 		if err != nil {
@@ -103,7 +105,9 @@ func (cmd *branchFoldCmd) Run(ctx context.Context, log *log.Logger, view ui.View
 	}
 
 	// Check out base and delete the branch we are folding.
-	if err := (&branchCheckoutCmd{Branch: b.Base}).Run(ctx, log, view); err != nil {
+	if err := (&branchCheckoutCmd{Branch: b.Base}).Run(
+		ctx, log, view, repo, store, svc,
+	); err != nil {
 		return fmt.Errorf("checkout base: %w", err)
 	}
 

--- a/branch_onto.go
+++ b/branch_onto.go
@@ -41,12 +41,14 @@ func (*branchOntoCmd) Help() string {
 	`)
 }
 
-func (cmd *branchOntoCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
-	repo, store, svc, err := openRepo(ctx, log, view)
-	if err != nil {
-		return err
-	}
-
+func (cmd *branchOntoCmd) Run(
+	ctx context.Context,
+	log *log.Logger,
+	view ui.View,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
+) error {
 	if cmd.Branch == "" {
 		currentBranch, err := repo.CurrentBranch(ctx)
 		if err != nil {
@@ -98,7 +100,7 @@ func (cmd *branchOntoCmd) Run(ctx context.Context, log *log.Logger, view ui.View
 		if err := (&upstackOntoCmd{
 			Branch: above,
 			Onto:   branch.Base,
-		}).Run(ctx, log, view); err != nil {
+		}).Run(ctx, log, view, repo, store, svc); err != nil {
 			return svc.RebaseRescue(ctx, spice.RebaseRescueRequest{
 				Err:     err,
 				Command: []string{"branch", "onto", cmd.Onto},

--- a/branch_rename.go
+++ b/branch_rename.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/must"
+	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/text"
 	"go.abhg.dev/gs/internal/ui"
 )
@@ -35,12 +36,12 @@ func (*branchRenameCmd) Help() string {
 	`)
 }
 
-func (cmd *branchRenameCmd) Run(ctx context.Context, log *log.Logger, view ui.View) (err error) {
-	repo, _, svc, err := openRepo(ctx, log, view)
-	if err != nil {
-		return err
-	}
-
+func (cmd *branchRenameCmd) Run(
+	ctx context.Context,
+	view ui.View,
+	repo *git.Repository,
+	svc *spice.Service,
+) (err error) {
 	oldName, newName := cmd.OldName, cmd.NewName
 	// For "gs branch rename <new>",
 	// we'll actually get oldName = <new> and newName = "".

--- a/branch_restack.go
+++ b/branch_restack.go
@@ -10,7 +10,6 @@ import (
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
-	"go.abhg.dev/gs/internal/ui"
 )
 
 type branchRestackCmd struct {
@@ -25,12 +24,12 @@ func (*branchRestackCmd) Help() string {
 	`)
 }
 
-func (cmd *branchRestackCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
-	repo, _, svc, err := openRepo(ctx, log, view)
-	if err != nil {
-		return err
-	}
-
+func (cmd *branchRestackCmd) Run(
+	ctx context.Context,
+	log *log.Logger,
+	repo *git.Repository,
+	svc *spice.Service,
+) error {
 	if cmd.Branch == "" {
 		currentBranch, err := repo.CurrentBranch(ctx)
 		if err != nil {

--- a/branch_split.go
+++ b/branch_split.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
 	"go.abhg.dev/gs/internal/ui"
@@ -50,12 +51,14 @@ func (*branchSplitCmd) Help() string {
 	`)
 }
 
-func (cmd *branchSplitCmd) Run(ctx context.Context, log *log.Logger, view ui.View) (err error) {
-	repo, store, svc, err := openRepo(ctx, log, view)
-	if err != nil {
-		return err
-	}
-
+func (cmd *branchSplitCmd) Run(
+	ctx context.Context,
+	log *log.Logger,
+	view ui.View,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
+) (err error) {
 	if cmd.Branch == "" {
 		cmd.Branch, err = repo.CurrentBranch(ctx)
 		if err != nil {

--- a/branch_submit.go
+++ b/branch_submit.go
@@ -100,14 +100,12 @@ func (cmd *branchSubmitCmd) Run(
 	secretStash secret.Stash,
 	log *log.Logger,
 	view ui.View,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
 ) error {
-	repo, store, svc, err := openRepo(ctx, log, view)
-	if err != nil {
-		return err
-	}
-
 	session := newSubmitSession(repo, store, secretStash, view, log)
-	if err := cmd.run(ctx, session, repo, store, svc, log, view); err != nil {
+	if err := cmd.run(ctx, session, log, view, repo, store, svc); err != nil {
 		return err
 	}
 
@@ -128,11 +126,11 @@ func (cmd *branchSubmitCmd) Run(
 func (cmd *branchSubmitCmd) run(
 	ctx context.Context,
 	session *submitSession,
+	log *log.Logger,
+	view ui.View,
 	repo *git.Repository,
 	store *state.Store,
 	svc *spice.Service,
-	log *log.Logger,
-	view ui.View,
 ) error {
 	if cmd.Branch == "" {
 		currentBranch, err := repo.CurrentBranch(ctx)

--- a/branch_track.go
+++ b/branch_track.go
@@ -10,7 +10,6 @@ import (
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
-	"go.abhg.dev/gs/internal/ui"
 )
 
 type branchTrackCmd struct {
@@ -28,13 +27,15 @@ func (*branchTrackCmd) Help() string {
 	`)
 }
 
-func (cmd *branchTrackCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
-	repo, store, svc, err := openRepo(ctx, log, view)
-	if err != nil {
-		return err
-	}
-
+func (cmd *branchTrackCmd) Run(
+	ctx context.Context,
+	log *log.Logger,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
+) error {
 	if cmd.Branch == "" {
+		var err error
 		cmd.Branch, err = repo.CurrentBranch(ctx)
 		if err != nil {
 			return fmt.Errorf("get current branch: %w", err)

--- a/branch_untrack.go
+++ b/branch_untrack.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
-	"go.abhg.dev/gs/internal/ui"
 )
 
 type branchUntrackCmd struct {
@@ -27,13 +27,13 @@ func (*branchUntrackCmd) Help() string {
 	`)
 }
 
-func (cmd *branchUntrackCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
-	repo, _, svc, err := openRepo(ctx, log, view)
-	if err != nil {
-		return err
-	}
-
+func (cmd *branchUntrackCmd) Run(
+	ctx context.Context,
+	repo *git.Repository,
+	svc *spice.Service,
+) error {
 	if cmd.Branch == "" {
+		var err error
 		cmd.Branch, err = repo.CurrentBranch(ctx)
 		if err != nil {
 			return fmt.Errorf("get current branch: %w", err)

--- a/commit_amend.go
+++ b/commit_amend.go
@@ -7,8 +7,9 @@ import (
 
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
-	"go.abhg.dev/gs/internal/ui"
 )
 
 type commitAmendCmd struct {
@@ -32,17 +33,16 @@ func (*commitAmendCmd) Help() string {
 	`)
 }
 
-func (cmd *commitAmendCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
+func (cmd *commitAmendCmd) Run(
+	ctx context.Context,
+	log *log.Logger,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
+) error {
 	if cmd.NoEditDeprecated {
 		cmd.NoEdit = true
 		log.Warn("flag '-n' is deprecated; use '--no-edit' instead")
-	}
-
-	repo, err := git.Open(ctx, ".", git.OpenOptions{
-		Log: log,
-	})
-	if err != nil {
-		return fmt.Errorf("open repository: %w", err)
 	}
 
 	if err := repo.Commit(ctx, git.CommitRequest{
@@ -73,5 +73,5 @@ func (cmd *commitAmendCmd) Run(ctx context.Context, log *log.Logger, view ui.Vie
 	return (&upstackRestackCmd{
 		Branch:    currentBranch,
 		SkipStart: true,
-	}).Run(ctx, log, view)
+	}).Run(ctx, log, repo, store, svc)
 }

--- a/commit_create.go
+++ b/commit_create.go
@@ -7,8 +7,9 @@ import (
 
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
-	"go.abhg.dev/gs/internal/ui"
 )
 
 type commitCreateCmd struct {
@@ -27,14 +28,13 @@ func (*commitCreateCmd) Help() string {
 	`)
 }
 
-func (cmd *commitCreateCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
-	repo, err := git.Open(ctx, ".", git.OpenOptions{
-		Log: log,
-	})
-	if err != nil {
-		return fmt.Errorf("open repository: %w", err)
-	}
-
+func (cmd *commitCreateCmd) Run(
+	ctx context.Context,
+	log *log.Logger,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
+) error {
 	if err := repo.Commit(ctx, git.CommitRequest{
 		Message:  cmd.Message,
 		All:      cmd.All,
@@ -62,5 +62,5 @@ func (cmd *commitCreateCmd) Run(ctx context.Context, log *log.Logger, view ui.Vi
 	return (&upstackRestackCmd{
 		Branch:    currentBranch,
 		SkipStart: true,
-	}).Run(ctx, log, view)
+	}).Run(ctx, log, repo, store, svc)
 }

--- a/commit_split.go
+++ b/commit_split.go
@@ -7,8 +7,9 @@ import (
 
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
-	"go.abhg.dev/gs/internal/ui"
 )
 
 type commitSplitCmd struct {
@@ -24,14 +25,13 @@ func (*commitSplitCmd) Help() string {
 	`)
 }
 
-func (cmd *commitSplitCmd) Run(ctx context.Context, log *log.Logger, view ui.View) (err error) {
-	repo, err := git.Open(ctx, ".", git.OpenOptions{
-		Log: log,
-	})
-	if err != nil {
-		return fmt.Errorf("open repository: %w", err)
-	}
-
+func (cmd *commitSplitCmd) Run(
+	ctx context.Context,
+	log *log.Logger,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
+) (err error) {
 	head, err := repo.Head(ctx)
 	if err != nil {
 		return fmt.Errorf("get HEAD: %w", err)
@@ -110,5 +110,5 @@ func (cmd *commitSplitCmd) Run(ctx context.Context, log *log.Logger, view ui.Vie
 	return (&upstackRestackCmd{
 		Branch:    currentBranch,
 		SkipStart: true,
-	}).Run(ctx, log, view)
+	}).Run(ctx, log, repo, store, svc)
 }

--- a/down.go
+++ b/down.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
 	"go.abhg.dev/gs/internal/ui"
 )
@@ -24,12 +27,14 @@ func (*downCmd) Help() string {
 	`)
 }
 
-func (cmd *downCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
-	repo, store, svc, err := openRepo(ctx, log, view)
-	if err != nil {
-		return err
-	}
-
+func (cmd *downCmd) Run(
+	ctx context.Context,
+	log *log.Logger,
+	view ui.View,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
+) error {
 	current, err := repo.CurrentBranch(ctx)
 	if err != nil {
 		// TODO: handle not a branch
@@ -70,5 +75,5 @@ outer:
 	return (&branchCheckoutCmd{
 		checkoutOptions: cmd.checkoutOptions,
 		Branch:          below,
-	}).Run(ctx, log, view)
+	}).Run(ctx, log, view, repo, store, svc)
 }

--- a/downstack_edit.go
+++ b/downstack_edit.go
@@ -7,8 +7,10 @@ import (
 	"slices"
 
 	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/must"
 	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
 	"go.abhg.dev/gs/internal/ui"
 )
@@ -34,12 +36,14 @@ func (*downstackEditCmd) Help() string {
 	`)
 }
 
-func (cmd *downstackEditCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
-	repo, store, svc, err := openRepo(ctx, log, view)
-	if err != nil {
-		return err
-	}
-
+func (cmd *downstackEditCmd) Run(
+	ctx context.Context,
+	log *log.Logger,
+	view ui.View,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
+) error {
 	if cmd.Editor == "" {
 		cmd.Editor = gitEditor(ctx, repo)
 	}
@@ -88,5 +92,5 @@ func (cmd *downstackEditCmd) Run(ctx context.Context, log *log.Logger, view ui.V
 
 	return (&branchCheckoutCmd{
 		Branch: res.Stack[len(res.Stack)-1],
-	}).Run(ctx, log, view)
+	}).Run(ctx, log, view, repo, store, svc)
 }

--- a/downstack_submit.go
+++ b/downstack_submit.go
@@ -7,8 +7,11 @@ import (
 	"slices"
 
 	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/must"
 	"go.abhg.dev/gs/internal/secret"
+	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
 	"go.abhg.dev/gs/internal/ui"
 )
@@ -32,12 +35,10 @@ func (cmd *downstackSubmitCmd) Run(
 	secretStash secret.Stash,
 	log *log.Logger,
 	view ui.View,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
 ) error {
-	repo, store, svc, err := openRepo(ctx, log, view)
-	if err != nil {
-		return err
-	}
-
 	if cmd.Branch == "" {
 		currentBranch, err := repo.CurrentBranch(ctx)
 		if err != nil {
@@ -65,7 +66,7 @@ func (cmd *downstackSubmitCmd) Run(
 		err := (&branchSubmitCmd{
 			submitOptions: cmd.submitOptions,
 			Branch:        downstack,
-		}).run(ctx, session, repo, store, svc, log, view)
+		}).run(ctx, session, log, view, repo, store, svc)
 		if err != nil {
 			return fmt.Errorf("submit %v: %w", downstack, err)
 		}

--- a/log.go
+++ b/log.go
@@ -12,6 +12,7 @@ import (
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/ui"
 	"go.abhg.dev/gs/internal/ui/fliptree"
 	"go.abhg.dev/gs/internal/ui/widget"
@@ -56,14 +57,14 @@ type branchLogOptions struct {
 	Log *log.Logger
 }
 
-func (cmd *branchLogCmd) run(ctx context.Context, view ui.View, opts *branchLogOptions) (err error) {
+func (cmd *branchLogCmd) run(
+	ctx context.Context,
+	opts *branchLogOptions,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
+) (err error) {
 	log := opts.Log
-
-	repo, store, svc, err := openRepo(ctx, log, view)
-	if err != nil {
-		return err
-	}
-
 	currentBranch, err := repo.CurrentBranch(ctx)
 	if err != nil {
 		currentBranch = "" // may be detached

--- a/log_long.go
+++ b/log_long.go
@@ -4,8 +4,10 @@ import (
 	"context"
 
 	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
-	"go.abhg.dev/gs/internal/ui"
 )
 
 type logLongCmd struct {
@@ -20,9 +22,15 @@ func (*logLongCmd) Help() string {
 	`)
 }
 
-func (cmd *logLongCmd) Run(ctx context.Context, log *log.Logger, view ui.View) (err error) {
-	return cmd.run(ctx, view, &branchLogOptions{
+func (cmd *logLongCmd) Run(
+	ctx context.Context,
+	log *log.Logger,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
+) (err error) {
+	return cmd.run(ctx, &branchLogOptions{
 		Log:     log,
 		Commits: true,
-	})
+	}, repo, store, svc)
 }

--- a/log_short.go
+++ b/log_short.go
@@ -4,8 +4,10 @@ import (
 	"context"
 
 	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
-	"go.abhg.dev/gs/internal/ui"
 )
 
 type logShortCmd struct {
@@ -20,8 +22,14 @@ func (*logShortCmd) Help() string {
 	`)
 }
 
-func (cmd *logShortCmd) Run(ctx context.Context, log *log.Logger, view ui.View) (err error) {
-	return cmd.run(ctx, view, &branchLogOptions{
+func (cmd *logShortCmd) Run(
+	ctx context.Context,
+	log *log.Logger,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
+) (err error) {
+	return cmd.run(ctx, &branchLogOptions{
 		Log: log,
-	})
+	}, repo, store, svc)
 }

--- a/rebase_abort.go
+++ b/rebase_abort.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
 	"go.abhg.dev/gs/internal/ui"
 )
@@ -27,19 +28,13 @@ func (*rebaseAbortCmd) Help() string {
 	`)
 }
 
-func (cmd *rebaseAbortCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
-	repo, err := git.Open(ctx, ".", git.OpenOptions{
-		Log: log,
-	})
-	if err != nil {
-		return fmt.Errorf("open repository: %w", err)
-	}
-
-	store, err := ensureStore(ctx, repo, log, view)
-	if err != nil {
-		return err
-	}
-
+func (cmd *rebaseAbortCmd) Run(
+	ctx context.Context,
+	log *log.Logger,
+	view ui.View,
+	repo *git.Repository,
+	store *state.Store,
+) error {
 	var wasRebasing bool
 	if _, err := repo.RebaseState(ctx); err != nil {
 		if !errors.Is(err, git.ErrNoRebase) {

--- a/rebase_continue.go
+++ b/rebase_continue.go
@@ -9,6 +9,7 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
 	"go.abhg.dev/gs/internal/ui"
 )
@@ -39,20 +40,10 @@ func (cmd *rebaseContinueCmd) Run(
 	ctx context.Context,
 	log *log.Logger,
 	view ui.View,
+	repo *git.Repository,
+	store *state.Store,
 	parser *kong.Kong,
 ) error {
-	repo, err := git.Open(ctx, ".", git.OpenOptions{
-		Log: log,
-	})
-	if err != nil {
-		return fmt.Errorf("open repository: %w", err)
-	}
-
-	store, err := ensureStore(ctx, repo, log, view)
-	if err != nil {
-		return err
-	}
-
 	if _, err := repo.RebaseState(ctx); err != nil {
 		if !errors.Is(err, git.ErrNoRebase) {
 			return fmt.Errorf("get rebase state: %w", err)

--- a/shell_completion.go
+++ b/shell_completion.go
@@ -39,7 +39,7 @@ func (c *shellCompletionCmd) Help() string {
 	`)
 }
 
-func predictBranches(args komplete.Args) (predictions []string) {
+func predictBranches(_ komplete.Args) (predictions []string) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
@@ -60,7 +60,7 @@ func predictBranches(args komplete.Args) (predictions []string) {
 	return predictions
 }
 
-func predictTrackedBranches(args komplete.Args) (predictions []string) {
+func predictTrackedBranches(_ komplete.Args) (predictions []string) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
@@ -83,7 +83,7 @@ func predictTrackedBranches(args komplete.Args) (predictions []string) {
 	return branches
 }
 
-func predictRemotes(args komplete.Args) (predictions []string) {
+func predictRemotes(_ komplete.Args) (predictions []string) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
@@ -128,7 +128,7 @@ func predictDirs(args komplete.Args) (predictions []string) {
 	return predictions
 }
 
-func predictForges(args komplete.Args) (predictions []string) {
+func predictForges(_ komplete.Args) (predictions []string) {
 	var ids []string
 	for f := range forge.All {
 		ids = append(ids, f.ID())

--- a/stack_edit.go
+++ b/stack_edit.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
 	"go.abhg.dev/gs/internal/ui"
 )
@@ -34,12 +36,14 @@ func (*stackEditCmd) Help() string {
 	`)
 }
 
-func (cmd *stackEditCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
-	repo, store, svc, err := openRepo(ctx, log, view)
-	if err != nil {
-		return err
-	}
-
+func (cmd *stackEditCmd) Run(
+	ctx context.Context,
+	log *log.Logger,
+	view ui.View,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
+) error {
 	if cmd.Editor == "" {
 		cmd.Editor = gitEditor(ctx, repo)
 	}
@@ -91,5 +95,7 @@ func (cmd *stackEditCmd) Run(ctx context.Context, log *log.Logger, view ui.View)
 		return fmt.Errorf("edit downstack: %w", err)
 	}
 
-	return (&branchCheckoutCmd{Branch: cmd.Branch}).Run(ctx, log, view)
+	return (&branchCheckoutCmd{
+		Branch: cmd.Branch,
+	}).Run(ctx, log, view, repo, store, svc)
 }

--- a/stack_restack.go
+++ b/stack_restack.go
@@ -8,8 +8,8 @@ import (
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
-	"go.abhg.dev/gs/internal/ui"
 )
 
 type stackRestackCmd struct{}
@@ -21,12 +21,13 @@ func (*stackRestackCmd) Help() string {
 	`)
 }
 
-func (*stackRestackCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
-	repo, store, svc, err := openRepo(ctx, log, view)
-	if err != nil {
-		return err
-	}
-
+func (*stackRestackCmd) Run(
+	ctx context.Context,
+	log *log.Logger,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
+) error {
 	currentBranch, err := repo.CurrentBranch(ctx)
 	if err != nil {
 		return fmt.Errorf("get current branch: %w", err)

--- a/stack_submit.go
+++ b/stack_submit.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/secret"
+	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
 	"go.abhg.dev/gs/internal/ui"
 )
@@ -26,12 +29,10 @@ func (cmd *stackSubmitCmd) Run(
 	secretStash secret.Stash,
 	log *log.Logger,
 	view ui.View,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
 ) error {
-	repo, store, svc, err := openRepo(ctx, log, view)
-	if err != nil {
-		return err
-	}
-
 	currentBranch, err := repo.CurrentBranch(ctx)
 	if err != nil {
 		return fmt.Errorf("get current branch: %w", err)
@@ -54,7 +55,7 @@ func (cmd *stackSubmitCmd) Run(
 		err := (&branchSubmitCmd{
 			submitOptions: cmd.submitOptions,
 			Branch:        branch,
-		}).run(ctx, session, repo, store, svc, log, view)
+		}).run(ctx, session, log, view, repo, store, svc)
 		if err != nil {
 			return fmt.Errorf("submit %v: %w", branch, err)
 		}

--- a/top.go
+++ b/top.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/must"
+	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
 	"go.abhg.dev/gs/internal/ui"
 	"go.abhg.dev/gs/internal/ui/widget"
@@ -24,12 +27,14 @@ func (*topCmd) Help() string {
 	`)
 }
 
-func (cmd *topCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
-	repo, _, svc, err := openRepo(ctx, log, view)
-	if err != nil {
-		return err
-	}
-
+func (cmd *topCmd) Run(
+	ctx context.Context,
+	log *log.Logger,
+	view ui.View,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
+) error {
 	current, err := repo.CurrentBranch(ctx)
 	if err != nil {
 		// TODO: handle not a branch
@@ -78,5 +83,5 @@ func (cmd *topCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error
 	return (&branchCheckoutCmd{
 		checkoutOptions: cmd.checkoutOptions,
 		Branch:          branch,
-	}).Run(ctx, log, view)
+	}).Run(ctx, log, view, repo, store, svc)
 }

--- a/trunk.go
+++ b/trunk.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/ui"
 )
 
@@ -13,22 +14,17 @@ type trunkCmd struct {
 	checkoutOptions
 }
 
-func (cmd *trunkCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
-	repo, err := git.Open(ctx, ".", git.OpenOptions{
-		Log: log,
-	})
-	if err != nil {
-		return fmt.Errorf("open repository: %w", err)
-	}
-
-	store, err := ensureStore(ctx, repo, log, view)
-	if err != nil {
-		return err
-	}
-
+func (cmd *trunkCmd) Run(
+	ctx context.Context,
+	log *log.Logger,
+	view ui.View,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
+) error {
 	trunk := store.Trunk()
 	return (&branchCheckoutCmd{
 		checkoutOptions: cmd.checkoutOptions,
 		Branch:          trunk,
-	}).Run(ctx, log, view)
+	}).Run(ctx, log, view, repo, store, svc)
 }

--- a/up.go
+++ b/up.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
 	"go.abhg.dev/gs/internal/ui"
 	"go.abhg.dev/gs/internal/ui/widget"
@@ -25,12 +28,14 @@ func (*upCmd) Help() string {
 	`)
 }
 
-func (cmd *upCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
-	repo, _, svc, err := openRepo(ctx, log, view)
-	if err != nil {
-		return err
-	}
-
+func (cmd *upCmd) Run(
+	ctx context.Context,
+	log *log.Logger,
+	view ui.View,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
+) error {
 	current, err := repo.CurrentBranch(ctx)
 	if err != nil {
 		// TODO: handle not a branch
@@ -87,5 +92,5 @@ outer:
 	return (&branchCheckoutCmd{
 		checkoutOptions: cmd.checkoutOptions,
 		Branch:          branch,
-	}).Run(ctx, log, view)
+	}).Run(ctx, log, view, repo, store, svc)
 }

--- a/upstack_onto.go
+++ b/upstack_onto.go
@@ -39,12 +39,14 @@ func (*upstackOntoCmd) Help() string {
 	`)
 }
 
-func (cmd *upstackOntoCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
-	repo, store, svc, err := openRepo(ctx, log, view)
-	if err != nil {
-		return err
-	}
-
+func (cmd *upstackOntoCmd) Run(
+	ctx context.Context,
+	log *log.Logger,
+	view ui.View,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
+) error {
 	if cmd.Branch == "" {
 		currentBranch, err := repo.CurrentBranch(ctx)
 		if err != nil {
@@ -106,5 +108,5 @@ func (cmd *upstackOntoCmd) Run(ctx context.Context, log *log.Logger, view ui.Vie
 
 	return (&upstackRestackCmd{
 		SkipStart: true, // we've already moved the current branch
-	}).Run(ctx, log, view)
+	}).Run(ctx, log, repo, store, svc)
 }

--- a/upstack_restack.go
+++ b/upstack_restack.go
@@ -8,8 +8,8 @@ import (
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
-	"go.abhg.dev/gs/internal/ui"
 )
 
 type upstackRestackCmd struct {
@@ -32,12 +32,13 @@ func (*upstackRestackCmd) Help() string {
 	`)
 }
 
-func (cmd *upstackRestackCmd) Run(ctx context.Context, log *log.Logger, view ui.View) error {
-	repo, store, svc, err := openRepo(ctx, log, view)
-	if err != nil {
-		return err
-	}
-
+func (cmd *upstackRestackCmd) Run(
+	ctx context.Context,
+	log *log.Logger,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
+) error {
 	if cmd.Branch == "" {
 		currentBranch, err := repo.CurrentBranch(ctx)
 		if err != nil {

--- a/upstack_submit.go
+++ b/upstack_submit.go
@@ -6,7 +6,10 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/secret"
+	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
 	"go.abhg.dev/gs/internal/ui"
 )
@@ -32,12 +35,10 @@ func (cmd *upstackSubmitCmd) Run(
 	secretStash secret.Stash,
 	log *log.Logger,
 	view ui.View,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
 ) error {
-	repo, store, svc, err := openRepo(ctx, log, view)
-	if err != nil {
-		return err
-	}
-
 	if cmd.Branch == "" {
 		currentBranch, err := repo.CurrentBranch(ctx)
 		if err != nil {
@@ -83,7 +84,7 @@ func (cmd *upstackSubmitCmd) Run(
 		err := (&branchSubmitCmd{
 			submitOptions: cmd.submitOptions,
 			Branch:        b,
-		}).run(ctx, session, repo, store, svc, log, view)
+		}).run(ctx, session, log, view, repo, store, svc)
 		if err != nil {
 			return fmt.Errorf("submit %v: %w", b, err)
 		}


### PR DESCRIPTION
These are needed by nearly all commands.
Inject them through the Kong Provider functionality
and pass them between commands that invoke each other
to reduce repeated work.