### PR TITLE
goreleaser: archives.format deprecated

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,7 +19,7 @@ builds:
       - -trimpath
 
 archives:
-  - format: tar.gz
+  - formats: tar.gz
     # uname compatible archive name.
     name_template: >-
       {{- .ProjectName }}.


### PR DESCRIPTION
This should now be archives.formats.

https://goreleaser.com/deprecations/#archivesformat