### PR TITLE
releaser/tap: Install completions

### DIFF
--- a/.changes/unreleased/Added-20250103-052535.yaml
+++ b/.changes/unreleased/Added-20250103-052535.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: The Homebrew tap will now install shell completions automatically.
+time: 2025-01-03T05:25:35.890095-08:00

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -68,6 +68,9 @@ brews:
     description: "A tool for stacking Git branches."
     license: "GPL-3.0-or-later"
     skip_upload: auto
+    install: |
+      bin.install "gs"
+      generate_completions_from_executable(bin/"gs", "shell", "completion")
     test: |
       system "#{bin}/gs --version"
 


### PR DESCRIPTION
Sets up the Homebrew tap to also install shell completions
generated from the `gs` executable.