### PR TITLE
repo sync: update even if trunk is checked out

### DIFF
--- a/.changes/unreleased/Added-20250319-181541.yaml
+++ b/.changes/unreleased/Added-20250319-181541.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'repo sync: Update the trunk branch even if it''s checked out in another worktree.'
+time: 2025-03-19T18:15:41.300182-07:00

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -135,3 +135,19 @@ func (r *Repository) WithEditor(editor string) *Repository {
 	newR.cfg.Editor = editor
 	return &newR
 }
+
+// SetWorktree changes the worktree that this Repository is operating in.
+func (r *Repository) SetWorktree(ctx context.Context, dir string) error {
+	other, err := Open(ctx, dir, OpenOptions{
+		Log:  r.log,
+		exec: r.exec,
+	})
+	if err != nil {
+		return fmt.Errorf("open worktree: %w", err)
+	}
+
+	// Copy over any meaningful state.
+	r.root = other.root
+	r.gitDir = other.gitDir
+	return nil
+}

--- a/testdata/script/repo_sync_trunk_checked_out_in_another_worktree.txt
+++ b/testdata/script/repo_sync_trunk_checked_out_in_another_worktree.txt
@@ -1,0 +1,50 @@
+# 'repo sync' from trunk, main branch checked out in another worktree.
+
+as 'Test <test@example.com>'
+at '2024-05-18T13:59:12Z'
+
+# setup
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+gs repo init --trunk=main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# start working on a feature
+git checkout -b feat1
+
+# check out trunk in another worktree
+git worktree add ../wt1 main
+
+# update the remote out of band
+cd ..
+shamhub clone alice/example.git fork
+cd fork
+cp $WORK/extra/feature1.txt .
+git add feature1.txt
+git commit -m 'Add feature1'
+git push origin main
+
+# sync the original repo
+cd ../repo
+gs repo sync
+stderr 'pulled 1 new commit'
+
+# not pulled into this worktree
+! exists feature1.txt
+
+# verify file was pulled in the other worktree
+cd ../wt1
+cmp feature1.txt $WORK/extra/feature1.txt
+
+-- extra/feature1.txt --
+Contents of feature1


### PR DESCRIPTION
If trunk is checked out in another worktree,
switch to operating on that worktree and update trunk there.
This is just a `git pull` or `git pull --rebase` in that directory.

Resolves #126