### PR TITLE
Custom slog-based Logger

### DIFF
--- a/internal/log/attr.go
+++ b/internal/log/attr.go
@@ -1,0 +1,13 @@
+package log
+
+import "log/slog"
+
+// NonZero returns a slog attribute for a non-zero value.
+// If the value is zero, the attribute is not included in the log.
+func NonZero[T comparable](name string, value T) slog.Attr {
+	var zero T
+	if value == zero {
+		return slog.Attr{}
+	}
+	return slog.Any(name, value)
+}

--- a/internal/log/attr_test.go
+++ b/internal/log/attr_test.go
@@ -1,0 +1,32 @@
+package log_test
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.abhg.dev/gs/internal/log"
+)
+
+func TestNonZero(t *testing.T) {
+	t.Run("Int", func(t *testing.T) {
+		zero := log.NonZero("zero", 0)
+		one := log.NonZero("one", 1)
+		assert.True(t, zero.Equal(slog.Attr{}))
+		assert.True(t, one.Equal(slog.Int("one", 1)))
+	})
+
+	t.Run("String", func(t *testing.T) {
+		empty := log.NonZero("empty", "")
+		one := log.NonZero("one", "1")
+		assert.True(t, empty.Equal(slog.Attr{}))
+		assert.True(t, one.Equal(slog.String("one", "1")))
+	})
+
+	t.Run("Bool", func(t *testing.T) {
+		zero := log.NonZero("zero", false)
+		one := log.NonZero("one", true)
+		assert.True(t, zero.Equal(slog.Attr{}))
+		assert.True(t, one.Equal(slog.Bool("one", true)))
+	})
+}

