### PR TITLE
branch split: Fix rev-parse logs while typing name

### DIFF
--- a/.changes/unreleased/Fixed-20250524-064820.yaml
+++ b/.changes/unreleased/Fixed-20250524-064820.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'branch split: Fix debug logs interrupting the branch name prompt.'
+time: 2025-05-24T06:48:20.484254-07:00

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -140,7 +140,7 @@ func (r *Repository) CreateBranch(ctx context.Context, req CreateBranchRequest) 
 
 // BranchExists reports whether a branch with the given name exists.
 func (r *Repository) BranchExists(ctx context.Context, branch string) bool {
-	return r.gitCmd(ctx, "rev-parse", "--verify", "refs/heads/"+branch).
+	return r.gitCmd(ctx, "rev-parse", "--verify", "--quiet", "refs/heads/"+branch).
 		Run(r.exec) == nil
 }
 


### PR DESCRIPTION
'gs branch split' prompts the usre for a branch name,
and its validation function uses 'git rev-parse --verify'
to check if the planned branch name exists.

Without the '--quiet' flag, rev-parse logs errors to stderr,
which will get printed to the terminal in verbose mode.