### PR TITLE
feat: support shell commands for custom shorthands

### DIFF
--- a/.changes/unreleased/Added-20250624-185032.yaml
+++ b/.changes/unreleased/Added-20250624-185032.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Custom shorthands now support invoking external shell commands, allowing for workflow-specific automations with `gs` subcommands.
+time: 2025-06-24T18:50:32.781141-07:00

--- a/doc/src/cli/shorthand.md
+++ b/doc/src/cli/shorthand.md
@@ -90,3 +90,44 @@ both will be expanded.
 {green}${reset} git config --global spice.shorthand.bb bco
 {gray}# bb will expand to bco, which will expand to "branch checkout"{reset}
 ```
+
+### Shell command aliases
+
+<!-- gs:version unreleased -->
+
+In addition to git-spice command shorthands,
+you can define aliases that execute arbitrary shell commands
+by prefixing the command with `!`.
+
+    spice.shorthand.<short> = !<shell-command>
+
+Shell command aliases run the specified command in a shell
+and pass any additional arguments to the command as `$1`, `$2`, etc.
+If you want to pass all arguments through to the command,
+add `"$@"` to the end of the command alias.
+
+You can use shell command aliases to create custom helpers
+on top of git-spice commands, and invoke them through the `gs` command.
+
+For example:
+
+```freeze language="terminal"
+{gray}# Shell alias that accepts arguments.{reset}
+{green}${reset} git config spice.shorthand.ls-commits \
+    {mag}'!git log --oneline -n "${1:-1}"'{reset}
+{green}${reset} gs ls-commits 3
+abc1234 Latest commit
+def5678 Second commit
+ghi9012 First commit
+
+{gray}# Shell alias that consumes all arguments.{reset}
+{green}${reset} git config spice.shorthand.from-up \
+    {mag}'!git checkout -p $(gs up -n) -- "$@"'{reset}
+{green}${reset} gs from-up -- file1.txt path/to/file2.txt
+```
+
+!!! tip "Argument handling"
+
+    Shell command aliases receive arguments as positional parameters (`$1`, `$2`, etc.).
+    You can use shell parameter expansion like `"${1:-default}"`
+    to provide default values when no arguments are given.

--- a/testdata/script/shell_aliases.txt
+++ b/testdata/script/shell_aliases.txt
@@ -1,0 +1,69 @@
+# Test shell aliases (commands prefixed with !) in spice.shorthand.* configurations.
+
+as 'Test <test@example.com>'
+at '2025-06-25T21:28:29Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# Create some test files and branches
+git checkout -b feature/foo
+git add foo.txt
+git commit -m 'Add foo'
+
+git checkout main
+git checkout -b feature/bar
+git add bar.txt
+git commit -m 'Add bar'
+
+git config spice.shorthand.current-branch '!git rev-parse --abbrev-ref HEAD'
+git config spice.shorthand.list-branches '!git branch | sed "s/^[* ] //"'
+git config spice.shorthand.commit-count '!git rev-list --count HEAD ^main'
+
+gs current-branch
+stdout 'feature/bar'
+
+gs list-branches
+stdout 'feature/bar'
+stdout 'feature/foo'
+stdout 'main'
+
+# Test commit count shell alias
+gs commit-count
+stdout '1'
+
+git checkout feature/foo
+gs current-branch
+stdout 'feature/foo'
+
+gs commit-count
+stdout '1'
+
+git config spice.shorthand.show-head '!git log -1 --oneline'
+gs show-head
+stdout -count=1 '[a-f0-9]+ Add foo'
+
+# Test shell alias with CLI arguments passed through
+# Set up an alias that uses $1, $2, etc. to access passed arguments
+git config spice.shorthand.show-commit '!git log --oneline -n "${1:-1}" | head -n "${1:-1}"'
+
+# Test with no arguments (should default to 1)
+gs show-commit
+stdout -count=1 '[a-f0-9]+ Add foo'
+
+# Test with argument passed through (should show 2 commits)
+gs show-commit 2
+stdout -count=1 '[a-f0-9]+ Add foo'
+stdout -count=1 '[a-f0-9]+ Initial commit'
+
+# Test shell alias that uses multiple arguments
+git config spice.shorthand.echo-args '!echo "arg1=$1 arg2=$2"'
+gs echo-args hello world
+stdout 'arg1=hello arg2=world'
+
+-- repo/foo.txt --
+foo content
+-- repo/bar.txt --
+bar content

--- a/testdata/script/shell_aliases_infinite_loop_prevention.txt
+++ b/testdata/script/shell_aliases_infinite_loop_prevention.txt
@@ -1,0 +1,44 @@
+# Test prevention of infinite loops in shorthand command expansion.
+# Verifies that shell commands that recursively call gs don't cause infinite loops.
+
+as 'Test <test@example.com>'
+at '2025-06-25T21:28:29Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# Test case 1: Shell command that calls gs directly should fail with depth limit
+# This would cause infinite recursion without proper protection.
+git config spice.shorthand.infinite-loop '!gs infinite-loop'
+
+# Try to run the infinite loop command - it should fail gracefully
+# with a depth limit exceeded error
+! gs infinite-loop
+stderr 'shell command recursion depth limit exceeded \(10\)'
+
+# Test case 2: More complex scenario with indirect recursion
+# where one command calls another that eventually calls back to the first.
+git config spice.shorthand.cmd1 '!gs cmd2'
+git config spice.shorthand.cmd2 '!gs cmd1'
+
+! gs cmd1
+stderr 'shell command recursion depth limit exceeded \(10\)'
+
+# Test case 3: Shell command that calls gs with different arguments should work
+# This is a legitimate use case that should not be blocked.
+git config spice.shorthand.current-branch '!git rev-parse --abbrev-ref HEAD'
+git config spice.shorthand.show-current '!gs current-branch'
+
+gs show-current
+stdout 'main'
+
+# Test case 4: Ensure regular shorthand expansion still works for non-recursive cases
+git config spice.shorthand.brc 'branch create'
+
+# This should work normally since it doesn't involve shell commands
+gs brc test-branch -m 'Create test branch'
+git branch --list test-branch
+stdout 'test-branch'


### PR DESCRIPTION
Implement support for shell commands in custom shorthands
by prefixing commands with '!'.
This allows users to define aliases that execute arbitrary shell
commands through the gs command interface.

Shell command aliases receive arguments as positional parameters
and can use shell parameter expansion for flexible command construction.
The implementation includes safeguards against infinite recursion.

Resolves #385