--- a/internal/log/handler.go
+++ b/internal/log/handler.go
@@ -1,0 +1,297 @@
+package log
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"go.abhg.dev/gs/internal/must"
+)
+
+// logHandler is a slog.Handler that writes to an io.Writer
+// with colored output.
+//
+// Output is in a logfmt-style format, with colored levels.
+// Other features include:
+//
+//   - rendering of trace level
+//   - multi-line fields are indented and aligned
+type logHandler struct {
+	lvl   slog.Leveler // required
+	style *Style       // required
+	outMu *sync.Mutex  // required
+	out   io.Writer    // required
+
+	// attrs holds attributes that have already been serialized
+	// with WithAttrs.
+	//
+	// This is set only at construction time (e.g. WithAttrs)
+	// and not modified afterwards.
+	attrs []byte
+
+	// groups is the current group stack.
+	groups []string
+
+	// prefix is a prefix added to each log line.
+	prefix string
+}
+
+var _ slog.Handler = (*logHandler)(nil)
+
+func newLogHandler(out io.Writer, lvl slog.Leveler, style *Style) *logHandler {
+	must.NotBeNilf(out, "output writer cannot be nil")
+	must.NotBeNilf(lvl, "leveler cannot be nil")
+	must.NotBeNilf(style, "style cannot be nil")
+
+	return &logHandler{
+		lvl:   lvl,
+		style: style,
+		outMu: new(sync.Mutex),
+		out:   out,
+	}
+}
+
+func (l *logHandler) Enabled(_ context.Context, lvl slog.Level) bool {
+	return l.lvl.Level() <= lvl
+}
+
+const (
+	lvlDelim     = " "  // separator between level and message
+	groupDelim   = "."  // separator between group names
+	msgAttrDelim = "  " // separator between message and attributes
+	attrDelim    = " "  // separator between attributes
+	indent       = "  " // indentation for multi-line attributes
+)
+
+func (l *logHandler) Handle(_ context.Context, rec slog.Record) error {
+	bs := *takeBuf()
+	defer releaseBuf(&bs)
+
+	lvlString := l.style.LevelLabels.Get(Level(rec.Level)).String()
+	// If the message is multi-line, we'll need to prepend the level
+	// to each line.
+	for line := range strings.Lines(rec.Message) {
+		bs = append(bs, lvlString...)
+		bs = append(bs, lvlDelim...)
+
+		var msg string
+		if l.prefix == "" {
+			msg = line
+		} else {
+			var sb strings.Builder
+			sb.WriteString(l.prefix)
+			sb.WriteString(l.style.PrefixDelimiter.Render())
+			sb.WriteString(line)
+			msg = sb.String()
+		}
+
+		msg = l.style.Messages.Get(Level(rec.Level)).Render(msg)
+		bs = append(bs, msg...)
+	}
+
+	// First attribute after the message is separated by two spaces.
+	bs = append(bs, msgAttrDelim...)
+
+	// withAttrs attributes are serialized into the buffer
+	if len(l.attrs) > 0 {
+		bs = append(bs, l.attrs...)
+	}
+
+	// Write the attributes.
+	formatter := attrFormatter{
+		buf:    bs,
+		style:  l.style,
+		groups: slices.Clone(l.groups),
+	}
+	rec.Attrs(func(attr slog.Attr) bool {
+		formatter.FormatAttr(attr)
+		return true
+	})
+	bs = formatter.buf
+
+	// Always a single trailing newline.
+	bs = append(bytes.TrimRight(bs, " \n"), '\n')
+
+	l.outMu.Lock()
+	defer l.outMu.Unlock()
+	_, err := l.out.Write(bs)
+	return err
+}
+
+func (l *logHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	f := attrFormatter{
+		buf:    slices.Clone(l.attrs),
+		groups: slices.Clone(l.groups),
+		style:  l.style,
+	}
+	for _, attr := range attrs {
+		f.FormatAttr(attr)
+	}
+	bs := f.buf
+
+	newL := *l
+	newL.attrs = bs
+	return &newL
+}
+
+func (l *logHandler) WithGroup(name string) slog.Handler {
+	newL := *l
+	newL.groups = append(slices.Clone(l.groups), name)
+	return &newL
+}
+
+func (l *logHandler) WithPrefix(prefix string) slog.Handler {
+	newL := *l
+	newL.prefix = prefix
+	return &newL
+}
+
+type attrFormatter struct {
+	buf    []byte
+	style  *Style
+	groups []string
+}
+
+func (f *attrFormatter) FormatAttr(attr slog.Attr) {
+	if attr.Equal(slog.Attr{}) {
+		return // skip empty attributes
+	}
+
+	value := attr.Value.Resolve()
+	if value.Kind() == slog.KindGroup {
+		// Groups just get splatted into their attributes
+		// prefixed with the group name.
+		f.groups = append(f.groups, attr.Key)
+		for _, a := range value.Group() {
+			f.FormatAttr(a)
+		}
+		f.groups = f.groups[:len(f.groups)-1]
+		return
+	}
+
+	// We serialize the attribute into a byte slice,
+	// and then decide how it goes into the output.
+	// This is because we need to handle multi-line attributes
+	// and indent them.
+	valbs := *takeBuf()
+	defer releaseBuf(&valbs)
+
+	switch value.Kind() {
+	case slog.KindBool:
+		valbs = strconv.AppendBool(valbs, value.Bool())
+	case slog.KindDuration:
+		valbs = append(valbs, value.Duration().String()...)
+	case slog.KindFloat64:
+		valbs = strconv.AppendFloat(valbs, value.Float64(), 'g', -1, 64)
+	case slog.KindInt64:
+		valbs = strconv.AppendInt(valbs, value.Int64(), 10)
+	case slog.KindString:
+		valbs = append(valbs, value.String()...)
+	case slog.KindTime:
+		valbs = value.Time().AppendFormat(valbs, time.Kitchen)
+	case slog.KindUint64:
+		valbs = strconv.AppendUint(valbs, value.Uint64(), 10)
+	default:
+		// TODO: reflection to handle structs, maps, slices, etc.
+		valbs = append(valbs, value.String()...)
+	}
+
+	// Add delimiter between attrs.
+	if len(f.buf) > 0 {
+		switch {
+		case f.buf[len(f.buf)-1] == '\n':
+			// If the last thing we wrote was multi-line,
+			// then we need to indent the next attribute.
+			f.buf = append(f.buf, indent...)
+		case f.buf[len(f.buf)-1] != ' ':
+			// All other attributes are separated by a space.
+			f.buf = append(f.buf, attrDelim...)
+		}
+	}
+
+	// Single-line attributes are rendered as:
+	//
+	//   key=value
+	//
+	// Multi-line attributes are rendered as:
+	//
+	//   key=
+	//     | line 1
+	//     | line 2
+	isMultiline := bytes.ContainsAny(valbs, "\r\n")
+	if isMultiline {
+		f.buf = append(f.buf, '\n')
+		f.buf = append(f.buf, indent...)
+	}
+
+	f.formatKey(attr.Key)
+	f.buf = append(f.buf, f.style.KeyValueDelimiter.Render()...) // =
+
+	valueStyle, hasStyle := f.style.Values[attr.Key]
+	if isMultiline {
+		prefixStyle := f.style.MultilinePrefix
+		if hasStyle {
+			prefixStyle = prefixStyle.Foreground(valueStyle.GetForeground())
+		}
+		prefix := indent + prefixStyle.Render()
+
+		// TODO: \r handling
+		f.buf = append(f.buf, '\n')
+		for line := range bytes.Lines(valbs) {
+			f.buf = append(f.buf, prefix...)
+			line = bytes.TrimRight(line, "\r\n")
+			if hasStyle {
+				f.buf = append(f.buf, valueStyle.Render(string(line))...)
+			} else {
+				f.buf = append(f.buf, line...) // includes \n already
+			}
+			f.buf = append(f.buf, '\n')
+		}
+
+		// If multi-line attribute value does not end with a newline,
+		// add one.
+		if f.buf[len(f.buf)-1] != '\n' {
+			f.buf = append(f.buf, '\n')
+		}
+	} else {
+		if hasStyle {
+			f.buf = append(f.buf, valueStyle.Render(string(valbs))...)
+		} else {
+			f.buf = append(f.buf, valbs...)
+		}
+	}
+}
+
+// formatKey writes a group-prefixed key to the buffer.
+func (f *attrFormatter) formatKey(key string) {
+	for _, group := range f.groups {
+		if group != "" {
+			f.buf = append(f.buf, f.style.Key.Render(group)...)
+			f.buf = append(f.buf, groupDelim...)
+		}
+	}
+	f.buf = append(f.buf, f.style.Key.Render(key)...)
+}
+
+var _bufPool = &sync.Pool{
+	New: func() any {
+		bs := make([]byte, 0, 1024)
+		return &bs
+	},
+}
+
+func takeBuf() *[]byte {
+	bs := _bufPool.Get().(*[]byte)
+	*bs = (*bs)[:0]
+	return bs
+}
+
+func releaseBuf(bs *[]byte) {
+	_bufPool.Put(bs)
+}

