### PR TITLE
refac(forge): Drop global registry

### DIFF
--- a/branch_split.go
+++ b/branch_split.go
@@ -58,6 +58,7 @@ func (cmd *branchSplitCmd) Run(
 	repo *git.Repository,
 	store *state.Store,
 	svc *spice.Service,
+	forges *forge.Registry,
 ) (err error) {
 	if cmd.Branch == "" {
 		cmd.Branch, err = repo.CurrentBranch(ctx)
@@ -261,6 +262,7 @@ func (cmd *branchSplitCmd) Run(
 			transfer, err := prepareChangeMetadataTransfer(
 				ctx,
 				log,
+				forges,
 				repo,
 				store,
 				cmd.Branch,
@@ -303,6 +305,7 @@ func (cmd *branchSplitCmd) Run(
 func prepareChangeMetadataTransfer(
 	ctx context.Context,
 	log *log.Logger,
+	forges *forge.Registry,
 	repo *git.Repository,
 	store *state.Store,
 	fromBranch, toBranch string,
@@ -311,7 +314,7 @@ func prepareChangeMetadataTransfer(
 	tx *state.BranchTx,
 ) (transfer func(), _ error) {
 	forgeID := meta.ForgeID()
-	f, ok := forge.Lookup(forgeID)
+	f, ok := forges.Lookup(forgeID)
 	if !ok {
 		return nil, fmt.Errorf("unknown forge: %v", forgeID)
 	}

--- a/branch_submit.go
+++ b/branch_submit.go
@@ -103,8 +103,9 @@ func (cmd *branchSubmitCmd) Run(
 	repo *git.Repository,
 	store *state.Store,
 	svc *spice.Service,
+	forges *forge.Registry,
 ) error {
-	session := newSubmitSession(repo, store, secretStash, view, log)
+	session := newSubmitSession(repo, store, secretStash, forges, view, log)
 	if err := cmd.run(ctx, session, log, view, repo, store, svc); err != nil {
 		return err
 	}

--- a/downstack_submit.go
+++ b/downstack_submit.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 
 	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/must"
 	"go.abhg.dev/gs/internal/secret"
@@ -38,6 +39,7 @@ func (cmd *downstackSubmitCmd) Run(
 	repo *git.Repository,
 	store *state.Store,
 	svc *spice.Service,
+	forges *forge.Registry,
 ) error {
 	if cmd.Branch == "" {
 		currentBranch, err := repo.CurrentBranch(ctx)
@@ -61,7 +63,7 @@ func (cmd *downstackSubmitCmd) Run(
 	// TODO: generalize into a service-level method
 	// TODO: separate preparation of the stack from submission
 
-	session := newSubmitSession(repo, store, secretStash, view, log)
+	session := newSubmitSession(repo, store, secretStash, forges, view, log)
 	for _, downstack := range downstacks {
 		err := (&branchSubmitCmd{
 			submitOptions: cmd.submitOptions,

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -54,27 +54,6 @@ func (r *Registry) Lookup(id string) (Forge, bool) {
 	return f.(Forge), true
 }
 
-// DefaultRegistry is the global Registry.
-//
-// TODO: delete
-var DefaultRegistry = new(Registry)
-
-// All is an iterator that yields all registered forges.
-func All(yield func(Forge) bool) {
-	DefaultRegistry.All()(yield)
-}
-
-// Register registers a forge with the given ID.
-// Returns a function to unregister the forge.
-func Register(f Forge) (unregister func()) {
-	return DefaultRegistry.Register(f)
-}
-
-// Lookup looks up a registered forge by its ID.
-func Lookup(id string) (Forge, bool) {
-	return DefaultRegistry.Lookup(id)
-}
-
 // MatchForgeURL attempts to match the given remote URL with a registered forge.
 // Returns the matched forge and true if a match was found.
 func MatchForgeURL(r *Registry, remoteURL string) (forge Forge, ok bool) {

--- a/internal/spice/branch.go
+++ b/internal/spice/branch.go
@@ -127,7 +127,7 @@ func (s *Service) LookupBranch(ctx context.Context, name string) (*LookupBranchR
 
 		if resp.ChangeMetadata != nil {
 			// TODO: This is ick. Service should have a Registry.
-			if f, ok := forge.Lookup(resp.ChangeForge); !ok {
+			if f, ok := s.forges.Lookup(resp.ChangeForge); !ok {
 				s.log.Warn("Ignoring unknown forge requested in change metadata",
 					"forge", resp.ChangeForge)
 			} else {
@@ -260,7 +260,7 @@ func (s *Service) RenameBranch(ctx context.Context, oldName, newName string) err
 		changeMetadata json.RawMessage
 	)
 	if md := oldBranch.Change; md != nil {
-		if f, ok := forge.Lookup(md.ForgeID()); ok {
+		if f, ok := s.forges.Lookup(md.ForgeID()); ok {
 			changeForge = f.ID()
 			changeMetadata, err = f.MarshalChangeMetadata(md)
 			if err != nil {

--- a/internal/spice/branch_test.go
+++ b/internal/spice/branch_test.go
@@ -49,7 +49,9 @@ func TestService_LookupBranch_changeAssociation(t *testing.T) {
 			APIURL: shamhubServer.URL,
 		},
 	}
-	t.Cleanup(forge.Register(shamhubForge))
+
+	var forgeReg forge.Registry
+	forgeReg.Register(shamhubForge)
 
 	// Without a remote set, the Service won't have a Forge connected.
 	t.Run("NoRemote", func(t *testing.T) {
@@ -67,7 +69,7 @@ func TestService_LookupBranch_changeAssociation(t *testing.T) {
 			Return(git.Hash("def123"), nil).
 			AnyTimes()
 
-		svc := NewService(mockRepo, mockStore, logutil.TestLogger(t))
+		svc := NewService(mockRepo, mockStore, &forgeReg, logutil.TestLogger(t))
 
 		// We should still be able to resolve metadata
 		// for known forges.
@@ -131,7 +133,7 @@ func TestService_LookupBranch_changeAssociation(t *testing.T) {
 				ChangeForge:    shamhubForge.ID(),
 			}, nil)
 
-		svc := NewService(mockRepo, mockStore, logutil.TestLogger(t))
+		svc := NewService(mockRepo, mockStore, &forgeReg, logutil.TestLogger(t))
 		resp, err := svc.LookupBranch(ctx, "feature")
 		require.NoError(t, err)
 

--- a/internal/spice/remote_test.go
+++ b/internal/spice/remote_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/logutil"
 	gomock "go.uber.org/mock/gomock"
@@ -68,7 +69,7 @@ func TestUnusedBranchName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
 			repo := NewMockGitRepository(mockCtrl)
-			svc := NewTestService(repo, NewMockStore(mockCtrl), log)
+			svc := NewTestService(repo, NewMockStore(mockCtrl), new(forge.Registry), log)
 
 			var lastCall *gomock.Call
 			for _, call := range tt.calls {
@@ -94,7 +95,7 @@ func TestUnusedBranchName(t *testing.T) {
 func TestUnusedBranchName_listError(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	repo := NewMockGitRepository(mockCtrl)
-	svc := NewTestService(repo, NewMockStore(mockCtrl), logutil.TestLogger(t))
+	svc := NewTestService(repo, NewMockStore(mockCtrl), new(forge.Registry), logutil.TestLogger(t))
 
 	repo.EXPECT().
 		ListRemoteRefs(gomock.Any(), "origin", gomock.Any()).

--- a/internal/spice/service.go
+++ b/internal/spice/service.go
@@ -6,6 +6,7 @@ import (
 	"iter"
 
 	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/spice/state"
 )
@@ -88,24 +89,32 @@ var _ Store = (*state.Store)(nil)
 // It combines together lower level pieces like access to the git repository
 // and the spice state.
 type Service struct {
-	repo  GitRepository
-	store Store
-	log   *log.Logger
+	repo   GitRepository
+	store  Store
+	log    *log.Logger
+	forges *forge.Registry
 }
 
 // NewService builds a new service operating on the given repository and store.
-func NewService(repo GitRepository, store Store, log *log.Logger) *Service {
-	return newService(repo, store, log)
+func NewService(
+	repo GitRepository,
+	store Store,
+	forges *forge.Registry,
+	log *log.Logger,
+) *Service {
+	return newService(repo, store, forges, log)
 }
 
 func newService(
 	repo GitRepository,
 	store Store,
+	forges *forge.Registry,
 	log *log.Logger,
 ) *Service {
 	return &Service{
-		repo:  repo,
-		store: store,
-		log:   log,
+		repo:   repo,
+		store:  store,
+		log:    log,
+		forges: forges,
 	}
 }

--- a/internal/spice/service_test.go
+++ b/internal/spice/service_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/charmbracelet/log"
 	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/logutil"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/spice/state/storage"
@@ -15,9 +16,10 @@ import (
 func NewTestService(
 	repo GitRepository,
 	store Store,
+	forgeReg *forge.Registry,
 	log *log.Logger,
 ) *Service {
-	return newService(repo, store, log)
+	return newService(repo, store, forgeReg, log)
 }
 
 // NewMemoryStore builds gs state storage

--- a/internal/spice/template_test.go
+++ b/internal/spice/template_test.go
@@ -44,7 +44,7 @@ func TestListChangeTemplates(t *testing.T) {
 		AnyTimes()
 
 	store := spice.NewMemoryStore(t)
-	svc := spice.NewTestService(repo, store, logutil.TestLogger(t))
+	svc := spice.NewTestService(repo, store, new(forge.Registry), logutil.TestLogger(t))
 
 	tmpl := &forge.ChangeTemplate{
 		Filename: "CHANGE_TEMPLATE.md",

--- a/remote.go
+++ b/remote.go
@@ -39,6 +39,7 @@ func (e *notLoggedInError) Error() string {
 func openRemoteRepositorySilent(
 	ctx context.Context,
 	stash secret.Stash,
+	forges *forge.Registry,
 	gitRepo *git.Repository,
 	remote string,
 ) (forge.Repository, error) {
@@ -47,7 +48,7 @@ func openRemoteRepositorySilent(
 		return nil, fmt.Errorf("get remote URL: %w", err)
 	}
 
-	f, ok := forge.MatchForgeURL(forge.DefaultRegistry, remoteURL)
+	f, ok := forge.MatchForgeURL(forges, remoteURL)
 	if !ok {
 		return nil, &unsupportedForgeError{
 			Remote:    remote,
@@ -70,10 +71,11 @@ func openRemoteRepository(
 	ctx context.Context,
 	log *log.Logger,
 	stash secret.Stash,
+	forges *forge.Registry,
 	gitRepo *git.Repository,
 	remote string,
 ) (forge.Repository, error) {
-	forgeRepo, err := openRemoteRepositorySilent(ctx, stash, gitRepo, remote)
+	forgeRepo, err := openRemoteRepositorySilent(ctx, stash, forges, gitRepo, remote)
 
 	var (
 		unsupportedErr *unsupportedForgeError

--- a/repo_sync.go
+++ b/repo_sync.go
@@ -46,6 +46,7 @@ func (cmd *repoSyncCmd) Run(
 	repo *git.Repository,
 	store *state.Store,
 	svc *spice.Service,
+	forges *forge.Registry,
 ) error {
 	remote, err := ensureRemote(ctx, repo, store, log, view)
 	// TODO: move ensure remote to Service
@@ -196,7 +197,7 @@ func (cmd *repoSyncCmd) Run(
 	}
 
 	var branchesToDelete []branchDeletion
-	if remoteRepo, err := openRemoteRepositorySilent(ctx, secretStash, repo, remote); err != nil {
+	if remoteRepo, err := openRemoteRepositorySilent(ctx, secretStash, forges, repo, remote); err != nil {
 		var unsupported *unsupportedForgeError
 		if !errors.As(err, &unsupported) {
 			return err

--- a/script_test.go
+++ b/script_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.abhg.dev/gs/internal/browser"
 	"go.abhg.dev/gs/internal/browser/browsertest"
-	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/forge/shamhub"
 	"go.abhg.dev/gs/internal/git/gittest"
 	"go.abhg.dev/gs/internal/mockedit"
@@ -74,7 +73,7 @@ func TestMain(m *testing.M) {
 				}
 			}
 
-			forge.Register(&shamhub.Forge{Log: logger})
+			_extraForges = append(_extraForges, &shamhub.Forge{Log: logger})
 			main()
 			return 0
 		},

--- a/shell_completion.go
+++ b/shell_completion.go
@@ -128,11 +128,13 @@ func predictDirs(args komplete.Args) (predictions []string) {
 	return predictions
 }
 
-func predictForges(_ komplete.Args) (predictions []string) {
-	var ids []string
-	for f := range forge.All {
-		ids = append(ids, f.ID())
+func predictForges(forges *forge.Registry) func(komplete.Args) (predictions []string) {
+	return func(komplete.Args) (predictions []string) {
+		var ids []string
+		for f := range forges.All() {
+			ids = append(ids, f.ID())
+		}
+		sort.Strings(ids)
+		return ids
 	}
-	sort.Strings(ids)
-	return ids
 }

--- a/stack_submit.go
+++ b/stack_submit.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/secret"
 	"go.abhg.dev/gs/internal/spice"
@@ -32,6 +33,7 @@ func (cmd *stackSubmitCmd) Run(
 	repo *git.Repository,
 	store *state.Store,
 	svc *spice.Service,
+	forges *forge.Registry,
 ) error {
 	currentBranch, err := repo.CurrentBranch(ctx)
 	if err != nil {
@@ -46,7 +48,7 @@ func (cmd *stackSubmitCmd) Run(
 	// TODO: generalize into a service-level method
 	// TODO: separate preparation of the stack from submission
 
-	session := newSubmitSession(repo, store, secretStash, view, log)
+	session := newSubmitSession(repo, store, secretStash, forges, view, log)
 	for _, branch := range stack {
 		if branch == store.Trunk() {
 			continue

--- a/submit.go
+++ b/submit.go
@@ -37,6 +37,7 @@ func newSubmitSession(
 	repo *git.Repository,
 	store *state.Store,
 	stash secret.Stash,
+	forges *forge.Registry,
 	view ui.View,
 	log *log.Logger,
 ) *submitSession {
@@ -51,7 +52,7 @@ func newSubmitSession(
 			return nil, err
 		}
 
-		return openRemoteRepository(ctx, log, stash, repo, remote)
+		return openRemoteRepository(ctx, log, stash, forges, repo, remote)
 	}
 	return &s
 }

--- a/upstack_submit.go
+++ b/upstack_submit.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/log"
+	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/secret"
 	"go.abhg.dev/gs/internal/spice"
@@ -38,6 +39,7 @@ func (cmd *upstackSubmitCmd) Run(
 	repo *git.Repository,
 	store *state.Store,
 	svc *spice.Service,
+	forges *forge.Registry,
 ) error {
 	if cmd.Branch == "" {
 		currentBranch, err := repo.CurrentBranch(ctx)
@@ -79,7 +81,7 @@ func (cmd *upstackSubmitCmd) Run(
 
 	// TODO: generalize into a service-level method
 	// TODO: separate preparation of the stack from submission
-	session := newSubmitSession(repo, store, secretStash, view, log)
+	session := newSubmitSession(repo, store, secretStash, forges, view, log)
 	for _, b := range upstacks {
 		err := (&branchSubmitCmd{
 			submitOptions: cmd.submitOptions,


### PR DESCRIPTION
Replace the global forge registry with
an explicitly plumbed Registry object.

[skip changelog]: no user facing changes