### PR TITLE
bco: Allow disabling "do you want to track this branch" prompt

### DIFF
--- a/.changes/unreleased/Added-20250511-105903.yaml
+++ b/.changes/unreleased/Added-20250511-105903.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'branch checkout: Add spice.branchCheckout.trackUntrackedPrompt configuration option to disable prompting to track untracked branches upon checkout.'
+time: 2025-05-11T10:59:03.163752-07:00

--- a/branch_checkout.go
+++ b/branch_checkout.go
@@ -22,6 +22,9 @@ type branchCheckoutCmd struct {
 	checkoutOptions
 	BranchPromptConfig
 
+	// Allow users to opt out of the "branch not tracked" prompt.
+	TrackUntrackedPrompt bool `config:"branchCheckout.trackUntrackedPrompt" hidden:"" default:"true" help:"Whether to prompt to track untracked branches when checked out."`
+
 	Untracked bool   `short:"u" config:"branchCheckout.showUntracked" help:"Show untracked branches if one isn't supplied"`
 	Branch    string `arg:"" optional:"" help:"Name of the branch to checkout" predictor:"branches"`
 }
@@ -93,7 +96,7 @@ func (cmd *branchCheckoutCmd) Run(
 			case errors.As(err, &restackErr):
 				log.Warnf("%v: needs to be restacked: run 'gs branch restack --branch=%v'", cmd.Branch, cmd.Branch)
 			case errors.Is(err, state.ErrNotExist):
-				if !ui.Interactive(view) {
+				if !ui.Interactive(view) || !cmd.TrackUntrackedPrompt {
 					log.Warnf("%v: branch not tracked: run 'gs branch track'", cmd.Branch)
 					break
 				}

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -506,7 +506,7 @@ By default, branches are sorted by name.
 * `--detach`: Detach HEAD after checking out
 * `-u`, `--untracked` ([:material-wrench:{ .middle title="spice.branchCheckout.showUntracked" }](/cli/config.md#spicebranchcheckoutshowuntracked)): Show untracked branches if one isn't supplied
 
-**Configuration**: [spice.branchCheckout.showUntracked](/cli/config.md#spicebranchcheckoutshowuntracked), [spice.branchPrompt.sort](/cli/config.md#spicebranchpromptsort)
+**Configuration**: [spice.branchCheckout.showUntracked](/cli/config.md#spicebranchcheckoutshowuntracked), [spice.branchCheckout.trackUntrackedPrompt](/cli/config.md#spicebranchcheckouttrackuntrackedprompt), [spice.branchPrompt.sort](/cli/config.md#spicebranchpromptsort)
 
 ### gs branch create
 

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -43,6 +43,28 @@ This option controls whether untracked branches are shown in the prompt.
 - `true`
 - `false` (default)
 
+### spice.branchCheckout.trackUntrackedPrompt
+
+<!-- gs:version unreleased -->
+
+If $$gs branch checkout$$ is used to checkout a branch that is not tracked,
+git-spice will present a prompt like the following to begin tracking it:
+
+```freeze language="terminal"
+{green}${reset} gs branch checkout {red}mybranch{reset}
+{yellow}WRN{reset} mybranch: branch not tracked
+{green}Do you want to track this branch now?{reset}: [{mag}Y{reset}/{mag}n{reset}]
+```
+
+This option allows you to disable the prompt
+if you frequently checkout untracked branches
+and don't want to be prompted to track them.
+
+**Accepted values:**
+
+- `true` (default)
+- `false`
+
 ### spice.branchPrompt.sort
 
 <!-- gs:version v0.11.0 -->

--- a/testdata/script/branch_checkout_track_prompt_opt_out.txt
+++ b/testdata/script/branch_checkout_track_prompt_opt_out.txt
@@ -1,0 +1,28 @@
+# Checkout out an untracked branch with 'branch checkout'
+# does not prompt if the user opts out of the prompt.
+
+as 'Test <test@example.com>'
+at '2025-05-11T10:48:49Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git checkout -b feature
+git add foo.txt
+git commit -m 'Add foo.txt'
+
+git checkout main
+
+git config spice.branchCheckout.trackUntrackedPrompt false
+
+# Enable interactive mode, but don't expect a prompt.
+env ROBOT_INPUT=$WORK/robot.golden ROBOT_OUTPUT=$WORK/robot.actual
+gs branch checkout feature
+cmp $WORK/robot.actual $WORK/robot.golden
+stderr 'branch not tracked'
+
+-- repo/foo.txt --
+whatever
+-- robot.golden --


### PR DESCRIPTION
When 'gs branch checkout' is used to checkout a branch
that is not tracked, git-spice presents a prompt to begin tracking it.
This can be annoying if you frequently open untracked branches.

This change adds a configuration option to opt out of the prompt.