### PR TITLE
branch create: reject untracked base branch earlier

### DIFF
--- a/.changes/unreleased/Changed-20250622-143159.yaml
+++ b/.changes/unreleased/Changed-20250622-143159.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: >-
+  branch create: Reject untracked base branches sooner in the process.
+  This prevents unnecessary work, such as writing a commit message
+  only to have the operation fail later.
+time: 2025-06-22T14:31:59.645137-07:00

--- a/internal/spice/branch.go
+++ b/internal/spice/branch.go
@@ -103,7 +103,7 @@ func (e *DeletedBranchError) Error() string {
 
 // LookupBranch returns information about a branch tracked by gs.
 //
-// It returns [git.ErrNotExist] if the branch is nt known to the repository,
+// It returns [git.ErrNotExist] if the branch is not known to the repository,
 // [state.ErrNotExist] if the branch is not tracked,
 // or a [DeletedBranchError] if the branch is tracked, but was deleted out of band.
 func (s *Service) LookupBranch(ctx context.Context, name string) (*LookupBranchResponse, error) {

--- a/testdata/script/branch_create_over_untracked.txt
+++ b/testdata/script/branch_create_over_untracked.txt
@@ -1,6 +1,6 @@
 # 'branch create' over an untracked branch
-# requires that the branch is first tracked.
-
+# requires that the branch is first tracked,
+# and it does so _before_ the user writes the commit message.
 
 as 'Test <test@example.com>'
 at '2024-09-19T05:06:07Z'
@@ -15,7 +15,8 @@ git add feat1.txt
 git commit -m 'Add feature 1'
 
 git add feat2.txt
-! gs bc feat2 -m 'Add feature 2'
+! gs bc feat2
+cmp stderr $WORK/golden/create-feat2-error.txt
 
 git graph --branches
 cmp stdout $WORK/golden/branch-graph.txt
@@ -27,6 +28,8 @@ cmp stdout $WORK/golden/status.txt
 feature 1
 -- repo/feat2.txt --
 feature 2
+-- golden/create-feat2-error.txt --
+FTL gs: branch not tracked: feat1
 -- golden/branch-graph.txt --
 * b6be74c (HEAD -> feat1) Add feature 1
 * 7cee8ef (main) Initial commit


### PR DESCRIPTION
branch create rejects untracked base branches,
but only after the user has written a commit message.
This is a form of lost work, especially if the commit message is long.

This changes branch create to reject untracked base branches earlier,
so that the user does not have to write a commit message first.

Resolves #652