### PR TITLE
log: Drop --verbosity flag and trace level

### DIFF
--- a/.changes/unreleased/Added-20250517-112151.yaml
+++ b/.changes/unreleased/Added-20250517-112151.yaml
@@ -1,5 +1,0 @@
-kind: Added
-body: >-
-  Add a `--verbosity=N` option that accepts values between 0 and 2 (inclusive).
-  The short form `-v` may be supplied multiple times to increase verbosity.
-time: 2025-05-17T11:21:51.281021-07:00

--- a/.changes/unreleased/Changed-20250521-194858.yaml
+++ b/.changes/unreleased/Changed-20250521-194858.yaml
@@ -1,3 +1,0 @@
-kind: Changed
-body: The `--verbose` flag is now an alias for `--verbosity=1`.
-time: 2025-05-21T19:48:58.482557-07:00

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -8,8 +8,7 @@ gs (git-spice) is a command line tool for stacking Git branches.
 
 * `-h`, `--help`: Show help for the command
 * `--version`: Print version information and quit
-* `--verbose`, `$GIT_SPICE_VERBOSE`: Alias for --verbosity=1
-* `-v`, `--verbosity`, `$GIT_SPICE_VERBOSITY`: Set verbosity level (0-2) <span class="mdx-badge"><span class="mdx-badge__icon">:material-tag-hidden:{ title="Released in version" }</span><span class="mdx-badge__text">Unreleased</span>
+* `-v`, `--verbose`, `$GIT_SPICE_VERBOSE`: Enable verbose output
 * `-C`, `--dir=DIR`: Change to DIR before doing anything
 * `--[no-]prompt`: Whether to prompt for missing information
 

