### PR TITLE
Add branch prefix option

### DIFF
--- a/.changes/unreleased/Added-20250513-145103.yaml
+++ b/.changes/unreleased/Added-20250513-145103.yaml
@@ -1,3 +1,4 @@
 kind: Added
-body: Add the prefix flag/config for branch creation
+body: |
+  Add 'spice.branchCreate.prefix' configuration option to always add a configured prefix to new branches.
 time: 2025-05-13T14:51:03.004049282-07:00

--- a/.changes/unreleased/Added-20250513-145103.yaml
+++ b/.changes/unreleased/Added-20250513-145103.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add the prefix flag/config for branch creation
+time: 2025-05-13T14:51:03.004049282-07:00

--- a/branch_create.go
+++ b/branch_create.go
@@ -14,7 +14,7 @@ import (
 )
 
 type branchCreateConfig struct {
-	Prefix string `default:"" config:"branchCreate.prefix" help:"Prepend a prefix to the name of the branch being created"`
+	Prefix string `default:"" config:"branchCreate.prefix" help:"Prepend a prefix to the name of the branch being created" hidden:""`
 }
 
 type branchCreateCmd struct {

--- a/branch_create.go
+++ b/branch_create.go
@@ -13,7 +13,13 @@ import (
 	"go.abhg.dev/gs/internal/text"
 )
 
+type branchCreateConfig struct {
+	Prefix string `default:"" config:"branchCreate.prefix" help:"Prepend a prefix to the name of the branch being created"`
+}
+
 type branchCreateCmd struct {
+	branchCreateConfig
+
 	Name string `arg:"" optional:"" help:"Name of the new branch"`
 
 	Insert bool   `help:"Restack the upstack of the target branch onto the new branch"`
@@ -217,6 +223,8 @@ func (cmd *branchCreateCmd) Run(
 		}
 	}
 
+	branchName := cmd.Prefix + cmd.Name
+
 	// Start the transaction and make sure it would work
 	// before actually creating the branch.
 	// This way, if the transaction would've failed anyway
@@ -225,12 +233,12 @@ func (cmd *branchCreateCmd) Run(
 	// and rollback to the original branch and staged changes.
 	branchTx := store.BeginBranchTx()
 	if err := branchTx.Upsert(ctx, state.UpsertRequest{
-		Name:            cmd.Name,
+		Name:            branchName,
 		Base:            baseName,
 		BaseHash:        baseHash,
 		MergedDownstack: newMergedDownstack,
 	}); err != nil {
-		return fmt.Errorf("add branch %v with base %v: %w", cmd.Name, baseName, err)
+		return fmt.Errorf("add branch %v with base %v: %w", branchName, baseName, err)
 	}
 
 	for _, branch := range restackOntoNew {
@@ -240,7 +248,7 @@ func (cmd *branchCreateCmd) Run(
 		// We'll run a restack command after this to update the state.
 		if err := branchTx.Upsert(ctx, state.UpsertRequest{
 			Name:            branch,
-			Base:            cmd.Name,
+			Base:            branchName,
 			MergedDownstack: restackedMergedDownstack,
 		}); err != nil {
 			return fmt.Errorf("update base branch of %v: %w", branch, err)
@@ -248,25 +256,25 @@ func (cmd *branchCreateCmd) Run(
 	}
 
 	if err := repo.CreateBranch(ctx, git.CreateBranchRequest{
-		Name: cmd.Name,
+		Name: branchName,
 		Head: branchAt.String(),
 	}); err != nil {
 		return fmt.Errorf("create branch: %w", err)
 	}
 
 	branchCreated = true
-	if err := repo.Checkout(ctx, cmd.Name); err != nil {
+	if err := repo.Checkout(ctx, branchName); err != nil {
 		return fmt.Errorf("checkout branch: %w", err)
 	}
 
 	var msg string
 	switch {
 	case cmd.Below:
-		msg = fmt.Sprintf("insert branch %s below %s", cmd.Name, cmd.Target)
+		msg = fmt.Sprintf("insert branch %s below %s", branchName, cmd.Target)
 	case cmd.Insert:
-		msg = fmt.Sprintf("insert branch %s above %s", cmd.Name, cmd.Target)
+		msg = fmt.Sprintf("insert branch %s above %s", branchName, cmd.Target)
 	default:
-		msg = "create branch " + cmd.Name
+		msg = "create branch " + branchName
 	}
 
 	if err := branchTx.Commit(ctx, msg); err != nil {

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -571,7 +571,6 @@ target (A) to the specified branch:
 
 **Flags**
 
-* `--prefix=""` ([:material-wrench:{ .middle title="spice.branchCreate.prefix" }](/cli/config.md#spicebranchcreateprefix)): Prepend a prefix to the name of the branch being created
 * `--insert`: Restack the upstack of the target branch onto the new branch
 * `--below`: Place the branch below the target branch and restack its upstack
 * `-t`, `--target=BRANCH`: Branch to create the new branch above/below

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -571,6 +571,7 @@ target (A) to the specified branch:
 
 **Flags**
 
+* `--prefix=""` ([:material-wrench:{ .middle title="spice.branchCreate.prefix" }](/cli/config.md#spicebranchcreateprefix)): Prepend a prefix to the name of the branch being created
 * `--insert`: Restack the upstack of the target branch onto the new branch
 * `--below`: Place the branch below the target branch and restack its upstack
 * `-t`, `--target=BRANCH`: Branch to create the new branch above/below
@@ -579,7 +580,7 @@ target (A) to the specified branch:
 * `--no-verify`: Bypass pre-commit and commit-msg hooks.
 * `--[no-]commit` ([:material-wrench:{ .middle title="spice.branchCreate.commit" }](/cli/config.md#spicebranchcreatecommit)): Commit staged changes to the new branch, or create an empty commit
 
-**Configuration**: [spice.branchCreate.commit](/cli/config.md#spicebranchcreatecommit)
+**Configuration**: [spice.branchCreate.commit](/cli/config.md#spicebranchcreatecommit), [spice.branchCreate.prefix](/cli/config.md#spicebranchcreateprefix)
 
 ### gs branch delete
 

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -100,6 +100,18 @@ and use the `--commit` flag to commit changes when needed.
 - `true` (default)
 - `false`
 
+### spice.branchCreate.prefix
+
+<!-- gs:version v0.14.0 -->
+
+If set, the prefix will be prepended to the name of every branch created 
+with $$gs branch create$$.
+
+Commonly used values are:
+
+- `<name>/`: the committers name
+- `<username>/`: the committers username
+
 ### spice.forge.github.apiUrl
 
 URL at which the GitHub API is available.

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -102,7 +102,7 @@ and use the `--commit` flag to commit changes when needed.
 
 ### spice.branchCreate.prefix
 
-<!-- gs:version v0.14.0 -->
+<!-- gs:version unreleased -->
 
 If set, the prefix will be prepended to the name of every branch created 
 with $$gs branch create$$.

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -109,8 +109,8 @@ with $$gs branch create$$.
 
 Commonly used values are:
 
-- `<name>/`: the committers name
-- `<username>/`: the committers username
+- `<name>/`: the committer's name
+- `<username>/`: the committer's username
 
 ### spice.forge.github.apiUrl
 

--- a/testdata/script/branch_create_prefix.txt
+++ b/testdata/script/branch_create_prefix.txt
@@ -1,0 +1,25 @@
+# branch create with spice.branchCreate.prefix adds a prefix to the name.
+
+as 'Test <test@example.com>'
+at '2025-05-13T20:18:32Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git config spice.branchCreate.prefix 'myuser/'
+
+git add feature.txt
+gs bc feature -m 'Add feature'
+
+gs ll -a
+cmp stderr $WORK/golden/ll.txt
+
+-- repo/feature.txt --
+feature
+
+-- golden/ll.txt --
+┏━■ myuser/feature ◀
+┃   eb4b3b8 Add feature (now)
+main


### PR DESCRIPTION
It'd be nice to be able to always add a prefix to the name of any branch that gets created.

Addresses https://github.com/abhinav/git-spice/issues/656