### PR TITLE
git/rebase: detect autostash conflicts

### DIFF
--- a/.changes/unreleased/Fixed-20250621-093946.yaml
+++ b/.changes/unreleased/Fixed-20250621-093946.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: >-
+  Rebase operations now detect conflicts caused by autostashed dirty changes
+  to prevent corrupted state.
+time: 2025-06-21T09:39:46.025035-07:00

--- a/internal/git/files_wt.go
+++ b/internal/git/files_wt.go
@@ -1,0 +1,47 @@
+package git
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"iter"
+)
+
+// ListFilesOptions shows information about files
+// in the worktree or the index.
+type ListFilesOptions struct {
+	// Unmerged states unmerged files should be shown in the output.
+	Unmerged bool
+}
+
+// ListFilesPaths lists files in the worktree or the index
+// using the given options to filter.
+func (w *Worktree) ListFilesPaths(ctx context.Context, opts *ListFilesOptions) iter.Seq2[string, error] {
+	opts = cmp.Or(opts, &ListFilesOptions{})
+	args := []string{"ls-files", "--format=%(path)"}
+	if opts.Unmerged {
+		args = append(args, "--unmerged")
+	}
+
+	shown := make(map[string]struct{})
+	return func(yield func(string, error) bool) {
+		cmd := w.gitCmd(ctx, args...)
+		for line, err := range cmd.ScanLines(w.exec) {
+			if err != nil {
+				yield("", fmt.Errorf("git ls-files: %w", err))
+				continue
+			}
+
+			path := string(line)
+			if _, ok := shown[path]; ok {
+				// Skip duplicates
+				continue
+			}
+			shown[path] = struct{}{}
+
+			if !yield(path, nil) {
+				return
+			}
+		}
+	}
+}

--- a/internal/git/files_wt_test.go
+++ b/internal/git/files_wt_test.go
@@ -1,0 +1,103 @@
+package git_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/git/gittest"
+	"go.abhg.dev/gs/internal/silog/silogtest"
+	"go.abhg.dev/gs/internal/sliceutil"
+	"go.abhg.dev/gs/internal/text"
+)
+
+func TestListFilesPaths(t *testing.T) {
+	t.Parallel()
+
+	fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+		as 'Test <test@example.com>'
+		at '2025-06-21T09:27:19Z'
+
+		git init
+		git add file1.txt
+		git commit -m 'Initial commit'
+
+		git add file2.txt
+		git commit -m 'Add file2'
+
+		-- file1.txt --
+		Contents of file1
+
+		-- file2.txt --
+		Contents of file2
+	`)))
+	require.NoError(t, err)
+	t.Cleanup(fixture.Cleanup)
+
+	wt, err := git.OpenWorktree(t.Context(), fixture.Dir(), git.OpenOptions{
+		Log: silogtest.New(t),
+	})
+	require.NoError(t, err)
+
+	paths, err := sliceutil.CollectErr(wt.ListFilesPaths(t.Context(), nil))
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []string{"file1.txt", "file2.txt"}, paths)
+}
+
+func TestListFilesPaths_unmerged(t *testing.T) {
+	t.Parallel()
+
+	fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+		as 'Test <test@example.com>'
+		at '2025-06-21T09:27:19Z'
+
+		git init
+		git add base.txt
+		git commit -m 'Initial commit'
+
+		git checkout -b feature
+		git add conflict.txt
+		git commit -m 'Add conflict file'
+
+		git checkout main
+		mv different-conflict.txt conflict.txt
+		git add conflict.txt
+		git commit -m 'Add different conflict file'
+
+		! git merge feature
+
+		-- base.txt --
+		Base file
+
+		-- conflict.txt --
+		Feature version
+
+		-- different-conflict.txt --
+		Main version
+	`)))
+	require.NoError(t, err)
+	t.Cleanup(fixture.Cleanup)
+
+	wt, err := git.OpenWorktree(t.Context(), fixture.Dir(), git.OpenOptions{
+		Log: silogtest.New(t),
+	})
+	require.NoError(t, err)
+
+	t.Run("ListAll", func(t *testing.T) {
+		paths, err := sliceutil.CollectErr(
+			wt.ListFilesPaths(t.Context(), nil))
+		require.NoError(t, err)
+
+		assert.Contains(t, paths, "base.txt")
+		assert.Contains(t, paths, "conflict.txt")
+	})
+
+	t.Run("ListUnmerged", func(t *testing.T) {
+		paths, err := sliceutil.CollectErr(
+			wt.ListFilesPaths(t.Context(), &git.ListFilesOptions{Unmerged: true}))
+		require.NoError(t, err)
+		assert.Equal(t, []string{"conflict.txt"}, paths)
+	})
+}

