### PR TITLE
Fix gitlab token regex

### DIFF
--- a/.changes/unreleased/Fixed-20250613-205329.yaml
+++ b/.changes/unreleased/Fixed-20250613-205329.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'GitLab: CLI authentication now recognizes the new token format (`glab-XXXX`).'
+time: 2025-06-13T20:53:29.030783-07:00

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -21,6 +21,6 @@ jobs:
       uses: ./.github/actions/go-cache
     - run: |
         mise run generate
-    - uses: autofix-ci/action@551dded8c6cc8a1054039c8bc0b8b48c51dfc6ef
+    - uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27
       with:
         fail-fast: true

--- a/internal/forge/gitlab/auth.go
+++ b/internal/forge/gitlab/auth.go
@@ -488,7 +488,7 @@ func (gc *glabCLI) Status(ctx context.Context, host string) (ok bool, err error)
 	return true, nil
 }
 
-var _tokenRe = regexp.MustCompile(`(?m)^\W+Token:\s+((\w+)(-\w+)?)\s*$`)
+var _tokenRe = regexp.MustCompile(`(?m)^\W+Token:\s+([\w\-]+)\s*$`)
 
 // Token returns the authentication token from the GitLab CLI.
 func (gc *glabCLI) Token(ctx context.Context, host string) (string, error) {

--- a/internal/forge/gitlab/auth.go
+++ b/internal/forge/gitlab/auth.go
@@ -488,7 +488,7 @@ func (gc *glabCLI) Status(ctx context.Context, host string) (ok bool, err error)
 	return true, nil
 }
 
-var _tokenRe = regexp.MustCompile(`(?m)^\W+Token:\s+(\w+)\s*$`)
+var _tokenRe = regexp.MustCompile(`(?m)^\W+Token:\s+((\w+)(-\w+)?)\s*$`)
 
 // Token returns the authentication token from the GitLab CLI.
 func (gc *glabCLI) Token(ctx context.Context, host string) (string, error) {

--- a/internal/forge/gitlab/auth_test.go
+++ b/internal/forge/gitlab/auth_test.go
@@ -476,3 +476,47 @@ func (g gitlabCLIStub) Token(ctx context.Context, hostname string) (string, erro
 func (g gitlabCLIStub) Status(ctx context.Context, hostname string) (bool, error) {
 	return g.StatusF(ctx, hostname)
 }
+
+func TestCLITokenParsing(t *testing.T) {
+	tests := []struct {
+		name string
+		give string
+		want string
+	}{
+		{
+			name: "Plain",
+			give: "  ✓ Token: 1234567890abcdef\n",
+			want: "1234567890abcdef",
+		},
+		{
+			name: "glabPrefix",
+			give: "  ✓ Token: glab-AAAAA\n",
+			want: "glab-AAAAA",
+		},
+		{
+			name: "Dashes",
+			give: "  ✓ Token: abc-def-ghi\n",
+			want: "abc-def-ghi",
+		},
+		{
+			name: "NoToken",
+			give: "  ✓ Token: \n",
+		},
+		{
+			name: "Unrelated",
+			give: "something else\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := _tokenRe.FindSubmatch([]byte(tt.give))
+			if len(tt.want) > 0 {
+				require.Len(t, m, 2)
+				assert.Equal(t, tt.want, string(m[1]))
+			} else {
+				assert.Len(t, m, 0)
+			}
+		})
+	}
+}


### PR DESCRIPTION
New gitlab token has format `glab-AAAAA`. The current regex doesn't work.

Tested here
https://go.dev/play/p/akATgbSqGmW