### PR TITLE
git/LocalBranches: include Worktree in result

### DIFF
--- a/branch_checkout.go
+++ b/branch_checkout.go
@@ -64,7 +64,7 @@ func (cmd *branchCheckoutCmd) AfterApply(
 
 		cmd.Branch, err = branchPrompt.Prompt(ctx, &branchPromptRequest{
 			Disabled: func(b git.LocalBranch) bool {
-				return b.Name != currentBranch && b.CheckedOut
+				return b.Name != currentBranch && b.Worktree != ""
 			},
 			Default:     currentBranch,
 			TrackedOnly: !cmd.Untracked,

--- a/internal/git/branch_test.go
+++ b/internal/git/branch_test.go
@@ -64,7 +64,7 @@ func TestIntegrationBranches(t *testing.T) {
 		assert.Equal(t, []git.LocalBranch{
 			{Name: "feature1"},
 			{Name: "feature2"},
-			{Name: "main", CheckedOut: true},
+			{Name: "main", Worktree: joinSlash(fixture.Dir())},
 		}, bs)
 	})
 
@@ -75,7 +75,7 @@ func TestIntegrationBranches(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, []git.LocalBranch{
-			{Name: "main", CheckedOut: true},
+			{Name: "main", Worktree: joinSlash(fixture.Dir())},
 			{Name: "feature1"},
 			{Name: "feature2"},
 		}, bs)
@@ -119,7 +119,7 @@ func TestIntegrationBranches(t *testing.T) {
 				{Name: "feature1"},
 				{Name: "feature2"},
 				{Name: "feature3"},
-				{Name: "main", CheckedOut: true},
+				{Name: "main", Worktree: joinSlash(fixture.Dir())},
 			}, bs)
 		}
 
@@ -135,7 +135,7 @@ func TestIntegrationBranches(t *testing.T) {
 			assert.Equal(t, []git.LocalBranch{
 				{Name: "feature1"},
 				{Name: "feature2"},
-				{Name: "main", CheckedOut: true},
+				{Name: "main", Worktree: joinSlash(fixture.Dir())},
 			}, bs)
 		})
 	})
@@ -157,7 +157,7 @@ func TestIntegrationBranches(t *testing.T) {
 				{Name: "feature1"},
 				{Name: "feature2"},
 				{Name: "feature4"},
-				{Name: "main", CheckedOut: true},
+				{Name: "main", Worktree: joinSlash(fixture.Dir())},
 			}, bs)
 		}
 
@@ -213,9 +213,9 @@ func TestIntegrationLocalBranchesWorktrees(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, []git.LocalBranch{
-		{Name: "feature1", CheckedOut: true},
+		{Name: "feature1", Worktree: joinSlash(fixture.Dir(), "wt1")},
 		{Name: "feature2"},
-		{Name: "main", CheckedOut: true},
+		{Name: "main", Worktree: joinSlash(fixture.Dir(), "repo")},
 	}, bs)
 }
 
@@ -298,4 +298,11 @@ func TestIntegrationRemoteBranches(t *testing.T) {
 		require.Error(t, err)
 		assert.ErrorIs(t, err, git.ErrNotExist)
 	})
+}
+
+// joinSlash joins the given paths and converts it to slash-separated path.
+//
+// Use this when the result is always /-separated, e.g. for git paths.
+func joinSlash(paths ...string) string {
+	return filepath.ToSlash(filepath.Join(paths...))
 }

--- a/repo_sync.go
+++ b/repo_sync.go
@@ -106,7 +106,7 @@ func (cmd *repoSyncCmd) Run(
 		// and mess up the other worktree.
 		trunkCheckedOut := slices.ContainsFunc(localBranches,
 			func(b git.LocalBranch) bool {
-				return b.Name == trunk && b.CheckedOut
+				return b.Name == trunk && b.Worktree != "" // checked out in another worktree
 			})
 		if trunkCheckedOut {
 			// TODO:


### PR DESCRIPTION
For LocalBranches, instead of just reporting
whether a branch is checked out, also report _where_ it's checked out.

Step towards solving #126