### PR TITLE
version: --short flag to print only the version

### DIFF
--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -1034,3 +1034,7 @@ gs version [flags]
 
 Print version information and quit
 
+**Flags**
+
+* `--short`: Print only the version number.
+

--- a/version.go
+++ b/version.go
@@ -19,9 +19,16 @@ func (v versionFlag) BeforeReset(app *kong.Kong) error {
 	return nil
 }
 
-type versionCmd struct{}
+type versionCmd struct {
+	Short bool `help:"Print only the version number."`
+}
 
 func (cmd *versionCmd) Run(app *kong.Kong) error {
+	if cmd.Short {
+		fmt.Fprintln(app.Stdout, _version)
+		return nil
+	}
+
 	fmt.Fprint(app.Stdout, "git-spice ", _version)
 	if report := _generateBuildReport(); report != "" {
 		fmt.Fprintf(app.Stdout, " (%s)", report)

--- a/version_test.go
+++ b/version_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/alecthomas/kong"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.abhg.dev/testing/stub"
 )
 
@@ -27,6 +28,30 @@ func TestVersionFlag(t *testing.T) {
 	assert.Zero(t, exitCode)
 	assert.Contains(t, stdout.String(), "git-spice "+_version)
 	assert.Contains(t, stdout.String(), "(commithash timestamp)")
+}
+
+func TestVersionCmd(t *testing.T) {
+	defer stub.Value(&_version, "v1.2.3")()
+
+	t.Run("Default", func(t *testing.T) {
+		var stdout bytes.Buffer
+		err := new(versionCmd).Run(&kong.Kong{
+			Stdout: &stdout,
+		})
+		require.NoError(t, err)
+
+		assert.Contains(t, stdout.String(), "git-spice v1.2.3")
+	})
+
+	t.Run("Short", func(t *testing.T) {
+		var stdout bytes.Buffer
+		err := (&versionCmd{Short: true}).Run(&kong.Kong{
+			Stdout: &stdout,
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, "v1.2.3\n", stdout.String())
+	})
 }
 
 func TestGenerateBuildReport(t *testing.T) {


### PR DESCRIPTION
Per discussion in #572, add a --short flag to the version command
to print only the version number.

[skip changelog]: version command is unreleased,
this is just an addition to that.

Resolves #572