### PR TITLE
refac(forge): extract global registry into type

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -141,7 +141,7 @@ func guessCurrentForge(ctx context.Context, log *log.Logger) (forge.Forge, error
 		return nil, fmt.Errorf("get remote URL: %w", err)
 	}
 
-	forge, ok := forge.MatchForgeURL(remoteURL)
+	forge, ok := forge.MatchForgeURL(forge.DefaultRegistry, remoteURL)
 	if !ok {
 		return nil, fmt.Errorf("no forge found for %s", remoteURL)
 	}

--- a/internal/forge/forge_test.go
+++ b/internal/forge/forge_test.go
@@ -10,14 +10,15 @@ import (
 )
 
 func TestRegister(t *testing.T) {
-	defer forge.Register(stubForge{
+	var registry forge.Registry
+	defer registry.Register(stubForge{
 		id:      "a",
 		baseURL: "https://example.com",
 	})()
 
 	t.Run("All", func(t *testing.T) {
 		var ok bool
-		for f := range forge.All {
+		for f := range registry.All() {
 			if f.ID() == "a" {
 				ok = true
 				break
@@ -27,23 +28,23 @@ func TestRegister(t *testing.T) {
 	})
 
 	t.Run("Lookup", func(t *testing.T) {
-		f, ok := forge.Lookup("a")
+		f, ok := registry.Lookup("a")
 		assert.True(t, ok, "forge not found")
 		assert.Equal(t, "a", f.ID(), "forge ID mismatch")
 
 		t.Run("NotFound", func(t *testing.T) {
-			_, ok := forge.Lookup("b")
+			_, ok := registry.Lookup("b")
 			assert.False(t, ok, "unexpected forge match")
 		})
 	})
 
 	t.Run("MatchForgeURL", func(t *testing.T) {
-		f, ok := forge.MatchForgeURL("https://example.com/foo")
+		f, ok := forge.MatchForgeURL(&registry, "https://example.com/foo")
 		assert.True(t, ok, "forge not found")
 		assert.Equal(t, "a", f.ID(), "forge ID mismatch")
 
 		t.Run("NoMatch", func(t *testing.T) {
-			_, ok := forge.MatchForgeURL("https://example.org/foo")
+			_, ok := forge.MatchForgeURL(&registry, "https://example.org/foo")
 			assert.False(t, ok, "unexpected forge match")
 		})
 	})

--- a/remote.go
+++ b/remote.go
@@ -47,7 +47,7 @@ func openRemoteRepositorySilent(
 		return nil, fmt.Errorf("get remote URL: %w", err)
 	}
 
-	f, ok := forge.MatchForgeURL(remoteURL)
+	f, ok := forge.MatchForgeURL(forge.DefaultRegistry, remoteURL)
 	if !ok {
 		return nil, &unsupportedForgeError{
 			Remote:    remote,


### PR DESCRIPTION
Move the logic from the global forge registry into a Registry type
that mirrors the APIs (more or less).
In this change, we still have a global registry;
following this we can drop the global registry.

[skip changelog]: no user facing changes