### PR TITLE
uitest: Add system for unit testing widgets

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -84,3 +84,5 @@ issues:
     - linters: [revive]
       text: 'empty-block: this block is empty, you can remove it'
 
+    - linters: [musttag]
+      path: _test.go$

--- a/internal/forge/github/flag_test.go
+++ b/internal/forge/github/flag_test.go
@@ -1,0 +1,5 @@
+package github
+
+import "flag"
+
+var UpdateFixtures = flag.Bool("update", false, "update test fixtures")

--- a/internal/forge/github/integration_test.go
+++ b/internal/forge/github/integration_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
-	"flag"
 	"io"
 	"net/http"
 	"os"
@@ -33,7 +32,7 @@ import (
 // using recorded fixtures.
 
 var (
-	_update   = flag.Bool("update", false, "update test fixtures")
+	_update   = github.UpdateFixtures
 	_fixtures = fixturetest.Config{Update: _update}
 )
 

--- a/internal/forge/github/testdata/auth/pat.txt
+++ b/internal/forge/github/testdata/auth/pat.txt
@@ -1,0 +1,64 @@
+init
+
+await Select an authentication method
+feed -r 3 <Down>
+snapshot
+await
+snapshot
+cmp stdout select
+feed <Enter>
+
+await
+snapshot
+cmp stdout prompt
+
+feed secret
+await
+snapshot
+cmp stdout filled
+
+feed <Enter>
+
+-- want_token --
+secret
+-- select --
+Select an authentication method:
+  OAuth
+  Authorize git-spice to act on your behalf from this device only.
+  git-spice will get access to all repositories: public and private.
+  For private repositories, you will need to request installation from a
+  repository owner.
+
+  OAuth: Public repositories only
+  Authorize git-spice to act on your behalf from this device only.
+  git-spice will only get access to public repositories.
+
+  GitHub App
+  Authorize git-spice to act on your behalf from this device only.
+  git-spice will only get access to repositories where the git-spice GitHub
+  App is installed explicitly.
+  Use https://github.com/apps/git-spice to install the App on repositories.
+  For private repositories, you will need to request installation from a
+  repository owner.
+
+▶ Personal Access Token
+  Enter a classic or fine-grained Personal Access Token generated from
+  https://github.com/settings/tokens.
+  Classic tokens need at least one of the following scopes: repo or
+  public_repo.
+  Fine-grained tokens need read/write access to Repository Contents and Pull
+  requests.
+  You can use this method if you do not have the ability to install a GitHub
+  or OAuth App on your repositories.
+
+  GitHub CLI
+  Re-use an existing GitHub CLI (https://cli.github.com) session.
+  You must be logged into gh with 'gh auth login' for this to work.
+  You can use this if you're just experimenting and don't want to set up a
+  token yet.
+-- prompt --
+Select an authentication method: Personal Access Token
+Enter Personal Access Token:
+-- filled --
+Select an authentication method: Personal Access Token
+Enter Personal Access Token: secret

--- a/internal/forge/github/testdata/auth/select/oauth.txt
+++ b/internal/forge/github/testdata/auth/select/oauth.txt
@@ -1,0 +1,91 @@
+init
+
+await Select an authentication method
+snapshot
+cmp stdout prompt
+
+# go through the list of options and roll back
+feed -r 3 <Down>
+await
+snapshot
+cmp stdout down
+
+feed -r 2 <Down>
+await
+snapshot
+cmp stdout prompt
+
+feed <Enter>
+
+-- want_type --
+*github.DeviceFlowAuthenticator
+-- prompt --
+Select an authentication method:
+▶ OAuth
+  Authorize git-spice to act on your behalf from this device only.
+  git-spice will get access to all repositories: public and private.
+  For private repositories, you will need to request installation from a
+  repository owner.
+
+  OAuth: Public repositories only
+  Authorize git-spice to act on your behalf from this device only.
+  git-spice will only get access to public repositories.
+
+  GitHub App
+  Authorize git-spice to act on your behalf from this device only.
+  git-spice will only get access to repositories where the git-spice GitHub
+  App is installed explicitly.
+  Use https://github.com/apps/git-spice to install the App on repositories.
+  For private repositories, you will need to request installation from a
+  repository owner.
+
+  Personal Access Token
+  Enter a classic or fine-grained Personal Access Token generated from
+  https://github.com/settings/tokens.
+  Classic tokens need at least one of the following scopes: repo or
+  public_repo.
+  Fine-grained tokens need read/write access to Repository Contents and Pull
+  requests.
+  You can use this method if you do not have the ability to install a GitHub
+  or OAuth App on your repositories.
+
+  GitHub CLI
+  Re-use an existing GitHub CLI (https://cli.github.com) session.
+  You must be logged into gh with 'gh auth login' for this to work.
+  You can use this if you're just experimenting and don't want to set up a
+  token yet.
+-- down --
+Select an authentication method:
+  OAuth
+  Authorize git-spice to act on your behalf from this device only.
+  git-spice will get access to all repositories: public and private.
+  For private repositories, you will need to request installation from a
+  repository owner.
+
+  OAuth: Public repositories only
+  Authorize git-spice to act on your behalf from this device only.
+  git-spice will only get access to public repositories.
+
+  GitHub App
+  Authorize git-spice to act on your behalf from this device only.
+  git-spice will only get access to repositories where the git-spice GitHub
+  App is installed explicitly.
+  Use https://github.com/apps/git-spice to install the App on repositories.
+  For private repositories, you will need to request installation from a
+  repository owner.
+
+▶ Personal Access Token
+  Enter a classic or fine-grained Personal Access Token generated from
+  https://github.com/settings/tokens.
+  Classic tokens need at least one of the following scopes: repo or
+  public_repo.
+  Fine-grained tokens need read/write access to Repository Contents and Pull
+  requests.
+  You can use this method if you do not have the ability to install a GitHub
+  or OAuth App on your repositories.
+
+  GitHub CLI
+  Re-use an existing GitHub CLI (https://cli.github.com) session.
+  You must be logged into gh with 'gh auth login' for this to work.
+  You can use this if you're just experimenting and don't want to set up a
+  token yet.

--- a/internal/forge/github/testdata/auth/select/oauth_public.txt
+++ b/internal/forge/github/testdata/auth/select/oauth_public.txt
@@ -1,0 +1,85 @@
+init
+
+await Select an authentication method
+snapshot
+cmp stdout prompt
+
+feed <Down>
+await
+snapshot
+cmp stdout select
+
+feed <Enter>
+
+-- want_type --
+*github.DeviceFlowAuthenticator
+-- prompt --
+Select an authentication method:
+▶ OAuth
+  Authorize git-spice to act on your behalf from this device only.
+  git-spice will get access to all repositories: public and private.
+  For private repositories, you will need to request installation from a
+  repository owner.
+
+  OAuth: Public repositories only
+  Authorize git-spice to act on your behalf from this device only.
+  git-spice will only get access to public repositories.
+
+  GitHub App
+  Authorize git-spice to act on your behalf from this device only.
+  git-spice will only get access to repositories where the git-spice GitHub
+  App is installed explicitly.
+  Use https://github.com/apps/git-spice to install the App on repositories.
+  For private repositories, you will need to request installation from a
+  repository owner.
+
+  Personal Access Token
+  Enter a classic or fine-grained Personal Access Token generated from
+  https://github.com/settings/tokens.
+  Classic tokens need at least one of the following scopes: repo or
+  public_repo.
+  Fine-grained tokens need read/write access to Repository Contents and Pull
+  requests.
+  You can use this method if you do not have the ability to install a GitHub
+  or OAuth App on your repositories.
+
+  GitHub CLI
+  Re-use an existing GitHub CLI (https://cli.github.com) session.
+  You must be logged into gh with 'gh auth login' for this to work.
+  You can use this if you're just experimenting and don't want to set up a
+  token yet.
+-- select --
+Select an authentication method:
+  OAuth
+  Authorize git-spice to act on your behalf from this device only.
+  git-spice will get access to all repositories: public and private.
+  For private repositories, you will need to request installation from a
+  repository owner.
+
+▶ OAuth: Public repositories only
+  Authorize git-spice to act on your behalf from this device only.
+  git-spice will only get access to public repositories.
+
+  GitHub App
+  Authorize git-spice to act on your behalf from this device only.
+  git-spice will only get access to repositories where the git-spice GitHub
+  App is installed explicitly.
+  Use https://github.com/apps/git-spice to install the App on repositories.
+  For private repositories, you will need to request installation from a
+  repository owner.
+
+  Personal Access Token
+  Enter a classic or fine-grained Personal Access Token generated from
+  https://github.com/settings/tokens.
+  Classic tokens need at least one of the following scopes: repo or
+  public_repo.
+  Fine-grained tokens need read/write access to Repository Contents and Pull
+  requests.
+  You can use this method if you do not have the ability to install a GitHub
+  or OAuth App on your repositories.
+
+  GitHub CLI
+  Re-use an existing GitHub CLI (https://cli.github.com) session.
+  You must be logged into gh with 'gh auth login' for this to work.
+  You can use this if you're just experimenting and don't want to set up a
+  token yet.

--- a/internal/forge/gitlab/auth.go
+++ b/internal/forge/gitlab/auth.go
@@ -239,6 +239,8 @@ type authenticator interface {
 	Authenticate(context.Context, ui.View) (*AuthenticationToken, error)
 }
 
+var _execLookPath = exec.LookPath
+
 var _authenticationMethods = []struct {
 	Title       string
 	Description func(focused bool) string
@@ -268,7 +270,7 @@ var _authenticationMethods = []struct {
 		Build: func(a authenticatorOptions) authenticator {
 			// Offer this option only if the user
 			// has the GitLab CLI installed.
-			glExe, err := exec.LookPath("glab")
+			glExe, err := _execLookPath("glab")
 			if err != nil {
 				return nil
 			}

--- a/internal/forge/gitlab/auth_test.go
+++ b/internal/forge/gitlab/auth_test.go
@@ -9,16 +9,18 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os/exec"
+	"reflect"
+	"strings"
 	"testing"
-	"time"
 
 	"github.com/charmbracelet/log"
+	"github.com/rogpeppe/go-internal/testscript"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/secret"
 	"go.abhg.dev/gs/internal/ui"
 	"go.abhg.dev/gs/internal/ui/uitest"
+	"go.abhg.dev/testing/stub"
 	"golang.org/x/oauth2"
 )
 
@@ -233,44 +235,40 @@ func TestAuthType(t *testing.T) {
 	})
 }
 
-func TestPATAuthenticator(t *testing.T) {
-	view := uitest.NewEmulatorView(nil)
+func TestSelectAuthenticator(t *testing.T) {
+	// Available authentication methods are affected by whether "glab"
+	// CLI is available.
+	stub.Func(&_execLookPath, "glab", nil)
 
-	type result struct {
-		tok forge.AuthenticationToken
-		err error
-	}
-	resultc := make(chan result, 1)
-	go func() {
-		defer close(resultc)
+	uitest.RunScripts(t, func(t testing.TB, ts *testscript.TestScript, view ui.InteractiveView) {
+		wantType := strings.TrimSpace(ts.ReadFile("want_type"))
 
-		got, err := (&PATAuthenticator{}).Authenticate(context.Background(), view)
-		resultc <- result{got, err}
-	}()
+		auth, err := selectAuthenticator(view, authenticatorOptions{
+			Endpoint: oauth2.Endpoint{},
+			ClientID: _oauthAppID,
+			Hostname: "https://gitlab.com",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, wantType, reflect.TypeOf(auth).String())
+	}, &uitest.RunScriptsOptions{
+		Update: *UpdateFixtures,
+	}, "testdata/auth/select_oauth.txt")
+}
 
-	// TODO: Generalize termtest and use that here
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		assert.Contains(t,
-			view.Screen(),
-			"Enter Personal Access Token",
-		)
-	}, time.Second, 50*time.Millisecond)
+func TestAuthenticationFlow_PAT(t *testing.T) {
+	uitest.RunScripts(t, func(t testing.TB, ts *testscript.TestScript, view ui.InteractiveView) {
+		wantToken := strings.TrimSpace(ts.ReadFile("want_token"))
 
-	require.NoError(t, view.FeedKeys("token\r"))
-
-	select {
-	case res, ok := <-resultc:
-		require.True(t, ok)
-		tok, err := res.tok, res.err
+		got, err := new(Forge).AuthenticationFlow(context.Background(), view)
 		require.NoError(t, err)
 
-		ght, ok := tok.(*AuthenticationToken)
-		require.True(t, ok, "want *gitlab.AuthenticationToken, got %T", tok)
-		assert.Equal(t, "token", ght.AccessToken)
-
-	case <-time.After(time.Second):
-		t.Fatal("timed out")
-	}
+		assert.Equal(t, &AuthenticationToken{
+			AuthType:    AuthTypePAT,
+			AccessToken: wantToken,
+		}, got)
+	}, &uitest.RunScriptsOptions{
+		Update: *UpdateFixtures,
+	}, "testdata/auth/pat.txt")
 }
 
 func TestGLabCLI(t *testing.T) {

--- a/internal/forge/gitlab/flag_test.go
+++ b/internal/forge/gitlab/flag_test.go
@@ -1,0 +1,5 @@
+package gitlab
+
+import "flag"
+
+var UpdateFixtures = flag.Bool("update", false, "update test fixtures")

--- a/internal/forge/gitlab/integration_test.go
+++ b/internal/forge/gitlab/integration_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
-	"flag"
 	"io"
 	"net/http"
 	"os"
@@ -31,8 +30,8 @@ import (
 // using recorded fixtures.
 
 var (
-	_update   = flag.Bool("update", false, "update test fixtures")
-	_fixtures = fixturetest.Config{Update: _update}
+	_update   = gitlab.UpdateFixtures
+	_fixtures = fixturetest.Config{Update: gitlab.UpdateFixtures}
 )
 
 // To avoid looking this up for every test that needs the repo ID,

--- a/internal/forge/gitlab/testdata/auth/pat.txt
+++ b/internal/forge/gitlab/testdata/auth/pat.txt
@@ -1,0 +1,47 @@
+init
+
+await Select an authentication method
+feed <Down>
+snapshot
+await
+snapshot
+cmp stdout select
+feed <Enter>
+
+await
+snapshot
+cmp stdout prompt
+
+feed secret
+await
+snapshot
+cmp stdout filled
+
+feed <Enter>
+
+-- want_token --
+secret
+-- select --
+Select an authentication method:
+  OAuth
+  Authorize git-spice to act on your behalf from this device only.
+  git-spice will get access to all repositories: public and private.
+  For private repositories, you will need to request installation from a
+  repository owner.
+
+▶ Personal Access Token
+  Enter a Personal Access Token generated from https://gitlab.com/-
+  /user_settings/personal_access_tokens.
+  The Personal Access Token need the following scope: api.
+
+  GitLab CLI
+  Re-use an existing GitLab CLI (https://gitlab.com/gitlab-org/cli) session.
+  You must be logged into glab with 'glab auth login' for this to work.
+  You can use this if you're just experimenting and don't want to set up a
+  token yet.
+-- prompt --
+Select an authentication method: Personal Access Token
+Enter Personal Access Token:
+-- filled --
+Select an authentication method: Personal Access Token
+Enter Personal Access Token: secret

--- a/internal/forge/gitlab/testdata/auth/select_oauth.txt
+++ b/internal/forge/gitlab/testdata/auth/select_oauth.txt
@@ -1,0 +1,57 @@
+init
+
+await Select an authentication method
+snapshot
+cmp stdout prompt
+
+# go through the list of options and roll back
+feed <Down>
+await
+snapshot
+cmp stdout down
+
+feed -r 2 <Down>
+await
+snapshot
+cmp stdout prompt
+
+feed <Enter>
+
+-- want_type --
+*gitlab.DeviceFlowAuthenticator
+-- prompt --
+Select an authentication method:
+▶ OAuth
+  Authorize git-spice to act on your behalf from this device only.
+  git-spice will get access to all repositories: public and private.
+  For private repositories, you will need to request installation from a
+  repository owner.
+
+  Personal Access Token
+  Enter a Personal Access Token generated from https://gitlab.com/-
+  /user_settings/personal_access_tokens.
+  The Personal Access Token need the following scope: api.
+
+  GitLab CLI
+  Re-use an existing GitLab CLI (https://gitlab.com/gitlab-org/cli) session.
+  You must be logged into glab with 'glab auth login' for this to work.
+  You can use this if you're just experimenting and don't want to set up a
+  token yet.
+-- down --
+Select an authentication method:
+  OAuth
+  Authorize git-spice to act on your behalf from this device only.
+  git-spice will get access to all repositories: public and private.
+  For private repositories, you will need to request installation from a
+  repository owner.
+
+▶ Personal Access Token
+  Enter a Personal Access Token generated from https://gitlab.com/-
+  /user_settings/personal_access_tokens.
+  The Personal Access Token need the following scope: api.
+
+  GitLab CLI
+  Re-use an existing GitLab CLI (https://gitlab.com/gitlab-org/cli) session.
+  You must be logged into glab with 'glab auth login' for this to work.
+  You can use this if you're just experimenting and don't want to set up a
+  token yet.

--- a/internal/ui/flag_test.go
+++ b/internal/ui/flag_test.go
@@ -1,0 +1,5 @@
+package ui
+
+import "flag"
+
+var UpdateFixtures = flag.Bool("update", false, "update test fixtures")

--- a/internal/ui/list_test.go
+++ b/internal/ui/list_test.go
@@ -1,0 +1,94 @@
+package ui_test
+
+import (
+	"encoding/json"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/rogpeppe/go-internal/testscript"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/ui"
+	"go.abhg.dev/gs/internal/ui/uitest"
+)
+
+// Expected files:
+//
+//   - give: []listItem options
+//   - selected (optional): starting value that will be selected
+//   - want: expected final string value
+//   - desc (optional): field description
+//
+// listItem has the schema:
+//
+//	{
+//		"value": string,        // text to display and resulting value
+//		"desc": string?,        // description of the entry (if any)
+//		"focusedDesc": string?, // different description to display for focused entries
+//	}
+func TestList(t *testing.T) {
+	type listItem struct {
+		Value       string `json:"value"`
+		Desc        string `json:"desc"`
+		FocusedDesc string `json:"focusedDesc"`
+	}
+
+	uitest.RunScripts(t,
+		func(t testing.TB, ts *testscript.TestScript, view ui.InteractiveView) {
+			var give []listItem
+			require.NoError(t,
+				json.Unmarshal([]byte(ts.ReadFile("give")), &give),
+				"read 'give' file")
+
+			want := strings.TrimSpace(ts.ReadFile("want"))
+
+			listItems := make([]ui.ListItem[string], len(give))
+			for i, item := range give {
+				listItems[i] = ui.ListItem[string]{
+					Title: item.Value,
+					Value: item.Value,
+					Description: func(focused bool) string {
+						desc := item.Desc
+						if focused && item.FocusedDesc != "" {
+							desc = item.FocusedDesc
+						}
+						return desc
+					},
+				}
+			}
+
+			var desc string
+			if _, err := os.Stat(ts.MkAbs("desc")); err == nil {
+				desc = strings.TrimSpace(ts.ReadFile("desc"))
+			}
+
+			var selectedIdx int
+			if _, err := os.Stat(ts.MkAbs("selected")); err == nil {
+				selected := strings.TrimSpace(ts.ReadFile("selected"))
+				selectedIdx = slices.IndexFunc(give, func(item listItem) bool {
+					return item.Value == selected
+				})
+				if selectedIdx == -1 {
+					t.Fatalf("Bad 'selected' file: %q not found", selected)
+				}
+			}
+
+			var got string
+			widget := ui.NewList[string]().
+				WithTitle("Pick an item").
+				WithValue(&got).
+				WithDescription(desc).
+				WithSelected(selectedIdx).
+				WithItems(listItems...)
+
+			require.NoError(t, ui.Run(view, widget))
+			assert.Equal(t, want, got)
+		},
+		&uitest.RunScriptsOptions{
+			Update: *ui.UpdateFixtures,
+		},
+		"testdata/script/list",
+	)
+}

--- a/internal/ui/multi_select_test.go
+++ b/internal/ui/multi_select_test.go
@@ -1,0 +1,81 @@
+package ui_test
+
+import (
+	"encoding/json"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/rogpeppe/go-internal/testscript"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/ui"
+	"go.abhg.dev/gs/internal/ui/uitest"
+)
+
+// Expected files:
+//
+//   - want: expected []string values
+//   - give: available []string options
+//   - selected (optional): []string values already selected
+//   - desc (optional): widget description
+func TestMultiSelect(t *testing.T) {
+	uitest.RunScripts(t,
+		func(t testing.TB, ts *testscript.TestScript, view ui.InteractiveView) {
+			var want []string
+			require.NoError(t,
+				json.Unmarshal([]byte(ts.ReadFile("want")), &want),
+				"read 'want' file")
+
+			var selected []string
+			if _, err := os.Stat(ts.MkAbs("selected")); err == nil {
+				require.NoError(t,
+					json.Unmarshal([]byte(ts.ReadFile("selected")), &selected),
+					"read 'selected' file")
+			}
+
+			var give []string
+			require.NoError(t,
+				json.Unmarshal([]byte(ts.ReadFile("give")), &give),
+				"read 'give' file")
+
+			options := make([]ui.MultiSelectOption[string], len(give))
+			for i, value := range give {
+				options[i] = ui.MultiSelectOption[string]{
+					Value:    value,
+					Selected: slices.Contains(selected, value),
+				}
+			}
+
+			var desc string
+			if _, err := os.Stat(ts.MkAbs("desc")); err == nil {
+				desc = strings.TrimSpace(ts.ReadFile("desc"))
+			}
+
+			widget := ui.NewMultiSelect[string](func(w ui.Writer, i int, opt ui.MultiSelectOption[string]) {
+				if opt.Selected {
+					w.WriteString("[X] ")
+				} else {
+					w.WriteString("[ ] ")
+				}
+				w.WriteString(opt.Value)
+			}).
+				WithTitle("Pick one or more").
+				WithDescription(desc).
+				WithOptions(options...)
+
+			require.NoError(t, ui.Run(view, widget))
+
+			var got []string
+			for _, value := range widget.Selected() {
+				got = append(got, give[value])
+			}
+			assert.Equal(t, want, got)
+		},
+		&uitest.RunScriptsOptions{
+			Update: *ui.UpdateFixtures,
+		},
+		"testdata/script/multi_select",
+	)
+}

--- a/internal/ui/select_test.go
+++ b/internal/ui/select_test.go
@@ -1,0 +1,70 @@
+package ui_test
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/rogpeppe/go-internal/testscript"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/ui"
+	"go.abhg.dev/gs/internal/ui/uitest"
+)
+
+// Expected files:
+//
+//   - want: expected string value
+//   - give: []string options
+//   - selected (optional): starting string value
+//   - visible (optional): number of items visible at a time
+func TestSelect(t *testing.T) {
+	uitest.RunScripts(t,
+		func(t testing.TB, ts *testscript.TestScript, view ui.InteractiveView) {
+			var want string
+			require.NoError(t,
+				json.Unmarshal([]byte(ts.ReadFile("want")), &want),
+				"read 'want' file")
+
+			var give []string
+			require.NoError(t,
+				json.Unmarshal([]byte(ts.ReadFile("give")), &give),
+				"read 'give' file")
+
+			var desc string
+			if _, err := os.Stat(ts.MkAbs("desc")); err == nil {
+				desc = strings.TrimSpace(ts.ReadFile("desc"))
+			}
+
+			var visible int
+			if _, err := os.Stat(ts.MkAbs("visible")); err == nil {
+				require.NoError(t,
+					json.Unmarshal([]byte(ts.ReadFile("visible")), &visible),
+					"read 'visible' file")
+			}
+
+			var selected string
+			if _, err := os.Stat(ts.MkAbs("selected")); err == nil {
+				require.NoError(t,
+					json.Unmarshal([]byte(ts.ReadFile("selected")), &selected),
+					"read 'selected' file")
+			}
+
+			var got string
+			widget := ui.NewSelect[string]().
+				WithTitle("Pick a value").
+				WithValue(&got).
+				WithDescription(desc).
+				WithVisible(visible).
+				With(ui.ComparableOptions(selected, give...))
+
+			require.NoError(t, ui.Run(view, widget))
+			assert.Equal(t, want, got)
+		},
+		&uitest.RunScriptsOptions{
+			Update: *ui.UpdateFixtures,
+		},
+		"testdata/script/select",
+	)
+}

--- a/internal/ui/testdata/script/confirm/default_no.txt
+++ b/internal/ui/testdata/script/confirm/default_no.txt
@@ -1,0 +1,13 @@
+init
+
+await Yes or no
+snapshot
+cmp stdout prompt
+feed <Enter>
+
+-- give --
+false
+-- want --
+false
+-- prompt --
+Yes or no?: [y/N]

--- a/internal/ui/testdata/script/confirm/default_yes.txt
+++ b/internal/ui/testdata/script/confirm/default_yes.txt
@@ -1,0 +1,13 @@
+init
+
+await Yes or no
+snapshot
+cmp stdout prompt
+feed <Enter>
+
+-- give --
+true
+-- want --
+true
+-- prompt --
+Yes or no?: [Y/n]

--- a/internal/ui/testdata/script/confirm/desc.txt
+++ b/internal/ui/testdata/script/confirm/desc.txt
@@ -1,0 +1,16 @@
+init
+
+await Yes or no
+snapshot
+cmp stdout prompt
+feed y
+
+-- give --
+false
+-- desc --
+Decide a thing.
+-- want --
+true
+-- prompt --
+Yes or no?: [y/N]
+Decide a thing.

--- a/internal/ui/testdata/script/confirm/explicit_no.txt
+++ b/internal/ui/testdata/script/confirm/explicit_no.txt
@@ -1,0 +1,13 @@
+init
+
+await Yes or no
+snapshot
+cmp stdout prompt
+feed n
+
+-- give --
+true
+-- want --
+false
+-- prompt --
+Yes or no?: [Y/n]

--- a/internal/ui/testdata/script/confirm/explicit_yes.txt
+++ b/internal/ui/testdata/script/confirm/explicit_yes.txt
@@ -1,0 +1,13 @@
+init
+
+await Yes or no
+snapshot
+cmp stdout prompt
+feed y
+
+-- give --
+false
+-- want --
+true
+-- prompt --
+Yes or no?: [y/N]

--- a/internal/ui/testdata/script/input/prefilled.txt
+++ b/internal/ui/testdata/script/input/prefilled.txt
@@ -1,0 +1,22 @@
+init
+
+await Please answer
+snapshot
+cmp stdout prompt
+
+feed -r 3 <BS>
+feed bar
+await
+snapshot
+cmp stdout corrected
+
+feed <Enter>
+
+-- give --
+foo
+-- want --
+bar
+-- prompt --
+Please answer: foo
+-- corrected --
+Please answer: bar

--- a/internal/ui/testdata/script/input/simple.txt
+++ b/internal/ui/testdata/script/input/simple.txt
@@ -1,0 +1,23 @@
+init
+
+await Please answer
+snapshot
+cmp stdout prompt
+
+feed foo
+await
+snapshot
+cmp stdout filled
+
+feed <Enter>
+
+-- want --
+foo
+-- desc --
+Need an input
+-- prompt --
+Please answer:
+Need an input
+-- filled --
+Please answer: foo
+Need an input

--- a/internal/ui/testdata/script/input/validation.txt
+++ b/internal/ui/testdata/script/input/validation.txt
@@ -1,0 +1,22 @@
+init
+
+await Please answer
+snapshot
+cmp stdout prompt
+
+feed foo <Enter>
+await
+snapshot
+cmp stdout prompt_invalid
+
+feed bar <Enter>
+
+-- want --
+foobar
+-- invalid --
+foo
+-- prompt --
+Please answer:
+-- prompt_invalid --
+Please answer: foo
+invalid value

--- a/internal/ui/testdata/script/list/basic.txt
+++ b/internal/ui/testdata/script/list/basic.txt
@@ -1,0 +1,81 @@
+init
+
+await Pick an item
+snapshot
+cmp stdout prompt
+
+feed <Down>
+await
+snapshot
+cmp stdout alt_desc
+
+feed <Down>
+await
+snapshot
+cmp stdout no_desc
+
+feed -r 3 <Down>
+await
+snapshot
+cmp stdout alt_desc
+
+feed <Enter>
+
+-- give --
+[
+  {
+    "value": "foo",
+    "desc": "no alternative description"
+  },
+  {
+    "value": "bar",
+    "desc": "This is a thing\nwith",
+    "focusedDesc": "This is a thing\nwith a multi-line description"
+  },
+  {
+    "value": "baz"
+  },
+  {
+    "value": "qux"
+  }
+]
+-- want --
+bar
+-- desc --
+We have multiple options
+-- prompt --
+Pick an item:
+▶ foo
+  no alternative description
+  bar
+  This is a thing
+  with
+  baz
+
+  qux
+
+We have multiple options
+-- alt_desc --
+Pick an item:
+  foo
+  no alternative description
+▶ bar
+  This is a thing
+  with a multi-line description
+  baz
+
+  qux
+
+We have multiple options
+-- no_desc --
+Pick an item:
+  foo
+  no alternative description
+  bar
+  This is a thing
+  with
+▶ baz
+
+  qux
+
+We have multiple options

--- a/internal/ui/testdata/script/list/preselected.txt
+++ b/internal/ui/testdata/script/list/preselected.txt
@@ -1,0 +1,31 @@
+init
+
+await Pick an item
+snapshot
+cmp stdout prompt
+
+feed <Down> <Enter>
+
+-- give --
+[
+  {"value": "foo"},
+  {"value": "bar"},
+  {"value": "baz"},
+  {"value": "qux"},
+  {"value": "quux"}
+]
+-- selected --
+baz
+-- want --
+qux
+-- prompt --
+Pick an item:
+  foo
+
+  bar
+
+▶ baz
+
+  qux
+
+  quux

--- a/internal/ui/testdata/script/multi_select/preselected.txt
+++ b/internal/ui/testdata/script/multi_select/preselected.txt
@@ -1,0 +1,40 @@
+init
+
+await Pick one or more
+snapshot
+cmp stdout prompt
+
+feed -r 2 <Enter>
+feed <Down>
+feed <Enter>
+await
+snapshot
+cmp stdout corrected
+
+feed <Enter>
+
+-- give --
+[
+  "foo",
+  "bar",
+  "baz",
+  "qux"
+]
+-- selected --
+["bar"]
+-- want --
+["foo", "qux"]
+-- prompt --
+Pick one or more:
+▶ [ ] foo
+  [X] bar
+  [ ] baz
+  [ ] qux
+  Done
+-- corrected --
+Pick one or more:
+  [X] foo
+  [ ] bar
+  [ ] baz
+  [X] qux
+▶ Done

--- a/internal/ui/testdata/script/multi_select/simple.txt
+++ b/internal/ui/testdata/script/multi_select/simple.txt
@@ -1,0 +1,41 @@
+init
+
+await Pick one or more
+snapshot
+cmp stdout prompt
+
+feed <Down>
+feed -r 2 <Space>
+await
+snapshot
+cmp stdout picked
+
+feed <Down> <Enter>
+
+-- want --
+["bar", "baz"]
+-- give --
+[
+  "foo",
+  "bar",
+  "baz",
+  "qux"
+]
+-- desc --
+We have too many
+-- prompt --
+Pick one or more:
+▶ [ ] foo
+  [ ] bar
+  [ ] baz
+  [ ] qux
+  Done
+We have too many
+-- picked --
+Pick one or more:
+  [ ] foo
+  [X] bar
+  [X] baz
+▶ [ ] qux
+  Done
+We have too many

--- a/internal/ui/testdata/script/select/filter.txt
+++ b/internal/ui/testdata/script/select/filter.txt
@@ -1,0 +1,49 @@
+init
+
+await Pick a value
+snapshot
+cmp stdout prompt
+
+feed ba
+await
+snapshot
+cmp stdout filtered
+
+feed r
+await
+snapshot
+cmp stdout wrong_filter
+
+# undo bad filter
+feed <BS>
+await
+snapshot
+cmp stdout filtered
+
+feed <Down> <Enter>
+
+-- give --
+[
+  "foo",
+  "bar",
+  "baz",
+  "qux"
+]
+-- want --
+"baz"
+-- prompt --
+Pick a value:
+
+▶ foo
+  bar
+  baz
+  qux
+-- filtered --
+Pick a value:
+
+▶ bar
+  baz
+-- wrong_filter --
+Pick a value:
+
+▶ bar

--- a/internal/ui/testdata/script/select/preselected.txt
+++ b/internal/ui/testdata/script/select/preselected.txt
@@ -1,0 +1,41 @@
+init
+
+await Pick a value
+snapshot
+cmp stdout prompt
+
+feed -r 2 <Down>
+await
+snapshot
+cmp stdout hover
+
+feed <Enter>
+
+-- give --
+[
+  "foo",
+  "bar",
+  "baz",
+  "qux",
+  "quux"
+]
+-- selected --
+"baz"
+-- want --
+"quux"
+-- prompt --
+Pick a value:
+
+  foo
+  bar
+▶ baz
+  qux
+  quux
+-- hover --
+Pick a value:
+
+  foo
+  bar
+  baz
+  qux
+▶ quux

--- a/internal/ui/testdata/script/select/scroll.txt
+++ b/internal/ui/testdata/script/select/scroll.txt
@@ -1,0 +1,71 @@
+init
+
+await Select something
+snapshot
+cmp stdout prompt
+
+feed -r 10 <down>
+await
+snapshot
+cmp stdout middle
+
+# wrap around
+feed -r 20 <up>
+await
+snapshot
+cmp stdout bottom
+
+feed foo
+await
+snapshot
+cmp stdout no_match
+
+feed -r 3 <BS>
+feed x <Enter>
+
+-- give --
+[
+  "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o",
+  "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"
+]
+-- want --
+"x"
+-- visible --
+4
+-- desc --
+Select something
+-- prompt --
+Pick a value:
+
+▶ a
+  b
+  c
+  d
+  ▼▼▼
+
+Select something
+-- middle --
+Pick a value:
+  ▲▲▲
+  h
+  i
+  j
+▶ k
+  ▼▼▼
+
+Select something
+-- bottom --
+Pick a value:
+  ▲▲▲
+▶ q
+  r
+  s
+  t
+  ▼▼▼
+
+Select something
+-- no_match --
+Pick a value:
+
+no matches for: foo
+Select something

--- a/internal/ui/testdata/script/select/simple.txt
+++ b/internal/ui/testdata/script/select/simple.txt
@@ -1,0 +1,42 @@
+init
+
+await Select something
+snapshot
+cmp stdout prompt
+
+feed -r 2 <Down>
+await
+snapshot
+cmp stdout hover
+
+feed <Enter>
+
+-- give --
+[
+  "foo",
+  "bar",
+  "baz",
+  "qux"
+]
+-- want --
+"baz"
+-- desc --
+Select something
+-- prompt --
+Pick a value:
+
+▶ foo
+  bar
+  baz
+  qux
+
+Select something
+-- hover --
+Pick a value:
+
+  foo
+  bar
+▶ baz
+  qux
+
+Select something

--- a/internal/ui/uitest/emulator.go
+++ b/internal/ui/uitest/emulator.go
@@ -2,10 +2,11 @@ package uitest
 
 import (
 	"cmp"
+	"errors"
 	"io"
-	"strings"
 	"sync"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/vito/midterm"
 	"go.abhg.dev/gs/internal/ui"
 )
@@ -13,9 +14,14 @@ import (
 // EmulatorView is a [ui.InteractiveView] that renders to an in-memory
 // terminal emulator, and allows interacting with it programmatically.
 type EmulatorView struct {
-	real  *ui.TerminalView
-	stdin io.WriteCloser
-	term  *lockedTerminal
+	logf func(string, ...any)
+
+	// TODO: v2
+	// renderer tea.Renderer
+
+	mu     sync.RWMutex
+	term   *midterm.Terminal
+	stdinW io.Writer // nil if not running a prompt
 }
 
 var _ ui.InteractiveView = (*EmulatorView)(nil)
@@ -29,6 +35,9 @@ type EmulatorViewOptions struct {
 	// NoAutoResize disables automatic resizing of the terminal
 	// as output is written to it.
 	NoAutoResize bool
+
+	// Log function to use, if any.
+	Logf func(string, ...any)
 }
 
 // NewEmulatorView creates a new [EmulatorView] with the given dimensions.
@@ -42,72 +51,78 @@ func NewEmulatorView(opts *EmulatorViewOptions) *EmulatorView {
 	)
 	term.AutoResizeX = !opts.NoAutoResize
 	term.AutoResizeY = !opts.NoAutoResize
-	lockedTerm := newLockedTerminal(term)
 
-	stdinR, stdinW := io.Pipe()
+	logf := opts.Logf
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
 
 	return &EmulatorView{
-		real: &ui.TerminalView{
-			R: stdinR,
-			W: lockedTerm,
-		},
-		term:  lockedTerm,
-		stdin: stdinW,
+		logf: logf,
+		term: term,
 	}
 }
 
 // Prompt prompts the user for input with the given interactive fields.
 func (e *EmulatorView) Prompt(fs ...ui.Field) error {
-	return e.real.Prompt(fs...)
+	stdinR, stdinW := io.Pipe()
+	defer func() {
+		_ = stdinR.Close()
+		e.mu.Lock()
+		e.stdinW = nil
+		e.mu.Unlock()
+	}()
+
+	e.mu.Lock()
+	w, h := e.term.Width, e.term.Height
+	e.stdinW = stdinW
+	e.mu.Unlock()
+
+	return ui.NewForm(fs...).Run(&ui.FormRunOptions{
+		Input:  stdinR,
+		Output: e,
+		// In-memory terminal emulator cannot be queried for size,
+		// so inject this manually.
+		SendMsg: tea.WindowSizeMsg{
+			Width:  w,
+			Height: h,
+		},
+		WithoutSignals: true,
+	})
 }
 
 // Write posts messages to the user.
 func (e *EmulatorView) Write(p []byte) (n int, err error) {
-	return e.real.Write(p)
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.term.Write(p)
 }
 
 // Close closes the EmulatorView and frees its resources.
 func (e *EmulatorView) Close() error {
-	return e.stdin.Close()
-}
-
-// Rows returns a list of rows in the terminal emulator.
-func (e *EmulatorView) Rows() []string {
-	return e.term.Rows()
-}
-
-// Screen returns a string representation of the terminal emulator.
-func (e *EmulatorView) Screen() string {
-	return e.term.Screen()
+	return nil // TODO: post EOT?
 }
 
 // FeedKeys feeds the given keys to the terminal emulator.
 func (e *EmulatorView) FeedKeys(keys string) error {
-	_, err := io.WriteString(e.stdin, keys)
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.stdinW == nil {
+		return errors.New("no prompt to fill")
+	}
+
+	_, err := io.WriteString(e.stdinW, keys)
 	return err
 }
 
-type lockedTerminal struct {
-	mu   sync.RWMutex
-	term *midterm.Terminal
-}
-
-func newLockedTerminal(term *midterm.Terminal) *lockedTerminal {
-	return &lockedTerminal{term: term}
-}
-
-func (l *lockedTerminal) Write(p []byte) (n int, err error) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	return l.term.Write(p)
-}
-
-func (l *lockedTerminal) Rows() []string {
-	l.mu.RLock()
-	defer l.mu.RUnlock()
+// Rows returns a list of rows in the terminal emulator.
+func (e *EmulatorView) Rows() []string {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
 
 	var lines []string
-	for _, row := range l.term.Content {
+	for _, row := range e.term.Content {
 		row = trimRightWS(row)
 		lines = append(lines, string(row))
 	}
@@ -121,20 +136,6 @@ func (l *lockedTerminal) Rows() []string {
 	}
 
 	return lines
-}
-
-func (l *lockedTerminal) Screen() string {
-	l.mu.RLock()
-	defer l.mu.RUnlock()
-
-	var s strings.Builder
-	for _, row := range l.term.Content {
-		row = trimRightWS(row)
-		s.WriteString(string(row))
-		s.WriteRune('\n')
-	}
-
-	return strings.TrimRight(s.String(), "\n")
 }
 
 func trimRightWS(rs []rune) []rune {

--- a/internal/ui/uitest/script.go
+++ b/internal/ui/uitest/script.go
@@ -5,13 +5,251 @@ import (
 	"bytes"
 	"cmp"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
+	"maps"
+	"os"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
+	"testing"
 	"time"
+
+	"github.com/rogpeppe/go-internal/testscript"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/ui"
 )
+
+// RunScriptsOptions defines options for RunScripts.
+type RunScriptsOptions struct {
+	// Size of the terminal. Defaults to 80x40.
+	Rows, Cols int
+
+	// Update specifies whether 'cmp' commands in scripts
+	// should update the test file in case of mismatch.
+	Update bool
+
+	// Cmds defines additional commands to provide to the test script.
+	Cmds map[string]func(*testscript.TestScript, bool, []string)
+}
+
+// RunScripts runs scripts defined in the given file or directory.
+//
+// It provides an "init" command that runs the provided startView function
+// inside a background goroutine with access to an in-memory terminal emulator.
+// Other commands provided by [SetupScript] are also available in the script.
+//
+// Files is a list of test script files or directories.
+// For any directory specified in files, its direct children matching the name
+// '*.txt' are run as scripts.
+func RunScripts(
+	t *testing.T,
+	startView func(testing.TB, *testscript.TestScript, ui.InteractiveView),
+	opts *RunScriptsOptions,
+	files ...string,
+) {
+	require.NotEmpty(t, files, "no files provided")
+
+	opts = cmp.Or(opts, &RunScriptsOptions{})
+
+	type tKey struct{}
+	params := testscript.Params{
+		UpdateScripts: opts.Update,
+		Setup: func(env *testscript.Env) error {
+			env.Values[tKey{}] = env.T().(testing.TB)
+			return nil
+		},
+	}
+
+	for _, file := range files {
+		info, err := os.Stat(files[0])
+		require.NoError(t, err)
+		if !info.IsDir() {
+			params.Files = append(params.Files, file)
+			continue
+		}
+
+		ents, err := os.ReadDir(file)
+		require.NoError(t, err)
+		for _, ent := range ents {
+			if ent.IsDir() || !strings.HasSuffix(ent.Name(), ".txt") {
+				continue // don't recurse
+			}
+
+			params.Files = append(params.Files, filepath.Join(file, ent.Name()))
+		}
+	}
+
+	// TODO: a means for waiting for the view to exit
+	// so that final form can also be seen.
+	setEmulator := SetupScript(&params)
+	params.Cmds["init"] = func(ts *testscript.TestScript, neg bool, args []string) {
+		t := ts.Value(tKey{}).(testing.TB)
+
+		emu := NewEmulatorView(&EmulatorViewOptions{
+			Rows: opts.Rows,
+			Cols: opts.Cols,
+			Logf: ts.Logf,
+		})
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+
+			// TODO: set up a testing.T that will kill this goroutine
+			// and mark the test as failed without panic-exploding.
+			startView(t, ts, emu)
+		}()
+		ts.Defer(func() {
+			// If the test failed, send Ctrl+C to the emulator.
+			if t.Failed() {
+				_ = emu.FeedKeys("\x03") // Send Ctrl+C
+
+				ts.Logf("Try updating fixtures with the following command:\n"+
+					"\tgo test -run %q -update", t.Name())
+			}
+
+			if err := emu.Close(); err != nil {
+				ts.Logf("closing emulator: %v", err)
+			}
+
+			select {
+			case <-done:
+				// ok
+
+			case <-time.After(3 * time.Second):
+				ts.Fatalf("view did not exit in time")
+			}
+		})
+
+		setEmulator(ts, emu)
+	}
+
+	if opts.Cmds != nil {
+		maps.Copy(params.Cmds, opts.Cmds)
+	}
+
+	testscript.Run(t, params)
+}
+
+// SetupScript may be used from testscripts to control a fake terminal emulator.
+// Install this in a testscript.Params,
+// and use the returned setEmulator to provide an emulator to a test script
+// with another command (e.g. "init").
+//
+// The source of input for the emulator should run in the background.
+//
+// The following commands are added to scripts:
+//
+//	clear
+//		Ignore current screen contents when awaiting text.
+//	await [txt]
+//		Wait for the given text to be visible on screen.
+//		If [txt] is absent, wait until the contents of the screen
+//		change compared to the last 'snapshot' call.
+//	snapshot
+//		Print a copy of the screen to the script's stdout.
+//	feed [-r N] txt
+//		Post the given text to the command's stdin.
+//		If -count is given, the input is repeated N times.
+func SetupScript(params *testscript.Params) (setEmulator func(*testscript.TestScript, Emulator)) {
+	type stateKey struct{}
+	type stateValue struct{ V *scriptState }
+
+	getState := func(ts *testscript.TestScript) *scriptState {
+		container := ts.Value(stateKey{}).(*stateValue)
+		if container.V == nil {
+			ts.Fatalf("setEmulator not called: no state found")
+		}
+		return container.V
+	}
+
+	oldSetup := params.Setup
+	params.Setup = func(env *testscript.Env) error {
+		if oldSetup != nil {
+			if err := oldSetup(env); err != nil {
+				return err
+			}
+		}
+
+		env.Values[stateKey{}] = new(stateValue)
+		return nil
+	}
+
+	if params.Cmds == nil {
+		params.Cmds = make(map[string]func(ts *testscript.TestScript, neg bool, args []string))
+	}
+
+	// clear
+	params.Cmds["clear"] = func(ts *testscript.TestScript, neg bool, args []string) {
+		if neg {
+			ts.Fatalf("usage: clear")
+		}
+
+		getState(ts).Clear()
+	}
+
+	// await [txt]
+	params.Cmds["await"] = func(ts *testscript.TestScript, neg bool, args []string) {
+		if neg {
+			ts.Fatalf("usage: await [txt]")
+		}
+
+		state := getState(ts)
+		want := strings.Join(args, " ")
+		if err := state.Await(want); err != nil {
+			ts.Fatalf("await %q: %v", want, err)
+		}
+	}
+
+	// snapshot
+	params.Cmds["snapshot"] = func(ts *testscript.TestScript, neg bool, args []string) {
+		if neg || len(args) != 0 {
+			ts.Fatalf("usage: snapshot")
+		}
+
+		state := getState(ts)
+		state.Snapshot("")
+	}
+
+	// TODO: up/down/enter?
+	// feed [-r n] txt
+	params.Cmds["feed"] = func(ts *testscript.TestScript, neg bool, args []string) {
+		flag := flag.NewFlagSet("feed", flag.ContinueOnError)
+		flag.Usage = func() {
+			ts.Logf("usage: feed [-r n] txt")
+		}
+		if neg {
+			flag.Usage()
+			ts.Fatalf("incorrect usage")
+		}
+
+		repeat := flag.Int("r", 1, "repetitions of the input")
+		if err := flag.Parse(args); err != nil {
+			ts.Fatalf("feed: %v", err)
+		}
+
+		args = flag.Args()
+		if len(args) == 0 {
+			flag.Usage()
+			ts.Fatalf("incorrect usage")
+		}
+
+		state := getState(ts)
+		keys := strings.Repeat(strings.Join(args, ""), *repeat)
+		if err := state.Feed(keys); err != nil {
+			ts.Fatalf("feed %q: %v", keys, err)
+		}
+	}
+
+	return func(ts *testscript.TestScript, emu Emulator) {
+		ts.Value(stateKey{}).(*stateValue).V = newScriptState(emu, &scriptStateOptions{
+			Logf:   ts.Logf,
+			Output: ts.Stdout,
+		})
+	}
+}
 
 // Emulator is a terminal emulator that receives input
 // and allows querying the terminal state.
@@ -59,6 +297,8 @@ type ScriptOptions struct {
 //     Examples: \r, \x1b[B
 //
 // Snapshots are written to [ScriptOptions.Output] if provided.
+//
+// New scripts should prefer using SetupScript for this purpose.
 func Script(emu Emulator, script []byte, opts *ScriptOptions) error {
 	opts = cmp.Or(opts, &ScriptOptions{})
 
@@ -235,7 +475,34 @@ func (s *scriptState) Snapshot(title string) {
 	}
 }
 
+var _keyReplacements = map[string]string{
+	"<Up>":    "\x1b[A",
+	"<Down>":  "\x1b[B",
+	"<Right>": "\x1b[C",
+
+	"<Enter>": "\r",
+	"<Space>": " ",
+	"<Tab>":   "\t",
+
+	"<Bs>":        "\x08",
+	"<Backspace>": "\x08",
+}
+
+var _keyReplacer *strings.Replacer
+
+func init() {
+	var repl []string
+	for k, v := range _keyReplacements {
+		repl = append(repl, k, v)
+		repl = append(repl, strings.ToUpper(k), v)
+		repl = append(repl, strings.ToLower(k), v)
+	}
+
+	_keyReplacer = strings.NewReplacer(repl...)
+}
+
 func (s *scriptState) Feed(keys string) error {
+	keys = _keyReplacer.Replace(keys)
 	if err := s.emu.FeedKeys(keys); err != nil {
 		return fmt.Errorf("feed keys %q: %w", keys, err)
 	}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -66,5 +66,8 @@ func (tv *TerminalView) Write(p []byte) (int, error) {
 
 // Prompt prompts the user for input with the given interactive fields.
 func (tv *TerminalView) Prompt(fields ...Field) error {
-	return NewForm(fields...).Run(tv)
+	return NewForm(fields...).Run(&FormRunOptions{
+		Input:  tv.R,
+		Output: tv.W,
+	})
 }

--- a/internal/ui/widget/branch_select_test.go
+++ b/internal/ui/widget/branch_select_test.go
@@ -1,0 +1,59 @@
+package widget
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/rogpeppe/go-internal/testscript"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/ui"
+	"go.abhg.dev/gs/internal/ui/uitest"
+)
+
+// Runs tests inside testdata/script/branch_select.
+// The following files are expected:
+//
+//   - want: name of the branch expected to be selected at the end
+//   - branches: branches available in the list. See below for format.
+//   - desc (optional): prompt description
+//
+// The branches file is a JSON-encoded file with the format:
+//
+//	[
+//		{branch: string, base: string?, disabled: bool?},
+//		...
+//	]
+func TestBranchTreeSelect_Script(t *testing.T) {
+	uitest.RunScripts(t,
+		func(t testing.TB, ts *testscript.TestScript, view ui.InteractiveView) {
+			wantBranch := strings.TrimSpace(ts.ReadFile("want"))
+
+			var input []BranchTreeItem
+			require.NoError(t,
+				json.Unmarshal([]byte(ts.ReadFile("branches")), &input),
+				"read 'branches' file")
+
+			var desc string
+			if _, err := os.Stat(ts.MkAbs("desc")); err == nil {
+				desc = strings.TrimSpace(ts.ReadFile("desc"))
+			}
+
+			var gotBranch string
+			widget := NewBranchTreeSelect().
+				WithTitle("Select a branch").
+				WithItems(input...).
+				WithDescription(desc).
+				WithValue(&gotBranch)
+
+			assert.NoError(t, ui.Run(view, widget))
+			assert.Equal(t, wantBranch, gotBranch)
+		},
+		&uitest.RunScriptsOptions{
+			Update: *UpdateFixtures,
+		},
+		"testdata/script/branch_tree_select",
+	)
+}

--- a/internal/ui/widget/branch_split_test.go
+++ b/internal/ui/widget/branch_split_test.go
@@ -1,0 +1,76 @@
+package widget
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rogpeppe/go-internal/testscript"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/ui"
+	"go.abhg.dev/gs/internal/ui/uitest"
+	"go.abhg.dev/testing/stub"
+)
+
+// Runs tests inside testdata/script/branch_split.
+// The following files are expected:
+//
+//   - commits: JSON describing input commit summaries
+//   - want: expected selected commits (list of git hashes as JSON)
+//   - head (optional): name of the HEAD commit
+//   - desc (optional): description for the prompt
+func TestBranchSplit_Script(t *testing.T) {
+	stub.Func(&_timeNow, time.Date(2024, 12, 11, 10, 9, 8, 7, time.UTC))
+
+	uitest.RunScripts(t,
+		func(t testing.TB, ts *testscript.TestScript, view ui.InteractiveView) {
+			var input []CommitSummary
+			require.NoError(t,
+				json.Unmarshal([]byte(ts.ReadFile("commits")), &input),
+				"read 'commits' file")
+
+			var want []git.Hash
+			require.NoError(t,
+				json.Unmarshal([]byte(ts.ReadFile("want")), &want),
+				"read 'want' file")
+
+			var head string
+			if _, err := os.Stat(ts.MkAbs("head")); err == nil {
+				head = strings.TrimSpace(ts.ReadFile("head"))
+			}
+
+			var desc string
+			if _, err := os.Stat(ts.MkAbs("desc")); err == nil {
+				desc = strings.TrimSpace(ts.ReadFile("desc"))
+			}
+
+			commits := make([]CommitSummary, len(input))
+			for i, c := range input {
+				commits[i] = CommitSummary(c)
+			}
+
+			widget := NewBranchSplit().
+				WithTitle("Select a commit").
+				WithCommits(commits...).
+				WithDescription(desc).
+				WithHEAD(head)
+
+			assert.NoError(t, ui.Run(view, widget))
+
+			var got []git.Hash
+			for _, idx := range widget.Selected() {
+				got = append(got, input[idx].ShortHash)
+			}
+
+			assert.Equal(t, want, got)
+		},
+		&uitest.RunScriptsOptions{
+			Update: *UpdateFixtures,
+		},
+		"testdata/script/branch_split",
+	)
+}

--- a/internal/ui/widget/flag_test.go
+++ b/internal/ui/widget/flag_test.go
@@ -1,0 +1,5 @@
+package widget
+
+import "flag"
+
+var UpdateFixtures = flag.Bool("update", false, "update test fixtures")

--- a/internal/ui/widget/testdata/script/branch_split/basic.txt
+++ b/internal/ui/widget/testdata/script/branch_split/basic.txt
@@ -1,0 +1,45 @@
+init
+
+await Select a commit
+
+snapshot
+cmp stdout prompt
+
+feed <enter>
+await
+snapshot
+cmp stdout selected
+
+feed <enter>
+
+-- commits --
+[
+  {
+    "shortHash": "abcdef",
+    "subject": "feat: add feature",
+    "authorDate": "2024-12-10T22:26:23Z"
+  },
+  {
+    "shortHash": "ghijkl",
+    "subject": "refac: unrelated change",
+    "authorDate": "2024-12-10T22:33:44Z"
+  }
+]
+-- head --
+main
+-- desc --
+Select which commits to introduce splits at.
+-- want --
+["abcdef"]
+-- prompt --
+Select a commit:
+▶   abcdef feat: add feature (11 hours ago)
+  ■ ghijkl refac: unrelated change (11 hours ago) [main]
+  Done
+Select which commits to introduce splits at.
+-- selected --
+Select a commit:
+  □ abcdef feat: add feature (11 hours ago)
+  ■ ghijkl refac: unrelated change (11 hours ago) [main]
+▶ Done
+Select which commits to introduce splits at.

--- a/internal/ui/widget/testdata/script/branch_split/no_head.txt
+++ b/internal/ui/widget/testdata/script/branch_split/no_head.txt
@@ -1,0 +1,46 @@
+init
+
+await Select a commit
+
+snapshot
+cmp stdout prompt
+
+feed <tab> <down>
+await
+snapshot
+cmp stdout selected
+
+feed <enter>
+
+-- commits --
+[
+  {
+    "shortHash": "abc",
+    "subject": "feat: add feature",
+    "authorDate": "2024-12-10T22:26:23Z"
+  },
+  {
+    "shortHash": "def",
+    "subject": "refac: unrelated change",
+    "authorDate": "2024-12-10T22:33:44Z"
+  },
+  {
+    "shortHash": "ghi",
+    "subject": "feat: add another feature",
+    "authorDate": "2024-12-10T22:45:44Z"
+  }
+]
+-- prompt --
+Select a commit:
+▶   abc feat: add feature (11 hours ago)
+    def refac: unrelated change (11 hours ago)
+  ■ ghi feat: add another feature (11 hours ago)
+  Done
+-- selected --
+Select a commit:
+  □ abc feat: add feature (11 hours ago)
+    def refac: unrelated change (11 hours ago)
+  ■ ghi feat: add another feature (11 hours ago)
+▶ Done
+-- want --
+["abc"]

--- a/internal/ui/widget/testdata/script/branch_tree_select/independent_branches.txt
+++ b/internal/ui/widget/testdata/script/branch_tree_select/independent_branches.txt
@@ -1,0 +1,27 @@
+# several branches without a shared base
+
+init
+
+await Select a branch
+snapshot
+cmp stdout prompt
+
+feed qu <Enter>
+
+-- branches --
+[
+  {"branch": "main"},
+  {"branch": "foo"},
+  {"branch": "bar"},
+  {"branch": "baz"},
+  {"branch": "qux"}
+]
+-- want --
+qux
+-- prompt --
+Select a branch:
+main ◀
+foo
+bar
+baz
+qux

--- a/internal/ui/widget/testdata/script/branch_tree_select/linear.txt
+++ b/internal/ui/widget/testdata/script/branch_tree_select/linear.txt
@@ -1,0 +1,43 @@
+init
+
+await Select a branch
+snapshot
+cmp stdout prompt
+
+feed -r 2 <Down>
+await
+snapshot
+cmp stdout hover
+
+feed <Enter>
+
+-- branches --
+[
+  {"branch": "main"},
+  {"branch": "foo", "base": "main"},
+  {"branch": "bar", "base": "foo"},
+  {"branch": "baz", "base": "bar"},
+  {"branch": "qux", "base": "baz"}
+]
+-- desc --
+We have many branches to choose from.
+-- want --
+bar
+-- prompt --
+Select a branch:
+      ┏━■ qux ◀
+    ┏━┻□ baz
+  ┏━┻□ bar
+┏━┻□ foo
+main
+
+We have many branches to choose from.
+-- hover --
+Select a branch:
+      ┏━□ qux
+    ┏━┻□ baz
+  ┏━┻■ bar ◀
+┏━┻□ foo
+main
+
+We have many branches to choose from.

--- a/internal/ui/widget/testdata/script/branch_tree_select/linear_filter.txt
+++ b/internal/ui/widget/testdata/script/branch_tree_select/linear_filter.txt
@@ -1,0 +1,34 @@
+init
+
+await Select a branch
+snapshot
+cmp stdout prompt
+
+feed ba
+await
+snapshot
+cmp stdout filter
+
+feed <Up> <Enter>
+
+-- branches --
+[
+  {"branch": "main"},
+  {"branch": "foo", "base": "main"},
+  {"branch": "bar", "base": "foo"},
+  {"branch": "baz", "base": "bar"},
+  {"branch": "qux", "base": "baz"}
+]
+-- want --
+baz
+-- prompt --
+Select a branch:
+      ┏━■ qux ◀
+    ┏━┻□ baz
+  ┏━┻□ bar
+┏━┻□ foo
+main
+-- filter --
+Select a branch:
+┏━□ baz
+bar ◀

--- a/internal/ui/widget/testdata/script/branch_tree_select/unselectable_base.txt
+++ b/internal/ui/widget/testdata/script/branch_tree_select/unselectable_base.txt
@@ -1,0 +1,48 @@
+# a base that isn't in the list of branches
+# cannot be selected.
+
+init
+
+await Select a branch
+snapshot
+cmp stdout prompt
+
+# down 2 will roll back around
+feed <Down>
+await
+snapshot
+feed <Down>
+await
+snapshot
+cmp stdout prompt
+
+# filter to 'foo' is useless
+feed foo
+await
+snapshot
+cmp stdout filter
+
+feed -r 3 <BS>
+await
+snapshot
+cmp stdout prompt
+
+feed <Down> <Enter>
+
+-- branches --
+[
+  {"branch": "bar", "base": "foo"},
+  {"branch": "baz", "base": "bar"}
+]
+-- want --
+bar
+-- prompt --
+Select a branch:
+  ┏━■ baz ◀
+┏━┻□ bar
+foo
+-- filter --
+Select a branch:
+foo
+
+no available matches: foo


### PR DESCRIPTION
Adds a testscript-based system for testing terminal widgets.
This is a generalized, in-memory, Windows-friendly version of with-term
intended for use in unit tests instead of end-to-end tests.
It uses testscript instead of a the custom commands format.

With this in place, we're able to unit test a bunch of the terminal
interactions that were previously untested,
or became untested following RobotView in #480.