### PR TITLE
branch prompt: Untracked branches are based on trunk

### DIFF
--- a/.changes/unreleased/Changed-20250222-094533.yaml
+++ b/.changes/unreleased/Changed-20250222-094533.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: '{branch checkout, branch delete}: In branch selection prompt, present untracked branches as being based on the trunk. '
+time: 2025-02-22T09:45:33.909981-05:00

--- a/branch.go
+++ b/branch.go
@@ -97,12 +97,18 @@ func (p *branchPrompt) Run(
 		return "", fmt.Errorf("list branches: %w", err)
 	}
 
+	trunk := store.Trunk()
 	bases := make(map[string]string) // branch -> base
 	for _, branch := range localBranches {
 		res, err := store.LookupBranch(ctx, branch.Name)
+		var base string
 		if err == nil {
-			bases[branch.Name] = res.Base
+			base = res.Base
+		} else if branch.Name != trunk {
+			base = trunk
 		}
+
+		bases[branch.Name] = base
 	}
 
 	items := make([]widget.BranchTreeItem, 0, len(localBranches))

--- a/testdata/script/branch_checkout_prompt.txt
+++ b/testdata/script/branch_checkout_prompt.txt
@@ -74,24 +74,24 @@ whatever
 "bar"
 ===
 > Select a branch to checkout: 
-> baz
 > ┏━□ bar
+> ┣━□ baz
 > ┣━□ foo
+> ┣━□ quux
+> ┣━□ qux
 > main ◀
-> quux
-> qux
 "baz"
 ===
 > Do you want to track this branch now?: [Y/n]
 true
 ===
 > Select a branch to checkout: 
-> baz
 > ┏━□ bar
+> ┣━□ baz
 > ┣━□ foo
+> ┣━□ quux
+> ┣━□ qux
 > main ◀
-> quux
-> qux
 "baz"
 ===
 > Do you want to track this branch now?: [Y/n]

--- a/testdata/script/branch_checkout_prompt_sort_by_committerdate.txt
+++ b/testdata/script/branch_checkout_prompt_sort_by_committerdate.txt
@@ -71,28 +71,28 @@ whatever
 -- robot.golden --
 ===
 > Select a branch to checkout: 
-> bcd
-> ccc
-> ddd
 > ┏━□ aaa
 > ┣━□ bbb
+> ┣━□ bcd
+> ┣━□ ccc
+> ┣━□ ddd
 > main ◀
 "bbb"
 ===
 > Select a branch to checkout: 
 > ┏━□ aaa
+> ┣━□ ccc
 > ┣━□ bbb
+> ┣━□ ddd
+> ┣━□ bcd
 > main ◀
-> ccc
-> ddd
-> bcd
 "aaa"
 ===
 > Select a branch to checkout: 
-> bcd
-> ddd
-> ccc
-> ┏━□ bbb
+> ┏━□ bcd
+> ┣━□ ddd
+> ┣━□ bbb
+> ┣━□ ccc
 > ┣━□ aaa
 > main ◀
 "bbb"

--- a/testdata/script/branch_delete_prompt_untracked.txt
+++ b/testdata/script/branch_delete_prompt_untracked.txt
@@ -26,10 +26,10 @@ cmp stderr $WORK/stderr.golden
 -- robot.golden --
 ===
 > Select a branch to delete: 
-> a
-> b
-> c ◀
-> d
+> ┏━□ a
+> ┣━□ b
+> ┣━■ c ◀
+> ┣━□ d
 > main
 true
 -- stderr.golden --


### PR DESCRIPTION
We currently list untracked branches as root nodes
when presenting the branch selection tree.

This doesn't seem right: untracked branches are still based off of trunk
(unless they have completely divergent histories,
which we won't account for -- at least for now).

Present untracked branches as being based on trunk.

Resolves #443