### PR TITLE
{repo sync, branch delete}: handle worktrees better

### DIFF
--- a/.changes/unreleased/Fixed-20250704-202339.yaml
+++ b/.changes/unreleased/Fixed-20250704-202339.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'repo sync: Don''t fail if a merged branch is checked out in another worktree. Instead, log a message and skip it.'
+time: 2025-07-04T20:23:39.921172-07:00

--- a/.changes/unreleased/Fixed-20250704-202433.yaml
+++ b/.changes/unreleased/Fixed-20250704-202433.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'branch delete: Don''t fail if the branch to check out after deletion is checked out in another worktree. Instead, log a message and detach HEAD.'
+time: 2025-07-04T20:24:33.005465-07:00

--- a/internal/git/wt.go
+++ b/internal/git/wt.go
@@ -36,6 +36,11 @@ func (r *Worktree) gitCmd(ctx context.Context, args ...string) *gitCmd {
 	return newGitCmd(ctx, r.log, args...).Dir(r.rootDir)
 }
 
+// RootDir returns the absolute path to the root directory of the worktree.
+func (r *Worktree) RootDir() string {
+	return r.rootDir
+}
+
 // Repository returns the Git repository that this worktree belongs to.
 func (r *Worktree) Repository() *Repository {
 	return r.repo

--- a/testdata/script/repo_sync_branch_in_another_wt_skip_deletion.txt
+++ b/testdata/script/repo_sync_branch_in_another_wt_skip_deletion.txt
@@ -1,0 +1,69 @@
+# 'repo sync' run from trunk in the main repository,
+# when a feature branch that should be deleted is checked out in another worktree.
+# The branch should be skipped for deletion with appropriate warning.
+
+as 'Test <test@example.com>'
+at '2025-06-20T21:28:29Z'
+
+# setup
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# set up a remote
+shamhub init
+shamhub new origin alice/example.git
+git push origin main
+
+# set up user
+shamhub register alice
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# start working on features
+git add feat1.txt
+gs bc -m 'feature 1' feat1
+gs bs --fill
+
+git add feat2.txt
+gs bc -m 'feature 2' feat2
+gs bs --fill
+
+# check out feat1 in another worktree
+git worktree add ../wt1 feat1
+
+# update the remote out of band
+cd ..
+shamhub clone alice/example.git fork
+cd fork
+cp $WORK/extra/feat3.txt feat3.txt
+git add feat3.txt
+git commit -m 'Add feature 3'
+git push origin main
+
+# merge feat1 server-side (this is the branch in another worktree)
+shamhub merge alice/example 1
+# merge feat2 server-side (this should be deleted normally)
+shamhub merge alice/example 2
+
+# sync from trunk - feat1 should be skipped, feat2 should be deleted
+cd ../repo
+git checkout main
+gs repo sync
+stderr 'INF main: pulled 3 new commit\(s\)'
+stderr 'INF feat1: #1 was merged'
+stderr 'INF feat2: #2 was merged'
+stderr 'WRN feat1: checked out in another worktree \(.+/wt1\), skipping deletion\.'
+stderr 'WRN Run ''gs branch delete'' or run ''gs repo sync'' again from that worktree to delete it\.'
+stderr 'INF feat2: deleted \(was [a-f0-9]+\)'
+
+-- repo/feat1.txt --
+feature 1
+
+-- repo/feat2.txt --
+feature 2
+
+-- extra/feat3.txt --
+feature 3

--- a/testdata/script/repo_sync_trunk_in_another_wt_current_branch_delete.txt
+++ b/testdata/script/repo_sync_trunk_in_another_wt_current_branch_delete.txt
@@ -1,0 +1,60 @@
+# 'repo sync' run from a feature branch in the main repository,
+# when trunk is checked out in another worktree,
+# and the feature branch has been merged, so it should be deleted.
+#
+# https://github.com/abhinav/git-spice/issues/665
+
+as 'Test <test@example.com>'
+at '2025-05-31T16:07:08Z'
+
+# setup
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# set up a remote
+shamhub init
+shamhub new origin alice/example.git
+git push origin main
+
+# set up user
+shamhub register alice
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# start working on a feature
+git add feat1.txt
+gs bc -m 'feature 1' feat1
+gs bs --fill
+
+# check out trunk in another worktree
+git worktree add ../wt1 main
+
+# update the remote out of band
+cd ..
+shamhub clone alice/example.git fork
+cd fork
+cp $WORK/extra/feat2.txt feat2.txt
+git add feat2.txt
+git commit -m 'Add feature 2'
+git push origin main
+
+# merge feat1 server-side
+shamhub merge alice/example 1
+
+# sync the original repo
+cd ../repo
+gs repo sync
+stderr 'INF main: pulled 3 new commit\(s\)'
+stderr 'INF feat1: #1 was merged'
+stderr 'WRN main: checked out in another worktree \(.+/wt1\), will detach HEAD'
+stderr 'WRN Use ''gs branch checkout'' to pick a branch and exit detached state'
+stderr 'INF feat1: deleted \(was [a-f0-9]+\)'
+
+-- repo/feat1.txt --
+feature 1
+
+-- extra/feat2.txt --
+feature 2


### PR DESCRIPTION
This changes 'repos sync' and 'branch delete' to handle two worktree
cases better:

- repo sync: if a branch slated for deletion is checked out
  in another worktree, skip it
- branch delete: if the branch that would be checked out after
  deletion is checked out in another worktree, detach HEAD

Resolves #665