### PR TITLE
internal/spice: Drop Forge from Service

### DIFF
--- a/internal/spice/branch_test.go
+++ b/internal/spice/branch_test.go
@@ -53,7 +53,6 @@ func TestService_LookupBranch_changeAssociation(t *testing.T) {
 
 	// Without a remote set, the Service won't have a Forge connected.
 	t.Run("NoRemote", func(t *testing.T) {
-		ctx := t.Context()
 		mockCtrl := gomock.NewController(t)
 		mockRepo := NewMockGitRepository(mockCtrl)
 		mockStore := NewMockStore(mockCtrl)
@@ -68,7 +67,7 @@ func TestService_LookupBranch_changeAssociation(t *testing.T) {
 			Return(git.Hash("def123"), nil).
 			AnyTimes()
 
-		svc := NewService(ctx, mockRepo, mockStore, logutil.TestLogger(t))
+		svc := NewService(mockRepo, mockStore, logutil.TestLogger(t))
 
 		// We should still be able to resolve metadata
 		// for known forges.
@@ -118,13 +117,6 @@ func TestService_LookupBranch_changeAssociation(t *testing.T) {
 		mockRepo := NewMockGitRepository(mockCtrl)
 		mockStore := NewMockStore(mockCtrl)
 
-		mockStore.EXPECT().
-			Remote().
-			Return("origin", nil)
-		mockRepo.EXPECT().
-			RemoteURL(gomock.Any(), "origin").
-			Return(shamhubServer.URL+"/foo", nil)
-
 		mockRepo.EXPECT().
 			PeelToCommit(gomock.Any(), "feature").
 			Return(git.Hash("def123"), nil).
@@ -139,7 +131,7 @@ func TestService_LookupBranch_changeAssociation(t *testing.T) {
 				ChangeForge:    shamhubForge.ID(),
 			}, nil)
 
-		svc := NewService(ctx, mockRepo, mockStore, logutil.TestLogger(t))
+		svc := NewService(mockRepo, mockStore, logutil.TestLogger(t))
 		resp, err := svc.LookupBranch(ctx, "feature")
 		require.NoError(t, err)
 

--- a/internal/spice/remote_test.go
+++ b/internal/spice/remote_test.go
@@ -68,7 +68,7 @@ func TestUnusedBranchName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
 			repo := NewMockGitRepository(mockCtrl)
-			svc := NewTestService(repo, NewMockStore(mockCtrl), nil, log)
+			svc := NewTestService(repo, NewMockStore(mockCtrl), log)
 
 			var lastCall *gomock.Call
 			for _, call := range tt.calls {
@@ -94,7 +94,7 @@ func TestUnusedBranchName(t *testing.T) {
 func TestUnusedBranchName_listError(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	repo := NewMockGitRepository(mockCtrl)
-	svc := NewTestService(repo, NewMockStore(mockCtrl), nil, logutil.TestLogger(t))
+	svc := NewTestService(repo, NewMockStore(mockCtrl), logutil.TestLogger(t))
 
 	repo.EXPECT().
 		ListRemoteRefs(gomock.Any(), "origin", gomock.Any()).

--- a/internal/spice/service.go
+++ b/internal/spice/service.go
@@ -6,7 +6,6 @@ import (
 	"iter"
 
 	"github.com/charmbracelet/log"
-	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/spice/state"
 )
@@ -91,35 +90,22 @@ var _ Store = (*state.Store)(nil)
 type Service struct {
 	repo  GitRepository
 	store Store
-	forge forge.Forge
 	log   *log.Logger
 }
 
 // NewService builds a new service operating on the given repository and store.
-func NewService(ctx context.Context, repo GitRepository, store Store, log *log.Logger) *Service {
-	var forg forge.Forge
-	if remote, err := store.Remote(); err == nil {
-		remoteURL, err := repo.RemoteURL(ctx, remote)
-		if err == nil {
-			if f, ok := forge.MatchForgeURL(remoteURL); ok {
-				forg = f
-			}
-		}
-	}
-
-	return newService(repo, store, forg, log)
+func NewService(repo GitRepository, store Store, log *log.Logger) *Service {
+	return newService(repo, store, log)
 }
 
 func newService(
 	repo GitRepository,
 	store Store,
-	forge forge.Forge,
 	log *log.Logger,
 ) *Service {
 	return &Service{
 		repo:  repo,
 		store: store,
-		forge: forge,
 		log:   log,
 	}
 }

--- a/internal/spice/service_test.go
+++ b/internal/spice/service_test.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/charmbracelet/log"
 	"github.com/stretchr/testify/require"
-	"go.abhg.dev/gs/internal/forge"
-	"go.abhg.dev/gs/internal/forge/shamhub"
 	"go.abhg.dev/gs/internal/logutil"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/spice/state/storage"
@@ -17,16 +15,9 @@ import (
 func NewTestService(
 	repo GitRepository,
 	store Store,
-	forge forge.Forge,
 	log *log.Logger,
 ) *Service {
-	if forge == nil {
-		forge = &shamhub.Forge{
-			Log: log,
-		}
-	}
-
-	return newService(repo, store, forge, log)
+	return newService(repo, store, log)
 }
 
 // NewMemoryStore builds gs state storage

--- a/internal/spice/template_test.go
+++ b/internal/spice/template_test.go
@@ -44,7 +44,7 @@ func TestListChangeTemplates(t *testing.T) {
 		AnyTimes()
 
 	store := spice.NewMemoryStore(t)
-	svc := spice.NewTestService(repo, store, mockForge, logutil.TestLogger(t))
+	svc := spice.NewTestService(repo, store, logutil.TestLogger(t))
 
 	tmpl := &forge.ChangeTemplate{
 		Filename: "CHANGE_TEMPLATE.md",

--- a/main.go
+++ b/main.go
@@ -285,7 +285,7 @@ func (cmd *mainCmd) AfterApply(ctx context.Context, kctx *kong.Context, logger *
 	}
 
 	err = kctx.BindToProvider(onceFunc(func(repo *git.Repository, store *state.Store) (*spice.Service, error) {
-		return spice.NewService(ctx, repo, store, logger), nil
+		return spice.NewService(repo, store, logger), nil
 	}))
 	if err != nil {
 		return fmt.Errorf("bind spice service: %w", err)


### PR DESCRIPTION
Service doesn't need to know Forge (at least at this time)
as all logic is implemented outside it.

[skip changelog]: no user-facing changes