### PR TITLE
fix(upstack onto): disable upstack branches in prompt

### DIFF
--- a/.changes/unreleased/Fixed-20250221-120939.yaml
+++ b/.changes/unreleased/Fixed-20250221-120939.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: >-
+  upstack onto:
+  When prompting for new base, do not allow selecting upstack branches,
+  as the operation will always be rejected to keep the graph acyclic.
+time: 2025-02-21T12:09:39.232259-08:00


### PR DESCRIPTION
When upstack onto presents a prompt to select the new base,
it should not allow selecting the current branch or any of its upstacks
as that operation will fail.