### PR TITLE
chore(cli): use kong.BindSingletonProvider

### DIFF
--- a/branch.go
+++ b/branch.go
@@ -51,14 +51,18 @@ type BranchPromptConfig struct {
 // BeforeApply is called by Kong as part of parsing.
 // This is the earliest hook we can introduce the binding in.
 func (cfg *BranchPromptConfig) BeforeApply(kctx *kong.Context) error {
-	return kctx.BindToProvider(onceFunc(func(view ui.View, repo *git.Repository, store *state.Store) (*branchPrompter, error) {
+	return kctx.BindSingletonProvider(func(
+		view ui.View,
+		repo *git.Repository,
+		store *state.Store,
+	) (*branchPrompter, error) {
 		return &branchPrompter{
 			sort:  cfg.BranchPromptSort,
 			view:  view,
 			repo:  repo,
 			store: store,
 		}, nil
-	}))
+	})
 }
 
 // branchPrompter presents the user with an interactive prompt

--- a/main.go
+++ b/main.go
@@ -9,9 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"reflect"
 	"strconv"
-	"sync"
 
 	"github.com/alecthomas/kong"
 	"github.com/charmbracelet/lipgloss"
@@ -271,7 +269,7 @@ func (cmd *mainCmd) AfterApply(ctx context.Context, kctx *kong.Context, logger *
 
 	// TODO: bind interfaces, not values
 
-	err = kctx.BindToProvider(onceFunc(func() (*git.Repository, error) {
+	err = kctx.BindSingletonProvider(func() (*git.Repository, error) {
 		repo, err := git.Open(ctx, ".", git.OpenOptions{
 			Log: logger,
 		})
@@ -279,25 +277,25 @@ func (cmd *mainCmd) AfterApply(ctx context.Context, kctx *kong.Context, logger *
 			return nil, fmt.Errorf("open repository: %w", err)
 		}
 		return repo, nil
-	}))
+	})
 	if err != nil {
 		return fmt.Errorf("bind git repository: %w", err)
 	}
 
-	err = kctx.BindToProvider(onceFunc(func(repo *git.Repository) (*state.Store, error) {
+	err = kctx.BindSingletonProvider(func(repo *git.Repository) (*state.Store, error) {
 		return ensureStore(ctx, repo, logger, view)
-	}))
+	})
 	if err != nil {
 		return fmt.Errorf("bind state store: %w", err)
 	}
 
-	err = kctx.BindToProvider(onceFunc(func(
+	err = kctx.BindSingletonProvider(func(
 		repo *git.Repository,
 		store *state.Store,
 		forges *forge.Registry,
 	) (*spice.Service, error) {
 		return spice.NewService(repo, store, forges, logger), nil
-	}))
+	})
 	if err != nil {
 		return fmt.Errorf("bind spice service: %w", err)
 	}
@@ -313,24 +311,4 @@ var _buildView = func(stdin io.Reader, stderr io.Writer, interactive bool) (ui.V
 		}, nil
 	}
 	return &ui.FileView{W: stderr}, nil
-}
-
-// onceFunc generates a copy of F that records its result after the first call
-// and reproduces it in all following calls.
-//
-// TODO: drop usage once https://github.com/alecthomas/kong/pull/501 is released.
-func onceFunc[F any](f F) F {
-	fv := reflect.ValueOf(f)
-	ft := fv.Type()
-
-	var (
-		once    sync.Once
-		outputs []reflect.Value
-	)
-	return reflect.MakeFunc(ft, func(inputs []reflect.Value) []reflect.Value {
-		once.Do(func() {
-			outputs = fv.Call(inputs)
-		})
-		return outputs
-	}).Interface().(F)
 }


### PR DESCRIPTION
New Kong was released with #501, which introduces BindSingletonProvider.
This allows dropping the `onceFunc` workaround.

[skip changelog]: no user-facing changes