### PR TITLE
tests: Handle Git output changes

### DIFF
--- a/internal/git/gittest/config.go
+++ b/internal/git/gittest/config.go
@@ -10,8 +10,10 @@ import (
 func DefaultConfig() Config {
 	return Config{
 		"init.defaultBranch": "main",
-		"alias.graph":        "log --graph --decorate --oneline",
-		"core.autocrlf":      "false",
+		// Freeze what refs get decorated in the log output.
+		"log.excludeDecoration": "refs/remotes/*/HEAD",
+		"alias.graph":           "log --graph --decorate --oneline",
+		"core.autocrlf":         "false",
 	}
 }
 

--- a/testdata/script/branch_submit_no_publish.txt
+++ b/testdata/script/branch_submit_no_publish.txt
@@ -75,7 +75,7 @@ INF Pushed feature1
 []
 -- golden/post-push.txt --
 * 9282351 (origin/feature1) feature1
-* a7a403e (HEAD -> main, origin/main, origin/HEAD) Initial commit
+* a7a403e (HEAD -> main, origin/main) Initial commit
 -- golden/post-publish.txt --
 [
   {

--- a/testdata/script/issue391_repo_sync_pull_unsupported_forge.txt
+++ b/testdata/script/issue391_repo_sync_pull_unsupported_forge.txt
@@ -74,13 +74,13 @@ feature 2
 * main
 -- golden/repo-sync-graph.txt --
 * b3ed169 (HEAD -> feat2, origin/feat2) feat2
-* 1993921 (origin/main, origin/HEAD, main) feat1
+* 1993921 (origin/main, main) feat1
 * 8b0535b Initial commit
 -- golden/repo-sync-ll.txt --
 ┏━■ feat2 ◀
 ┃   b3ed169 feat2 (now)
 main
 -- golden/repo-sync-graph-2.txt --
-* b3ed169 (HEAD -> main, origin/main, origin/HEAD) feat2
+* b3ed169 (HEAD -> main, origin/main) feat2
 * 1993921 feat1
 * 8b0535b Initial commit

--- a/testdata/script/repo_sync_merged_pr.txt
+++ b/testdata/script/repo_sync_merged_pr.txt
@@ -35,7 +35,7 @@ gs repo sync
 stderr 'feature1: #1 was merged'
 
 git branch -r
-cmp stdout $WORK/golden/merged-branches.txt
+! stdout 'origin/feature1'
 
 # we should now be on main,
 # feature1 branch should be gone,
@@ -53,8 +53,6 @@ Contents of feature1
 -- repo/feature2.txt --
 Contents of feature2
 
--- golden/merged-branches.txt --
-  origin/main
 -- golden/pull.json --
 {
   "number": 1,

--- a/testdata/script/repo_sync_remote_already_deleted.txt
+++ b/testdata/script/repo_sync_remote_already_deleted.txt
@@ -32,7 +32,7 @@ git pull origin main
 
 # sanity check: the tracking branch is gone
 git branch -r
-cmp stdout $WORK/golden/branch-gone.txt
+! stdout 'origin/feature'
 
 gs repo sync
 stderr 'feature: #\d was merged'
@@ -41,5 +41,3 @@ stderr 'feature: deleted'
 
 -- repo/feature.txt --
 Contents of feature
--- golden/branch-gone.txt --
-  origin/main


### PR DESCRIPTION
Looks like `git log --graph --decorate` now includes origin/HEAD
in the output in newer versions.

Rather than try to make the output match different versions,
freeze some of the bits, e.g. never list origin/HEAD.