--- a/internal/log/handler_test.go
+++ b/internal/log/handler_test.go
@@ -20,21 +20,15 @@ func TestLogHandler_Enabled(t *testing.T) {
 		disabled []Level
 	}{
 		{
-			name:    "trace",
-			leveler: LevelTrace,
-			enabled: []Level{LevelTrace, LevelDebug, LevelInfo},
-		},
-		{
-			name:     "debug",
-			leveler:  LevelDebug,
-			enabled:  []Level{LevelDebug, LevelInfo},
-			disabled: []Level{LevelTrace},
+			name:    "debug",
+			leveler: LevelDebug,
+			enabled: []Level{LevelDebug, LevelInfo},
 		},
 		{
 			name:     "info",
 			leveler:  LevelInfo,
 			enabled:  []Level{LevelInfo, LevelWarn},
-			disabled: []Level{LevelDebug, LevelTrace},
+			disabled: []Level{LevelDebug},
 		},
 		{
 			name:     "warn",

--- a/internal/log/level.go
+++ b/internal/log/level.go
@@ -9,7 +9,6 @@ var _ slog.Leveler = (Level)(0)
 
 // Supported log levels.
 const (
-	LevelTrace = Level(-8)
 	LevelDebug = Level(slog.LevelDebug)
 	LevelInfo  = Level(slog.LevelInfo)
 	LevelWarn  = Level(slog.LevelWarn)
@@ -19,7 +18,6 @@ const (
 
 // Levels is a list of all supported log levels.
 var Levels = []Level{
-	LevelTrace,
 	LevelDebug,
 	LevelInfo,
 	LevelWarn,
@@ -30,8 +28,6 @@ var Levels = []Level{
 // String returns the string representation of the log level.
 func (l Level) String() string {
 	switch l {
-	case LevelTrace:
-		return "trace"
 	case LevelDebug:
 		return "debug"
 	case LevelInfo:
@@ -54,7 +50,6 @@ func (l Level) Level() slog.Level {
 
 // ByLevel is a struct that contains fields for each log level.
 type ByLevel[T any] struct {
-	Trace T
 	Debug T
 	Info  T
 	Warn  T
@@ -65,8 +60,6 @@ type ByLevel[T any] struct {
 // Get returns the value associated with the given log level.
 func (b *ByLevel[T]) Get(lvl Level) T {
 	switch lvl {
-	case LevelTrace:
-		return b.Trace
 	case LevelDebug:
 		return b.Debug
 	case LevelInfo:

--- a/internal/log/level_test.go
+++ b/internal/log/level_test.go
@@ -12,7 +12,6 @@ func TestLevel_String(t *testing.T) {
 		level    log.Level
 		expected string
 	}{
-		{log.LevelTrace, "trace"},
 		{log.LevelDebug, "debug"},
 		{log.LevelInfo, "info"},
 		{log.LevelWarn, "warn"},
@@ -30,7 +29,6 @@ func TestLevel_String(t *testing.T) {
 
 func TestByLevel_Get(t *testing.T) {
 	byLevel := log.ByLevel[string]{
-		Trace: "trace",
 		Debug: "debug",
 		Info:  "info",
 		Warn:  "warn",
@@ -42,7 +40,6 @@ func TestByLevel_Get(t *testing.T) {
 		level log.Level
 		want  string
 	}{
-		{log.LevelTrace, "trace"},
 		{log.LevelDebug, "debug"},
 		{log.LevelInfo, "info"},
 		{log.LevelWarn, "warn"},

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -69,7 +69,7 @@ func New(w io.Writer, opts *Options) *Logger {
 		Level: LevelInfo,
 	})
 
-	must.Bef(opts.Level >= LevelTrace, "level must be >= LevelTrace, got %d", opts.Level)
+	must.Bef(opts.Level >= LevelDebug, "level must be >= LevelDebug, got %d", opts.Level)
 	must.Bef(opts.Level <= LevelError, "level must be <= LevelError, got %d", opts.Level)
 
 	if opts.Style == nil {
@@ -152,9 +152,6 @@ func (l *Logger) Logf(lvl Level, format string, args ...any) {
 	l.Log(lvl, fmt.Sprintf(format, args...))
 }
 
-// Trace posts a structured log message with the level [LevelTrace].
-func (l *Logger) Trace(msg string, kvs ...any) { l.Log(LevelTrace, msg, kvs...) }
-
 // Debug posts a structured log message with the level [LevelDebug].
 func (l *Logger) Debug(msg string, kvs ...any) { l.Log(LevelDebug, msg, kvs...) }
 
@@ -170,9 +167,6 @@ func (l *Logger) Error(msg string, kvs ...any) { l.Log(LevelError, msg, kvs...) 
 // Fatal posts a structured log message with the level [LevelFatal].
 // It also exits the program with a non-zero status code.
 func (l *Logger) Fatal(msg string, kvs ...any) { l.Log(LevelFatal, msg, kvs...) }
-
-// Tracef posts a printf-style log message with the level [LevelTrace].
-func (l *Logger) Tracef(format string, args ...any) { l.Logf(LevelTrace, format, args...) }
 
 // Debugf posts a printf-style log message with the level [LevelDebug].
 func (l *Logger) Debugf(format string, args ...any) { l.Logf(LevelDebug, format, args...) }

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -35,7 +35,7 @@ func TestLogger_changeLevel(t *testing.T) {
 func TestLogger_formatting(t *testing.T) {
 	var buffer strings.Builder
 	log := log.New(&buffer, &log.Options{
-		Level: log.LevelTrace,
+		Level: log.LevelDebug,
 	})
 
 	assertLines := func(t *testing.T, lines ...string) bool {
@@ -59,7 +59,6 @@ func TestLogger_formatting(t *testing.T) {
 			logFn func(string, ...any)
 			want  string
 		}{
-			{"trace", log.Trace, "TRC hello"},
 			{"debug", log.Debug, "DBG hello"},
 			{"info", log.Info, "INF hello"},
 			{"warn", log.Warn, "WRN hello"},
@@ -80,7 +79,6 @@ func TestLogger_formatting(t *testing.T) {
 			logFn func(string, ...any)
 			want  string
 		}{
-			{"trace", log.Tracef, "TRC hello world"},
 			{"debug", log.Debugf, "DBG hello world"},
 			{"info", log.Infof, "INF hello world"},
 			{"warn", log.Warnf, "WRN hello world"},

--- a/internal/log/logtest/logger.go
+++ b/internal/log/logtest/logger.go
@@ -9,6 +9,6 @@ import (
 // New creates a new logger that writes to the given testing.TB.
 func New(t ioutil.TestLogger) *log.Logger {
 	return log.New(ioutil.TestLogWriter(t, ""), &log.Options{
-		Level: log.LevelTrace,
+		Level: log.LevelDebug,
 	})
 }

--- a/internal/log/style.go
+++ b/internal/log/style.go
@@ -24,7 +24,6 @@ func DefaultStyle() *Style {
 		KeyValueDelimiter: ui.NewStyle().SetString("=").Faint(true),
 		MultilinePrefix:   ui.NewStyle().SetString("| ").Faint(true),
 		LevelLabels: ByLevel[lipgloss.Style]{
-			Trace: ui.NewStyle().SetString("TRC").Foreground(lipgloss.Color("8")),  // gray
 			Debug: ui.NewStyle().SetString("DBG"),                                  // default
 			Info:  ui.NewStyle().SetString("INF").Foreground(lipgloss.Color("10")), // green
 			Warn:  ui.NewStyle().SetString("WRN").Foreground(lipgloss.Color("11")), // yellow
@@ -32,7 +31,6 @@ func DefaultStyle() *Style {
 			Fatal: ui.NewStyle().SetString("FTL").Foreground(lipgloss.Color("9")),  // red
 		},
 		Messages: ByLevel[lipgloss.Style]{
-			Trace: ui.NewStyle().Foreground(lipgloss.Color("8")), // gray
 			Debug: ui.NewStyle().Faint(true),
 			Info:  ui.NewStyle().Bold(true),
 			Warn:  ui.NewStyle().Bold(true),
@@ -51,7 +49,6 @@ func PlainStyle() *Style {
 		KeyValueDelimiter: ui.NewStyle().SetString("="),
 		MultilinePrefix:   ui.NewStyle().SetString("  | "),
 		LevelLabels: ByLevel[lipgloss.Style]{
-			Trace: ui.NewStyle().SetString("TRC"),
 			Debug: ui.NewStyle().SetString("DBG"),
 			Info:  ui.NewStyle().SetString("INF"),
 			Warn:  ui.NewStyle().SetString("WRN"),

--- a/main.go
+++ b/main.go
@@ -223,13 +223,10 @@ type mainCmd struct {
 	// Global options that are never accessed directly by subcommands.
 	Globals struct {
 		// Flags with built-in side effects.
-		Version versionFlag `help:"Print version information and quit"`
-
-		Verbose   bool `name:"verbose" help:"Alias for --verbosity=1" env:"GIT_SPICE_VERBOSE"`
-		Verbosity int  `short:"v" type:"counter" help:"Set verbosity level (0-2)" env:"GIT_SPICE_VERBOSITY" released:"unreleased"`
-
-		Dir    kong.ChangeDirFlag `short:"C" placeholder:"DIR" help:"Change to DIR before doing anything" predictor:"dirs"`
-		Prompt bool               `name:"prompt" negatable:"" default:"${defaultPrompt}" help:"Whether to prompt for missing information"`
+		Version versionFlag        `help:"Print version information and quit"`
+		Verbose bool               `short:"v" help:"Enable verbose output" env:"GIT_SPICE_VERBOSE"`
+		Dir     kong.ChangeDirFlag `short:"C" placeholder:"DIR" help:"Change to DIR before doing anything" predictor:"dirs"`
+		Prompt  bool               `name:"prompt" negatable:"" default:"${defaultPrompt}" help:"Whether to prompt for missing information"`
 	} `embed:"" group:"globals"`
 
 	Shell shellCmd `cmd:"" group:"Shell"`
@@ -261,14 +258,8 @@ type mainCmd struct {
 }
 
 func (cmd *mainCmd) AfterApply(ctx context.Context, kctx *kong.Context, logger *log.Logger) error {
-	if cmd.Globals.Verbose && cmd.Globals.Verbosity == 0 {
-		cmd.Globals.Verbosity = 1
-	}
-
-	if cmd.Globals.Verbosity == 1 {
+	if cmd.Globals.Verbose {
 		logger.SetLevel(log.LevelDebug)
-	} else if cmd.Globals.Verbosity >= 2 {
-		logger.SetLevel(log.LevelTrace)
 	}
 
 	view, err := _buildView(os.Stdin, kctx.Stderr, cmd.Globals.Prompt)


### PR DESCRIPTION
We'll stick with just debug logging for now.
Trace should be easy to add back later if needed.