### PR TITLE
commit amend: Detect rebase with unresolved conflicts

### DIFF
--- a/.changes/unreleased/Changed-20250622-152432.yaml
+++ b/.changes/unreleased/Changed-20250622-152432.yaml
@@ -1,6 +1,7 @@
 kind: Changed
 body: >-
   commit amend:
-  To prevent mistakes, when 'gs commit amend' is called from the trunk branch,
-  confirm user intent, providing an option to create a new branch instead.
+  Confirm user intent when called from the trunk branch,
+  providing an option to create a new branch instead.
+  This prevents accidental changes to the trunk branch.
 time: 2025-06-22T15:24:32.431866-07:00

--- a/.changes/unreleased/Changed-20250622-165742.yaml
+++ b/.changes/unreleased/Changed-20250622-165742.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: >-
+  commit amend:
+  Confirm user intent when called during a rebase operation with unresolved conflicts.
+  This prevents accidental amendments that could complicate the rebase process.
+time: 2025-06-22T16:57:42.741195-07:00

--- a/testdata/script/commit_amend_rebase_prompt.txt
+++ b/testdata/script/commit_amend_rebase_prompt.txt
@@ -13,7 +13,7 @@ git add conflict.txt
 gs branch create feature -m 'Add conflict.txt with content A'
 
 gs trunk
-cp conflict-main.txt conflict.txt
+mv conflict-main.txt conflict.txt
 git add conflict.txt
 git commit -m 'Add conflict.txt with content B'
 
@@ -23,13 +23,25 @@ gs bco feature
 # Interactive mode should prompt with suggestion to run 'git add'
 env ROBOT_INPUT=$WORK/golden/robot.txt ROBOT_OUTPUT=$WORK/robot.actual
 
-! gs commit amend -m 'Another amend attempt'
+! gs commit amend --no-edit -a -m 'Another amend attempt'
 cmp $WORK/robot.actual $WORK/golden/robot.txt
+
+git status --porcelain
+cmp stdout $WORK/golden/status-conflicted.txt
+
+cp $WORK/other/conflict-resolved.txt conflict.txt
+git add conflict.txt
+gs rebase continue --no-edit
+
+git graph --branches
+cmp stdout $WORK/golden/graph-after-rebase.txt
 
 -- repo/conflict.txt --
 Content A
 -- repo/conflict-main.txt --
 Content B
+-- other/conflict-resolved.txt --
+Content A and B
 -- golden/robot.txt --
 ===
 > Do you want to amend the commit?: 
@@ -40,3 +52,9 @@ Content B
 > You are in the middle of a rebase with unmerged paths.
 > You might want to resolve the conflicts and run 'git add', then 'gs rebase continue' instead.
 "No"
+-- golden/status-conflicted.txt --
+AA conflict.txt
+-- golden/graph-after-rebase.txt --
+* f8fc3c9 (HEAD -> feature) Add conflict.txt with content A
+* 2f55407 (main) Add conflict.txt with content B
+* f8331be Initial commit

--- a/testdata/script/commit_amend_rebase_prompt.txt
+++ b/testdata/script/commit_amend_rebase_prompt.txt
@@ -1,0 +1,42 @@
+# commit amend during rebase with unmerged paths should suggest 'git add'
+
+as 'Test <test@example.com>'
+at '2025-06-22T21:28:29Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# Create a conflict scenario.
+git add conflict.txt
+gs branch create feature -m 'Add conflict.txt with content A'
+
+gs trunk
+cp conflict-main.txt conflict.txt
+git add conflict.txt
+git commit -m 'Add conflict.txt with content B'
+
+gs bco feature
+! gs branch restack
+
+# Interactive mode should prompt with suggestion to run 'git add'
+env ROBOT_INPUT=$WORK/golden/robot.txt ROBOT_OUTPUT=$WORK/robot.actual
+
+! gs commit amend -m 'Another amend attempt'
+cmp $WORK/robot.actual $WORK/golden/robot.txt
+
+-- repo/conflict.txt --
+Content A
+-- repo/conflict-main.txt --
+Content B
+-- golden/robot.txt --
+===
+> Do you want to amend the commit?: 
+> ▶ Yes                                                                         
+>   Continue with commit amend                                                   
+>   No                                                                          
+>   Abort the operation                                                         
+> You are in the middle of a rebase with unmerged paths.
+> You might want to resolve the conflicts and run 'git add', then 'gs rebase continue' instead.
+"No"


### PR DESCRIPTION
If commit amend is called during a rebase operation
with unresolved conflicts, the user probably didn't want to do that.
Offer to abort the operation.

Resolves #700