### PR TITLE
chore: use BranchExists instead of PeelToCommit

### DIFF
--- a/branch_create.go
+++ b/branch_create.go
@@ -110,7 +110,7 @@ func (cmd *branchCreateCmd) Run(
 	// If a branch name was specified, verify it's unused.
 	// We do this before any changes to the working tree or index.
 	if cmd.Name != "" {
-		if _, err := repo.PeelToCommit(ctx, cmd.Name); err == nil {
+		if repo.BranchExists(ctx, cmd.Name) {
 			return fmt.Errorf("branch already exists: %v", cmd.Name)
 		}
 	}
@@ -213,10 +213,8 @@ func (cmd *branchCreateCmd) Run(
 
 			// If the auto-generated branch name already exists,
 			// append a number to it until we find an unused name.
-			_, err = repo.PeelToCommit(ctx, current)
-			for num := 2; err == nil; num++ {
+			for num := 2; repo.BranchExists(ctx, current); num++ {
 				current = fmt.Sprintf("%s-%d", name, num)
-				_, err = repo.PeelToCommit(ctx, current)
 			}
 
 			cmd.Name = current

--- a/branch_delete.go
+++ b/branch_delete.go
@@ -281,7 +281,7 @@ func (cmd *branchDeleteCmd) Run(
 			if err := repo.DeleteBranch(ctx, branch, opts); err != nil {
 				// If the branch still exists,
 				// it's likely because it's not merged.
-				if _, peelErr := repo.PeelToCommit(ctx, branch); peelErr == nil {
+				if repo.BranchExists(ctx, branch) {
 					log.Error("git refused to delete the branch", "err", err)
 					log.Error("try re-running with --force")
 					return errors.New("branch not deleted")


### PR DESCRIPTION
In cases where PeelToCommit is only used to check if a branch exists,
use BranchExists instead.

[skip changelog]: no user-facing changes