### PR TITLE
ci: Run tests with race detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,13 @@ jobs:
         git --version
 
     - name: Test
-      run: mise run ${{ (matrix.no-cover == true) && 'test' || 'cover' }}
+      run: >-  # join lines with spaces
+        mise run
+        ${{ (matrix.no-cover == true) && 'test' || 'cover' }}
+        ${{ (matrix.os != 'windows-latest') && '--race' || '' }}
+      # NB:
+      # Windows tests are already slow.
+      # Run them without race detection to avoid slowing them further.
       shell: bash
       env:
         GOTESTSUM_FORMAT: github-actions

--- a/mise.toml
+++ b/mise.toml
@@ -43,13 +43,13 @@ run = [
 [tasks.test]
 wait_for = ["generate"]
 description = "Run tests"
-run = "gotestsum -- ./..."
+run = "gotestsum -- -race={{flag(name='race')}} ./..."
 
 [tasks.cover]
 wait_for = ["generate"]
 description = "Run tests with coverage"
 run = [
-  "gotestsum -- '-coverprofile=cover.out' '-coverpkg=./...' ./...",
+  "gotestsum -- '-coverprofile=cover.out' '-coverpkg=./...' -race={{flag(name='race')}} ./...",
   "go tool cover '-html=cover.out' -o cover.html",
 ]
 


### PR DESCRIPTION
PR #636 introduced parallel workers for log data collection.
We may add more parallelism in the future.

Race detection was previously disabled to keep test execution time
low back when it was sub 30 seconds.
With Windows tests, it takes 5 minutes anyway,
so there's no reason to keep it disabled for Linux.

[skip changelog]: no user facing changes
