### PR TITLE
doc: Add 'unreleased' support to CLI commands

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -37,6 +37,11 @@ jobs:
           xargs perl -p -i -e \
           's/<!-- gs:version unreleased -->/<!-- gs:version ${{ steps.run.outputs.latest }} -->/g'
 
+        grep -lF 'released:"unreleased"' ./*.go |
+          xargs perl -p -i -e \
+          's/released:"unreleased"/released:"${{ steps.run.outputs.latest }}"/g'
+
+        mise run generate
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v7

--- a/branch.go
+++ b/branch.go
@@ -21,7 +21,7 @@ type branchCmd struct {
 	Delete branchDeleteCmd `cmd:"" aliases:"d,rm" help:"Delete branches"`
 	Fold   branchFoldCmd   `cmd:"" aliases:"fo" help:"Merge a branch into its base"`
 	Split  branchSplitCmd  `cmd:"" aliases:"sp" help:"Split a branch on commits"`
-	Squash branchSquashCmd `cmd:"" aliases:"sq" help:"Squash a branch into one commit"`
+	Squash branchSquashCmd `cmd:"" aliases:"sq" help:"Squash a branch into one commit" released:"unreleased"`
 
 	// Mutation
 	Edit    branchEditCmd    `cmd:"" aliases:"e" help:"Edit the commits in a branch"`

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -648,6 +648,8 @@ For example:
 gs branch (b) squash (sq) [flags]
 ```
 
+<span class="mdx-badge"><span class="mdx-badge__icon">:material-tag-hidden:{ title="Released in version" }</span><span class="mdx-badge__text">Unreleased</span>
+
 Squash a branch into one commit
 
 Squash all commits in the current branch into a single commit

--- a/dumpmd.go
+++ b/dumpmd.go
@@ -158,6 +158,30 @@ func (cmd cliDumper) dumpCommand(node *kong.Node, level int) {
 	cmd.println("```")
 	cmd.println()
 
+	if version := node.Tag.Get("released"); version != "" {
+		icon := ":material-tag:"
+		text := version
+		href := fmt.Sprintf("/changelog.md#%s", version)
+		if version == "unreleased" {
+			icon = ":material-tag-hidden:"
+			text = "Unreleased"
+			href = ""
+		}
+
+		cmd.printf(`<span class="mdx-badge">`)
+		cmd.printf(`<span class="mdx-badge__icon">`)
+		cmd.printf(`%s{ title="Released in version" }`, icon)
+		cmd.printf(`</span>`)
+		cmd.printf(`<span class="mdx-badge__text">`)
+		if href != "" {
+			cmd.printf("[%s](%s)", text, href)
+		} else {
+			cmd.printf("%s", text)
+		}
+		cmd.printf(`</span>`)
+		cmd.printf("\n\n")
+	}
+
 	if node.Help != "" {
 		cmd.println(node.Help)
 		cmd.println()


### PR DESCRIPTION
For new commands, report which version they were released in
(if at all).