### PR TITLE
fix(gitlab): Actually support GITLAB_TOKEN

### DIFF
--- a/.changes/unreleased/Fixed-20250305-215537.yaml
+++ b/.changes/unreleased/Fixed-20250305-215537.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'gitlab: Fix rejection of `GITLAB_TOKEN` environment variable for authentication.'
+time: 2025-03-05T21:55:37.669148-08:00

--- a/internal/forge/gitlab/client_int_test.go
+++ b/internal/forge/gitlab/client_int_test.go
@@ -1,4 +1,82 @@
 package gitlab
 
-// GitlabClient is a GitLab client exported for testing.
-type GitlabClient = gitlabClient
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
+)
+
+// Client is a GitLab client exported for testing.
+type Client = gitlabClient
+
+func TestNewGitLabClient_authMethods(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		switch r.URL.Path {
+		case "/api/v4/user":
+			var u gitlab.User
+			switch {
+			case r.Header.Get("Private-Token") == "personal-access-token":
+				u.Username = "pat-user"
+
+			case r.Header.Get("Private-Token") == "pat-from-env":
+				u.Username = "pat-from-env-user"
+
+			case r.Header.Get("Authorization") == "Bearer oauth2-token":
+				u.Username = "oauth2-user"
+
+			default:
+				t.Errorf("unknown request: %v %v", r.Method, r.URL.Path)
+				t.Errorf("headers: %v", r.Header)
+			}
+
+			assert.NoError(t, enc.Encode(u))
+
+		default:
+			t.Errorf("unknown request: %v %v", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	t.Run("PAT", func(t *testing.T) {
+		client, err := newGitLabClient(t.Context(), srv.URL, &AuthenticationToken{
+			AuthType:    AuthTypePAT,
+			AccessToken: "personal-access-token",
+		})
+		require.NoError(t, err)
+
+		u, _, err := client.Users.CurrentUser(gitlab.WithContext(t.Context()))
+		require.NoError(t, err)
+		assert.Equal(t, "pat-user", u.Username)
+	})
+
+	t.Run("OAuth2", func(t *testing.T) {
+		client, err := newGitLabClient(t.Context(), srv.URL, &AuthenticationToken{
+			AuthType:    AuthTypeOAuth2,
+			AccessToken: "oauth2-token",
+		})
+		require.NoError(t, err)
+
+		u, _, err := client.Users.CurrentUser(gitlab.WithContext(t.Context()))
+		require.NoError(t, err)
+		assert.Equal(t, "oauth2-user", u.Username)
+	})
+
+	t.Run("EnvironmentVariable", func(t *testing.T) {
+		client, err := newGitLabClient(t.Context(), srv.URL, &AuthenticationToken{
+			AuthType:    AuthTypeEnvironmentVariable,
+			AccessToken: "pat-from-env",
+		})
+		require.NoError(t, err)
+
+		u, _, err := client.Users.CurrentUser(gitlab.WithContext(t.Context()))
+		require.NoError(t, err)
+		assert.Equal(t, "pat-from-env-user", u.Username)
+	})
+}

--- a/internal/forge/gitlab/integration_test.go
+++ b/internal/forge/gitlab/integration_test.go
@@ -77,7 +77,7 @@ func newRecorder(t *testing.T, name string) *recorder.Recorder {
 
 func newGitLabClient(
 	httpClient *http.Client,
-) *gitlab.GitlabClient {
+) *gitlab.Client {
 	tok, exists := os.LookupEnv("GITLAB_TOKEN")
 	var token string
 	if !exists {
@@ -86,7 +86,7 @@ func newGitLabClient(
 		token = tok
 	}
 	client, _ := gogitlab.NewClient(token, gogitlab.WithHTTPClient(httpClient))
-	return &gitlab.GitlabClient{
+	return &gitlab.Client{
 		MergeRequests:    client.MergeRequests,
 		Notes:            client.Notes,
 		ProjectTemplates: client.ProjectTemplates,


### PR DESCRIPTION
The GitLab forge was rejecting use of the GITLAB_TOKEN env var
for authentication despite advertising support for it.

The issue was that the client constructor was exploding
when the auth type was `AuthTypeEnvironmentVariable`
because it was not in the list of known auth types.

Fix this by adding a case for it, and add tests to verify.

Resolves #612