### PR TITLE
log {long, short}: fetch branch information in parallel

### DIFF
--- a/.changes/unreleased/Changed-20250405-111557.yaml
+++ b/.changes/unreleased/Changed-20250405-111557.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'log: Fetch branch information in parallel to speed up the operation.'
+time: 2025-04-05T11:15:57.798965-07:00


### PR DESCRIPTION
Instead of fetching branch information serially,
fetch it with a bunch of parallel workers to speed up the process.

Results:
On my laptop, even with just 17 branches,
'gs ll -a' went from ~510ms to ~160ms.

```
# Before
❯ hyperfine --warmup 5 'gs ll -a'
Benchmark 1: gs ll -a
  Time (mean ± σ):     515.4 ms ±   3.5 ms    [User: 282.2 ms, System: 215.3 ms]
  Range (min … max):   511.1 ms … 522.5 ms    10 runs

# After
❯ hyperfine --warmup 5 'gs ll -a'
Benchmark 1: gs ll -a
  Time (mean ± σ):     160.9 ms ±   3.7 ms    [User: 404.6 ms, System: 475.9 ms]
  Range (min … max):   156.7 ms … 172.3 ms    18 runs
```

I also created a repository with 100 branches with:

```bash
git init
git commit --allow-empty -m "init"
gs repo init
for num in {0..100}; do
	gs trunk
	echo "$num" > "file.$num.txt"
	git add "file.$num.txt"
	gs bc branch-"$num" -m "add file.$num.txt"
done
```

This went from 2.9s to 800ms.

```
# Before
❯ hyperfine --warmup 5 '../bin/gs ll -a'
Benchmark 1: ../bin/gs ll -a
  Time (mean ± σ):      2.926 s ±  0.009 s    [User: 1.604 s, System: 1.215 s]
  Range (min … max):    2.916 s …  2.948 s    10 runs

# After
❯ hyperfine --warmup 5 '../bin/gs ll -a'
Benchmark 1: ../bin/gs ll -a
  Time (mean ± σ):     818.1 ms ±   6.9 ms    [User: 2425.4 ms, System: 2964.3 ms]
  Range (min … max):   808.4 ms … 830.4 ms    10 runs
```

Resolves #251