### PR TITLE
feat: add ctrl+k and ctrl+j navigation keys for select uis

### DIFF
--- a/.changes/unreleased/Added-20250521-144134.yaml
+++ b/.changes/unreleased/Added-20250521-144134.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Support CTRL+J/K to navigate selection UIs that accept text input, i.e branch selection.
+time: 2025-05-21T14:41:34.94713-07:00

--- a/internal/ui/select.go
+++ b/internal/ui/select.go
@@ -22,11 +22,11 @@ type SelectKeyMap struct {
 // DefaultSelectKeyMap is the default key map for a [Select].
 var DefaultSelectKeyMap = SelectKeyMap{
 	Up: key.NewBinding(
-		key.WithKeys("up"),
+		key.WithKeys("up", "ctrl+k"),
 		key.WithHelp("up", "go up"),
 	),
 	Down: key.NewBinding(
-		key.WithKeys("down"),
+		key.WithKeys("down", "ctrl+j"),
 		key.WithHelp("down", "go down"),
 	),
 	Accept: key.NewBinding(

--- a/internal/ui/widget/branch_select.go
+++ b/internal/ui/widget/branch_select.go
@@ -28,11 +28,11 @@ type BranchSelectKeyMap struct {
 // DefaultBranchSelectKeyMap is the default key map for a [Select].
 var DefaultBranchSelectKeyMap = BranchSelectKeyMap{
 	Up: key.NewBinding(
-		key.WithKeys("up"),
+		key.WithKeys("up", "ctrl+k"),
 		key.WithHelp("up", "go up"),
 	),
 	Down: key.NewBinding(
-		key.WithKeys("down"),
+		key.WithKeys("down", "ctrl+j"),
 		key.WithHelp("down", "go down"),
 	),
 	Accept: key.NewBinding(


### PR DESCRIPTION
in addition to up and down arrows, to navigate selection lists where text input is allowed to refine the list of options, this adds ctrl+k and ctrl+j as alternatives, similar to other tools like fzf.

i didn't see existing tests for up/down to build off of, but i did manually test this locally and it behaves as expected.