### PR TITLE
refac(git/tree): use iterators for Make, List, etc.

### DIFF
--- a/internal/sliceutil/all.go
+++ b/internal/sliceutil/all.go
@@ -1,0 +1,16 @@
+package sliceutil
+
+import "iter"
+
+// All2 returns an iterator over the items in the slice,
+// using the zero value for the second type B.
+func All2[B, A any](items []A) iter.Seq2[A, B] {
+	return func(yield func(A, B) bool) {
+		var zeroB B
+		for _, item := range items {
+			if !yield(item, zeroB) {
+				return
+			}
+		}
+	}
+}

--- a/internal/sliceutil/empty.go
+++ b/internal/sliceutil/empty.go
@@ -1,0 +1,9 @@
+package sliceutil
+
+import "iter"
+
+// Empty2 returns an empty iterator for a sequence of two types A and B.
+func Empty2[A, B any]() iter.Seq2[A, B] {
+	return func(func(A, B) bool) {
+	}
+}


### PR DESCRIPTION
Avoids allocating slices repeatedly.