### PR TITLE
log: support downgrades

### DIFF
--- a/internal/silog/level.go
+++ b/internal/silog/level.go
@@ -13,7 +13,7 @@ const (
 	LevelInfo  = Level(slog.LevelInfo)
 	LevelWarn  = Level(slog.LevelWarn)
 	LevelError = Level(slog.LevelError)
-	LevelFatal = Level(16)
+	LevelFatal = Level(slog.LevelError + 4)
 )
 
 // Levels is a list of all supported log levels.
@@ -46,6 +46,11 @@ func (l Level) String() string {
 // Level returns the level as a slog.Level.
 func (l Level) Level() slog.Level {
 	return slog.Level(l)
+}
+
+// Dec lowers the log level by N steps.
+func (l Level) Dec(n int) Level {
+	return l - Level(n*4)
 }
 
 // ByLevel is a struct that contains fields for each log level.

--- a/internal/silog/level_test.go
+++ b/internal/silog/level_test.go
@@ -27,6 +27,25 @@ func TestLevel_String(t *testing.T) {
 	}
 }
 
+func TestLevel_Dec(t *testing.T) {
+	tests := []struct {
+		give, want silog.Level
+	}{
+		{silog.LevelDebug, silog.Level(-8)},
+		{silog.LevelInfo, silog.LevelDebug},
+		{silog.LevelWarn, silog.LevelInfo},
+		{silog.LevelError, silog.LevelWarn},
+		{silog.LevelFatal, silog.LevelError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.give.String(), func(t *testing.T) {
+			got := tt.give.Dec(1)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestByLevel_Get(t *testing.T) {
 	byLevel := silog.ByLevel[string]{
 		Debug: "debug",

--- a/internal/silog/log_test.go
+++ b/internal/silog/log_test.go
@@ -298,6 +298,24 @@ func TestLogger_formatting(t *testing.T) {
 			"INF prefix: baz",
 		)
 	})
+
+	t.Run("Downgrade", func(t *testing.T) {
+		downLog := log.Downgrade()
+
+		downLog.Debug("foo")
+		downLog.Info("bar")
+		downLog.Warn("baz")
+		downLog.Error("qux")
+
+		assertLines(t,
+			"DBG bar",
+			"INF baz",
+			"WRN qux")
+
+		log.Debug("quux")
+		assertLines(t,
+			"DBG quux")
+	})
 }
 
 func TestLogger_Fatal(t *testing.T) {

--- a/repo_init.go
+++ b/repo_init.go
@@ -131,7 +131,7 @@ func newRepoStorage(repo storage.GitRepository, log *silog.Logger) *storage.DB {
 		Ref:         _dataRef,
 		AuthorName:  _authorName,
 		AuthorEmail: _authorEmail,
-		Log:         log,
+		Log:         log.Downgrade(),
 	}))
 }
 


### PR DESCRIPTION
Add support for down-leveling log messages,
(so INF is logged as DBG, etc.)

Useful for adjusting verbosity of different components dynamically.

[skip changelog]: not yet released