### PR TITLE
feat(log.pushStatusFormat): support aheadBehind

### DIFF
--- a/.changes/unreleased/Added-20250316-082145.yaml
+++ b/.changes/unreleased/Added-20250316-082145.yaml
@@ -1,6 +1,6 @@
 kind: Added
 body: >-
-  log: Add `spice.log.pushStatusFormat = (true | false)`
-  to show whether a branch is in sync with its remote branch.
-  The default is `true`.
+  log: Add `spice.log.pushStatusFormat = (true | false | aheadBehind)`
+  to show whether a branch is out-of-sync with its remote,
+  and optionally, by how many commits. Defaults to `true`.
 time: 2025-03-16T08:21:45.085254-07:00

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -157,6 +157,9 @@ whether the branch is in sync with its pushed counterpart.
 
 - `true` (default): show the push status
 - `false`: don't show the push status
+- `"aheadBehind"`:
+  show the number of outgoing and incoming commits in the form `⇡1⇣2`,
+  where `⇡` indicates outgoing commits and `⇣` indicates incoming commits
 
 ### spice.rebaseContinue.edit
 

--- a/internal/git/commit_test.go
+++ b/internal/git/commit_test.go
@@ -1,0 +1,121 @@
+package git_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/git/gittest"
+	"go.abhg.dev/gs/internal/logutil"
+	"go.abhg.dev/gs/internal/text"
+)
+
+func TestCommitAheadBehind(t *testing.T) {
+	t.Parallel()
+
+	fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+		at '2025-03-16T18:19:20Z'
+
+		cd upstream
+		git init
+		git commit --allow-empty -m 'Initial commit'
+
+		git checkout -b feat1
+		git add feat1.txt
+		git commit -m 'Add feat1'
+		git branch feat2
+		git branch feat3
+		git branch feat4
+
+		cd ..
+		git clone upstream fork
+		cd fork
+
+		git checkout feat1
+		git checkout feat3
+
+		git checkout feat2
+		cp $WORK/extra/feat2.txt .
+		git add feat2.txt
+		git commit -m 'Add feat2'
+
+		cd ../upstream
+		git checkout feat3
+		git add feat3.txt
+		git commit -m 'Add feat3'
+
+		git checkout feat4
+		git add feat4.txt
+		git commit -m 'Add feat4'
+
+		cd ../fork
+		git checkout feat4
+		cp $WORK/extra/feat4.txt .
+		git add feat4.txt
+		git commit -m 'Add feat4-fork'
+		git fetch
+
+		-- upstream/feat1.txt --
+		feat1
+		-- upstream/feat3.txt --
+		feat3
+		-- upstream/feat4.txt --
+		feat4
+		-- extra/feat2.txt --
+		feat2
+		-- extra/feat4.txt --
+		feat4-fork
+	`)))
+	require.NoError(t, err)
+	t.Cleanup(fixture.Cleanup)
+
+	// From the point of view of the fork:
+	//
+	//   - feat1 is in sync with upstream
+	//   - feat2 is ahead by 1 commit (the one we just made)
+	//   - feat3 is behind by 1 commit (the one we just made in upstream)
+	//   - feat4 is ahead and behind by 1 commit
+	ctx := t.Context()
+	fork, err := git.Open(ctx, filepath.Join(fixture.Dir(), "fork"), git.OpenOptions{
+		Log: logutil.TestLogger(t),
+	})
+	require.NoError(t, err)
+
+	t.Run("Synced", func(t *testing.T) {
+		t.Parallel()
+
+		ahead, behind, err := fork.CommitAheadBehind(ctx, "origin/feat1", "feat1")
+		require.NoError(t, err)
+		assert.Zero(t, ahead, "expected 0 commits ahead")
+		assert.Zero(t, behind, "expected 0 commits behind")
+	})
+
+	t.Run("Ahead", func(t *testing.T) {
+		t.Parallel()
+
+		ahead, behind, err := fork.CommitAheadBehind(ctx, "origin/feat2", "feat2")
+		require.NoError(t, err)
+		assert.Equal(t, 1, ahead, "expected 1 commit ahead")
+		assert.Zero(t, behind, "expected 0 commits behind")
+	})
+
+	t.Run("Behind", func(t *testing.T) {
+		t.Parallel()
+
+		ahead, behind, err := fork.CommitAheadBehind(ctx, "origin/feat3", "feat3")
+		require.NoError(t, err)
+		assert.Zero(t, ahead, "expected 0 commits ahead")
+		assert.Equal(t, 1, behind, "expected 1 commit behind")
+	})
+
+	t.Run("Both", func(t *testing.T) {
+		t.Parallel()
+
+		ahead, behind, err := fork.CommitAheadBehind(ctx, "origin/feat4", "feat4")
+		require.NoError(t, err)
+		assert.Equal(t, 1, ahead, "expected 1 commit ahead")
+		assert.Equal(t, 1, behind, "expected 1 commit behind")
+	})
+}

--- a/log_test.go
+++ b/log_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPushStatusFormat(t *testing.T) {
+	tests := []struct {
+		give        string
+		want        pushStatusFormat
+		wantStr     string
+		wantEnabled bool
+	}{
+		{
+			give:        "true",
+			want:        pushStatusEnabled,
+			wantStr:     "true",
+			wantEnabled: true,
+		},
+		{
+			give:        "yes",
+			want:        pushStatusEnabled,
+			wantStr:     "true",
+			wantEnabled: true,
+		},
+		{
+			give:        "false",
+			want:        pushStatusDisabled,
+			wantStr:     "false",
+			wantEnabled: false,
+		},
+		{
+			give:        "no",
+			want:        pushStatusDisabled,
+			wantStr:     "false",
+			wantEnabled: false,
+		},
+		{
+			give:        "aheadbehind",
+			want:        pushStatusAheadBehind,
+			wantStr:     "aheadBehind",
+			wantEnabled: true,
+		},
+		{
+			give:        "aheadBehind",
+			want:        pushStatusAheadBehind,
+			wantStr:     "aheadBehind",
+			wantEnabled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.give, func(t *testing.T) {
+			t.Run("Unmarshal", func(t *testing.T) {
+				var got pushStatusFormat
+				err := got.UnmarshalText([]byte(tt.give))
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			})
+
+			t.Run("String", func(t *testing.T) {
+				got := tt.want.String()
+				assert.Equal(t, tt.wantStr, got)
+			})
+
+			t.Run("Enabled", func(t *testing.T) {
+				got := tt.want.Enabled()
+				assert.Equal(t, tt.wantEnabled, got)
+			})
+		})
+	}
+
+	t.Run("invalid", func(t *testing.T) {
+		t.Run("Unmarshal", func(t *testing.T) {
+			var got pushStatusFormat
+			err := got.UnmarshalText([]byte("invalid"))
+			require.Error(t, err)
+		})
+
+		t.Run("String", func(t *testing.T) {
+			got := pushStatusFormat(999) // invalid value
+			assert.Equal(t, "unknown", got.String())
+		})
+
+		t.Run("Enabled", func(t *testing.T) {
+			got := pushStatusFormat(999) // invalid value
+			assert.False(t, got.Enabled())
+		})
+	})
+}

--- a/testdata/script/config_log_push_status_format.txt
+++ b/testdata/script/config_log_push_status_format.txt
@@ -62,6 +62,14 @@ cmp stderr $WORK/golden/ls-feat2-enabled.txt
 gs ll
 cmp stderr $WORK/golden/ll-feat2-enabled.txt
 
+# Try with aheadBehind
+git config spice.log.pushStatusFormat aheadBehind
+
+gs ls
+cmp stderr $WORK/golden/ls-feat2-aheadBehind.txt
+gs ll
+cmp stderr $WORK/golden/ll-feat2-aheadBehind.txt
+
 -- repo/feat1.txt --
 feat1
 -- repo/feat2.txt --
@@ -110,6 +118,21 @@ main
     ┃   e00a44b update feat3 (now)
     ┃   61be7b8 feat3 (now)
   ┏━┻■ feat2 (#2) (needs push) ◀
+  ┃    b5b29cc update feat2 (now)
+  ┃    92d90ce feat2 (now)
+┏━┻□ feat1 (#1)
+┃    8761af2 feat1 (now)
+main
+-- golden/ls-feat2-aheadBehind.txt --
+    ┏━□ feat3 (#3) (needs restack) (⇡1)
+  ┏━┻■ feat2 (#2) (⇡1) ◀
+┏━┻□ feat1 (#1)
+main
+-- golden/ll-feat2-aheadBehind.txt --
+    ┏━□ feat3 (#3) (needs restack) (⇡1)
+    ┃   e00a44b update feat3 (now)
+    ┃   61be7b8 feat3 (now)
+  ┏━┻■ feat2 (#2) (⇡1) ◀
   ┃    b5b29cc update feat2 (now)
   ┃    92d90ce feat2 (now)
 ┏━┻□ feat1 (#1)


### PR DESCRIPTION
Allow setting log.pushStatusFormat to aheadBehind,
which will report the number of commits a branch is ahead/behind
its upstream in the form `⇡1⇣2`.

This is similar to what is produced
by popular terminal prompt plugins for Git
(e.g. powerlevel10k, starship).

Examples:

<img width="547" alt="image" src="https://github.com/user-attachments/assets/973aeba9-f067-4a95-ad6a-b989c668e2e5" />
<img width="334" alt="image" src="https://github.com/user-attachments/assets/1fdffcf1-4453-4729-b276-81e4092280f5" />
