### PR TITLE
commit {create, amend}: Adds --allow-empty flag

### DIFF
--- a/.changes/unreleased/Added-20250425-161027.yaml
+++ b/.changes/unreleased/Added-20250425-161027.yaml
@@ -1,3 +1,3 @@
 kind: Added
-body: 'commit create,amend: Added --allow-empty flag to allow commits without repo changes'
+body: 'commit {create, amend}: Add --allow-empty flag to allow commits without any changes.'
 time: 2025-04-25T16:10:27.297298-07:00

--- a/.changes/unreleased/Added-20250425-161027.yaml
+++ b/.changes/unreleased/Added-20250425-161027.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'commit create,amend: Added --allow-empty flag to allow commits without repo changes'
+time: 2025-04-25T16:10:27.297298-07:00

--- a/commit_amend.go
+++ b/commit_amend.go
@@ -14,7 +14,7 @@ import (
 
 type commitAmendCmd struct {
 	All        bool   `short:"a" help:"Stage all changes before committing."`
-	AllowEmpty bool   `help:"Create a new commit without changing any files in the repository."`
+	AllowEmpty bool   `help:"Create a commit even if it contains no changes."`
 	Message    string `short:"m" placeholder:"MSG" help:"Use the given message as the commit message."`
 
 	NoEdit   bool `help:"Don't edit the commit message"`

--- a/commit_amend.go
+++ b/commit_amend.go
@@ -13,8 +13,9 @@ import (
 )
 
 type commitAmendCmd struct {
-	All     bool   `short:"a" help:"Stage all changes before committing."`
-	Message string `short:"m" placeholder:"MSG" help:"Use the given message as the commit message."`
+	All        bool   `short:"a" help:"Stage all changes before committing."`
+	AllowEmpty bool   `help:"Create a new commit without changing any files in the repository."`
+	Message    string `short:"m" placeholder:"MSG" help:"Use the given message as the commit message."`
 
 	NoEdit   bool `help:"Don't edit the commit message"`
 	NoVerify bool `help:"Bypass pre-commit and commit-msg hooks."`
@@ -46,11 +47,12 @@ func (cmd *commitAmendCmd) Run(
 	}
 
 	if err := repo.Commit(ctx, git.CommitRequest{
-		Message:  cmd.Message,
-		Amend:    true,
-		NoEdit:   cmd.NoEdit,
-		NoVerify: cmd.NoVerify,
-		All:      cmd.All,
+		Message:    cmd.Message,
+		AllowEmpty: cmd.AllowEmpty,
+		Amend:      true,
+		NoEdit:     cmd.NoEdit,
+		NoVerify:   cmd.NoVerify,
+		All:        cmd.All,
 	}); err != nil {
 		return fmt.Errorf("commit: %w", err)
 	}

--- a/commit_create.go
+++ b/commit_create.go
@@ -13,10 +13,11 @@ import (
 )
 
 type commitCreateCmd struct {
-	All      bool   `short:"a" help:"Stage all changes before committing."`
-	Fixup    string `help:"Create a fixup commit."`
-	Message  string `short:"m" help:"Use the given message as the commit message."`
-	NoVerify bool   `help:"Bypass pre-commit and commit-msg hooks."`
+	All        bool   `short:"a" help:"Stage all changes before committing."`
+	AllowEmpty bool   `help:"Create a new commit without changing any files in the repository."`
+	Fixup      string `help:"Create a fixup commit."`
+	Message    string `short:"m" help:"Use the given message as the commit message."`
+	NoVerify   bool   `help:"Bypass pre-commit and commit-msg hooks."`
 }
 
 func (*commitCreateCmd) Help() string {
@@ -36,10 +37,11 @@ func (cmd *commitCreateCmd) Run(
 	svc *spice.Service,
 ) error {
 	if err := repo.Commit(ctx, git.CommitRequest{
-		Message:  cmd.Message,
-		All:      cmd.All,
-		Fixup:    cmd.Fixup,
-		NoVerify: cmd.NoVerify,
+		Message:    cmd.Message,
+		All:        cmd.All,
+		AllowEmpty: cmd.AllowEmpty,
+		Fixup:      cmd.Fixup,
+		NoVerify:   cmd.NoVerify,
 	}); err != nil {
 		return fmt.Errorf("commit: %w", err)
 	}

--- a/commit_create.go
+++ b/commit_create.go
@@ -14,7 +14,7 @@ import (
 
 type commitCreateCmd struct {
 	All        bool   `short:"a" help:"Stage all changes before committing."`
-	AllowEmpty bool   `help:"Create a new commit without changing any files in the repository."`
+	AllowEmpty bool   `help:"Create a new commit even if it contains no changes."`
 	Fixup      string `help:"Create a fixup commit."`
 	Message    string `short:"m" help:"Use the given message as the commit message."`
 	NoVerify   bool   `help:"Bypass pre-commit and commit-msg hooks."`

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -844,6 +844,7 @@ followed by 'gs upstack restack'.
 **Flags**
 
 * `-a`, `--all`: Stage all changes before committing.
+* `--allow-empty`: Create a new commit without changing any files in the repository.
 * `--fixup=STRING`: Create a fixup commit.
 * `-m`, `--message=STRING`: Use the given message as the commit message.
 * `--no-verify`: Bypass pre-commit and commit-msg hooks.
@@ -864,6 +865,7 @@ followed by 'gs upstack restack'.
 **Flags**
 
 * `-a`, `--all`: Stage all changes before committing.
+* `--allow-empty`: Create a new commit without changing any files in the repository.
 * `-m`, `--message=MSG`: Use the given message as the commit message.
 * `--no-edit`: Don't edit the commit message
 * `--no-verify`: Bypass pre-commit and commit-msg hooks.

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -844,7 +844,7 @@ followed by 'gs upstack restack'.
 **Flags**
 
 * `-a`, `--all`: Stage all changes before committing.
-* `--allow-empty`: Create a new commit without changing any files in the repository.
+* `--allow-empty`: Create a new commit even if it contains no changes.
 * `--fixup=STRING`: Create a fixup commit.
 * `-m`, `--message=STRING`: Use the given message as the commit message.
 * `--no-verify`: Bypass pre-commit and commit-msg hooks.
@@ -865,7 +865,7 @@ followed by 'gs upstack restack'.
 **Flags**
 
 * `-a`, `--all`: Stage all changes before committing.
-* `--allow-empty`: Create a new commit without changing any files in the repository.
+* `--allow-empty`: Create a commit even if it contains no changes.
 * `-m`, `--message=MSG`: Use the given message as the commit message.
 * `--no-edit`: Don't edit the commit message
 * `--no-verify`: Bypass pre-commit and commit-msg hooks.

--- a/testdata/script/commit_amend_allow_empty.txt
+++ b/testdata/script/commit_amend_allow_empty.txt
@@ -1,0 +1,27 @@
+# Commit amend with --allow-empty
+
+as 'Test <test@example.com>'
+at '2024-03-30T14:59:32Z'
+
+# setup
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git checkout -b feature
+gs branch track --base main
+
+gs ca --allow-empty -m 'Allow empty commit'
+
+# verify the output
+git log
+cmp stdout $WORK/golden/log.1.txt
+
+-- golden/log.1.txt --
+commit 083acb009676ede496ab78b128ab6a4dc1c15acb
+Author: Test <test@example.com>
+Date:   Sat Mar 30 14:59:32 2024 +0000
+
+    Allow empty commit

--- a/testdata/script/commit_create_allow_empty.txt
+++ b/testdata/script/commit_create_allow_empty.txt
@@ -1,0 +1,33 @@
+# Commit create with --allow-empty
+
+as 'Test <test@example.com>'
+at '2024-03-30T14:59:32Z'
+
+# setup
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git checkout -b feature
+gs branch track --base main
+
+gs cc -m 'Allow empty commit' --allow-empty
+
+# verify the output
+git log
+cmp stdout $WORK/golden/log.1.txt
+
+-- golden/log.1.txt --
+commit 0eab9a007f15066d7308788ce1ef8a664cc27d6a
+Author: Test <test@example.com>
+Date:   Sat Mar 30 14:59:32 2024 +0000
+
+    Allow empty commit
+
+commit 9bad92b764fe1d56cb99b394f373a71cdefd8e86
+Author: Test <test@example.com>
+Date:   Sat Mar 30 14:59:32 2024 +0000
+
+    Initial commit


### PR DESCRIPTION
This allows empty commits to be created and amended. Empty commits contain an message, but no changes to the repository.