--- a/testdata/script/issue701_stack_edit_with_unstaged_changes.txt
+++ b/testdata/script/issue701_stack_edit_with_unstaged_changes.txt
@@ -1,0 +1,110 @@
+# Editing the order of a stack with 'stack edit' with unstaged changes
+# that might conflict with reordering the stack.
+#
+# https://github.com/abhinav/git-spice/issues/701
+
+as 'Test <test@example.com>'
+at '2025-06-20T21:25:26Z'
+
+# set up
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git add feat2.txt
+gs branch create feat2 -m 'Add feature 2'
+
+git add feat1.txt
+gs branch create feat1 -m 'Add feature 1'
+
+# Stage feat3 and make unstaged changes to feat2.
+git add feat3.txt
+mv $WORK/other/feat2-new.txt feat2.txt
+
+# Oops, realize that feat1 is above feat2.
+gs ls
+cmp stderr $WORK/golden/ls-before.txt
+
+# gs stack edit fails because of the conflict
+env MOCKEDIT_GIVE=$WORK/edit/give.txt MOCKEDIT_RECORD=$WORK/edit/got.txt
+! gs stack edit
+cmp stderr $WORK/golden/stack-edit-fail.txt
+cmp $WORK/edit/got.txt $WORK/edit/want.txt
+
+# Branch has been rebased but the internal state has not been updated.
+gs ll -a
+cmp stderr $WORK/golden/ls-after-fail.txt
+git graph --branches
+cmp stdout $WORK/golden/graph-after-fail.txt
+# TODO: Ideally, we restore the old state but that's a bit tricky.
+# Perhaps we need to manage autostashing on our end.
+
+# Manually resolve the conflict and continue.
+# TODO: Ideally, we can handle this on our end.
+git rm feat2.txt
+gs bco feat2
+gs branch onto feat1
+git stash pop
+
+gs ll -a
+cmp stderr $WORK/golden/ls-after.txt
+git graph --branches
+cmp stdout $WORK/golden/graph-after.txt
+
+grep 'modified' feat2.txt
+
+-- repo/feat1.txt --
+Feature 1
+-- repo/feat2.txt --
+Feature 2
+-- repo/feat3.txt --
+Feature 3
+-- other/feat2-new.txt --
+Feature 2 (modified)
+-- golden/ls-before.txt --
+  ┏━■ feat1 ◀
+┏━┻□ feat2
+main
+-- edit/give.txt --
+feat2
+feat1
+-- edit/want.txt --
+feat1
+feat2
+
+# Edit the order of branches by modifying the list above.
+# The branch at the bottom of the list will be merged into trunk first.
+# Branches above that will be stacked on top of it in the order they appear.
+# Branches deleted from the list will not be modified.
+#
+# Save and quit the editor to apply the changes.
+# Delete all lines in the editor to abort the operation.
+-- golden/stack-edit-fail.txt --
+ERR Dirty changes in the worktree were stashed, but could not be re-applied.
+ERR The following files were left unmerged:
+ERR   - feat2.txt
+ERR Resolve the conflict and run 'git stash drop' to remove the stash entry.
+ERR Or change to a branch where the stash can apply, and run 'git stash pop'.
+FTL gs: edit downstack: branch feat1 onto main: rebase: feat1: dirty changes could not be re-applied
+-- golden/ls-after-fail.txt --
+  ┏━■ feat1 (needs restack) ◀
+  ┃   94ce439 Add feature 1 (now)
+┏━┻□ feat2
+┃    d9e6a97 Add feature 2 (now)
+main
+-- golden/graph-after-fail.txt --
+* 94ce439 (HEAD -> feat1) Add feature 1
+| * d9e6a97 (feat2) Add feature 2
+|/  
+* 632b702 (main) Initial commit
+-- golden/ls-after.txt --
+  ┏━■ feat2 ◀
+  ┃   c709a8d Add feature 2 (now)
+┏━┻□ feat1
+┃    94ce439 Add feature 1 (now)
+main
+-- golden/graph-after.txt --
+* c709a8d (HEAD -> feat2) Add feature 2
+* 94ce439 (feat1) Add feature 1
+* 632b702 (main) Initial commit


### PR DESCRIPTION
'git rebase --autostash' exits with a zero exit code
even when the auto-stashed changes fail to apply,
and leaves the worktree in a conflicted state
(with merge-pending files).

This can result in multi-rebase operations
(`gs stack edit`, `gs upstack restack`, etc.)
trying to continue with the following rebases in a conflicted state,
also updating internal state to reflect the new branch order.

This implements an imperfect workaround to the problem:
detect if there are any unmerged files after the rebase,
and if so, fail the entire operation with an error message.

We should explore a more robust solution in the future,
but this will at least prevent the state from getting corrupted.

Resolves #701