### PR TITLE
forge: Learn to calculate change URLs

### DIFF
--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -90,6 +90,16 @@ type Forge interface {
 	// This will only be called if MatchURL reports true.
 	OpenURL(ctx context.Context, tok AuthenticationToken, remoteURL string) (Repository, error)
 
+	// ChangeURL returns the web URL for the given change ID hosted on the forge,
+	// given the remote URL of the repository.
+	//
+	// TODO(abhinav): This is a hack to work around the fact
+	// that OpenURL requires authentication.
+	//
+	// An upcoming change will allow separating "parsing" the forge URL
+	// and "opening" the remote repository.
+	ChangeURL(remoteURL string, changeID ChangeID) (string, error)
+
 	// ChangeTemplatePaths reports the case-insensitive paths at which
 	// it's possible to define change templates in the repository.
 	ChangeTemplatePaths() []string

--- a/internal/forge/forgetest/mocks.go
+++ b/internal/forge/forgetest/mocks.go
@@ -160,6 +160,45 @@ func (c *MockForgeChangeTemplatePathsCall) DoAndReturn(f func() []string) *MockF
 	return c
 }
 
+// ChangeURL mocks base method.
+func (m *MockForge) ChangeURL(remoteURL string, changeID forge.ChangeID) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ChangeURL", remoteURL, changeID)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ChangeURL indicates an expected call of ChangeURL.
+func (mr *MockForgeMockRecorder) ChangeURL(remoteURL, changeID any) *MockForgeChangeURLCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeURL", reflect.TypeOf((*MockForge)(nil).ChangeURL), remoteURL, changeID)
+	return &MockForgeChangeURLCall{Call: call}
+}
+
+// MockForgeChangeURLCall wrap *gomock.Call
+type MockForgeChangeURLCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockForgeChangeURLCall) Return(arg0 string, arg1 error) *MockForgeChangeURLCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockForgeChangeURLCall) Do(f func(string, forge.ChangeID) (string, error)) *MockForgeChangeURLCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockForgeChangeURLCall) DoAndReturn(f func(string, forge.ChangeID) (string, error)) *MockForgeChangeURLCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ClearAuthenticationToken mocks base method.
 func (m *MockForge) ClearAuthenticationToken(arg0 secret.Stash) error {
 	m.ctrl.T.Helper()

--- a/internal/forge/github/forge.go
+++ b/internal/forge/github/forge.go
@@ -87,6 +87,18 @@ func (f *Forge) MatchURL(remoteURL string) bool {
 	return err == nil
 }
 
+// ChangeURL returns a URL to view a change on GitHub.
+// Returns an empty string if the URL is not a valid GitHub URL.
+func (f *Forge) ChangeURL(remoteURL string, id forge.ChangeID) (string, error) {
+	owner, repo, err := extractRepoInfo(f.URL(), remoteURL)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", forge.ErrUnsupportedURL, err)
+	}
+
+	pr := mustPR(id)
+	return fmt.Sprintf("%s/%s/%s/pull/%d", f.URL(), owner, repo, pr.Number), nil
+}
+
 // OpenURL opens a GitHub repository from a remote URL.
 // Returns [forge.ErrUnsupportedURL] if the URL is not a valid GitHub URL.
 func (f *Forge) OpenURL(ctx context.Context, tok forge.AuthenticationToken, remoteURL string) (forge.Repository, error) {

--- a/internal/forge/github/forge_test.go
+++ b/internal/forge/github/forge_test.go
@@ -185,3 +185,18 @@ func TestExtractRepoInfoErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestChangeURL(t *testing.T) {
+	f := Forge{Options: Options{URL: DefaultURL}}
+
+	t.Run("Valid", func(t *testing.T) {
+		got, err := f.ChangeURL("https://github.com/example/repo.git", &PR{Number: 123})
+		require.NoError(t, err)
+		assert.Equal(t, "https://github.com/example/repo/pull/123", got)
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		_, err := f.ChangeURL("https://notgithub.com/example/repo.git", &PR{Number: 123})
+		require.Error(t, err)
+	})
+}

--- a/internal/forge/gitlab/forge.go
+++ b/internal/forge/gitlab/forge.go
@@ -65,6 +65,17 @@ func (f *Forge) MatchURL(remoteURL string) bool {
 	return err == nil
 }
 
+// ChangeURL returns the URL for a Change hosted on GitLab.
+func (f *Forge) ChangeURL(remoteURL string, id forge.ChangeID) (string, error) {
+	owner, repo, err := extractRepoInfo(f.URL(), remoteURL)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", forge.ErrUnsupportedURL, err)
+	}
+
+	mr := mustMR(id)
+	return fmt.Sprintf("%s/%s/%s/-/merge_requests/%v", f.URL(), owner, repo, mr.Number), nil
+}
+
 // OpenURL opens a GitLab repository from a remote URL.
 // Returns [forge.ErrUnsupportedURL] if the URL is not a valid GitLab URL.
 func (f *Forge) OpenURL(ctx context.Context, token forge.AuthenticationToken, remoteURL string) (forge.Repository, error) {

--- a/internal/forge/gitlab/forge_test.go
+++ b/internal/forge/gitlab/forge_test.go
@@ -178,3 +178,18 @@ func TestExtractRepoInfoErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestChangeURL(t *testing.T) {
+	f := Forge{Options: Options{URL: "https://gitlab.com"}}
+
+	t.Run("Valid", func(t *testing.T) {
+		got, err := f.ChangeURL("https://gitlab.com/example/repo", &MR{Number: 42})
+		require.NoError(t, err)
+		assert.Equal(t, "https://gitlab.com/example/repo/-/merge_requests/42", got)
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		_, err := f.ChangeURL("https://notgitlab.com/example/repo", &MR{Number: 42})
+		require.Error(t, err)
+	})
+}

--- a/internal/forge/shamhub/repo.go
+++ b/internal/forge/shamhub/repo.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/charmbracelet/log"
 	"go.abhg.dev/gs/internal/forge"
@@ -61,15 +60,9 @@ func (f *Forge) OpenURL(_ context.Context, token forge.AuthenticationToken, remo
 		"Authentication-Token": tok,
 	}
 
-	tail, ok := strings.CutPrefix(remoteURL, f.URL)
-	if !ok {
-		return nil, forge.ErrUnsupportedURL
-	}
-
-	tail = strings.TrimSuffix(strings.TrimPrefix(tail, "/"), ".git")
-	owner, repo, ok := strings.Cut(tail, "/")
-	if !ok {
-		return nil, fmt.Errorf("%w: no '/' found in %q", forge.ErrUnsupportedURL, tail)
+	owner, repo, err := extractRepoInfo(f.URL, remoteURL)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", forge.ErrUnsupportedURL, err)
 	}
 
 	apiURL, err := url.Parse(f.APIURL)


### PR DESCRIPTION
Needed for #610, #615

We currently don't expose a standard way to determine the URL
at which a CR can be viewed in a forge-agnostic way.

This adds a ChangeURL method to Forge that can be used for this purpose.

The method is a bit of a hack as this information should typically
come from the Repository, except right now,
we do not have a means of narrowing down to a Repository
without "opening" it, which may perform network requests.

There's an in-flight change that separates the act of
parsing a repository URL and opening it,
which will allow making this cleaner in the future.