### PR TITLE
state: detect upstream ref deletion

### DIFF
--- a/.changes/unreleased/Fixed-20250517-164653.yaml
+++ b/.changes/unreleased/Fixed-20250517-164653.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: >-
+  If a remote branch reference (e.g. origin/feature)
+  is deleted after pushing to it with git-spice,
+  we will no longer hold onto the stale reference.
+time: 2025-05-17T16:46:53.993389-07:00

--- a/internal/spice/state/branch_int_test.go
+++ b/internal/spice/state/branch_int_test.go
@@ -1,0 +1,117 @@
+package state
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBranchChangeStateUnmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		give string
+
+		want    *branchChangeState
+		wantErr string
+	}{
+		{
+			name: "Valid",
+			give: `{"github": {"number": 123}}`,
+			want: &branchChangeState{
+				Forge:  "github",
+				Change: json.RawMessage(`{"number": 123}`),
+			},
+		},
+		{
+			name:    "NotAnObject",
+			give:    `123`,
+			wantErr: "unmarshal change state",
+		},
+		{
+			name: "MultipleForges",
+			give: `{
+				"github": {"number": 123},
+				"gitlab": {"number": 456}
+			}`,
+			wantErr: "expected 1 forge key, got 2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got branchChangeState
+			err := json.Unmarshal([]byte(tt.give), &got)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, &got)
+		})
+	}
+}
+
+func TestBranchStateUnmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		give string
+
+		want    *branchState
+		wantErr string
+	}{
+		{
+			name: "Simple",
+			give: `{
+				"base": {"name": "main", "hash": "abc123"},
+				"upstream": {"branch": "main"},
+				"change": {"github": {"number": 123}}
+			}`,
+			want: &branchState{
+				Base: branchStateBase{
+					Name: "main",
+					Hash: "abc123",
+				},
+				Upstream: &branchUpstreamState{
+					Branch: "main",
+				},
+				Change: &branchChangeState{
+					Forge:  "github",
+					Change: json.RawMessage(`{"number": 123}`),
+				},
+			},
+		},
+
+		{
+			name: "NoUpstream",
+			give: `{
+				"base": {"name": "main", "hash": "abc123"}
+			}`,
+			want: &branchState{
+				Base: branchStateBase{
+					Name: "main",
+					Hash: "abc123",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got branchState
+			err := json.Unmarshal([]byte(tt.give), &got)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, &got)
+		})
+	}
+}

--- a/internal/spice/state/statetest/statetest.go
+++ b/internal/spice/state/statetest/statetest.go
@@ -1,0 +1,45 @@
+// Package statetest provides utilities for testing code
+// that makes use of the state package.
+package statetest
+
+import (
+	"context"
+	"fmt"
+
+	"go.abhg.dev/gs/internal/spice/state"
+)
+
+// UpdateRequest is a request to add, update, or delete information about branches.
+type UpdateRequest struct {
+	// Upserts are requests to add or update information about branches.
+	Upserts []state.UpsertRequest
+
+	// Deletes are requests to delete information about branches.
+	Deletes []string
+
+	// Message is a message specifying the reason for the update.
+	// This will be persisted in the Git commit message.
+	Message string
+}
+
+// UpdateBranch applies an UpdateRequest to the given Store in a transaction.
+func UpdateBranch(ctx context.Context, s *state.Store, req *UpdateRequest) error {
+	tx := s.BeginBranchTx()
+	for idx, upsert := range req.Upserts {
+		if err := tx.Upsert(ctx, upsert); err != nil {
+			return fmt.Errorf("upsert [%d] %q: %w", idx, upsert.Name, err)
+		}
+	}
+
+	for idx, name := range req.Deletes {
+		if err := tx.Delete(ctx, name); err != nil {
+			return fmt.Errorf("delete [%d] %q: %w", idx, name, err)
+		}
+	}
+
+	if err := tx.Commit(ctx, req.Message); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+
+	return nil
+}

--- a/internal/spice/state/store_test.go
+++ b/internal/spice/state/store_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.abhg.dev/gs/internal/logutil"
 	"go.abhg.dev/gs/internal/spice/state"
