### PR TITLE
git/Repository: Add Worktrees method

### DIFF
--- a/internal/git/wt.go
+++ b/internal/git/wt.go
@@ -1,8 +1,10 @@
 package git
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"iter"
 	"strings"
 
 	"go.abhg.dev/gs/internal/silog"
@@ -30,6 +32,15 @@ func newWorktree(gitDir, rootDir string, repo *Repository, log *silog.Logger, ex
 	}
 }
 
+func (r *Worktree) gitCmd(ctx context.Context, args ...string) *gitCmd {
+	return newGitCmd(ctx, r.log, args...).Dir(r.rootDir)
+}
+
+// Repository returns the Git repository that this worktree belongs to.
+func (r *Worktree) Repository() *Repository {
+	return r.repo
+}
+
 // OpenWorktree opens a worktree of this repository at the given directory.
 func (r *Repository) OpenWorktree(ctx context.Context, dir string) (*Worktree, error) {
 	out, err := r.gitCmd(ctx, "rev-parse", "--show-toplevel", "--absolute-git-dir").
@@ -46,11 +57,78 @@ func (r *Repository) OpenWorktree(ctx context.Context, dir string) (*Worktree, e
 	return newWorktree(gitDir, rootDir, r, r.log, r.exec), nil
 }
 
-func (r *Worktree) gitCmd(ctx context.Context, args ...string) *gitCmd {
-	return newGitCmd(ctx, r.log, args...).Dir(r.rootDir)
+// WorktreeListItem represents a worktree associated with a repository.
+type WorktreeListItem struct {
+	// Path is the path to the worktree.
+	// Use this with Repository.OpenWorktree.
+	Path string
+
+	// Bare reports that the worktree is a bare repository.
+	Bare bool
+
+	// Detached reports that the worktree is in a detached HEAD state.
+	Detached bool
+
+	// LockedReason reports why the worktree is locked, if it is.
+	// It is empty if the worktree is not locked.
+	LockedReason string
+
+	// Branch is the name of the branch checked out in this worktree.
+	// If empty, the worktree may not have a branch checked out.
+	Branch string
+
+	// Head is the hash of the HEAD commit in this worktree.
+	Head Hash
 }
 
-// Repository returns the Git repository that this worktree belongs to.
-func (r *Worktree) Repository() *Repository {
-	return r.repo
+// Worktrees returns a list of worktrees associated with the repository.
+func (r *Repository) Worktrees(ctx context.Context) iter.Seq2[*WorktreeListItem, error] {
+	return func(yield func(*WorktreeListItem, error) bool) {
+		var item *WorktreeListItem
+		for line, err := range r.gitCmd(ctx, "worktree", "list", "--porcelain", "-z").Scan(r.exec, splitNullByte) {
+			if err != nil {
+				yield(nil, fmt.Errorf("worktree list: %w", err))
+				return
+			}
+
+			// worktree list porcelain has output in the form:
+			//
+			//	worktree <path>
+			//	attr1 <value>
+			//	attr2 <value>
+			//	boolattr1
+			//	boolattr2
+			//
+			// Where worktree is the first line for a worktree,
+			// and then the attributes follow.
+			// An empty line indicates the end of a worktree entry.
+			if len(line) == 0 {
+				if item != nil {
+					if !yield(item, nil) {
+						return
+					}
+				}
+				item = nil
+				continue
+			}
+
+			key, value, _ := bytes.Cut(line, []byte(" "))
+			switch string(key) {
+			case "worktree":
+				item = &WorktreeListItem{Path: string(value)}
+			case "detached":
+				item.Detached = true
+			case "bare":
+				item.Bare = true
+			case "branch":
+				item.Branch = strings.TrimPrefix(string(value), "refs/heads/")
+			case "HEAD":
+				item.Head = Hash(value)
+			case "locked":
+				item.LockedReason = string(value)
+			default:
+				// Ignore unknown attributes.
+			}
+		}
+	}
 }

--- a/internal/git/wt_test.go
+++ b/internal/git/wt_test.go
@@ -1,0 +1,93 @@
+package git_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/git/gittest"
+	"go.abhg.dev/gs/internal/silog/silogtest"
+	"go.abhg.dev/gs/internal/sliceutil"
+	"go.abhg.dev/gs/internal/text"
+)
+
+func TestIntegrationWorktrees(t *testing.T) {
+	t.Parallel()
+
+	fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+		cd setup-repo
+
+		at '2024-08-27T21:48:32Z'
+		git init
+		git add init.txt
+		git commit -m 'Initial commit'
+
+		git checkout -b feature1
+		git add feature1.txt
+		git commit -m 'Add feature1'
+
+		git checkout -b feature2
+		git add feature2.txt
+		git commit -m 'Add feature2'
+
+		git checkout main
+
+		cd ..
+		git clone --bare setup-repo bare
+		cd bare
+
+		# Create worktree with branch checked out
+		git worktree add ../wt-feature1 feature1
+
+		# Create worktree in detached HEAD state
+		git worktree add --detach ../wt-detached HEAD
+
+		# Create locked worktree
+		git worktree add ../wt-locked feature2
+		git worktree lock --reason 'i have my reasons' ../wt-locked
+
+		-- setup-repo/init.txt --
+		Initial
+
+		-- setup-repo/feature1.txt --
+		Contents of feature1
+
+		-- setup-repo/feature2.txt --
+		Contents of feature2
+
+	`)))
+	require.NoError(t, err)
+
+	repo, err := git.Open(t.Context(), filepath.Join(fixture.Dir(), "bare"), git.OpenOptions{
+		Log: silogtest.New(t),
+	})
+	require.NoError(t, err)
+
+	worktrees, err := sliceutil.CollectErr(repo.Worktrees(t.Context()))
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []*git.WorktreeListItem{
+		{
+			Path: joinSlash(fixture.Dir(), "bare"),
+			Bare: true,
+		},
+		{
+			Path:     joinSlash(fixture.Dir(), "wt-detached"),
+			Detached: true,
+			Head:     "a5fe281e95373c84144272b944ec2a1c2e82ed62",
+		},
+		{
+			Path:   joinSlash(fixture.Dir(), "wt-feature1"),
+			Branch: "feature1",
+			Head:   "bbd92eb0593b60e0bb9e923c9cb74f8bc8422c71",
+		},
+		{
+			Path:         joinSlash(fixture.Dir(), "wt-locked"),
+			Branch:       "feature2",
+			LockedReason: "i have my reasons",
+			Head:         "c149b81591a121a1ef9ae4b27bd0c6d43565cea6",
+		},
+	}, worktrees)
+}


### PR DESCRIPTION
Add a means of listing all known worktrees for a repository
and their attributes.