### PR TITLE
doc/cliref: Include environment variables

### DIFF
--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -8,7 +8,7 @@ gs (git-spice) is a command line tool for stacking Git branches.
 
 * `-h`, `--help`: Show help for the command
 * `--version`: Print version information and quit
-* `-v`, `--verbose`: Enable verbose output
+* `-v`, `--verbose`, `$GIT_SPICE_VERBOSE`: Enable verbose output
 * `-C`, `--dir=DIR`: Change to DIR before doing anything
 * `--[no-]prompt`: Whether to prompt for missing information
 

--- a/dumpmd.go
+++ b/dumpmd.go
@@ -280,6 +280,12 @@ func (cmd cliDumper) dumpFlag(flag *kong.Flag) {
 	}
 	cmd.printf("`")
 
+	// If the flag can be set with an environment variable,
+	// mention that here.
+	if env := flag.Tag.Get("env"); env != "" {
+		cmd.printf(", `$%s`", env)
+	}
+
 	// If the flag can also be set by configuration,
 	// add a link to /cli/config.md#<key>.
 	// This will ensure all configuration keys are documented.


### PR DESCRIPTION
If a flag can be set with an environment variable,
mention that in the CLI reference.