### PR TITLE
--version copyright: drop year

### DIFF
--- a/version.go
+++ b/version.go
@@ -17,7 +17,7 @@ func (v versionFlag) BeforeReset(app *kong.Kong) error {
 	}
 
 	fmt.Fprintln(app.Stdout)
-	fmt.Fprintln(app.Stdout, "Copyright (C) 2024 Abhinav Gupta")
+	fmt.Fprintln(app.Stdout, "Copyright (C) Abhinav Gupta")
 	fmt.Fprintln(app.Stdout, "  <https://github.com/abhinav/git-spice>")
 	fmt.Fprintln(app.Stdout, "This program comes with ABSOLUTELY NO WARRANTY")
 	fmt.Fprintln(app.Stdout, "This is free software, and you are welcome to redistribute it")


### PR DESCRIPTION
Rather than try to keep year up-to-date or generate on demand,
just drop the year. That's also considered okay.

https://daniel.haxx.se/blog/2023/01/08/copyright-without-years/

[skip changelog]: not really user-facing