### PR TITLE
fix(log): fix multiline message formatting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/creack/pty v1.1.24
 	github.com/dustin/go-humanize v1.0.1
 	github.com/mattn/go-isatty v0.0.20
+	github.com/muesli/termenv v0.16.0
 	github.com/rogpeppe/go-internal v1.14.1
 	github.com/sahilm/fuzzy v0.1.1
 	github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7
@@ -54,7 +55,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466 // indirect

--- a/internal/log/handler.go
+++ b/internal/log/handler.go
@@ -77,8 +77,18 @@ func (l *logHandler) Handle(_ context.Context, rec slog.Record) error {
 		bs = append(bs, lvlString...)
 		bs = append(bs, lvlDelim...)
 
+		// line may end with \n.
+		// That should not be included in the rendering logic.
+		var trailingNewline bool
+		if line[len(line)-1] == '\n' {
+			trailingNewline = true
+			line = line[:len(line)-1]
+		}
 		line = l.style.Messages.Get(Level(rec.Level)).Render(line)
 		bs = append(bs, line...)
+		if trailingNewline {
+			bs = append(bs, '\n')
+		}
 	}
 
 	// First attribute after the message is separated by two spaces.
@@ -229,7 +239,7 @@ func (f *attrFormatter) FormatAttr(attr slog.Attr) {
 			if hasStyle {
 				f.buf = append(f.buf, valueStyle.Render(string(line))...)
 			} else {
-				f.buf = append(f.buf, line...) // includes \n already
+				f.buf = append(f.buf, line...)
 			}
 			f.buf = append(f.buf, '\n')
 		}

--- a/internal/log/handler_slog_test.go
+++ b/internal/log/handler_slog_test.go
@@ -1,0 +1,90 @@
+package log
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"testing/slogtest"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogHandler_slogtest(t *testing.T) {
+	var (
+		buffer strings.Builder
+		saver  saveTimeHandler
+	)
+	slogtest.Run(t, func(*testing.T) slog.Handler {
+		buffer.Reset()
+
+		saver.Handler = newLogHandler(&buffer, slog.LevelDebug, PlainStyle())
+		return &saver
+	}, func(t *testing.T) map[string]any {
+		attrs := make(map[string]any)
+		if !saver.saved.IsZero() {
+			attrs[slog.TimeKey] = saver.saved
+		}
+
+		line := strings.TrimSpace(buffer.String())
+		lvlstr, line, ok := strings.Cut(line, lvlDelim)
+		require.True(t, ok, "missing level delimiter: %q", buffer.String())
+
+		switch lvlstr {
+		case "DBG":
+			attrs[slog.LevelKey] = slog.LevelDebug
+		case "INF":
+			attrs[slog.LevelKey] = slog.LevelInfo
+		case "WRN":
+			attrs[slog.LevelKey] = slog.LevelWarn
+		case "ERR":
+			attrs[slog.LevelKey] = slog.LevelError
+		default:
+			t.Fatalf("unknown level: %q", lvlstr)
+		}
+
+		attrs[slog.MessageKey], line, _ = strings.Cut(line, msgAttrDelim)
+
+		for pair := range strings.SplitSeq(line, attrDelim) {
+			if pair == "" {
+				continue
+			}
+			key, value, ok := strings.Cut(pair, "=")
+			require.True(t, ok, "missing attribute delimiter: %q", pair)
+
+			curAttrs := attrs
+			for len(key) > 0 {
+				groupKey, valKey, ok := strings.Cut(key, groupDelim)
+				if !ok {
+					// No more groups.
+					curAttrs[key] = value
+					break
+				}
+
+				groupAttrs, ok := curAttrs[groupKey].(map[string]any)
+				if !ok {
+					groupAttrs = make(map[string]any)
+					curAttrs[groupKey] = groupAttrs
+				}
+				curAttrs = groupAttrs
+				key = valKey
+			}
+		}
+
+		t.Logf("buffer: %q", buffer.String())
+		t.Logf("attrs: %q", attrs)
+		return attrs
+	})
+}
+
+type saveTimeHandler struct {
+	slog.Handler
+
+	saved time.Time
+}
+
+func (h *saveTimeHandler) Handle(ctx context.Context, rec slog.Record) error {
+	h.saved = rec.Time
+	return h.Handler.Handle(ctx, rec)
+}

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -135,6 +135,22 @@ func TestLogger_formatting(t *testing.T) {
 		)
 	})
 
+	t.Run("MultilineMessageWithLeadingSpaces", func(t *testing.T) {
+		var s strings.Builder
+		s.WriteString("foo\n")
+		s.WriteString("  bar\n")
+		s.WriteString("    baz\n")
+		s.WriteString("qux\n")
+		log.Info(s.String())
+
+		assertLines(t,
+			"INF foo",
+			"INF   bar",
+			"INF     baz",
+			"INF qux",
+		)
+	})
+
 	t.Run("WithAttrs", func(t *testing.T) {
 		log := log.With("k1", true, "k2", 2, "k3", 3.0, "k4", "foo")
 		log.Info("bar")
@@ -155,6 +171,17 @@ func TestLogger_formatting(t *testing.T) {
 		assertLines(t,
 			"INF bar",
 			"INF baz  k1=true k2=2 k3=3 k4=foo",
+		)
+	})
+
+	t.Run("MultilineMessageWithAttrsAndLeadingNewline", func(t *testing.T) {
+		log := log.With("k1", true, "k2", 2, "k3", 3.0, "k4", "foo")
+		log.Info("bar\nbaz\n")
+
+		assertLines(t,
+			"INF bar",
+			"INF baz",
+			"  k1=true k2=2 k3=3 k4=foo",
 		)
 	})
 
@@ -244,6 +271,16 @@ func TestLogger_formatting(t *testing.T) {
 			"    | baz",
 			"  a.b.c.e=qux",
 		)
+	})
+
+	t.Run("LeadingWhitespace", func(t *testing.T) {
+		log.Info(" foo")
+		assertLines(t, "INF  foo")
+	})
+
+	t.Run("TrailingWhitespace", func(t *testing.T) {
+		log.Info("foo ")
+		assertLines(t, "INF foo")
 	})
 }
 


### PR DESCRIPTION
Styling should not cross newline boundaries,
i.e. Render(line) should never have a newline in it.