--- a/internal/log/handler_test.go
+++ b/internal/log/handler_test.go
@@ -1,0 +1,180 @@
+package log
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"testing/slogtest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogHandler_Enabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		leveler  slog.Leveler
+		enabled  []Level
+		disabled []Level
+	}{
+		{
+			name:    "trace",
+			leveler: LevelTrace,
+			enabled: []Level{LevelTrace, LevelDebug, LevelInfo},
+		},
+		{
+			name:     "debug",
+			leveler:  LevelDebug,
+			enabled:  []Level{LevelDebug, LevelInfo},
+			disabled: []Level{LevelTrace},
+		},
+		{
+			name:     "info",
+			leveler:  LevelInfo,
+			enabled:  []Level{LevelInfo, LevelWarn},
+			disabled: []Level{LevelDebug, LevelTrace},
+		},
+		{
+			name:     "warn",
+			leveler:  LevelWarn,
+			enabled:  []Level{LevelWarn, LevelError},
+			disabled: []Level{LevelDebug, LevelInfo},
+		},
+		{
+			name:     "error",
+			leveler:  LevelError,
+			enabled:  []Level{LevelError, LevelFatal},
+			disabled: []Level{LevelInfo, LevelWarn},
+		},
+		{
+			name:     "fatal",
+			leveler:  LevelFatal,
+			enabled:  []Level{LevelFatal},
+			disabled: []Level{LevelWarn, LevelError},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newLogHandler(io.Discard, tt.leveler, PlainStyle())
+			for _, level := range tt.enabled {
+				assert.True(t, h.Enabled(t.Context(), level.Level()), "level %s should be enabled", level)
+			}
+			for _, level := range tt.disabled {
+				assert.False(t, h.Enabled(t.Context(), level.Level()), "level %s should be disabled", level)
+			}
+		})
+	}
+}
+
+func TestLogHandler_withAttrsConcurrent(t *testing.T) {
+	const (
+		NumWorkers = 10
+		NumWrites  = 100
+	)
+
+	var buffer strings.Builder
+	log := slog.New(newLogHandler(&buffer, LevelDebug, PlainStyle()))
+
+	var ready, done sync.WaitGroup
+	ready.Add(NumWorkers)
+	for range NumWorkers {
+		done.Add(1)
+		go func() {
+			defer done.Done()
+
+			ready.Done()
+			ready.Wait()
+
+			for i := range NumWrites {
+				log.Info("message", "i", i)
+			}
+		}()
+	}
+
+	done.Wait()
+
+	assert.Equal(t, NumWorkers*NumWrites, strings.Count(buffer.String(), "INF message"))
+}
+
+func TestLogHandler_slogtest(t *testing.T) {
+	var (
+		buffer strings.Builder
+		saver  saveTimeHandler
+	)
+	slogtest.Run(t, func(*testing.T) slog.Handler {
+		buffer.Reset()
+
+		saver.Handler = newLogHandler(&buffer, slog.LevelDebug, PlainStyle())
+		return &saver
+	}, func(t *testing.T) map[string]any {
+		attrs := make(map[string]any)
+		if !saver.saved.IsZero() {
+			attrs[slog.TimeKey] = saver.saved
+		}
+
+		line := strings.TrimSpace(buffer.String())
+		lvlstr, line, ok := strings.Cut(line, lvlDelim)
+		require.True(t, ok, "missing level delimiter: %q", buffer.String())
+
+		switch lvlstr {
+		case "DBG":
+			attrs[slog.LevelKey] = slog.LevelDebug
+		case "INF":
+			attrs[slog.LevelKey] = slog.LevelInfo
+		case "WRN":
+			attrs[slog.LevelKey] = slog.LevelWarn
+		case "ERR":
+			attrs[slog.LevelKey] = slog.LevelError
+		default:
+			t.Fatalf("unknown level: %q", lvlstr)
+		}
+
+		attrs[slog.MessageKey], line, _ = strings.Cut(line, msgAttrDelim)
+
+		for pair := range strings.SplitSeq(line, attrDelim) {
+			if pair == "" {
+				continue
+			}
+			key, value, ok := strings.Cut(pair, "=")
+			require.True(t, ok, "missing attribute delimiter: %q", pair)
+
+			curAttrs := attrs
+			for len(key) > 0 {
+				groupKey, valKey, ok := strings.Cut(key, groupDelim)
+				if !ok {
+					// No more groups.
+					curAttrs[key] = value
+					break
+				}
+
+				groupAttrs, ok := curAttrs[groupKey].(map[string]any)
+				if !ok {
+					groupAttrs = make(map[string]any)
+					curAttrs[groupKey] = groupAttrs
+				}
+				curAttrs = groupAttrs
+				key = valKey
+			}
+		}
+
+		t.Logf("buffer: %q", buffer.String())
+		t.Logf("attrs: %q", attrs)
+		return attrs
+	})
+}
+
+type saveTimeHandler struct {
+	slog.Handler
+
+	saved time.Time
+}
+
+func (h *saveTimeHandler) Handle(ctx context.Context, rec slog.Record) error {
+	h.saved = rec.Time
+	return h.Handler.Handle(ctx, rec)
+}

