### PR TITLE
config: branchCheckout.sort => branchPrompt.sort

### DIFF
--- a/.changes/unreleased/Added-20250202-192729.yaml
+++ b/.changes/unreleased/Added-20250202-192729.yaml
@@ -1,3 +1,3 @@
 kind: Added
-body: 'branch squash: Squashses all commits in the current branch into a single commit and restacks the upstack branches.'
+body: 'branch squash: Squashes all commits in the current branch into a single commit and restacks the upstack branches.'
 time: 2025-02-02T19:27:29.806629-08:00

--- a/.changes/unreleased/Added-20250219-110433.yaml
+++ b/.changes/unreleased/Added-20250219-110433.yaml
@@ -1,5 +1,6 @@
 kind: Added
 body: >-
-  branch checkout: Add `--sort` flag and corresponding `spice.branchCheckout.sort` configuration option
-  to control sort order of branches in the branch checkout prompt.
+  Add `spice.branchPrompt.sort` configuration option
+  to control sort order of branches in the branch selection prompt
+  used by 'branch checkout', 'branch onto', 'branch delete', and others.
 time: 2025-02-19T11:04:33.240268-08:00

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -337,11 +337,6 @@ gs upstack (us) onto (o) [<onto>] [flags]
 Move a branch onto another branch
 
 The current branch and its upstack will move onto the new base.
-Use 'gs branch onto' to leave the branch's upstack alone.
-Use --branch to move a different branch than the current one.
-
-A prompt will allow selecting the new base.
-Provide the new base name as an argument to skip the prompt.
 
 For example, given the following stack with B checked out,
 'gs upstack onto main' will have the following effect:
@@ -353,6 +348,17 @@ For example, given the following stack with B checked out,
 	┌─┴ A                   ├── A
 	trunk                   trunk
 
+Use 'gs branch onto' to leave the branch's upstack alone.
+
+Use --branch to move a different branch than the current one.
+
+A prompt will allow selecting the new base.
+Use the spice.branchPrompt.sort configuration option
+to specify the sort order of branches in the prompt.
+Commonly used field names include "refname", "commiterdate", etc.
+By default, branches are sorted by name.
+Provide the new base name as an argument to skip the prompt.
+
 **Arguments**
 
 * `onto`: Destination branch
@@ -360,6 +366,8 @@ For example, given the following stack with B checked out,
 **Flags**
 
 * `--branch=NAME`: Branch to start at
