### PR TITLE
fix(git): show command name in log prefix

### DIFF
--- a/.changes/unreleased/Fixed-20250221-092625.yaml
+++ b/.changes/unreleased/Fixed-20250221-092625.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fix debug messages for some Git commands prefixed with incorrect names.
+time: 2025-02-21T09:26:25.788742-08:00

--- a/internal/git/cmd_test.go
+++ b/internal/git/cmd_test.go
@@ -1,0 +1,59 @@
+package git
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/charmbracelet/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGitCmd_logPrefix(t *testing.T) {
+	var logBuffer bytes.Buffer
+	log := log.NewWithOptions(&logBuffer, log.Options{
+		Level: log.DebugLevel,
+	})
+
+	t.Run("DefaultPrefixNoCommand", func(t *testing.T) {
+		defer logBuffer.Reset()
+
+		_ = newGitCmd(t.Context(), log, nil, "--unknown-flag").
+			Dir(t.TempDir()).
+			Run(_realExec)
+
+		assert.Contains(t, logBuffer.String(), " git: ")
+	})
+
+	t.Run("DefaultPrefixCommand", func(t *testing.T) {
+		defer logBuffer.Reset()
+
+		_ = newGitCmd(t.Context(), log, nil, "unknown-cmd").
+			Dir(t.TempDir()).
+			Run(_realExec)
+
+		assert.Contains(t, logBuffer.String(), " git unknown-cmd: ")
+	})
+
+	t.Run("PriorPrefix", func(t *testing.T) {
+		defer logBuffer.Reset()
+
+		log := log.WithPrefix("custom")
+		_ = newGitCmd(t.Context(), log, nil, "whatever").
+			Dir(t.TempDir()).
+			Run(_realExec)
+
+		assert.Contains(t, logBuffer.String(), " custom: ")
+	})
+
+	t.Run("LogPrefixAfterwards", func(t *testing.T) {
+		defer logBuffer.Reset()
+
+		log := log.WithPrefix("custom")
+		_ = newGitCmd(t.Context(), log, nil, "whatever").
+			Dir(t.TempDir()).
+			LogPrefix("different").
+			Run(_realExec)
+
+		assert.Contains(t, logBuffer.String(), " different: ")
+	})
+}

--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -147,7 +147,7 @@ func (cfg *Config) list(ctx context.Context, args ...string) iter.Seq2[ConfigEnt
 	log := cfg.log
 	args = append([]string{"config", "--null"}, args...)
 	return func(yield func(ConfigEntry, error) bool) {
-		cmd := newGitCmd(ctx, cfg.log, args...).
+		cmd := newGitCmd(ctx, cfg.log, nil /* extraConfig */, args...).
 			Dir(cfg.dir).
 			AppendEnv(cfg.env...)
 

--- a/internal/git/config_test.go
+++ b/internal/git/config_test.go
@@ -230,7 +230,7 @@ func TestIntegrationConfigListRegexp(t *testing.T) {
 			log := logutil.TestLogger(t)
 			for _, set := range tt.sets {
 				args := append([]string{"config", "--global"}, set...)
-				err := newGitCmd(ctx, log, args...).
+				err := newGitCmd(ctx, log, nil /* extra config */, args...).
 					Dir(home).
 					AppendEnv(env...).
 					Run(_realExec)

--- a/internal/git/rebase.go
+++ b/internal/git/rebase.go
@@ -118,7 +118,7 @@ func (r *Repository) Rebase(ctx context.Context, req RebaseRequest) error {
 		args = append(args, req.Branch)
 	}
 
-	cmd := r.gitCmd(ctx, args...)
+	cmd := r.gitCmd(ctx, args...).LogPrefix("git rebase")
 	if req.Interactive {
 		cmd.Stdin(os.Stdin).Stdout(os.Stdout)
 	}

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -10,7 +10,7 @@ import (
 
 // ListRemotes returns a list of remotes for the repository.
 func (r *Repository) ListRemotes(ctx context.Context) ([]string, error) {
-	cmd := newGitCmd(ctx, r.log, "remote")
+	cmd := r.gitCmd(ctx, "remote")
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, fmt.Errorf("pipe stdout: %w", err)

--- a/internal/git/var.go
+++ b/internal/git/var.go
@@ -8,7 +8,7 @@ import (
 
 // Var returns the value of the given Git variable.
 func (r *Repository) Var(ctx context.Context, name string) (string, error) {
-	cmd := newGitCmd(ctx, r.log, "var", name)
+	cmd := newGitCmd(ctx, r.log, nil /* extraConfig */, "var", name)
 	out, err := cmd.Output(r.exec)
 	if err != nil {
 		return "", fmt.Errorf("git var %s: %w", name, err)


### PR DESCRIPTION
As we were injecting configurations into git commands at runtime,
log prefixes for affected commands were just `-c`.

To fix this, make newGitCmd aware of extraConfig
so it can guess at a command name while ignoring the `-c` flags,
and add the ability to change the log prefix,
as that's required for rebase command when --no-edit is enabled.