--- a/internal/log/level.go
+++ b/internal/log/level.go
@@ -1,0 +1,83 @@
+package log
+
+import "log/slog"
+
+// Level is a log level.
+type Level slog.Level
+
+var _ slog.Leveler = (Level)(0)
+
+// Supported log levels.
+const (
+	LevelTrace = Level(-8)
+	LevelDebug = Level(slog.LevelDebug)
+	LevelInfo  = Level(slog.LevelInfo)
+	LevelWarn  = Level(slog.LevelWarn)
+	LevelError = Level(slog.LevelError)
+	LevelFatal = Level(16)
+)
+
+// Levels is a list of all supported log levels.
+var Levels = []Level{
+	LevelTrace,
+	LevelDebug,
+	LevelInfo,
+	LevelWarn,
+	LevelError,
+	LevelFatal,
+}
+
+// String returns the string representation of the log level.
+func (l Level) String() string {
+	switch l {
+	case LevelTrace:
+		return "trace"
+	case LevelDebug:
+		return "debug"
+	case LevelInfo:
+		return "info"
+	case LevelWarn:
+		return "warn"
+	case LevelError:
+		return "error"
+	case LevelFatal:
+		return "fatal"
+	default:
+		return slog.Level(l).String()
+	}
+}
+
+// Level returns the level as a slog.Level.
+func (l Level) Level() slog.Level {
+	return slog.Level(l)
+}
+
+// ByLevel is a struct that contains fields for each log level.
+type ByLevel[T any] struct {
+	Trace T
+	Debug T
+	Info  T
+	Warn  T
+	Error T
+	Fatal T
+}
+
+// Get returns the value associated with the given log level.
+func (b *ByLevel[T]) Get(lvl Level) T {
+	switch lvl {
+	case LevelTrace:
+		return b.Trace
+	case LevelDebug:
+		return b.Debug
+	case LevelInfo:
+		return b.Info
+	case LevelWarn:
+		return b.Warn
+	case LevelError:
+		return b.Error
+	case LevelFatal:
+		return b.Fatal
+	default:
+		panic("invalid log level: " + lvl.String())
+	}
+}

