### PR TITLE
submit: add --no-verify flag to bypass pre-push hooks

### DIFF
--- a/.changes/unreleased/Added-20250621-143644.yaml
+++ b/.changes/unreleased/Added-20250621-143644.yaml
@@ -1,0 +1,4 @@
+kind: Added
+body: >-
+  submit: Add --no-verify flag to bypass pre-push hooks.
+time: 2025-06-21T14:36:44.957961-07:00

--- a/branch_submit.go
+++ b/branch_submit.go
@@ -34,6 +34,7 @@ type submitOptions struct {
 	NavigationComment navigationCommentWhen `name:"nav-comment" config:"submit.navigationComment" enum:"true,false,multiple" default:"true" help:"Whether to add a navigation comment to the change request. Must be one of: true, false, multiple."`
 
 	Force      bool `help:"Force push, bypassing safety checks"`
+	NoVerify   bool `help:"Bypass pre-push hooks when pushing to the remote." released:"unreleased"`
 	UpdateOnly bool `short:"u" help:"Only update existing change requests, do not create new ones"`
 
 	// TODO: Other creation options e.g.:
@@ -424,7 +425,8 @@ func (cmd *branchSubmitCmd) run(
 			Refspec: git.Refspec(
 				commitHash.String() + ":refs/heads/" + upstreamBranch,
 			),
-			Force: cmd.Force,
+			Force:    cmd.Force,
+			NoVerify: cmd.NoVerify,
 		}
 
 		// If we've already pushed this branch before,
@@ -535,7 +537,8 @@ func (cmd *branchSubmitCmd) run(
 				Refspec: git.Refspec(
 					commitHash.String() + ":refs/heads/" + upstreamBranch,
 				),
-				Force: cmd.Force,
+				Force:    cmd.Force,
+				NoVerify: cmd.NoVerify,
 			}
 			if !cmd.Force {
 				// Force push, but only if the ref is exactly

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -221,6 +221,7 @@ or --nav-comment=multiple to post those comments only if there are multiple CRs 
 * `-w`, `--[no-]web` ([:material-wrench:{ .middle title="spice.submit.web" }](/cli/config.md#spicesubmitweb)): Open submitted changes in a web browser
 * `--nav-comment=true` ([:material-wrench:{ .middle title="spice.submit.navigationComment" }](/cli/config.md#spicesubmitnavigationcomment)): Whether to add a navigation comment to the change request. Must be one of: true, false, multiple.
 * `--force`: Force push, bypassing safety checks
+* `--no-verify`: Bypass pre-push hooks when pushing to the remote. <span class="mdx-badge"><span class="mdx-badge__icon">:material-tag-hidden:{ title="Released in version" }</span><span class="mdx-badge__text">Unreleased</span>
 * `-u`, `--update-only`: Only update existing change requests, do not create new ones
 
 **Configuration**: [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.web](/cli/config.md#spicesubmitweb)
@@ -299,6 +300,7 @@ or --nav-comment=multiple to post those comments only if there are multiple CRs 
 * `-w`, `--[no-]web` ([:material-wrench:{ .middle title="spice.submit.web" }](/cli/config.md#spicesubmitweb)): Open submitted changes in a web browser
 * `--nav-comment=true` ([:material-wrench:{ .middle title="spice.submit.navigationComment" }](/cli/config.md#spicesubmitnavigationcomment)): Whether to add a navigation comment to the change request. Must be one of: true, false, multiple.
 * `--force`: Force push, bypassing safety checks
+* `--no-verify`: Bypass pre-push hooks when pushing to the remote. <span class="mdx-badge"><span class="mdx-badge__icon">:material-tag-hidden:{ title="Released in version" }</span><span class="mdx-badge__text">Unreleased</span>
 * `-u`, `--update-only`: Only update existing change requests, do not create new ones
 * `--branch=NAME`: Branch to start at
 
@@ -405,6 +407,7 @@ or --nav-comment=multiple to post those comments only if there are multiple CRs 
 * `-w`, `--[no-]web` ([:material-wrench:{ .middle title="spice.submit.web" }](/cli/config.md#spicesubmitweb)): Open submitted changes in a web browser
 * `--nav-comment=true` ([:material-wrench:{ .middle title="spice.submit.navigationComment" }](/cli/config.md#spicesubmitnavigationcomment)): Whether to add a navigation comment to the change request. Must be one of: true, false, multiple.
 * `--force`: Force push, bypassing safety checks
+* `--no-verify`: Bypass pre-push hooks when pushing to the remote. <span class="mdx-badge"><span class="mdx-badge__icon">:material-tag-hidden:{ title="Released in version" }</span><span class="mdx-badge__text">Unreleased</span>
 * `-u`, `--update-only`: Only update existing change requests, do not create new ones
 * `--branch=NAME`: Branch to start at
 
@@ -819,6 +822,7 @@ or --nav-comment=multiple to post those comments only if there are multiple CRs 
 * `-w`, `--[no-]web` ([:material-wrench:{ .middle title="spice.submit.web" }](/cli/config.md#spicesubmitweb)): Open submitted changes in a web browser
 * `--nav-comment=true` ([:material-wrench:{ .middle title="spice.submit.navigationComment" }](/cli/config.md#spicesubmitnavigationcomment)): Whether to add a navigation comment to the change request. Must be one of: true, false, multiple.
 * `--force`: Force push, bypassing safety checks
+* `--no-verify`: Bypass pre-push hooks when pushing to the remote. <span class="mdx-badge"><span class="mdx-badge__icon">:material-tag-hidden:{ title="Released in version" }</span><span class="mdx-badge__text">Unreleased</span>
 * `-u`, `--update-only`: Only update existing change requests, do not create new ones
 * `--title=TITLE`: Title of the change request
 * `--body=BODY`: Body of the change request

--- a/internal/git/push.go
+++ b/internal/git/push.go
@@ -30,6 +30,9 @@ type PushOptions struct {
 	// Refspec is the refspec to push.
 	// If empty, the current branch is pushed to the remote.
 	Refspec Refspec
+
+	// NoVerify indicates that pre-push hooks should be bypassed.
+	NoVerify bool
 }
 
 // Push pushes objects and refs to a remote repository.
@@ -49,6 +52,9 @@ func (r *Repository) Push(ctx context.Context, opts PushOptions) error {
 	}
 	if opts.Force {
 		args = append(args, "--force")
+	}
+	if opts.NoVerify {
+		args = append(args, "--no-verify")
 	}
 	if opts.Remote != "" {
 		args = append(args, opts.Remote)

--- a/internal/git/push_test.go
+++ b/internal/git/push_test.go
@@ -1,0 +1,81 @@
+package git
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestPushOptions_NoVerify(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		opts    PushOptions
+		wantCmd []string
+	}{
+		{
+			name: "RefspecOnly",
+			opts: PushOptions{
+				Remote:  "origin",
+				Refspec: "HEAD:refs/heads/main",
+			},
+			wantCmd: []string{"push", "origin", "HEAD:refs/heads/main"},
+		},
+		{
+			name: "NoVerify",
+			opts: PushOptions{
+				Remote:   "origin",
+				Refspec:  "HEAD:refs/heads/main",
+				NoVerify: true,
+			},
+			wantCmd: []string{"push", "--no-verify", "origin", "HEAD:refs/heads/main"},
+		},
+		{
+			name: "NoVerifyWithForce",
+			opts: PushOptions{
+				Remote:   "origin",
+				Refspec:  "HEAD:refs/heads/main",
+				Force:    true,
+				NoVerify: true,
+			},
+			wantCmd: []string{"push", "--force", "--no-verify", "origin", "HEAD:refs/heads/main"},
+		},
+		{
+			name: "NoVerifyWithForceWithLease",
+			opts: PushOptions{
+				Remote:         "origin",
+				Refspec:        "HEAD:refs/heads/main",
+				ForceWithLease: "main:abc123",
+				NoVerify:       true,
+			},
+			wantCmd: []string{"push", "--force-with-lease=main:abc123", "--no-verify", "origin", "HEAD:refs/heads/main"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotCmd []string
+			mockExecer := NewMockExecer(gomock.NewController(t))
+			mockExecer.EXPECT().
+				Run(gomock.Any()).
+				DoAndReturn(func(cmd *exec.Cmd) error {
+					gotCmd = cmd.Args[1:]
+					return nil
+				})
+
+			repo := &Repository{
+				exec: mockExecer,
+			}
+
+			err := repo.Push(t.Context(), tt.opts)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantCmd, gotCmd)
+		})
+	}
+}

--- a/testdata/script/branch_submit_no_verify.txt
+++ b/testdata/script/branch_submit_no_verify.txt
@@ -1,0 +1,47 @@
+# 'gs branch submit --no-verify' bypasses pre-push hooks.
+
+as 'Test <test@example.com>'
+at '2025-06-21T12:00:00Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub register alice
+shamhub new origin alice/example.git
+git push origin main
+
+# create a branch
+git add feature1.txt
+gs bc -m 'Add feature1' feature1
+
+# Install a pre-push hook that will fail
+mkdir -p .git/hooks
+cp $WORK/extra/pre-push .git/hooks/pre-push
+chmod 755 .git/hooks/pre-push
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# First try without --no-verify, should fail due to pre-push hook
+! gs branch submit --fill
+stderr 'pre-push hook failed'
+
+# Now try with --no-verify, should succeed
+gs branch submit --fill --no-verify
+stderr 'Created'
+
+# Verify the branch was actually pushed
+shamhub dump changes
+stdout 'feature1'
+
+-- repo/feature1.txt --
+Contents of feature1
+
+-- extra/pre-push --
+#!/bin/sh
+echo "pre-push hook failed" >&2
+exit 1


### PR DESCRIPTION
Adds a `--no-verify` flag similar to `gs commit create --no-verify`
that allows users to bypass pre-push hooks when submitting branches.

Resolves #635