+	"go.abhg.dev/gs/internal/spice/state/statetest"
 	"go.abhg.dev/gs/internal/spice/state/storage"
 )
 
@@ -29,7 +30,7 @@ func TestStore(t *testing.T) {
 		assert.ErrorIs(t, err, state.ErrNotExist)
 	})
 
-	err = state.UpdateBranch(ctx, store, &state.UpdateRequest{
+	err = statetest.UpdateBranch(ctx, store, &statetest.UpdateRequest{
 		Upserts: []state.UpsertRequest{{
 			Name:           "foo",
 			Base:           "main",
@@ -51,7 +52,7 @@ func TestStore(t *testing.T) {
 		assert.JSONEq(t, `{"number": 42}`, string(res.ChangeMetadata))
 	})
 
-	require.NoError(t, state.UpdateBranch(ctx, store, &state.UpdateRequest{
+	require.NoError(t, statetest.UpdateBranch(ctx, store, &statetest.UpdateRequest{
 		Upserts: []state.UpsertRequest{{
 			Name:           "bar2",
 			Base:           "main",
@@ -63,7 +64,7 @@ func TestStore(t *testing.T) {
 
 	t.Run("overwrite", func(t *testing.T) {
 		ctx := t.Context()
-		err := state.UpdateBranch(ctx, store, &state.UpdateRequest{
+		err := statetest.UpdateBranch(ctx, store, &statetest.UpdateRequest{
 			Upserts: []state.UpsertRequest{
 				{
 					Name:           "foo",
@@ -87,7 +88,7 @@ func TestStore(t *testing.T) {
 
 	t.Run("name with slash", func(t *testing.T) {
 		ctx := t.Context()
-		err := state.UpdateBranch(ctx, store, &state.UpdateRequest{
+		err := statetest.UpdateBranch(ctx, store, &statetest.UpdateRequest{
 			Upserts: []state.UpsertRequest{{
 				Name:           "bar/baz",
 				Base:           "main",
@@ -109,7 +110,7 @@ func TestStore(t *testing.T) {
 	t.Run("upstream branch", func(t *testing.T) {
 		ctx := t.Context()
 		upstream := "remoteBranch"
-		err := state.UpdateBranch(ctx, store, &state.UpdateRequest{
+		err := statetest.UpdateBranch(ctx, store, &statetest.UpdateRequest{
 			Upserts: []state.UpsertRequest{{
 				Name:           "localBranch",
 				Base:           "main",

--- a/testdata/script/branch_submit_rename_and_delete_after_push.txt
+++ b/testdata/script/branch_submit_rename_and_delete_after_push.txt
@@ -1,0 +1,48 @@
+# 'branch submit --no-publish' followed by renaming the branch
+# and deleting the upstream branch ref should use the new branch name.
+
+as 'Test <test@example.com>'
+at '2025-05-17T17:58:32Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+git add feature.txt
+gs bc -m 'add feature' feat
+gs bs --no-publish
+
+git graph
+cmp stdout $WORK/golden/graph-before.txt
+
+# verify no PRs
+shamhub dump changes
+stdout '^\[\]$'
+
+# rename the branch, delete the upstream ref
+gs branch rename feature
+git push origin :feat
+git branch --unset-upstream
+
+# push again
+gs bs --no-publish
+git graph
+cmp stdout $WORK/golden/graph-after.txt
+
+-- repo/feature.txt --
+feature
+-- golden/graph-before.txt --
+* 333a263 (HEAD -> feat, origin/feat) add feature
+* fc89e28 (origin/main, main) Initial commit
+-- golden/graph-after.txt --
+* 333a263 (HEAD -> feature, origin/feature) add feature
+* fc89e28 (origin/main, main) Initial commit


### PR DESCRIPTION
If an upstream branch reference is deleted manually
(e.g. with git push --delete, or by deleting the remote branch),
then the state's local knowledge of the upstream branch name is stale
and should be deleted.

This does not solve, but helps with issues like #655,
as the user won't have to untrack the branch
to delete stale information.