### PR TITLE
config: add spice.{logShort, logLong}.crFormat options

### DIFF
--- a/.changes/unreleased/Added-20250620-211723.yaml
+++ b/.changes/unreleased/Added-20250620-211723.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: >-
+  log short: Add `spice.logShort.crFormat` configuration option.
+  This takes precedence over `spice.log.crFormat` for `gs log short`/`gs ls`.
+time: 2025-06-20T21:17:23.549145-07:00

--- a/.changes/unreleased/Added-20250622-211724.yaml
+++ b/.changes/unreleased/Added-20250622-211724.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: >-
+  log long: Add `spice.logLong.crFormat` configuration option.
+  This takes precedence over `spice.log.crFormat` for `gs log long`/`gs ll`.
+time: 2025-06-20T21:17:23.549145-07:00

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -164,7 +164,7 @@ Use with the -a/--all flag to show all tracked branches.
 
 * `-a`, `--all` ([:material-wrench:{ .middle title="spice.log.all" }](/cli/config.md#spicelogall)): Show all tracked branches, not just the current stack.
 
-**Configuration**: [spice.log.all](/cli/config.md#spicelogall), [spice.log.crFormat](/cli/config.md#spicelogcrformat), [spice.log.pushStatusFormat](/cli/config.md#spicelogpushstatusformat)
+**Configuration**: [spice.log.all](/cli/config.md#spicelogall), [spice.log.crFormat](/cli/config.md#spicelogcrformat), [spice.log.pushStatusFormat](/cli/config.md#spicelogpushstatusformat), [spice.logLong.crFormat](/cli/config.md#spiceloglongcrformat), [spice.logShort.crFormat](/cli/config.md#spicelogshortcrformat)
 
 ### gs log long
 
@@ -182,7 +182,7 @@ Use with the -a/--all flag to show all tracked branches.
 
 * `-a`, `--all` ([:material-wrench:{ .middle title="spice.log.all" }](/cli/config.md#spicelogall)): Show all tracked branches, not just the current stack.
 
-**Configuration**: [spice.log.all](/cli/config.md#spicelogall), [spice.log.crFormat](/cli/config.md#spicelogcrformat), [spice.log.pushStatusFormat](/cli/config.md#spicelogpushstatusformat)
+**Configuration**: [spice.log.all](/cli/config.md#spicelogall), [spice.log.crFormat](/cli/config.md#spicelogcrformat), [spice.log.pushStatusFormat](/cli/config.md#spicelogpushstatusformat), [spice.logLong.crFormat](/cli/config.md#spiceloglongcrformat), [spice.logShort.crFormat](/cli/config.md#spicelogshortcrformat)
 
 ## Stack
 

--- a/doc/mise.lock
+++ b/doc/mise.lock
@@ -1,11 +1,10 @@
 [tools.python]
-version = "3.13.4"
+version = "3.13.5"
 backend = "core:python"
 
 [tools.uv]
-version = "0.5.30"
+version = "0.7.13"
 backend = "aqua:astral-sh/uv"
 
 [tools.uv.checksums]
-"uv-aarch64-apple-darwin.tar.gz" = "sha256:654c3e010c9c53b024fa752d08b949e0f80f10ec4e3a1acea9437a1d127a1053"
-"uv-x86_64-unknown-linux-musl.tar.gz" = "sha256:7cc79871e5fcd2678474d756bfc32c6c3d28e136963dda10902c516fab67fa2d"
+"uv-aarch64-apple-darwin.tar.gz" = "sha256:721f532b73171586574298d4311a91d5ea2c802ef4db3ebafc434239330090c6"

--- a/doc/mise.lock
+++ b/doc/mise.lock
@@ -8,3 +8,4 @@ backend = "aqua:astral-sh/uv"
 
 [tools.uv.checksums]
 "uv-aarch64-apple-darwin.tar.gz" = "sha256:721f532b73171586574298d4311a91d5ea2c802ef4db3ebafc434239330090c6"
+"uv-x86_64-unknown-linux-musl.tar.gz" = "sha256:560bb64e060354e45138d7dd47c8dd48a4f7a349af5520d29cd3c704e79f286c"

--- a/doc/mise.toml
+++ b/doc/mise.toml
@@ -15,7 +15,7 @@ _.python.venv = { path = ".venv", create = true }
 _BIN_DIR = "{{ env.PROJECT_ROOT }}/bin"
 
 [tools]
-python = "3.13.4"
+python = "latest"
 uv = "latest"
 
 [tasks.build]

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -180,6 +180,30 @@ to any remote branches.
 - `"url"`: show the CR URL
 - `"id"`: (default) show the CR ID
 
+### spice.logShort.crFormat
+
+<!-- gs:version unreleased -->
+
+Override for $$gs log short$$ to control how change requests are displayed.
+If not set, falls back to `spice.log.crFormat`.
+
+**Accepted values:**
+
+- `"url"`: show the CR URL
+- `"id"`: show the CR ID
+
+### spice.logLong.crFormat
+
+<!-- gs:version unreleased -->
+
+Override for $$gs log long$$ to control how change requests are displayed.
+If not set, falls back to `spice.log.crFormat`.
+
+**Accepted values:**
+
+- `"url"`: show the CR URL
+- `"id"`: show the CR ID
+
 ### spice.log.pushStatusFormat
 
 <!-- gs:version v0.13.0 -->

--- a/mise.lock
+++ b/mise.lock
@@ -29,12 +29,11 @@ backend = "aqua:golangci/golangci-lint"
 "golangci-lint-2.1.6-linux-amd64.tar.gz" = "sha256:e55e0eb515936c0fbd178bce504798a9bd2f0b191e5e357768b18fd5415ee541"
 
 [tools.gotestsum]
-version = "1.12.2"
+version = "1.12.3"
 backend = "aqua:gotestyourself/gotestsum"
 
 [tools.gotestsum.checksums]
-"gotestsum_1.12.2_darwin_arm64.tar.gz" = "sha256:062d33b93d5eb9a84083dc74286fa014be11b19e9e861424bf96136d682a5bbb"
-"gotestsum_1.12.2_linux_amd64.tar.gz" = "sha256:50818a05193c58e6f7ff29bc6306e464e5b84c59d7422e676bbe5070a99a9899"
+"gotestsum_1.12.3_darwin_arm64.tar.gz" = "sha256:a2cdc441a1355c8cfe35f4deaa0d6c8b73a9530f8c8d02e2c00fe4fae7aa5c45"
 
 [tools.requiredfield]
 version = "0.5.0"

--- a/mise.lock
+++ b/mise.lock
@@ -34,6 +34,7 @@ backend = "aqua:gotestyourself/gotestsum"
 
 [tools.gotestsum.checksums]
 "gotestsum_1.12.3_darwin_arm64.tar.gz" = "sha256:a2cdc441a1355c8cfe35f4deaa0d6c8b73a9530f8c8d02e2c00fe4fae7aa5c45"
+"gotestsum_1.12.3_linux_amd64.tar.gz" = "sha256:dd644e817b509fa8e216887ec93facdd85722d1b78f6a19149ee1bc9f59fca64"
 
 [tools.requiredfield]
 version = "0.5.0"

--- a/testdata/script/config_log_combined_change_format.txt
+++ b/testdata/script/config_log_combined_change_format.txt
@@ -1,0 +1,92 @@
+# Both 'gs log short' and 'gs log long' commands respect their specific options
+# and fall back to the general 'spice.log.crFormat' option when not set.
+
+as 'Test <test@example.com>'
+at '2024-08-07T06:05:04Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake remote
+shamhub init
+shamhub register alice
+shamhub new origin alice/example.git
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+gs repo init
+
+# create a simple stack: feat1 -> feat2
+gs bc feat1 -m 'feat1'
+gs bc feat2 -m 'feat2'
+
+# submit the bottom-most branch
+gs bottom
+gs branch submit --fill
+gs branch checkout feat2
+
+# Test 1: Both commands should use general config fallback
+git config spice.log.crFormat 'url'
+
+gs ls
+cmpenv stderr $WORK/golden/ls-general-url.txt
+
+gs ll
+cmpenv stderr $WORK/golden/ll-general-url.txt
+
+# Test 2: Set specific configs that override general config
+git config spice.logShort.crFormat 'id'
+git config spice.logLong.crFormat 'url'
+# spice.log.crFormat is still 'url' from above
+
+gs ls
+cmpenv stderr $WORK/golden/ls-specific-id.txt
+
+gs ll
+cmpenv stderr $WORK/golden/ll-specific-url.txt
+
+# Test 3: Remove specific configs, both should fall back to general
+git config --unset spice.logShort.crFormat
+git config --unset spice.logLong.crFormat
+git config spice.log.crFormat 'id'
+
+gs ls
+cmpenv stderr $WORK/golden/ls-fallback-id.txt
+
+gs ll
+cmpenv stderr $WORK/golden/ll-fallback-id.txt
+
+-- golden/ls-general-url.txt --
+  ┏━■ feat2 ◀
+┏━┻□ feat1 ($SHAMHUB_URL/alice/example/changes/1)
+main
+-- golden/ll-general-url.txt --
+  ┏━■ feat2 ◀
+  ┃   562c8c6 feat2 (now)
+┏━┻□ feat1 ($SHAMHUB_URL/alice/example/changes/1)
+┃    ecc906e feat1 (now)
+main
+-- golden/ls-specific-id.txt --
+  ┏━■ feat2 ◀
+┏━┻□ feat1 (#1)
+main
+-- golden/ll-specific-url.txt --
+  ┏━■ feat2 ◀
+  ┃   562c8c6 feat2 (now)
+┏━┻□ feat1 ($SHAMHUB_URL/alice/example/changes/1)
+┃    ecc906e feat1 (now)
+main
+-- golden/ls-fallback-id.txt --
+  ┏━■ feat2 ◀
+┏━┻□ feat1 (#1)
+main
+-- golden/ll-fallback-id.txt --
+  ┏━■ feat2 ◀
+  ┃   562c8c6 feat2 (now)
+┏━┻□ feat1 (#1)
+┃    ecc906e feat1 (now)
+main

--- a/testdata/script/config_log_long_change_format.txt
+++ b/testdata/script/config_log_long_change_format.txt
@@ -1,0 +1,90 @@
+# 'gs log long' (ll) command supports logLong.crFormat option and fallback to log.crFormat.
+
+as 'Test <test@example.com>'
+at '2024-08-07T06:05:04Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake remote
+shamhub init
+shamhub register alice
+shamhub new origin alice/example.git
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+gs repo init
+
+# create a simple stack: feat1 -> feat2
+gs bc feat1 -m 'feat1'
+gs bc feat2 -m 'feat2'
+
+# submit the bottom-most branch
+gs bottom
+gs branch submit --fill
+gs branch checkout feat2
+
+# Test 1: Default behavior (should show ID)
+gs ll
+cmpenv stderr $WORK/golden/ll-default.txt
+
+# Test 2: Set logLong.crFormat to 'url'
+git config spice.logLong.crFormat 'url'
+
+gs ll
+cmpenv stderr $WORK/golden/ll-loglong-url.txt
+
+# Test 3: Set logLong.crFormat to 'id' (explicit)
+git config spice.logLong.crFormat 'id'
+
+gs ll
+cmpenv stderr $WORK/golden/ll-loglong-id.txt
+
+# Test 4: Fallback behavior - remove logLong.crFormat, set log.crFormat to 'url'
+git config --unset spice.logLong.crFormat
+git config spice.log.crFormat 'url'
+
+gs ll
+cmpenv stderr $WORK/golden/ll-fallback-url.txt
+
+# Test 5: logLong.crFormat overrides log.crFormat
+git config spice.logLong.crFormat 'id'
+# spice.log.crFormat is still 'url' from previous test
+
+gs ll
+cmpenv stderr $WORK/golden/ll-override-id.txt
+
+-- golden/ll-default.txt --
+  ┏━■ feat2 ◀
+  ┃   562c8c6 feat2 (now)
+┏━┻□ feat1 (#1)
+┃    ecc906e feat1 (now)
+main
+-- golden/ll-loglong-url.txt --
+  ┏━■ feat2 ◀
+  ┃   562c8c6 feat2 (now)
+┏━┻□ feat1 ($SHAMHUB_URL/alice/example/changes/1)
+┃    ecc906e feat1 (now)
+main
+-- golden/ll-loglong-id.txt --
+  ┏━■ feat2 ◀
+  ┃   562c8c6 feat2 (now)
+┏━┻□ feat1 (#1)
+┃    ecc906e feat1 (now)
+main
+-- golden/ll-fallback-url.txt --
+  ┏━■ feat2 ◀
+  ┃   562c8c6 feat2 (now)
+┏━┻□ feat1 ($SHAMHUB_URL/alice/example/changes/1)
+┃    ecc906e feat1 (now)
+main
+-- golden/ll-override-id.txt --
+  ┏━■ feat2 ◀
+  ┃   562c8c6 feat2 (now)
+┏━┻□ feat1 (#1)
+┃    ecc906e feat1 (now)
+main

--- a/testdata/script/config_log_short_change_format.txt
+++ b/testdata/script/config_log_short_change_format.txt
@@ -1,0 +1,80 @@
+# 'gs log short' (ls) command supports logShort.crFormat option and fallback to log.crFormat.
+
+as 'Test <test@example.com>'
+at '2024-08-07T06:05:04Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake remote
+shamhub init
+shamhub register alice
+shamhub new origin alice/example.git
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+gs repo init
+
+# create a simple stack: feat1 -> feat2
+gs bc feat1 -m 'feat1'
+gs bc feat2 -m 'feat2'
+
+# submit the bottom-most branch
+gs bottom
+gs branch submit --fill
+gs branch checkout feat2
+
+# Test 1: Default behavior (should show ID)
+gs ls
+cmpenv stderr $WORK/golden/ls-default.txt
+
+# Test 2: Set logShort.crFormat to 'url'
+git config spice.logShort.crFormat 'url'
+
+gs ls
+cmpenv stderr $WORK/golden/ls-logshort-url.txt
+
+# Test 3: Set logShort.crFormat to 'id' (explicit)
+git config spice.logShort.crFormat 'id'
+
+gs ls
+cmpenv stderr $WORK/golden/ls-logshort-id.txt
+
+# Test 4: Fallback behavior - remove logShort.crFormat, set log.crFormat to 'url'
+git config --unset spice.logShort.crFormat
+git config spice.log.crFormat 'url'
+
+gs ls
+cmpenv stderr $WORK/golden/ls-fallback-url.txt
+
+# Test 5: logShort.crFormat overrides log.crFormat
+git config spice.logShort.crFormat 'id'
+# spice.log.crFormat is still 'url' from previous test
+
+gs ls
+cmpenv stderr $WORK/golden/ls-override-id.txt
+
+-- golden/ls-default.txt --
+  ┏━■ feat2 ◀
+┏━┻□ feat1 (#1)
+main
+-- golden/ls-logshort-url.txt --
+  ┏━■ feat2 ◀
+┏━┻□ feat1 ($SHAMHUB_URL/alice/example/changes/1)
+main
+-- golden/ls-logshort-id.txt --
+  ┏━■ feat2 ◀
+┏━┻□ feat1 (#1)
+main
+-- golden/ls-fallback-url.txt --
+  ┏━■ feat2 ◀
+┏━┻□ feat1 ($SHAMHUB_URL/alice/example/changes/1)
+main
+-- golden/ls-override-id.txt --
+  ┏━■ feat2 ◀
+┏━┻□ feat1 (#1)
+main


### PR DESCRIPTION
Adds the `gs ll` and `gs ls` specific overrides for crFormat
discussed in #693.

Resolves #693