### PR TITLE
feat(branch): add `gs branch squash`

### DIFF
--- a/.changes/unreleased/Added-20250202-192729.yaml
+++ b/.changes/unreleased/Added-20250202-192729.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'branch squash: Squashses all commits in the current branch into a single commit and restacks the upstack branches.'
+time: 2025-02-02T19:27:29.806629-08:00

--- a/branch.go
+++ b/branch.go
@@ -21,6 +21,7 @@ type branchCmd struct {
 	Delete branchDeleteCmd `cmd:"" aliases:"d,rm" help:"Delete branches"`
 	Fold   branchFoldCmd   `cmd:"" aliases:"fo" help:"Merge a branch into its base"`
 	Split  branchSplitCmd  `cmd:"" aliases:"sp" help:"Split a branch on commits"`
+	Squash branchSquashCmd `cmd:"" aliases:"sq" help:"Squash a branch into one commit"`
 
 	// Mutation
 	Edit    branchEditCmd    `cmd:"" aliases:"e" help:"Edit the commits in a branch"`

--- a/branch_checkout.go
+++ b/branch_checkout.go
@@ -22,7 +22,7 @@ type branchCheckoutCmd struct {
 	checkoutOptions
 
 	Untracked bool   `short:"u" config:"branchCheckout.showUntracked" help:"Show untracked branches if one isn't supplied"`
-	Branch    string `arg:"" optional:"" help:"Name of the branch to delete" predictor:"branches"`
+	Branch    string `arg:"" optional:"" help:"Name of the branch to checkout" predictor:"branches"`
 }
 
 func (*branchCheckoutCmd) Help() string {

--- a/branch_squash.go
+++ b/branch_squash.go
@@ -43,6 +43,10 @@ func (cmd *branchSquashCmd) Run(
 		return fmt.Errorf("get current branch: %w", err)
 	}
 
+	if branchName == store.Trunk() {
+		return fmt.Errorf("cannot squash the trunk branch")
+	}
+
 	branch, err := svc.LookupBranch(ctx, branchName)
 	if err != nil {
 		return fmt.Errorf("lookup branch %q: %w", branchName, err)

--- a/branch_squash.go
+++ b/branch_squash.go
@@ -24,6 +24,9 @@ func (*branchSquashCmd) Help() string {
 	return text.Dedent(`
 		Squash all commits in the current branch into a single commit
 		and restack upstack branches.
+
+		An editor will open to edit the commit message of the squashed commit.
+		Use the -m/--message flag to specify a commit message without editing.
 	`)
 }
 

--- a/branch_squash.go
+++ b/branch_squash.go
@@ -15,6 +15,8 @@ import (
 )
 
 type branchSquashCmd struct {
+	NoVerify bool `help:"Bypass pre-commit and commit-msg hooks."`
+
 	Message string `short:"m" placeholder:"MSG" help:"Use the given message as the commit message."`
 }
 
@@ -105,6 +107,7 @@ func (cmd *branchSquashCmd) Run(
 	if err := repo.Commit(ctx, git.CommitRequest{
 		Message:  cmd.Message,
 		Template: commitTemplate,
+		NoVerify: cmd.NoVerify,
 	}); err != nil {
 		return fmt.Errorf("commit squashed changes: %w", err)
 	}

--- a/branch_squash.go
+++ b/branch_squash.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/state"
+	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
+)
+
+type branchSquashCmd struct {
+	Message string `short:"m" placeholder:"MSG" help:"Use the given message as the commit message."`
+}
+
+func (*branchSquashCmd) Help() string {
+	return text.Dedent(`
+		Squash all commits in the current branch into a single commit
+		and restack upstack branches.
+	`)
+}
+
+func (cmd *branchSquashCmd) Run(
+	ctx context.Context,
+	log *log.Logger,
+	view ui.View,
+	repo *git.Repository,
+	store *state.Store,
+	svc *spice.Service,
+) error {
+	branchName, err := repo.CurrentBranch(ctx)
+	if err != nil {
+		return fmt.Errorf("get current branch: %w", err)
+	}
+
+	branch, err := svc.LookupBranch(ctx, branchName)
+	if err != nil {
+		return fmt.Errorf("lookup branch %q: %w", branchName, err)
+	}
+
+	if err := svc.VerifyRestacked(ctx, branchName); err != nil {
+		var restackErr *spice.BranchNeedsRestackError
+		if errors.As(err, &restackErr) {
+			return fmt.Errorf("branch %v needs to be restacked before it can be squashed", branchName)
+		}
+		return fmt.Errorf("verify restacked: %w", err)
+	}
+
+	commitMsg := cmd.Message
+
+	if commitMsg == "" {
+		commitMessages, err := repo.CommitMessageRange(ctx, branch.Head.String(), branch.BaseHash.String())
+		if err != nil {
+			return fmt.Errorf("get commit messages: %w", err)
+		}
+		commitMsg = commitMessages[len(commitMessages)-1].String()
+	}
+
+	// Checkout the branch in detached mode
+	if err := (&branchCheckoutCmd{
+		Branch: branchName,
+		checkoutOptions: checkoutOptions{
+			Detach: true,
+		},
+	}).Run(ctx, log, view, repo, store, svc); err != nil {
+		return err
+	}
+
+	// Reset the detached branch to the base commit
+	if err := repo.Reset(ctx, branch.BaseHash.String(), git.ResetOptions{Mode: git.ResetSoft}); err != nil {
+		return err
+	}
+
+	// Commit the changes
+	if err := repo.Commit(ctx, git.CommitRequest{Message: commitMsg}); err != nil {
+		return err
+	}
+
+	// Replace the HEAD ref of `branchName` with the new commit
+	headHash, err := repo.Head(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := repo.SetRef(ctx, git.SetRefRequest{
+		Ref:  "refs/heads/" + branchName,
+		Hash: headHash,
+	}); err != nil {
+		return err
+	}
+
+	// Check out the original branch
+	if err := repo.Checkout(ctx, branchName); err != nil {
+		return err
+	}
+
+	return (&upstackRestackCmd{}).Run(ctx, log, repo, store, svc)
+}

--- a/branch_squash.go
+++ b/branch_squash.go
@@ -117,6 +117,9 @@ func (cmd *branchSquashCmd) Run(
 	if err := repo.SetRef(ctx, git.SetRefRequest{
 		Ref:  "refs/heads/" + branchName,
 		Hash: headHash,
+		// Ensure that another tree didn't update the branch
+		// while we weren't looking.
+		OldHash: branch.Head,
 	}); err != nil {
 		return fmt.Errorf("update branch ref: %w", err)
 	}

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -653,6 +653,9 @@ Squash a branch into one commit
 Squash all commits in the current branch into a single commit
 and restack upstack branches.
 
+An editor will open to edit the commit message of the squashed commit.
+Use the -m/--message flag to specify a commit message without editing.
+
 **Flags**
 
 * `--no-verify`: Bypass pre-commit and commit-msg hooks.

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -484,7 +484,7 @@ Use -u/--untracked to show untracked branches in the prompt.
 
 **Arguments**
 
-* `branch`: Name of the branch to delete
+* `branch`: Name of the branch to checkout
 
 **Flags**
 
@@ -641,6 +641,21 @@ For example:
 
 * `--at=COMMIT:NAME,...`: Commits to split the branch at.
 * `--branch=NAME`: Branch to split commits of.
+
+### gs branch squash
+
+```
+gs branch (b) squash (sq) [flags]
+```
+
+Squash a branch into one commit
+
+Squash all commits in the current branch into a single commit
+and restack upstack branches.
+
+**Flags**
+
+* `-m`, `--message=MSG`: Use the given message as the commit message.
 
 ### gs branch edit
 

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -655,6 +655,7 @@ and restack upstack branches.
 
 **Flags**
 
+* `--no-verify`: Bypass pre-commit and commit-msg hooks.
 * `-m`, `--message=MSG`: Use the given message as the commit message.
 
 ### gs branch edit

--- a/doc/includes/cli-shorthands.md
+++ b/doc/includes/cli-shorthands.md
@@ -10,6 +10,7 @@
 | gs brn | [gs branch rename](/cli/reference.md#gs-branch-rename) |
 | gs bs | [gs branch submit](/cli/reference.md#gs-branch-submit) |
 | gs bsp | [gs branch split](/cli/reference.md#gs-branch-split) |
+| gs bsq | [gs branch squash](/cli/reference.md#gs-branch-squash) |
 | gs btr | [gs branch track](/cli/reference.md#gs-branch-track) |
 | gs buntr | [gs branch untrack](/cli/reference.md#gs-branch-untrack) |
 | gs ca | [gs commit amend](/cli/reference.md#gs-commit-amend) |

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -131,7 +131,8 @@ func (r *Repository) BranchExists(ctx context.Context, branch string) bool {
 }
 
 // DetachHead detaches the HEAD from the current branch
-// while staying at the same commit.
+// and points it to the specified commitish (if provided).
+// Otherwise, it stays at the current commit.
 func (r *Repository) DetachHead(ctx context.Context, commitish string) error {
 	args := []string{"checkout", "--detach"}
 	if len(commitish) > 0 {

--- a/testdata/script/branch_squash.txt
+++ b/testdata/script/branch_squash.txt
@@ -1,0 +1,47 @@
+# Squashing a branch into one commit with 'squash'
+
+as 'Test <test@example.com>'
+at '2024-03-30T14:59:32Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo i
+
+# Create a branch with two commits
+git add feature1.txt
+gs branch create feature-1 -m 'First message in squashed branch'
+git add feature2.txt
+git commit -m 'Second message in squashed branch'
+
+# Create another branch
+git add feature3.txt
+gs branch create feature2 -m 'First message in rebased branch'
+
+git graph --branches
+cmp stdout $WORK/golden/graph-before.txt
+
+# Go back to branch that will be squashed
+gs down
+gs branch squash
+
+git graph --branches
+cmp stdout $WORK/golden/graph.txt
+
+-- repo/dirty.txt --
+Dirty
+-- repo/feature1.txt --
+Feature 1
+-- repo/feature2.txt --
+Feature 2
+-- repo/feature3.txt --
+Feature 3
+-- golden/graph-before.txt --
+* d805cb2 (HEAD -> feature2) First message in rebased branch
+* 0239007 (feature-1) Second message in squashed branch
+* 7ebfd80 First message in squashed branch
+* 9bad92b (main) Initial commit
+-- golden/graph.txt --
+* cbeb99e (feature2) First message in rebased branch
+* 6ca0ea8 (HEAD -> feature-1) First message in squashed branch
+* 9bad92b (main) Initial commit

--- a/testdata/script/branch_squash.txt
+++ b/testdata/script/branch_squash.txt
@@ -1,32 +1,38 @@
 # Squashing a branch into one commit with 'squash'
 
 as 'Test <test@example.com>'
-at '2024-03-30T14:59:32Z'
+at '2025-02-02T20:00:01Z'
 
 cd repo
 git init
 git commit --allow-empty -m 'Initial commit'
-gs repo i
+gs repo init
 
 # Create a branch with two commits
 git add feature1.txt
-gs branch create feature-1 -m 'First message in squashed branch'
+gs branch create feature1 -m 'First message in squashed branch'
 git add feature2.txt
 git commit -m 'Second message in squashed branch'
 
 # Create another branch
 git add feature3.txt
-gs branch create feature2 -m 'First message in rebased branch'
+gs branch create feature3 -m 'First message in rebased branch'
 
 git graph --branches
 cmp stdout $WORK/golden/graph-before.txt
 
 # Go back to branch that will be squashed
 gs down
+
+mkdir $WORK/output
+env EDITOR=mockedit
+env MOCKEDIT_RECORD=$WORK/output/initial-msg.txt
+env MOCKEDIT_GIVE=$WORK/input/squashed-msg.txt
 gs branch squash
 
 git graph --branches
 cmp stdout $WORK/golden/graph.txt
+cmp $WORK/output/initial-msg.txt $WORK/golden/initial-msg.txt
 
 -- repo/dirty.txt --
 Dirty
@@ -37,11 +43,33 @@ Feature 2
 -- repo/feature3.txt --
 Feature 3
 -- golden/graph-before.txt --
-* d805cb2 (HEAD -> feature2) First message in rebased branch
-* 0239007 (feature-1) Second message in squashed branch
-* 7ebfd80 First message in squashed branch
-* 9bad92b (main) Initial commit
+* a956270 (HEAD -> feature3) First message in rebased branch
+* adfd1b6 (feature1) Second message in squashed branch
+* 3143d6f First message in squashed branch
+* 2b5f0cb (main) Initial commit
 -- golden/graph.txt --
-* cbeb99e (feature2) First message in rebased branch
-* 6ca0ea8 (HEAD -> feature-1) First message in squashed branch
-* 9bad92b (main) Initial commit
+* c012e99 (feature3) First message in rebased branch
+* 67f0d51 (HEAD -> feature1) Squashed commit message
+* 2b5f0cb (main) Initial commit
+-- input/squashed-msg.txt --
+Squashed commit message
+
+This contains features 1 and 2.
+-- golden/initial-msg.txt --
+The original commit messages were:
+
+Second message in squashed branch
+
+First message in squashed branch
+
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# HEAD detached from refs/heads/feature1
+# Changes to be committed:
+#	new file:   feature1.txt
+#	new file:   feature2.txt
+#
+# Untracked files:
+#	dirty.txt
+#

--- a/testdata/script/branch_squash_err.txt
+++ b/testdata/script/branch_squash_err.txt
@@ -1,0 +1,52 @@
+# Common errors with 'branch squash'.
+
+as 'Test <test@example.com>'
+at '2025-02-02T20:18:19Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+! gs branch squash
+stderr 'cannot squash the trunk branch'
+
+# feat1 -> feat2, with feat1 diverging
+git add feat1.txt
+gs bc -m feat1
+git add feat2.txt
+gs bc -m feat2
+git add feat2-pt2.txt
+gs cc -m 'feat2 part 2'
+gs down
+git add feat1-pt2.txt
+git commit -m 'feat1 part 2'
+gs up
+
+# branch is not restacked
+! gs branch squash
+stderr 'branch feat2 needs to be restacked'
+gs stack restack  # fix it
+
+# abort the commit
+git diff --quiet # verify no changes
+git graph --branches
+cmp stdout $WORK/golden/abort-before.txt
+env EDITOR=mockedit MOCKEDIT_GIVE=$WORK/input/empty.txt
+! gs branch squash
+stderr 'empty commit message'
+# must still be in the branch
+git graph --branches
+cmp stdout $WORK/golden/abort-before.txt
+
+-- repo/feat1.txt --
+-- repo/feat1-pt2.txt --
+-- repo/feat2.txt --
+-- repo/feat2-pt2.txt --
+-- input/empty.txt --
+-- golden/abort-before.txt --
+* 01fbf9b (HEAD -> feat2) feat2 part 2
+* 4b08080 feat2
+* 833ec52 (feat1) feat1 part 2
+* 48855c7 feat1
+* da2d8d1 (main) Initial commit

--- a/testdata/script/branch_squash_message.txt
+++ b/testdata/script/branch_squash_message.txt
@@ -1,0 +1,47 @@
+# Squashing a branch into one commit with 'squash'
+
+as 'Test <test@example.com>'
+at '2024-03-30T14:59:32Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo i
+
+# Create a branch with two commits
+git add feature1.txt
+gs branch create feature-1 -m 'First message in squashed branch'
+git add feature2.txt
+git commit -m 'Second message in squashed branch'
+
+# Create another branch
+git add feature3.txt
+gs branch create feature2 -m 'First message in rebased branch'
+
+git graph --branches
+cmp stdout $WORK/golden/graph-before.txt
+
+# Go back to branch that will be squashed
+gs down
+gs branch squash -m 'squash feature-1 into one commit'
+
+git graph --branches
+cmp stdout $WORK/golden/graph.txt
+
+-- repo/dirty.txt --
+Dirty
+-- repo/feature1.txt --
+Feature 1
+-- repo/feature2.txt --
+Feature 2
+-- repo/feature3.txt --
+Feature 3
+-- golden/graph-before.txt --
+* d805cb2 (HEAD -> feature2) First message in rebased branch
+* 0239007 (feature-1) Second message in squashed branch
+* 7ebfd80 First message in squashed branch
+* 9bad92b (main) Initial commit
+-- golden/graph.txt --
+* 8323247 (feature2) First message in rebased branch
+* 3267250 (HEAD -> feature-1) squash feature-1 into one commit
+* 9bad92b (main) Initial commit


### PR DESCRIPTION
Resolves #558, using the procedure discussed, namely

1. Verifies that the current branch can be squashed
1. Checks out the current branch in a detached state
2. Resets the detached branch to the base branch
3. Commits all staged changes, using either the original first commit msg, or a provided message
4. Updates the HEAD ref of the current branch to the hash that was created in the previous step
5. Checks out the current branch