### PR TITLE
ci: Move Git installation to a separate action

### DIFF
--- a/.github/actions/install-git/action.yml
+++ b/.github/actions/install-git/action.yml
@@ -1,0 +1,45 @@
+# Install a specific version of git and cache it for future runs.
+#
+# To use, add:
+#
+#   - name: Install Git
+#     uses: ./.github/actions/install-git
+#     with:
+#       version: 2.39.1
+#
+# Must run after checkout and mise-action.
+
+name: Install Git
+
+inputs:
+  version:
+    description: 'The version of git to install.'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: Determine Git cache directory
+      id: env
+      shell: bash
+      run: |
+        echo "cache_dir=$HOME/.cache/git/$GIT_VERSION" >> "$GITHUB_OUTPUT"
+      env:
+        GIT_VERSION: ${{ inputs.version }}
+
+    - name: Restore cached Git
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.env.outputs.cache_dir }}
+        key: ${{ runner.os }}-git-${{ inputs.version }}
+
+    - name: Install Git
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: >-
+        go run ./tools/ci/install-git
+        -debian
+        -prefix "$GIT_CACHE_DIR"
+        -version "$GIT_VERSION"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,29 +46,11 @@ jobs:
     - name: Go cache
       uses: ./.github/actions/go-cache
 
-    # TODO: extract into separate action
-    - name: Determine Git cache directory
-      shell: bash
-      if: matrix.git-version != 'system'
-      run: |
-        echo "GIT_VERSION=$GIT_VERSION" >> "$GITHUB_ENV"
-        echo "GIT_CACHE_DIR=$HOME/.cache/git/$GIT_VERSION" >> "$GITHUB_ENV"
-      env:
-        GIT_VERSION: ${{ matrix.git-version }}
-    - name: Fill Git cache
-      if: matrix.git-version != 'system'
-      uses: actions/cache@v4
-      with:
-        path: ${{ env.GIT_CACHE_DIR }}
-        key: ${{ runner.os }}-git-${{ matrix.git-version }}
     - name: Install Git
-      shell: bash
+      uses: ./.github/actions/install-git
       if: matrix.git-version != 'system'
-      run: >-
-        go run ./tools/ci/install-git
-        -debian
-        -prefix "$GIT_CACHE_DIR"
-        -version "$GIT_VERSION"
+      with:
+        version: ${{ matrix.git-version }}
     - name: Report Git version
       shell: bash
       run:


### PR DESCRIPTION
The main CI workflow is messy.
Clean it up a bit with a separate action to install Git.

[skip changelog]: No user facing changes
