### PR TITLE
branch submit: Better error when base hasn't been pushed

### DIFF
--- a/.changes/unreleased/Fixed-20250531-093358.yaml
+++ b/.changes/unreleased/Fixed-20250531-093358.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'branch submit: If a GitHub PR cannot be submitted because the base branch hasn''t been pushed, present a more friendly error message.'
+time: 2025-05-31T09:33:58.473984-07:00

--- a/branch_submit.go
+++ b/branch_submit.go
@@ -882,6 +882,14 @@ func (b *preparedBranch) Publish(ctx context.Context) (forge.ChangeID, string, e
 		Draft:   b.draft,
 	})
 	if err != nil {
+		// If the branch could not be submitted because the base branch
+		// has not been pushed yet, provide a more user-friendly error.
+		if errors.Is(err, forge.ErrUnsubmittedBase) {
+			b.log.Errorf("%v: cannot be submitted because base branch %q does not exist in the remote.", b.Name, b.base)
+			b.log.Errorf("Try submitting the base branch first:")
+			b.log.Errorf("  gs branch submit --branch=%s", b.base)
+			return nil, "", fmt.Errorf("create change: %w", err)
+		}
 		return nil, "", fmt.Errorf("create change: %w", err)
 	}
 

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -165,11 +165,22 @@ type RepositoryID interface {
 	ChangeURL(changeID ChangeID) string
 }
 
+// ErrUnsubmittedBase indicates that a change cannot be submitted
+// because the base branch has not been pushed yet.
+var ErrUnsubmittedBase = errors.New("base branch has not been submitted yet")
+
 // Repository is a Git repository hosted on a forge.
 type Repository interface {
 	Forge() Forge
 
+	// SubmitChange creates a new change request in the repository.
+	//
+	// Special errors:
+	//
+	//  - ErrUnsubmittedBase indicates that the change cannot be submitted
+	//    because the base branch has not been pushed to the remote yet.
 	SubmitChange(ctx context.Context, req SubmitChangeRequest) (SubmitChangeResult, error)
+
 	EditChange(ctx context.Context, id ChangeID, opts EditChangeOptions) error
 	FindChangesByBranch(ctx context.Context, branch string, opts FindChangesOptions) ([]*FindChangeItem, error)
 	FindChangeByID(ctx context.Context, id ChangeID) (*FindChangeItem, error)

--- a/internal/forge/github/integration_test.go
+++ b/internal/forge/github/integration_test.go
@@ -384,6 +384,96 @@ func TestIntegration_Repository_SubmitEditChange(t *testing.T) {
 	})
 }
 