--- a/internal/log/level_test.go
+++ b/internal/log/level_test.go
@@ -1,0 +1,65 @@
+package log_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.abhg.dev/gs/internal/log"
+)
+
+func TestLevel_String(t *testing.T) {
+	tests := []struct {
+		level    log.Level
+		expected string
+	}{
+		{log.LevelTrace, "trace"},
+		{log.LevelDebug, "debug"},
+		{log.LevelInfo, "info"},
+		{log.LevelWarn, "warn"},
+		{log.LevelError, "error"},
+		{log.LevelFatal, "fatal"},
+		{log.Level(100), "ERROR+92"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.level.String())
+		})
+	}
+}
+
+func TestByLevel_Get(t *testing.T) {
+	byLevel := log.ByLevel[string]{
+		Trace: "trace",
+		Debug: "debug",
+		Info:  "info",
+		Warn:  "warn",
+		Error: "error",
+		Fatal: "fatal",
+	}
+
+	tests := []struct {
+		level log.Level
+		want  string
+	}{
+		{log.LevelTrace, "trace"},
+		{log.LevelDebug, "debug"},
+		{log.LevelInfo, "info"},
+		{log.LevelWarn, "warn"},
+		{log.LevelError, "error"},
+		{log.LevelFatal, "fatal"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := byLevel.Get(tt.level)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	t.Run("unknown", func(t *testing.T) {
+		assert.Panics(t, func() {
+			byLevel.Get(log.Level(100))
+		})
+	})
+}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,0 +1,202 @@
+// Package log wraps slog.Logger with support for:
+//
+//   - printf-style functions for each level
+//     to break out of structured logging when needed
+//   - trace and fatal levels
+package log
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+
+	"github.com/mattn/go-isatty"
+	"go.abhg.dev/gs/internal/must"
+)
+
+// Options defines options for the logger.
+type Options struct {
+	// Level is the minimum log level to log.
+	// It must be one of the supported log levels.
+	// The default is LevelInfo.
+	Level Level
+
+	// OnFatal is a function that will be called
+	// when a fatal log message is logged.
+	//
+	// This SHOULD stop control flow.
+	// If it does not, the default implementation will panic.
+	//
+	// If unset, the program will exit with a non-zero status code
+	// when a fatal log message is logged.
+	OnFatal func() // optional
+
+	// Style is the style to use for the logger.
+	// If unset, the style will be picked based on whether
+	// the output is a terminal or not.
+	Style *Style // optional
+}
+
+// Logger is a logger that provided structured and printf-style logging.
+// It supports the following levels: Trace, Debug, Info, Warn, Error.
+// For each level, the logger provides a structured logging method (e.g. Info)
+// and a printf-style method (e.g. Infof).
+type Logger struct {
+	sl      *slog.Logger   // required
+	lvl     *slog.LevelVar // required
+	onFatal func()         // required
+}
+
+// Nop returns a no-op logger that discards all log messages.
+func Nop(options ...*Options) *Logger {
+	if len(options) > 1 {
+		panic("too many options")
+	}
+	var opts *Options
+	if len(options) == 1 {
+		opts = options[0]
+	}
+	return New(io.Discard, opts)
+}
+
+// New creates a new logger that writes to the given writer.
+// Options customize the behavior of the logger if specified.
+func New(w io.Writer, opts *Options) *Logger {
+	opts = cmp.Or(opts, &Options{
+		Level: LevelInfo,
+	})
+
+	must.Bef(opts.Level >= LevelTrace, "level must be >= LevelTrace, got %d", opts.Level)
+	must.Bef(opts.Level <= LevelError, "level must be <= LevelError, got %d", opts.Level)
+
+	if opts.Style == nil {
+		// The output writer must be file-like to check if it is a TTY.
+		var isTTY bool
+		if fileLike, ok := w.(interface{ Fd() uintptr }); ok {
+			isTTY = isatty.IsTerminal(fileLike.Fd())
+		}
+
+		if isTTY {
+			opts.Style = DefaultStyle()
+		} else {
+			opts.Style = PlainStyle()
+		}
+	}
+
+	var lvl slog.LevelVar
+	lvl.Set(opts.Level.Level())
+	sl := slog.New(newLogHandler(w, &lvl, opts.Style))
+
+	onFatal := opts.OnFatal
+	if onFatal == nil {
+		onFatal = exitOnFatal
+	}
+
+	return &Logger{
+		sl:      sl,
+		lvl:     &lvl,
+		onFatal: onFatal,
+	}
+}
+
+// Clone returns a new logger with the same configuration
+// as the original logger.
+func (l *Logger) Clone() *Logger {
+	newL := *l
+	return &newL
+}
+
+// Level returns the current log level of the logger.
+func (l *Logger) Level() Level {
+	return Level(l.lvl.Level())
+}
+
+// SetLevel changes the log level of the logger
+// and all loggers cloned from it.
+func (l *Logger) SetLevel(lvl Level) {
+	l.lvl.Set(lvl.Level())
+}
+
+// SetPrefix specifies a prefix that will be added to all log messages.
+// A ": " separator will be added between the prefix and the message
+// automatically.
+//
+// Existing prefix (if any) is replaced.
+func (l *Logger) SetPrefix(prefix string) {
+	l.sl = slog.New(l.sl.Handler().(*logHandler).WithPrefix(prefix))
+}
+
+// WithGroup returns a copy of the logger with the given group name added.
+func (l *Logger) WithGroup(name string) *Logger {
+	newL := l.Clone()
+	newL.sl = newL.sl.WithGroup(name)
+	return newL
+}
+
+// With returns a copy of the logger with the given attributes added.
+func (l *Logger) With(attrs ...any) *Logger {
+	if len(attrs) == 0 {
+		return l
+	}
+
+	newL := l.Clone()
+	newL.sl = newL.sl.With(attrs...)
+	return newL
+}
+
+// Log logs a message at the given level with the given key-value pairs.
+func (l *Logger) Log(lvl Level, msg string, kvs ...any) {
+	l.sl.Log(context.Background(), lvl.Level(), msg, kvs...)
+	if lvl >= LevelFatal {
+		l.onFatal()
+		panic("unreachable: onFatal should stop control flow")
+	}
+}
+
+// Logf logs a message at the given level with the given format and arguments.
+func (l *Logger) Logf(lvl Level, format string, args ...any) {
+	l.Log(lvl, fmt.Sprintf(format, args...))
+}
+
+// Trace posts a structured log message with the level [LevelTrace].
+func (l *Logger) Trace(msg string, kvs ...any) { l.Log(LevelTrace, msg, kvs...) }
+
+// Debug posts a structured log message with the level [LevelDebug].
+func (l *Logger) Debug(msg string, kvs ...any) { l.Log(LevelDebug, msg, kvs...) }
+
+// Info posts a structured log message with the level [LevelInfo].
+func (l *Logger) Info(msg string, kvs ...any) { l.Log(LevelInfo, msg, kvs...) }
+
+// Warn posts a structured log message with the level [LevelWarn].
+func (l *Logger) Warn(msg string, kvs ...any) { l.Log(LevelWarn, msg, kvs...) }
+
+// Error posts a structured log message with the level [LevelError].
+func (l *Logger) Error(msg string, kvs ...any) { l.Log(LevelError, msg, kvs...) }
+
+// Fatal posts a structured log message with the level [LevelFatal].
+// It also exits the program with a non-zero status code.
+func (l *Logger) Fatal(msg string, kvs ...any) { l.Log(LevelFatal, msg, kvs...) }
+
+// Tracef posts a printf-style log message with the level [LevelTrace].
+func (l *Logger) Tracef(format string, args ...any) { l.Logf(LevelTrace, format, args...) }
+
+// Debugf posts a printf-style log message with the level [LevelDebug].
+func (l *Logger) Debugf(format string, args ...any) { l.Logf(LevelDebug, format, args...) }
+
+// Infof posts a printf-style log message with the level [LevelInfo].
+func (l *Logger) Infof(format string, args ...any) { l.Logf(LevelInfo, format, args...) }
+
+// Warnf posts a printf-style log message with the level [LevelWarn].
+func (l *Logger) Warnf(format string, args ...any) { l.Logf(LevelWarn, format, args...) }
+
+// Errorf posts a printf-style log message with the level [LevelError].
+func (l *Logger) Errorf(format string, args ...any) { l.Logf(LevelError, format, args...) }
+
+// Fatalf posts a printf-style log message with the level [LevelFatal].
+// It also exits the program with a non-zero status code.
+func (l *Logger) Fatalf(format string, args ...any) { l.Logf(LevelFatal, format, args...) }
+
+func exitOnFatal() { os.Exit(1) }

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -1,0 +1,312 @@
+package log_test
+
+import (
+	"log/slog"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.abhg.dev/gs/internal/log"
+)
+
+func TestNop(*testing.T) {
+	log := log.Nop(nil)
+	log.Info("foo")
+}
+
+func TestLogger_changeLevel(t *testing.T) {
+	var buffer strings.Builder
+	logger := log.New(&buffer, nil)
+
+	assert.Equal(t, log.LevelInfo, logger.Level(),
+		"default level should be Info")
+
+	logger.Debug("foo")
+	assert.Empty(t, buffer.String())
+
+	logger.SetLevel(log.LevelDebug)
+
+	logger.Debug("foo")
+	assert.Equal(t, "DBG foo\n", buffer.String())
+}
+
+func TestLogger_formatting(t *testing.T) {
+	var buffer strings.Builder
+	log := log.New(&buffer, &log.Options{
+		Level: log.LevelTrace,
+	})
+
+	assertLines := func(t *testing.T, lines ...string) bool {
+		t.Helper()
+
+		defer buffer.Reset()
+
+		want := strings.Join(lines, "\n") + "\n"
+		got := buffer.String()
+		return assert.Equal(t, want, got)
+	}
+
+	t.Run("Message", func(t *testing.T) {
+		log.Info("foo")
+		assertLines(t, "INF foo")
+	})
+
+	t.Run("Levels", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			logFn func(string, ...any)
+			want  string
+		}{
+			{"trace", log.Trace, "TRC hello"},
+			{"debug", log.Debug, "DBG hello"},
+			{"info", log.Info, "INF hello"},
+			{"warn", log.Warn, "WRN hello"},
+			{"error", log.Error, "ERR hello"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				tt.logFn("hello")
+				assertLines(t, tt.want)
+			})
+		}
+	})
+
+	t.Run("Printf", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			logFn func(string, ...any)
+			want  string
+		}{
+			{"trace", log.Tracef, "TRC hello world"},
+			{"debug", log.Debugf, "DBG hello world"},
+			{"info", log.Infof, "INF hello world"},
+			{"warn", log.Warnf, "WRN hello world"},
+			{"error", log.Errorf, "ERR hello world"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				tt.logFn("hello %s", "world")
+				assertLines(t, tt.want)
+			})
+		}
+	})
+
+	t.Run("Attrs", func(t *testing.T) {
+		someDate := time.Date(2025, 5, 20, 21, 0, 0, 0, time.UTC)
+
+		tests := []struct {
+			name  string
+			value any
+			want  string
+		}{
+			{"Bool", true, "true"},
+			{"Duration", time.Second, "1s"},
+			{"Float64", 3.14, "3.14"},
+			{"Int64", int64(42), "42"},
+			{"String", "foo", "foo"},
+			{"Time", someDate, "9:00PM"},
+			{"Uint64", uint64(42), "42"},
+			{"Stringer", &testStringer{"foo"}, "foo"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				log.Info("foo", "k1", tt.value)
+				assertLines(t, "INF foo  k1="+tt.want)
+			})
+		}
+	})
+
+	t.Run("EmptyAttr", func(t *testing.T) {
+		log.Info("foo", slog.Attr{}, "foo", "bar")
+		assertLines(t, "INF foo  foo=bar")
+	})
+
+	t.Run("Prefix", func(t *testing.T) {
+		log := log.Clone()
+		log.SetPrefix("prefix")
+
+		log.Info("foo")
+		assertLines(t, "INF prefix: foo")
+	})
+
+	t.Run("MultilineMessage", func(t *testing.T) {
+		log.Info("foo\nbar\nbaz")
+		assertLines(t,
+			"INF foo",
+			"INF bar",
+			"INF baz",
+		)
+	})
+
+	t.Run("MultilineMessageWithPrefix", func(t *testing.T) {
+		log := log.Clone()
+		log.SetPrefix("prefix")
+
+		log.Info("foo\nbar\nbaz")
+		assertLines(t,
+			"INF prefix: foo",
+			"INF prefix: bar",
+			"INF prefix: baz",
+		)
+	})
+
+	t.Run("WithAttrs", func(t *testing.T) {
+		log := log.With("k1", true, "k2", 2, "k3", 3.0, "k4", "foo")
+		log.Info("bar")
+
+		assertLines(t, "INF bar  k1=true k2=2 k3=3 k4=foo")
+	})
+
+	t.Run("WithAttrsEmpty", func(t *testing.T) {
+		log := log.With()
+		log.Info("bar")
+		assertLines(t, "INF bar")
+	})
+
+	t.Run("MultilineMessageWithAttrs", func(t *testing.T) {
+		log := log.With("k1", true, "k2", 2, "k3", 3.0, "k4", "foo")
+		log.Info("bar\nbaz")
+
+		assertLines(t,
+			"INF bar",
+			"INF baz  k1=true k2=2 k3=3 k4=foo",
+		)
+	})
+
+	t.Run("Attrs", func(t *testing.T) {
+		log.Info("foo", "k1", true, "k2", 2, "k3", 3.0, "k4", "bar")
+		assertLines(t, "INF foo  k1=true k2=2 k3=3 k4=bar")
+	})
+
+	t.Run("AttrsWithAttrs", func(t *testing.T) {
+		log := log.With("k1", true, "k2", 2)
+		log.Info("foo", "k3", 3.0, "k4", "bar")
+		log.Warn("baz", "k5", 5.0, "k6", "qux")
+
+		assertLines(t,
+			"INF foo  k1=true k2=2 k3=3 k4=bar",
+			"WRN baz  k1=true k2=2 k5=5 k6=qux",
+		)
+	})
+
+	t.Run("WithGroup", func(t *testing.T) {
+		log := log.WithGroup("g")
+		log.Info("foo", "k1", true, "k2", 2, "k3", 3.0, "k4", "bar")
+		assertLines(t, "INF foo  g.k1=true g.k2=2 g.k3=3 g.k4=bar")
+	})
+
+	t.Run("WithGroupEmpty", func(t *testing.T) {
+		log := log.WithGroup("")
+		log.Info("foo", "k1", true)
+		assertLines(t, "INF foo  k1=true")
+	})
+
+	t.Run("WithGroupWithAttrs", func(t *testing.T) {
+		log := log.WithGroup("g").With("k1", true, "k2", 2)
+		log.Info("foo", "k3", 3.0, "k4", "bar")
+		log.Warn("baz", "k5", 5.0, "k6", "qux")
+
+		assertLines(t,
+			"INF foo  g.k1=true g.k2=2 g.k3=3 g.k4=bar",
+			"WRN baz  g.k1=true g.k2=2 g.k5=5 g.k6=qux",
+		)
+	})
+
+	t.Run("AttrGroup", func(t *testing.T) {
+		log.Info("foo", slog.Group("bar", "k1", true, "k2", 2, "k3", 3.0, "k4", "bar"))
+		assertLines(t, "INF foo  bar.k1=true bar.k2=2 bar.k3=3 bar.k4=bar")
+	})
+
+	t.Run("AttrGroupEmptyAttr", func(t *testing.T) {
+		log.Info("foo", slog.Group("bar", slog.Attr{}, "k1", true, "k2", 2, "k3", 3.0, "k4", "bar")) //nolint:loggercheck
+		assertLines(t, "INF foo  bar.k1=true bar.k2=2 bar.k3=3 bar.k4=bar")
+	})
+
+	t.Run("TrailingNewlineMessage", func(t *testing.T) {
+		log.Info("foo\n")
+		assertLines(t, "INF foo")
+	})
+
+	t.Run("TrailingNewlineMessageWithAttr", func(t *testing.T) {
+		log.Info("foo\n", "k1", true)
+		assertLines(t,
+			"INF foo",
+			"  k1=true",
+		)
+	})
+
+	t.Run("MultilineAttrValue", func(t *testing.T) {
+		log.Info("foo", "k1", "bar\nbaz\nqux", "k2", "quux")
+		assertLines(t,
+			"INF foo  ",
+			"  k1=",
+			"    | bar",
+			"    | baz",
+			"    | qux",
+			"  k2=quux",
+		)
+	})
+
+	t.Run("MultlineAttrValueNestedInGroup", func(t *testing.T) {
+		log := log.WithGroup("a").WithGroup("b")
+		log.Info("foo", slog.Group("c", "d", "foo\nbar\nbaz", "e", "qux"))
+
+		assertLines(t,
+			"INF foo  ",
+			"  a.b.c.d=",
+			"    | foo",
+			"    | bar",
+			"    | baz",
+			"  a.b.c.e=qux",
+		)
+	})
+}
+
+func TestLogger_Fatal(t *testing.T) {
+	var buffer strings.Builder
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		logger := log.New(&buffer, &log.Options{
+			OnFatal: runtime.Goexit,
+		})
+
+		logger.Fatal("foo")
+
+		t.Errorf("logger should not return")
+	}()
+	<-done
+
+	assert.Equal(t, "FTL foo\n", buffer.String())
+}
+
+func TestLogger_Fatalf(t *testing.T) {
+	var buffer strings.Builder
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		logger := log.New(&buffer, &log.Options{
+			OnFatal: runtime.Goexit,
+		})
+
+		logger.Fatalf("foo %s", "bar")
+
+		t.Errorf("logger should not return")
+	}()
+	<-done
+
+	assert.Equal(t, "FTL foo bar\n", buffer.String())
+}
+
+type testStringer struct{ v string }
+
+func (s *testStringer) String() string { return s.v }

