### PR TITLE
fix(branch create): prefix in branch name conflict resolution

### DIFF
--- a/testdata/script/branch_create_prefix_with_generated_name.txt
+++ b/testdata/script/branch_create_prefix_with_generated_name.txt
@@ -1,0 +1,27 @@
+# branch create generates a branch name
+# that respects the configured prefix,
+# and handles conflicts with existing branches.
+
+as 'Test <test@example.com>'
+at '2025-05-24T11:30:00Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+git config spice.branchCreate.prefix 'myuser/'
+git branch myuser/add-feature
+
+git add feature.txt
+gs bc -m 'Add feature'
+
+gs ll -a
+cmp stderr $WORK/golden/ll.txt
+
+-- repo/feature.txt --
+This is a feature file.
+-- golden/ll.txt --
+┏━■ myuser/add-feature-2 ◀
+┃   702c658 Add feature (now)
+main


### PR DESCRIPTION
When 'branch create' generates a branch name based on the commit,
if the branch name already exists, it appends a number to the name.
Right now, we add the prefix to the generated name afterwards,
which means that there's a chance that the final name
will conflict with an existing branch.

This change fixes this by ensuring that the prefix is taken into account
when generating the branch name.

[skip changelog]: change hasn't been released yet