### PR TITLE
ci(lint): enable usetesting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - gofumpt
     - nolintlint
     - revive
+    - usetesting
 
     # With Go 1.22 for loop semantics,
     # no need to copy loop variables.

--- a/internal/fixturetest/fixturetest_test.go
+++ b/internal/fixturetest/fixturetest_test.go
@@ -2,24 +2,15 @@ package fixturetest_test
 
 import (
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.abhg.dev/gs/internal/fixturetest"
 )
 
 func TestFixture(t *testing.T) {
-	cwd, err := os.Getwd()
-	require.NoError(t, err)
-
-	dir := t.TempDir()
-	require.NoError(t, os.Chdir(dir))
-	t.Cleanup(func() {
-		assert.NoError(t, os.Chdir(cwd))
-	})
+	t.Chdir(t.TempDir())
 
 	cfg := fixturetest.Config{Update: new(bool)}
 	fixture := fixturetest.New(cfg, "number", rand.Int)

--- a/internal/forge/github/integration_test.go
+++ b/internal/forge/github/integration_test.go
@@ -292,7 +292,7 @@ func TestIntegration_Repository_SubmitEditChange(t *testing.T) {
 		t.Cleanup(func() {
 			t.Logf("Deleting remote branch: %s", branchName)
 			assert.NoError(t,
-				gitRepo.Push(context.Background(), git.PushOptions{
+				gitRepo.Push(context.WithoutCancel(ctx), git.PushOptions{
 					Remote:  "origin",
 					Refspec: git.Refspec(":" + branchName),
 				}), "error deleting branch")
@@ -331,8 +331,9 @@ func TestIntegration_Repository_SubmitEditChange(t *testing.T) {
 
 			t.Cleanup(func() {
 				t.Logf("Deleting remote branch: %s", newBase)
+				ctx := context.WithoutCancel(t.Context())
 				require.NoError(t,
-					gitRepo.Push(context.Background(), git.PushOptions{
+					gitRepo.Push(ctx, git.PushOptions{
 						Remote:  "origin",
 						Refspec: git.Refspec(":" + newBase),
 					}), "error deleting branch")
@@ -346,8 +347,9 @@ func TestIntegration_Repository_SubmitEditChange(t *testing.T) {
 			}), "could not update base branch for PR")
 		t.Cleanup(func() {
 			t.Logf("Changing base back to: main")
+			ctx := context.WithoutCancel(t.Context())
 			require.NoError(t,
-				repo.EditChange(context.Background(), changeID, forge.EditChangeOptions{
+				repo.EditChange(ctx, changeID, forge.EditChangeOptions{
 					Base: "main",
 				}), "error restoring base branch")
 		})
@@ -367,10 +369,11 @@ func TestIntegration_Repository_SubmitEditChange(t *testing.T) {
 				Draft: &draft,
 			}), "could not update draft status for PR")
 		t.Cleanup(func() {
+			ctx := context.WithoutCancel(t.Context())
 			t.Logf("Changing to ready for review")
 			draft = false
 			require.NoError(t,
-				repo.EditChange(context.Background(), changeID, forge.EditChangeOptions{
+				repo.EditChange(ctx, changeID, forge.EditChangeOptions{
 					Draft: &draft,
 				}), "error restoring draft status")
 		})
@@ -398,10 +401,11 @@ func TestIntegration_Repository_comments(t *testing.T) {
 	}, commentBody)
 	require.NoError(t, err, "could not post comment")
 	t.Cleanup(func() {
+		ctx := context.WithoutCancel(t.Context())
 		t.Logf("Deleting comment: %s", commentID)
 
 		require.NoError(t,
-			repo.DeleteChangeComment(context.Background(), commentID),
+			repo.DeleteChangeComment(ctx, commentID),
 			"could not delete comment")
 	})
 
@@ -482,7 +486,7 @@ func TestIntegration_Repository_ListChangeComments_paginated(t *testing.T) {
 
 	var commentIDs []forge.ChangeCommentID
 	t.Cleanup(func() {
-		ctx := context.Background()
+		ctx := context.WithoutCancel(t.Context())
 		for _, commentID := range commentIDs {
 			t.Logf("Deleting comment: %s", commentID)
 

--- a/internal/forge/gitlab/integration_test.go
+++ b/internal/forge/gitlab/integration_test.go
@@ -301,9 +301,10 @@ func TestIntegration_Repository_SubmitEditChange(t *testing.T) {
 			}), "error pushing branch")
 
 		t.Cleanup(func() {
+			ctx := context.WithoutCancel(t.Context())
 			t.Logf("Deleting remote branch: %s", branchName)
 			assert.NoError(t,
-				gitRepo.Push(context.Background(), git.PushOptions{
+				gitRepo.Push(ctx, git.PushOptions{
 					Remote:  "origin",
 					Refspec: git.Refspec(":" + branchName),
 				}), "error deleting branch")
@@ -342,9 +343,10 @@ func TestIntegration_Repository_SubmitEditChange(t *testing.T) {
 				}), "could not push base branch")
 
 			t.Cleanup(func() {
+				ctx := context.WithoutCancel(t.Context())
 				t.Logf("Deleting remote branch: %s", newBase)
 				require.NoError(t,
-					gitRepo.Push(context.Background(), git.PushOptions{
+					gitRepo.Push(ctx, git.PushOptions{
 						Remote:  "origin",
 						Refspec: git.Refspec(":" + newBase),
 					}), "error deleting branch")
@@ -357,9 +359,10 @@ func TestIntegration_Repository_SubmitEditChange(t *testing.T) {
 				Base: newBase,
 			}), "could not update base branch for PR")
 		t.Cleanup(func() {
+			ctx := context.WithoutCancel(t.Context())
 			t.Logf("Changing base back to: main")
 			require.NoError(t,
-				repo.EditChange(context.Background(), changeID, forge.EditChangeOptions{
+				repo.EditChange(ctx, changeID, forge.EditChangeOptions{
 					Base: "main",
 				}), "error restoring base branch")
 		})
@@ -380,10 +383,11 @@ func TestIntegration_Repository_SubmitEditChange(t *testing.T) {
 				Draft: &draft,
 			}), "could not update draft status for PR")
 		t.Cleanup(func() {
+			ctx := context.WithoutCancel(t.Context())
 			t.Logf("Changing to ready for review")
 			draft = false
 			require.NoError(t,
-				repo.EditChange(context.Background(), changeID, forge.EditChangeOptions{
+				repo.EditChange(ctx, changeID, forge.EditChangeOptions{
 					Draft: &draft,
 				}), "error restoring draft status")
 		})
@@ -413,8 +417,9 @@ func TestIntegration_Repository_comments(t *testing.T) {
 	t.Cleanup(func() {
 		t.Logf("Deleting comment: %s", commentID)
 
+		ctx := context.WithoutCancel(t.Context())
 		require.NoError(t,
-			repo.DeleteChangeComment(context.Background(), commentID),
+			repo.DeleteChangeComment(ctx, commentID),
 			"could not delete comment")
 	})
 
@@ -495,11 +500,12 @@ func TestIntegration_Repository_ListChangeComments_paginated(t *testing.T) {
 
 	var commentIDs []forge.ChangeCommentID
 	t.Cleanup(func() {
+		ctx := context.WithoutCancel(t.Context())
 		for _, commentID := range commentIDs {
 			t.Logf("Deleting comment: %s", commentID)
 
 			assert.NoError(t,
-				repo.DeleteChangeComment(context.Background(), commentID),
+				repo.DeleteChangeComment(ctx, commentID),
 				"could not delete comment")
 		}
 	})

--- a/mise.lock
+++ b/mise.lock
@@ -22,11 +22,8 @@ gofumpt-linux-x86_64 = "sha256:6ff459c1dcae3b0b00844c1a5a4a5b0f547237d8a4f3624aa
 gofumpt-macos-aarch64 = "sha256:08f23114760a090b090706d92b8c52b9875b9eb352d76c77aa354d6aa20b045a"
 
 [tools.golangci-lint]
-version = "1.64.2"
+version = "1.64.5"
 backend = "aqua:golangci/golangci-lint"
-
-[tools.golangci-lint.checksums]
-"golangci-lint-1.64.2-linux-amd64.tar.gz" = "sha256:a893e7c9211f70a0cb8c5121ab80d5b089109c23af6bc2923820ba8b42365072"
 
 [tools.gotestsum]
 version = "1.12.0"

--- a/mise.lock
+++ b/mise.lock
@@ -25,6 +25,9 @@ gofumpt-macos-aarch64 = "sha256:08f23114760a090b090706d92b8c52b9875b9eb352d76c77
 version = "1.64.5"
 backend = "aqua:golangci/golangci-lint"
 
+[tools.golangci-lint.checksums]
+"golangci-lint-1.64.5-linux-amd64.tar.gz" = "sha256:e6bd399a0479c5fd846dcf9f3990d20448b4f0d1e5027d82348eab9f80f7ac71"
+
 [tools.gotestsum]
 version = "1.12.0"
 backend = "aqua:gotestyourself/gotestsum"


### PR DESCRIPTION
This commit enables the `usetesting` linter in the golangci.yml file
and fixes issues found by it.