### PR TITLE
feat(log): WithLevel and WithPrefix

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -120,10 +120,35 @@ func (l *Logger) SetLevel(lvl Level) {
 	l.lvl.Set(lvl.Level())
 }
 
+// WithLevel returns a copy of this logger
+// that will log at the given level.
+func (l *Logger) WithLevel(lvl Level) *Logger {
+	if lvl == l.Level() {
+		return l
+	}
+
+	newL := l.Clone()
+	newL.lvl = new(slog.LevelVar)
+	newL.lvl.Set(lvl.Level())
+	newL.sl = slog.New(newL.sl.Handler().(*logHandler).WithLeveler(newL.lvl))
+	return newL
+}
+
 // WithGroup returns a copy of the logger with the given group name added.
 func (l *Logger) WithGroup(name string) *Logger {
 	newL := l.Clone()
 	newL.sl = newL.sl.WithGroup(name)
+	return newL
+}
+
+// WithPrefix returns a copy of the logger that will add the given prefix
+// to all log messages.
+// Any existing prefix will be replaced with the new one.
+// If the prefix is empty, an existing prefix will be removed.
+// If the prefix is non-empty, a ": " delimiter will be added.
+func (l *Logger) WithPrefix(prefix string) *Logger {
+	newL := l.Clone()
+	newL.sl = slog.New(newL.sl.Handler().(*logHandler).WithPrefix(prefix))
 	return newL
 }
 

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -282,6 +282,24 @@ func TestLogger_formatting(t *testing.T) {
 		log.Info("foo ")
 		assertLines(t, "INF foo")
 	})
+
+	t.Run("Prefix", func(t *testing.T) {
+		log := log.WithPrefix("prefix")
+
+		log.Info("foo")
+		assertLines(t, "INF prefix: foo")
+	})
+
+	t.Run("MultilineMessageWithPrefix", func(t *testing.T) {
+		log := log.WithPrefix("prefix")
+
+		log.Info("foo\nbar\nbaz")
+		assertLines(t,
+			"INF prefix: foo",
+			"INF prefix: bar",
+			"INF prefix: baz",
+		)
+	})
 }
 
 func TestLogger_Fatal(t *testing.T) {
@@ -322,6 +340,23 @@ func TestLogger_Fatalf(t *testing.T) {
 	<-done
 
 	assert.Equal(t, "FTL foo bar\n", buffer.String())
+}
+
+func TestLogger_WithLevel(t *testing.T) {
+	var buffer strings.Builder
+
+	rootLogger := log.New(&buffer, nil)
+
+	rootLogger.Debug("foo")
+	assert.Empty(t, buffer.String())
+
+	debugLogger := rootLogger.WithLevel(log.LevelDebug)
+	debugLogger.Debug("foo")
+	assert.Equal(t, "DBG foo\n", buffer.String())
+	buffer.Reset()
+
+	rootLogger.Debug("foo")
+	assert.Empty(t, buffer.String())
 }
 
 type testStringer struct{ v string }

--- a/internal/log/style.go
+++ b/internal/log/style.go
@@ -12,6 +12,7 @@ type Style struct {
 	KeyValueDelimiter lipgloss.Style          // required
 	LevelLabels       ByLevel[lipgloss.Style] // required
 	MultilinePrefix   lipgloss.Style          // required
+	PrefixDelimiter   lipgloss.Style          // required
 
 	Messages ByLevel[lipgloss.Style]
 	Values   map[string]lipgloss.Style
@@ -23,6 +24,7 @@ func DefaultStyle() *Style {
 		Key:               ui.NewStyle().Faint(true),
 		KeyValueDelimiter: ui.NewStyle().SetString("=").Faint(true),
 		MultilinePrefix:   ui.NewStyle().SetString("| ").Faint(true),
+		PrefixDelimiter:   ui.NewStyle().SetString(": "),
 		LevelLabels: ByLevel[lipgloss.Style]{
 			Trace: ui.NewStyle().SetString("TRC").Foreground(lipgloss.Color("8")),  // gray
 			Debug: ui.NewStyle().SetString("DBG"),                                  // default
@@ -50,6 +52,7 @@ func PlainStyle() *Style {
 	return &Style{
 		KeyValueDelimiter: ui.NewStyle().SetString("="),
 		MultilinePrefix:   ui.NewStyle().SetString("  | "),
+		PrefixDelimiter:   ui.NewStyle().SetString(": "),
 		LevelLabels: ByLevel[lipgloss.Style]{
 			Trace: ui.NewStyle().SetString("TRC"),
 			Debug: ui.NewStyle().SetString("DBG"),

--- a/internal/log/style_test.go
+++ b/internal/log/style_test.go
@@ -20,6 +20,7 @@ func TestDefaultStyle(t *testing.T) {
 
 	assertHasValue(t, style.KeyValueDelimiter, "KeyValueDelimiter")
 	assertHasValue(t, style.MultilinePrefix, "MultilinePrefix")
+	assertHasValue(t, style.PrefixDelimiter, "PrefixDelimiter")
 
 	for _, lvl := range log.Levels {
 		t.Run(lvl.String(), func(t *testing.T) {


### PR DESCRIPTION
Add WithLevel and WithPrefix methods to the logger.

Versus SetLevel, WithLevel returns a new logger,
leaving old level unchanged.