### PR TITLE
(revert #590) branch select: untracked branches are on their own

### DIFF
--- a/.changes/unreleased/Changed-20250222-094533.yaml
+++ b/.changes/unreleased/Changed-20250222-094533.yaml
@@ -1,3 +1,0 @@
-kind: Changed
-body: '{branch checkout, branch delete}: In branch selection prompt, present untracked branches as being based on the trunk. '
-time: 2025-02-22T09:45:33.909981-05:00

--- a/branch.go
+++ b/branch.go
@@ -135,14 +135,9 @@ func (p *branchPrompter) Prompt(ctx context.Context, req *branchPromptRequest) (
 	bases := make(map[string]string) // branch -> base
 	for _, branch := range localBranches {
 		res, err := p.store.LookupBranch(ctx, branch.Name)
-		var base string
 		if err == nil {
-			base = res.Base
-		} else if branch.Name != trunk {
-			base = trunk
+			bases[branch.Name] = res.Base
 		}
-
-		bases[branch.Name] = base
 	}
 
 	items := make([]widget.BranchTreeItem, 0, len(localBranches))

--- a/testdata/script/branch_checkout_prompt.txt
+++ b/testdata/script/branch_checkout_prompt.txt
@@ -74,24 +74,24 @@ whatever
 "bar"
 ===
 > Select a branch to checkout: 
+> baz
 > ┏━□ bar
-> ┣━□ baz
 > ┣━□ foo
-> ┣━□ quux
-> ┣━□ qux
 > main ◀
+> quux
+> qux
 "baz"
 ===
 > Do you want to track this branch now?: [Y/n]
 true
 ===
 > Select a branch to checkout: 
+> baz
 > ┏━□ bar
-> ┣━□ baz
 > ┣━□ foo
-> ┣━□ quux
-> ┣━□ qux
 > main ◀
+> quux
+> qux
 "baz"
 ===
 > Do you want to track this branch now?: [Y/n]

--- a/testdata/script/branch_checkout_prompt_sort_order.txt
+++ b/testdata/script/branch_checkout_prompt_sort_order.txt
@@ -73,28 +73,28 @@ whatever
 -- robot.golden --
 ===
 > Select a branch to checkout: 
+> bcd
+> ccc
+> ddd
 > ┏━□ aaa
 > ┣━□ bbb
-> ┣━□ bcd
-> ┣━□ ccc
-> ┣━□ ddd
 > main ◀
 "bbb"
 ===
 > Select a branch to checkout: 
 > ┏━□ aaa
-> ┣━□ ccc
 > ┣━□ bbb
-> ┣━□ ddd
-> ┣━□ bcd
 > main ◀
+> ccc
+> ddd
+> bcd
 "aaa"
 ===
 > Select a branch to checkout: 
-> ┏━□ bcd
-> ┣━□ ddd
-> ┣━□ bbb
-> ┣━□ ccc
+> bcd
+> ddd
+> ccc
+> ┏━□ bbb
 > ┣━□ aaa
 > main ◀
 "bbb"

--- a/testdata/script/branch_delete_prompt_sort_order.txt
+++ b/testdata/script/branch_delete_prompt_sort_order.txt
@@ -63,15 +63,15 @@ whatever
 -- robot.golden --
 ===
 > Select a branch to delete: 
-> ┏━■ aaa ◀
+> ccc ◀
+> ┏━□ aaa
 > ┣━□ bbb
-> ┣━□ ccc
 > main
 "ccc"
 ===
 > Select a branch to delete: 
 > ┏━■ bbb ◀
-> ┣━□ ccc
 > ┣━□ aaa
 > main
+> ccc
 "bbb"

--- a/testdata/script/branch_delete_prompt_untracked.txt
+++ b/testdata/script/branch_delete_prompt_untracked.txt
@@ -26,10 +26,10 @@ cmp stderr $WORK/stderr.golden
 -- robot.golden --
 ===
 > Select a branch to delete: 
-> ┏━□ a
-> ┣━□ b
-> ┣━■ c ◀
-> ┣━□ d
+> a
+> b
+> c ◀
+> d
 > main
 true
 -- stderr.golden --


### PR DESCRIPTION
Putting untracked branches under main takes away knowledge
that they are untracked in the branch selection prompt.