--- a/internal/log/logtest/logger.go
+++ b/internal/log/logtest/logger.go
@@ -1,0 +1,14 @@
+// Package logtest provides a logger for testing.
+package logtest
+
+import (
+	"go.abhg.dev/gs/internal/log"
+	"go.abhg.dev/io/ioutil"
+)
+
+// New creates a new logger that writes to the given testing.TB.
+func New(t ioutil.TestLogger) *log.Logger {
+	return log.New(ioutil.TestLogWriter(t, ""), &log.Options{
+		Level: log.LevelTrace,
+	})
+}

--- a/internal/log/logtest/logger_test.go
+++ b/internal/log/logtest/logger_test.go
@@ -1,0 +1,42 @@
+package logtest_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.abhg.dev/gs/internal/log/logtest"
+)
+
+func TestTestLogger(t *testing.T) {
+	var stub testOutputStub
+	logger := logtest.New(&stub)
+
+	logger.Infof("Hello, %s!", "world")
+	logger.Error("Sadness", "error", errors.New("oh no"))
+
+	assert.Equal(t, []string{
+		"INF Hello, world!",
+		`ERR Sadness  error=oh no`,
+	}, stub.logs)
+}
+
+type testOutputStub struct {
+	logs    []string
+	cleanup func()
+}
+
+func (t *testOutputStub) Logf(format string, args ...any) {
+	t.logs = append(t.logs, fmt.Sprintf(format, args...))
+}
+
+func (t *testOutputStub) Cleanup(f func()) {
+	old := t.cleanup
+	t.cleanup = func() {
+		f()
+		if old != nil {
+			old()
+		}
+	}
+}