+func TestIntegration_Repository_SubmitChange_baseBranchDoesNotExist(t *testing.T) {
+	branchFixture := fixturetest.New(_fixtures, "branch", func() string {
+		return randomString(8)
+	})
+	baseBranchFixture := fixturetest.New(_fixtures, "base-branch", func() string {
+		return randomString(8)
+	})
+
+	branchName := branchFixture.Get(t)
+	baseBranchName := baseBranchFixture.Get(t)
+	t.Logf("Creating branch %s with base branch %s", branchName, baseBranchName)
+
+	var gitRepo *git.Repository // only when _update is true
+	if *_update {
+		t.Setenv("GIT_AUTHOR_EMAIL", "bot@example.com")
+		t.Setenv("GIT_AUTHOR_NAME", "gs-test[bot]")
+		t.Setenv("GIT_COMMITTER_EMAIL", "bot@example.com")
+		t.Setenv("GIT_COMMITTER_NAME", "gs-test[bot]")
+
+		output := ioutil.TestLogWriter(t, "[git] ")
+
+		t.Logf("Cloning test-repo...")
+		repoDir := t.TempDir()
+		cmd := exec.Command("git", "clone", "https://github.com/abhinav/test-repo", repoDir)
+		cmd.Stdout = output
+		cmd.Stdout = output
+		require.NoError(t, cmd.Run(), "failed to clone test-repo")
+
+		ctx := t.Context()
+
+		var err error
+		gitRepo, err = git.Open(ctx, repoDir, git.OpenOptions{
+			Log: silogtest.New(t),
+		})
+		require.NoError(t, err, "failed to open git repo")
+
+		require.NoError(t, gitRepo.CreateBranch(ctx, git.CreateBranchRequest{
+			Name: branchName,
+		}), "could not create branch: %s", branchName)
+		require.NoError(t, gitRepo.Checkout(ctx, branchName),
+			"could not checkout branch: %s", branchName)
+		require.NoError(t, os.WriteFile(
+			filepath.Join(repoDir, branchName+".txt"),
+			[]byte(randomString(32)),
+			0o644,
+		), "could not write file to branch")
+
+		cmd = exec.Command("git", "add", ".")
+		cmd.Dir = repoDir
+		cmd.Stdout = output
+		cmd.Stderr = output
+		require.NoError(t, cmd.Run(), "git add failed")
+		require.NoError(t, gitRepo.Commit(ctx, git.CommitRequest{
+			Message: "commit from test",
+		}), "could not commit changes")
+
+		t.Logf("Pushing to origin")
+		require.NoError(t,
+			gitRepo.Push(ctx, git.PushOptions{
+				Remote:  "origin",
+				Refspec: git.Refspec(branchName),
+			}), "error pushing branch")
+
+		t.Cleanup(func() {
+			t.Logf("Deleting remote branch: %s", branchName)
+			assert.NoError(t,
+				gitRepo.Push(context.WithoutCancel(ctx), git.PushOptions{
+					Remote:  "origin",
+					Refspec: git.Refspec(":" + branchName),
+				}), "error deleting branch")
+		})
+	}
+
+	rec := newRecorder(t, t.Name())
+	ghc := newGitHubClient(rec.GetDefaultClient())
+	repo, err := github.NewRepository(
+		t.Context(), new(github.Forge), "abhinav", "test-repo", silogtest.New(t), ghc, _testRepoID,
+	)
+	require.NoError(t, err)
+
+	_, err = repo.SubmitChange(t.Context(), forge.SubmitChangeRequest{
+		Subject: branchName,
+		Body:    "Test PR",
+		Base:    baseBranchName, // This branch does not exist in remote
+		Head:    branchName,
+	})
+	require.Error(t, err, "error creating PR")
+	assert.ErrorIs(t, err, forge.ErrUnsubmittedBase)
+}
+
 func TestIntegration_Repository_comments(t *testing.T) {
 	rec := newRecorder(t, t.Name())
 	ghc := newGitHubClient(rec.GetDefaultClient())

--- a/internal/forge/github/ref.go
+++ b/internal/forge/github/ref.go
@@ -1,0 +1,30 @@
+package github
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/shurcooL/githubv4"
+)
+
+// RefExists checks if a reference exists in the repository.
+// ref must be a fully qualified reference name,
+func (r *Repository) RefExists(ctx context.Context, ref string) (bool, error) {
+	var q struct {
+		Repository struct {
+			Ref struct {
+				Name githubv4.String `graphql:"name"`
+			} `graphql:"ref(qualifiedName: $ref)"`
+		} `graphql:"repository(owner: $owner, name: $repo)"`
+	}
+
+	if err := r.client.Query(ctx, &q, map[string]any{
+		"owner": githubv4.String(r.owner),
+		"repo":  githubv4.String(r.repo),
+		"ref":   githubv4.String(ref),
+	}); err != nil {
+		return false, fmt.Errorf("check ref existence: %w", err)
+	}
+
+	return q.Repository.Ref.Name != "", nil
+}

--- a/internal/forge/github/testdata/TestIntegration_Repository_SubmitChange_baseBranchDoesNotExist/base-branch
+++ b/internal/forge/github/testdata/TestIntegration_Repository_SubmitChange_baseBranchDoesNotExist/base-branch
@@ -1,0 +1,1 @@
+"yvWaNeIc"

--- a/internal/forge/github/testdata/TestIntegration_Repository_SubmitChange_baseBranchDoesNotExist/branch
+++ b/internal/forge/github/testdata/TestIntegration_Repository_SubmitChange_baseBranchDoesNotExist/branch
@@ -1,0 +1,1 @@
+"kbkBQvKp"