+
+**Configuration**: [spice.branchPrompt.sort](/cli/config.md#spicebranchpromptsort)
 
 ### gs downstack submit
 
@@ -483,10 +491,9 @@ Provide a branch name as an argument to skip the prompt.
 
 Use -u/--untracked to show untracked branches in the prompt.
 
-Use --sort=<field> to sort branches at the same level by the given field.
-Commonly used field names include "refname", "commiterdate", "authordate", and more.
-See git-for-each-ref(1) for a full list of valid fields.
-Prefix the field name with "-" to sort in reverse order.
+Use the spice.branchPrompt.sort configuration option
+to specify the sort order of branches in the prompt.
+Commonly used field names include "refname", "commiterdate", etc.
 By default, branches are sorted by name.
 
 **Arguments**
@@ -497,10 +504,9 @@ By default, branches are sorted by name.
 
 * `-n`, `--dry-run`: Print the target branch without checking it out
 * `--detach`: Detach HEAD after checking out
-* `--sort=STRING` ([:material-wrench:{ .middle title="spice.branchCheckout.sort" }](/cli/config.md#spicebranchcheckoutsort)): Sort branches by the given field
 * `-u`, `--untracked` ([:material-wrench:{ .middle title="spice.branchCheckout.showUntracked" }](/cli/config.md#spicebranchcheckoutshowuntracked)): Show untracked branches if one isn't supplied
 
-**Configuration**: [spice.branchCheckout.showUntracked](/cli/config.md#spicebranchcheckoutshowuntracked), [spice.branchCheckout.sort](/cli/config.md#spicebranchcheckoutsort)
+**Configuration**: [spice.branchCheckout.showUntracked](/cli/config.md#spicebranchcheckoutshowuntracked), [spice.branchPrompt.sort](/cli/config.md#spicebranchpromptsort)
 
 ### gs branch create
 
@@ -588,6 +594,10 @@ Branches above the deleted branches are rebased onto
 the next branches available downstack.
 
 A prompt will allow selecting the target branch if none are provided.
+Use the spice.branchPrompt.sort configuration option
+to specify the sort order of branches in the prompt.
+Commonly used field names include "refname", "commiterdate", etc.
+By default, branches are sorted by name.
 
 **Arguments**
 
@@ -596,6 +606,8 @@ A prompt will allow selecting the target branch if none are provided.
 **Flags**
 
 * `--force`: Force deletion of the branch
+
+**Configuration**: [spice.branchPrompt.sort](/cli/config.md#spicebranchpromptsort)
 
 ### gs branch fold
 
@@ -739,10 +751,6 @@ Move a branch onto another branch
 The commits of the current branch are transplanted onto another
 branch.
 Branches upstack are moved to point to its original base.
-Use --branch to move a different branch than the current one.
-
-A prompt will allow selecting the new base.
-Provide the new base name as an argument to skip the prompt.
 
 For example, given the following stack with B checked out,
 running 'gs branch onto main' will move B onto main
@@ -755,6 +763,15 @@ and leave C on top of A.
 	┌─┴ A                   ├─┴ A
 	trunk                   trunk
 
+Use --branch to move a different branch than the current one.
+
+A prompt will allow selecting the new base.
+Use the spice.branchPrompt.sort configuration option
+to specify the sort order of branches in the prompt.
+Commonly used field names include "refname", "commiterdate", etc.
+By default, branches are sorted by name.
+Provide the new base name as an argument to skip the prompt.
+
 **Arguments**
 
 * `onto`: Destination branch
@@ -762,6 +779,8 @@ and leave C on top of A.
 **Flags**
 
 * `--branch=NAME`: Branch to move
+
+**Configuration**: [spice.branchPrompt.sort](/cli/config.md#spicebranchpromptsort)
 
 ### gs branch submit
 

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -43,12 +43,13 @@ This option controls whether untracked branches are shown in the prompt.
 - `true`
 - `false` (default)
 
-### spice.branchCheckout.sort
+### spice.branchPrompt.sort
 
 <!-- gs:version unreleased -->
 
-When running $$gs branch checkout$$ without any arguments,
-git-spice presents a prompt to select a branch to checkout.
+Commands like $$gs branch checkout$$, $$gs branch onto$$, etc.,
+that require a branch name will present an interactive prompt
+to select the branch when one isn't provided.
 
 This option controls the sort order of branches in the prompt.
 It is git-spice's equivalent of
@@ -65,7 +66,6 @@ for a full list of available fields.
 
 Prefix a field name with `-` to sort in descending order.
 For example, use `-committerdate` to sort by commit date in descending order.
-
 
 ### spice.branchCreate.commit
 

--- a/testdata/script/branch_checkout_prompt_sort_order.txt
+++ b/testdata/script/branch_checkout_prompt_sort_order.txt
@@ -1,4 +1,4 @@
-# branch checkout prompt supports sorting by committerdate.
+# branch checkout prompt supports sorting with spice.branchPrompt.sort.
 
 as 'Test <test@example.com>'
 at '2025-02-19T17:00:00Z'
@@ -43,13 +43,15 @@ stdout 'bbb'
 
 # sort by committerdate
 gs trunk
-gs branch checkout -u --sort=committerdate
+git config spice.branchPrompt.sort committerdate
+gs branch checkout -u
 git branch --show-current
 stdout 'aaa'
 
 # sort by committerdate descending
 gs trunk
-gs branch checkout -u --sort=-committerdate
+git config spice.branchPrompt.sort '-committerdate'
+gs branch checkout -u
 git branch --show-current
 stdout 'bbb'
 

--- a/testdata/script/branch_delete_prompt_sort_order.txt
+++ b/testdata/script/branch_delete_prompt_sort_order.txt
@@ -1,0 +1,77 @@
+# branch delete prompt respects spice.branchPrompt.sort.
+
+as 'Test <test@example.com>'
+at '2025-02-23T09:15:00Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+
+# tracked: aaa
+at '2025-02-19T17:05:00Z'
+git add aaa.txt
+gs bc aaa -m 'Add aaa'
+
+# untracked: ccc
+at '2025-02-19T17:10:00Z'
+git checkout -b ccc
+git add ccc.txt
+git commit -m 'Add ccc'
+
+# tracked: bbb
+at '2025-02-19T17:15:00Z'
+gs trunk
+git add bbb.txt
+gs bc bbb -m 'add bbb.txt'
+
+env ROBOT_INPUT=$WORK/robot.golden ROBOT_OUTPUT=$WORK/robot.actual
+
+gs trunk
+git graph --branches
+cmp stdout $WORK/graph-before.golden
+
+# default sort order
+gs trunk
+gs branch delete --force
+git branch ccc 56fafeb  # add it back
+
+# sort by committerdate descending
+gs trunk
+git config spice.branchPrompt.sort -committerdate
+gs branch delete --force
+
+cmp $WORK/robot.actual $WORK/robot.golden
+
+-- repo/aaa.txt --
+whatever
+
+-- repo/bbb.txt --
+whatever
+
+-- repo/ccc.txt --
+whatever
+
+-- graph-before.golden --
+* d5fb182 (bbb) add bbb.txt
+| * 56fafeb (ccc) Add ccc
+| * 3290c95 (aaa) Add aaa
+|/  
+* faed779 (HEAD -> main) Initial commit
+-- robot.golden --
+===
+> Select a branch to delete: 
+> ┏━■ aaa ◀
+> ┣━□ bbb
+> ┣━□ ccc
+> main
+"ccc"
+===
+> Select a branch to delete: 
+> ┏━■ bbb ◀
+> ┣━□ ccc
+> ┣━□ aaa
+> main
+"bbb"

--- a/testdata/script/branch_onto_prompt_sort_order.txt
+++ b/testdata/script/branch_onto_prompt_sort_order.txt
@@ -1,0 +1,63 @@
+# branch onto supports the spice.branchPrompt.sort config.
+
+as 'Test <test@example.com>'
+at '2025-02-25T09:00:35Z'
+
+# set up
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+at '2025-02-25T09:10:00Z'
+gs trunk
+git add aaa.txt
+gs branch create aaa -m 'Add feature 1'
+
+at '2025-02-25T09:08:00Z'
+gs trunk
+git add ccc.txt
+gs branch create ccc -m 'Add feature 2'
+
+at '2025-02-25T09:06:00Z'
+gs trunk
+git add bbb.txt
+gs branch create bbb -m 'Add feature 3'
+
+# Now we have:
+#   main -> {aaa, bbb, ccc}
+# Alphabetical ordering is that, but timestamp ordering is {bbb, ccc, aaa}.
+
+env ROBOT_INPUT=$WORK/robot.golden ROBOT_OUTPUT=$WORK/robot.actual
+
+# Move bbb to be based on aaa
+git config spice.branchPrompt.sort 'committerdate'
+gs branch onto
+
+git graph --branches
+cmp stdout $WORK/graph-after.golden
+
+cmp $WORK/robot.actual $WORK/robot.golden
+
+-- repo/aaa.txt --
+Feature 1
+-- repo/ccc.txt --
+Feature 2
+-- repo/bbb.txt --
+Feature 3
+-- robot.golden --
+===
+> Select a branch to move onto: 
+> ┏━□ bbb
+> ┣━□ ccc
+> ┣━□ aaa
+> main ◀
+>
+> Moving bbb onto another branch
+"aaa"
+-- graph-after.golden --
+* 5646a25 (ccc) Add feature 2
+| * f062ab3 (HEAD -> bbb) Add feature 3
+| * d80c805 (aaa) Add feature 1
+|/  
+* 9778e0e (main) Initial commit

--- a/testdata/script/upstack_onto_prompt_sort_order.txt
+++ b/testdata/script/upstack_onto_prompt_sort_order.txt
@@ -1,0 +1,63 @@
+# branch onto supports the spice.branchPrompt.sort config.
+
+as 'Test <test@example.com>'
+at '2025-02-25T09:00:35Z'
+
+# set up
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+at '2025-02-25T09:10:00Z'
+gs trunk
+git add aaa.txt
+gs branch create aaa -m 'Add feature 1'
+
+at '2025-02-25T09:08:00Z'
+gs trunk
+git add ccc.txt
+gs branch create ccc -m 'Add feature 2'
+
+at '2025-02-25T09:06:00Z'
+gs trunk
+git add bbb.txt
+gs branch create bbb -m 'Add feature 3'
+
+# Now we have:
+#   main -> {aaa, bbb, ccc}
+# Alphabetical ordering is that, but timestamp ordering is {bbb, ccc, aaa}.
+
+env ROBOT_INPUT=$WORK/robot.golden ROBOT_OUTPUT=$WORK/robot.actual
+
+# Move bbb to be based on aaa
+git config spice.branchPrompt.sort 'committerdate'
+gs upstack onto
+
+git graph --branches
+cmp stdout $WORK/graph-after.golden
+
+cmp $WORK/robot.actual $WORK/robot.golden
+
+-- repo/aaa.txt --
+Feature 1
+-- repo/ccc.txt --
+Feature 2
+-- repo/bbb.txt --
+Feature 3
+-- robot.golden --
+===
+> Select a branch to move onto: 
+> ┏━□ bbb
+> ┣━□ ccc
+> ┣━□ aaa
+> main ◀
+>
+> Moving the upstack of bbb onto another branch
+"aaa"
+-- graph-after.golden --
+* 5646a25 (ccc) Add feature 2
+| * f062ab3 (HEAD -> bbb) Add feature 3
+| * d80c805 (aaa) Add feature 1
+|/  
+* 9778e0e (main) Initial commit


### PR DESCRIPTION
Drop the `--sort` flag on `branch checkout`
and use a shared `branchPrompt.sort` configuration
that affects the sort order of branches in the prompt
for all commands that use this prompt.