--- a/internal/log/style.go
+++ b/internal/log/style.go
@@ -1,0 +1,65 @@
+package log
+
+import (
+	"github.com/charmbracelet/lipgloss"
+	"go.abhg.dev/gs/internal/ui"
+)
+
+// Style defines the output styling for the logger.
+type Style struct {
+	Key lipgloss.Style
+
+	KeyValueDelimiter lipgloss.Style          // required
+	PrefixDelimiter   lipgloss.Style          // required
+	LevelLabels       ByLevel[lipgloss.Style] // required
+	MultilinePrefix   lipgloss.Style          // required
+
+	Messages ByLevel[lipgloss.Style]
+	Values   map[string]lipgloss.Style
+}
+
+// DefaultStyle returns the default style for the logger.
+func DefaultStyle() *Style {
+	return &Style{
+		Key:               ui.NewStyle().Faint(true),
+		KeyValueDelimiter: ui.NewStyle().SetString("=").Faint(true),
+		PrefixDelimiter:   ui.NewStyle().SetString(": "),
+		MultilinePrefix:   ui.NewStyle().SetString("| ").Faint(true),
+		LevelLabels: ByLevel[lipgloss.Style]{
+			Trace: ui.NewStyle().SetString("TRC").Foreground(lipgloss.Color("8")),  // gray
+			Debug: ui.NewStyle().SetString("DBG"),                                  // default
+			Info:  ui.NewStyle().SetString("INF").Foreground(lipgloss.Color("10")), // green
+			Warn:  ui.NewStyle().SetString("WRN").Foreground(lipgloss.Color("11")), // yellow
+			Error: ui.NewStyle().SetString("ERR").Foreground(lipgloss.Color("9")),  // red
+			Fatal: ui.NewStyle().SetString("FTL").Foreground(lipgloss.Color("9")),  // red
+		},
+		Messages: ByLevel[lipgloss.Style]{
+			Trace: ui.NewStyle().Foreground(lipgloss.Color("8")), // gray
+			Debug: ui.NewStyle().Faint(true),
+			Info:  ui.NewStyle().Bold(true),
+			Warn:  ui.NewStyle().Bold(true),
+			Error: ui.NewStyle().Bold(true),
+			Fatal: ui.NewStyle().Bold(true),
+		},
+		Values: map[string]lipgloss.Style{
+			"error": ui.NewStyle().Foreground(lipgloss.Color("9")), // red
+		},
+	}
+}
+
+// PlainStyle returns a style for the logger without any colors.
+func PlainStyle() *Style {
+	return &Style{
+		KeyValueDelimiter: ui.NewStyle().SetString("="),
+		PrefixDelimiter:   ui.NewStyle().SetString(": "),
+		MultilinePrefix:   ui.NewStyle().SetString("  | "),
+		LevelLabels: ByLevel[lipgloss.Style]{
+			Trace: ui.NewStyle().SetString("TRC"),
+			Debug: ui.NewStyle().SetString("DBG"),
+			Info:  ui.NewStyle().SetString("INF"),
+			Warn:  ui.NewStyle().SetString("WRN"),
+			Error: ui.NewStyle().SetString("ERR"),
+			Fatal: ui.NewStyle().SetString("FTL"),
+		},
+	}
+}

