### PR TITLE
Add version command

### DIFF
--- a/.changes/unreleased/Added-20250224-083159.yaml
+++ b/.changes/unreleased/Added-20250224-083159.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add 'version' command as alternative to '--version' flag.
+time: 2025-02-24T08:31:59.329806-05:00

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -1026,3 +1026,11 @@ Move to the trunk branch
 * `-n`, `--dry-run`: Print the target branch without checking it out
 * `--detach`: Detach HEAD after checking out
 
+## gs version
+
+```
+gs version [flags]
+```
+
+Print version information and quit
+

--- a/main.go
+++ b/main.go
@@ -245,6 +245,8 @@ type mainCmd struct {
 	Bottom bottomCmd `cmd:"" aliases:"D" group:"Navigation" help:"Move to the bottom of the stack"`
 	Trunk  trunkCmd  `cmd:"" group:"Navigation" help:"Move to the trunk branch"`
 
+	Version versionCmd `cmd:"" help:"Print version information and quit"`
+
 	// Hidden commands:
 	DumpMD dumpMarkdownCmd `name:"dumpmd" hidden:"" cmd:"" help:"Dump a Markdown reference to stdout and quit"`
 }

--- a/version.go
+++ b/version.go
@@ -11,8 +11,19 @@ import (
 type versionFlag bool
 
 func (v versionFlag) BeforeReset(app *kong.Kong) error {
+	if err := new(versionCmd).Run(app); err != nil {
+		return err
+	}
+
+	app.Exit(0)
+	return nil
+}
+
+type versionCmd struct{}
+
+func (cmd *versionCmd) Run(app *kong.Kong) error {
 	fmt.Fprint(app.Stdout, "git-spice ", _version)
-	if report := generateBuildReport(); report != "" {
+	if report := _generateBuildReport(); report != "" {
 		fmt.Fprintf(app.Stdout, " (%s)", report)
 	}
 
@@ -22,12 +33,14 @@ func (v versionFlag) BeforeReset(app *kong.Kong) error {
 	fmt.Fprintln(app.Stdout, "This program comes with ABSOLUTELY NO WARRANTY")
 	fmt.Fprintln(app.Stdout, "This is free software, and you are welcome to redistribute it")
 	fmt.Fprintln(app.Stdout, "under certain conditions; see source for details.")
-	app.Exit(0)
+
 	return nil
 }
 
-var generateBuildReport = func() string {
-	info, ok := debug.ReadBuildInfo()
+var _debugReadBuildInfo = debug.ReadBuildInfo
+
+var _generateBuildReport = func() string {
+	info, ok := _debugReadBuildInfo()
 	if !ok {
 		return ""
 	}


### PR DESCRIPTION
Adds a version subcommand to report version information
instead of/in addition to the --version flag.

In service to #572