--- a/internal/forge/github/testdata/fixtures/TestIntegration_Repository_SubmitChange_baseBranchDoesNotExist.yaml
+++ b/internal/forge/github/testdata/fixtures/TestIntegration_Repository_SubmitChange_baseBranchDoesNotExist.yaml
@@ -1,0 +1,71 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 255
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"yvWaNeIc","headRefName":"kbkBQvKp","title":"kbkBQvKp","body":"Test PR"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"createPullRequest":{"pullRequest":null}},"errors":[{"type":"UNPROCESSABLE","path":["createPullRequest"],"locations":[{"line":1,"column":42}],"message":"Head sha can''t be blank, Base sha can''t be blank, No commits between yvWaNeIc and kbkBQvKp, Base ref must be a branch"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 442.131416ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 210
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"query":"query($owner:String!$ref:String!$repo:String!){repository(owner: $owner, name: $repo){ref(qualifiedName: $ref){name}}}","variables":{"owner":"abhinav","ref":"refs/heads/yvWaNeIc","repo":"test-repo"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"repository":{"ref":null}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 189.35925ms

--- a/internal/forge/shamhub/ref.go
+++ b/internal/forge/shamhub/ref.go
@@ -1,0 +1,70 @@
+package shamhub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os/exec"
+
+	"go.abhg.dev/gs/internal/silog"
+)
+
+type refExistsRequest struct {
+	Ref string `json:"ref"`
+}
+
+type refExistsResponse struct {
+	Exists bool `json:"exists"`
+}
+
+var _ = shamhubHandler("POST /{owner}/{repo}/ref/exists", (*ShamHub).handleRefExists)
+
+func (sh *ShamHub) handleRefExists(w http.ResponseWriter, r *http.Request) {
+	owner, repo := r.PathValue("owner"), r.PathValue("repo")
+	if owner == "" || repo == "" {
+		http.Error(w, "owner and repo are required", http.StatusBadRequest)
+		return
+	}
+
+	var data refExistsRequest
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&data); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	ctx := r.Context()
+	exists := sh.refExists(ctx, owner, repo, data.Ref)
+
+	resp := refExistsResponse{Exists: exists}
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func (r *forgeRepository) RefExists(ctx context.Context, ref string) (bool, error) {
+	u := r.apiURL.JoinPath(r.owner, r.repo, "ref", "exists")
+	var res refExistsResponse
+	if err := r.client.Post(ctx, u.String(), refExistsRequest{Ref: ref}, &res); err != nil {
+		return false, fmt.Errorf("check ref exists: %w", err)
+	}
+	return res.Exists, nil
+}
+
+func (sh *ShamHub) refExists(ctx context.Context, owner, repo, ref string) bool {
+	logw, flush := silog.Writer(sh.log, silog.LevelDebug)
+	defer flush()
+
+	cmd := exec.CommandContext(ctx, sh.gitExe,
+		"show-ref", "--verify", "--quiet", ref)
+	cmd.Dir = sh.repoDir(owner, repo)
+	cmd.Stderr = logw
+	return cmd.Run() == nil
+}
+
+func (sh *ShamHub) branchRefExists(ctx context.Context, owner, repo, branch string) bool {
+	return sh.refExists(ctx, owner, repo, "refs/heads/"+branch)
+}

--- a/internal/graphqlutil/error.go
+++ b/internal/graphqlutil/error.go
@@ -18,8 +18,9 @@ import (
 // Common errors that may be returned by GraphQL APIs.
 // These may be matched with errors.Is.
 var (
-	ErrNotFound  = errors.New("not found")
-	ErrForbidden = errors.New("forbidden")
+	ErrNotFound      = errors.New("not found")
+	ErrForbidden     = errors.New("forbidden")
+	ErrUnprocessable = errors.New("unprocessable")
 )
 
 // graphQLTransport wraps an HTTP transport
@@ -126,6 +127,8 @@ func (e *Error) Is(target error) bool {
 		return e.Type == "NOT_FOUND"
 	case ErrForbidden:
 		return e.Type == "FORBIDDEN"
+	case ErrUnprocessable:
+		return e.Type == "UNPROCESSABLE"
 	default:
 		return false
 	}

--- a/testdata/script/branch_submit_unsubmitted_base.txt
+++ b/testdata/script/branch_submit_unsubmitted_base.txt
@@ -1,0 +1,37 @@
+# 'gs branch submit' when the base branch has not been submitted yet
+# reports a reasonable error message.
+#
+# https://github.com/abhinav/git-spice/issues/460
+# https://github.com/abhinav/git-spice/issues/686
+
+as 'Test <test@example.com>'
+at '2025-05-31T09:23:25Z'
+
+# setup repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# setup remote
+shamhub init
+shamhub register alice
+shamhub new origin alice/example.git
+git push origin main
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+git add feat1.txt
+gs bc -m 'Add feat1' feat1
+
+git add feat2.txt
+gs bc -m 'Add feat2' feat2
+
+! gs branch submit --fill
+stderr 'feat2: cannot be submitted'
+stderr 'base branch "feat1" does not exist'
+stderr 'gs branch submit --branch=feat1'
+
+-- repo/feat1.txt --
+feature 1
+-- repo/feat2.txt --
+feature 2


### PR DESCRIPTION
When GitHub rejects a PR because the base branch doesn't exist,
the error is super unhelpful:

```
FTL gs: create change:
create pull request: Post "https://api.github.com/graphql":
createPullRequest: UNPROCESSABLE:
Head sha can't be blank,
Base sha can't be blank,
No commits between he/feat1 and he/feat2,
Base ref must be a branch
```

(Newlines added for readability.)

To improve the UX around this, this change adds a check at submission:
if the request failed, and the base branch does not exist,
we return a more user-friendly error message.

Note that this error isn't returned for GitLab yet;
from experimentation, GitLab lets you submit an MR
even without the base branch being pushed,
and just reports the warning in the UI on the website.

Resolves #686, #460