--- a/internal/log/style_test.go
+++ b/internal/log/style_test.go
@@ -1,0 +1,30 @@
+package log_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/assert"
+	"go.abhg.dev/gs/internal/log"
+)
+
+func TestDefaultStyle(t *testing.T) {
+	assertHasValue := func(t *testing.T, style lipgloss.Style, msgArgs ...any) {
+		t.Helper()
+
+		assert.NotEmpty(t, strings.TrimSpace(style.String()), msgArgs...)
+	}
+
+	style := log.DefaultStyle()
+
+	assertHasValue(t, style.KeyValueDelimiter, "KeyValueDelimiter")
+	assertHasValue(t, style.PrefixDelimiter, "PrefixDelimiter")
+	assertHasValue(t, style.MultilinePrefix, "MultilinePrefix")
+
+	for _, lvl := range log.Levels {
+		t.Run(lvl.String(), func(t *testing.T) {
+			assertHasValue(t, style.LevelLabels.Get(lvl), "LevelLabels.Get(%s)", lvl)
+		})
+	}
+}

--- a/internal/log/writer.go
+++ b/internal/log/writer.go
@@ -1,0 +1,27 @@
+package log
+
+import (
+	"io"
+
+	"go.abhg.dev/io/ioutil"
+)
+
+// Writer builds and returns an io.Writer that
+// writes messages to the given logger.
+// If the logger is nil, a no-op writer is returned.
+//
+// If prefix is non-empty, it is prepended to each message.
+// The done function must be called when the writer is no longer needed.
+// It will flush any buffered text to the logger.
+//
+// The returned writer is not thread-safe.
+func Writer(log *Logger, lvl Level) (w io.Writer, done func()) {
+	if log == nil {
+		return io.Discard, func() {}
+	}
+
+	w, flush := ioutil.PrintfWriter(func(msg string, args ...any) {
+		log.Logf(lvl, msg, args...)
+	}, "")
+	return w, flush
+}

--- a/internal/log/writer_test.go
+++ b/internal/log/writer_test.go
@@ -1,0 +1,31 @@
+package log_test
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/log"
+)
+
+func TestLogWriter(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.New(&buf, nil)
+	writer, done := log.Writer(logger, log.LevelInfo)
+
+	_, err := fmt.Fprint(writer, "hello world")
+	require.NoError(t, err)
+	done()
+
+	assert.Equal(t, "INF hello world\n", buf.String())
+}
+
+func TestLogWriter_nil(t *testing.T) {
+	writer, done := log.Writer(nil, log.LevelInfo)
+
+	_, err := fmt.Fprint(writer, "hello world")
+	require.NoError(t, err)
+	done()
+}


### PR DESCRIPTION
charmbracelet/log has gotten us pretty far,
but for the level of control I want going forward,
we need our own wrapper around slog.

This changes just adds the new logger implementation.
Following changes will switch to it.

logtest and log.Writer are copy-pasted from the versions in logutil.

[skip changelog]: This change contains no user facing changes yet.