### PR TITLE
fix(branch rename): tab-complete old branch name

### DIFF
--- a/.changes/unreleased/Fixed-20250222-113654.yaml
+++ b/.changes/unreleased/Fixed-20250222-113654.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'branch rename: Provide shell completions for the current branch.'
+time: 2025-02-22T11:36:54.096449-05:00

--- a/branch_rename.go
+++ b/branch_rename.go
@@ -13,7 +13,7 @@ import (
 )
 
 type branchRenameCmd struct {
-	OldName string `arg:"" optional:"" help:"Old name of the branch"`
+	OldName string `arg:"" predictor:"branches" optional:"" help:"Old name of the branch"`
 	NewName string `arg:"" optional:"" help:"New name of the branch"`
 }
 


### PR DESCRIPTION
Support tab completions on the old branch name
when using `gs branch rename <old> <new>` form.