### PR TITLE
submit: add 'spice.submit.draft' to change --draft/--no-draft default

### DIFF
--- a/.changes/unreleased/Added-20250704-204310.yaml
+++ b/.changes/unreleased/Added-20250704-204310.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'submit: Add ''spice.submit.draft'' configuration option to control the default value of --draft/--no-draft for new CRs.'
+time: 2025-07-04T20:43:10.847598-07:00

--- a/branch_submit.go
+++ b/branch_submit.go
@@ -37,6 +37,12 @@ type submitOptions struct {
 	NoVerify   bool `help:"Bypass pre-push hooks when pushing to the remote." released:"v0.15.0"`
 	UpdateOnly bool `short:"u" help:"Only update existing change requests, do not create new ones"`
 
+	// DraftDefault is used to set the default draft value
+	// when creating new Change Requests.
+	//
+	// --draft/--no-draft will override this value.
+	DraftDefault bool `config:"submit.draft" hidden:"" default:"false"`
+
 	// TODO: Other creation options e.g.:
 	// - assignees
 	// - labels
@@ -764,7 +770,8 @@ func (cmd *branchSubmitCmd) preparePublish(
 	// Don't mess with draft setting if we're not prompting
 	// and the user didn't explicitly set it.
 	if ui.Interactive(view) && cmd.Draft == nil {
-		cmd.Draft = new(bool)
+		draftDefault := cmd.DraftDefault
+		cmd.Draft = &draftDefault
 		fields = append(fields, form.draftField(cmd.Draft))
 	}
 
@@ -814,7 +821,7 @@ func (cmd *branchSubmitCmd) preparePublish(
 		Body:    cmd.Body,
 	}
 
-	var draft bool
+	draft := cmd.DraftDefault
 	if cmd.Draft != nil {
 		draft = *cmd.Draft
 	}

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -224,7 +224,7 @@ or --nav-comment=multiple to post those comments only if there are multiple CRs 
 * `--no-verify`: Bypass pre-push hooks when pushing to the remote. <span class="mdx-badge"><span class="mdx-badge__icon">:material-tag:{ title="Released in version" }</span><span class="mdx-badge__text">[v0.15.0](/changelog.md#v0.15.0)</span>
 * `-u`, `--update-only`: Only update existing change requests, do not create new ones
 
-**Configuration**: [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.web](/cli/config.md#spicesubmitweb)
+**Configuration**: [spice.submit.draft](/cli/config.md#spicesubmitdraft), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.web](/cli/config.md#spicesubmitweb)
 
 ### gs stack restack
 
@@ -304,7 +304,7 @@ or --nav-comment=multiple to post those comments only if there are multiple CRs 
 * `-u`, `--update-only`: Only update existing change requests, do not create new ones
 * `--branch=NAME`: Branch to start at
 
-**Configuration**: [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.web](/cli/config.md#spicesubmitweb)
+**Configuration**: [spice.submit.draft](/cli/config.md#spicesubmitdraft), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.web](/cli/config.md#spicesubmitweb)
 
 ### gs upstack restack
 
@@ -411,7 +411,7 @@ or --nav-comment=multiple to post those comments only if there are multiple CRs 
 * `-u`, `--update-only`: Only update existing change requests, do not create new ones
 * `--branch=NAME`: Branch to start at
 
-**Configuration**: [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.web](/cli/config.md#spicesubmitweb)
+**Configuration**: [spice.submit.draft](/cli/config.md#spicesubmitdraft), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.web](/cli/config.md#spicesubmitweb)
 
 ### gs downstack edit
 
@@ -828,7 +828,7 @@ or --nav-comment=multiple to post those comments only if there are multiple CRs 
 * `--body=BODY`: Body of the change request
 * `--branch=NAME`: Branch to submit
 
-**Configuration**: [spice.submit.listTemplatesTimeout](/cli/config.md#spicesubmitlisttemplatestimeout), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.web](/cli/config.md#spicesubmitweb)
+**Configuration**: [spice.submit.draft](/cli/config.md#spicesubmitdraft), [spice.submit.listTemplatesTimeout](/cli/config.md#spicesubmitlisttemplatestimeout), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.web](/cli/config.md#spicesubmitweb)
 
 ## Commit
 

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -233,6 +233,39 @@ If set to false, you can opt in to opening the editor with the `--edit` flag.
 - `true` (default)
 - `false`
 
+### spice.submit.draft
+
+<!-- gs:version unreleased -->
+
+Default value for the `--draft`/`--no-draft` flag when creating new change
+requests with $$gs branch submit$$ and friends.
+
+```freeze language="terminal" float="right"
+{green}${reset} git config {red}spice.submit.draft{reset} {mag}true{reset}
+{green}${reset} gs branch submit{reset}
+{gray}# ...{reset}
+{green}Draft{reset}: [{mag}Y{reset}/{mag}n{reset}]
+{gray}Mark the change as a draft?{reset}
+
+{green}${reset} git config {red}spice.submit.draft{reset} {mag}false{reset}
+{green}${reset} gs branch submit{reset}
+{gray}# ...{reset}
+{green}Draft{reset}: [{mag}y{reset}/{mag}N{reset}]
+{gray}Mark the change as a draft?{reset}
+```
+
+This option affects both interactive and non-interactive modes:
+
+- In *non-interactive mode*, setting this value to true
+  will cause git-spice to assume `--draft` when creating new change requests.
+- In *interactive mode*, this value is used as the default for the prompt
+  asking whether to create the change request as a draft.
+
+**Accepted values:**
+
+- `true`: create CRs as drafts by default
+- `false` (default): create CRs as ready for review by default
+
 ### spice.submit.listTemplatesTimeout
 
 <!-- gs:version v0.8.0 -->

--- a/testdata/script/branch_submit_draft_config_interactive.txt
+++ b/testdata/script/branch_submit_draft_config_interactive.txt
@@ -1,0 +1,148 @@
+# Test spice.submit.draft configuration with interactive submit
+# Tests behavior when spice.submit.draft is set to true in interactive mode
+
+as 'Test <test@example.com>'
+at '2025-07-05T21:28:29Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# Set spice.submit.draft to true
+git config spice.submit.draft true
+
+env ROBOT_INPUT=$WORK/robot.golden ROBOT_OUTPUT=$WORK/robot.actual
+
+# Test case 1: interactive submit without any flags
+# should prompt with draft=true as default due to config
+git add feature1.txt
+gs bc -m 'Add feature1' feature1
+gs branch submit
+stderr 'Created #'
+
+shamhub dump change 1
+cmpenvJSON stdout $WORK/golden/draft-default.json
+
+# Test case 2: interactive submit with --no-draft flag
+# should not prompt and create non-draft PR
+git add feature2.txt
+gs bc -m 'Add feature2' feature2
+gs branch submit --no-draft
+stderr 'Created #'
+
+shamhub dump change 2
+cmpenvJSON stdout $WORK/golden/draft-override.json
+
+# Test case 3: interactive submit with --draft flag
+# should not prompt and create draft PR
+git add feature3.txt
+gs bc -m 'Add feature3' feature3
+gs branch submit --draft
+stderr 'Created #'
+
+shamhub dump change 3
+cmpenvJSON stdout $WORK/golden/draft-explicit.json
+
+cmp $WORK/robot.actual $WORK/robot.golden
+
+-- repo/feature1.txt --
+Contents of feature1
+
+-- repo/feature2.txt --
+Contents of feature2
+
+-- repo/feature3.txt --
+Contents of feature3
+
+-- robot.golden --
+===
+> Title: Add feature1 
+> Short summary of the change
+"Add feature1"
+===
+> Body: Press [e] to open mockedit or [enter/tab] to skip
+> Open your editor to write a detailed description of the change
+""
+===
+> Draft: [Y/n]
+> Mark the change as a draft?
+true
+===
+> Title: Add feature2 
+> Short summary of the change
+"Add feature2"
+===
+> Body: Press [e] to open mockedit or [enter/tab] to skip
+> Open your editor to write a detailed description of the change
+""
+===
+> Title: Add feature3 
+> Short summary of the change
+"Add feature3"
+===
+> Body: Press [e] to open mockedit or [enter/tab] to skip
+> Open your editor to write a detailed description of the change
+""
+
+-- golden/draft-default.json --
+{
+  "number": 1,
+  "state": "open",
+  "title": "Add feature1",
+  "draft": true,
+  "body": "",
+  "html_url": "$SHAMHUB_URL/alice/example/change/1",
+  "head": {
+    "ref": "feature1",
+    "sha": "dbcf2133e568c7abf343166d32aefb2ecd3ec8be"
+  },
+  "base": {
+    "ref": "main",
+    "sha": "3bcbc80b165d8b4bb7fe792b7ca9effc713b32a5"
+  }
+}
+
+-- golden/draft-override.json --
+{
+  "number": 2,
+  "state": "open",
+  "title": "Add feature2",
+  "body": "",
+  "html_url": "$SHAMHUB_URL/alice/example/change/2",
+  "head": {
+    "ref": "feature2",
+    "sha": "ca0588e9603d29d74b9c81b8536be941e9a868f4"
+  },
+  "base": {
+    "ref": "feature1",
+    "sha": "dbcf2133e568c7abf343166d32aefb2ecd3ec8be"
+  }
+}
+
+-- golden/draft-explicit.json --
+{
+  "number": 3,
+  "state": "open",
+  "title": "Add feature3",
+  "draft": true,
+  "body": "",
+  "html_url": "$SHAMHUB_URL/alice/example/change/3",
+  "head": {
+    "ref": "feature3",
+    "sha": "ae33cf76131b929e42f9e86d80f03aba22aea1b7"
+  },
+  "base": {
+    "ref": "feature2",
+    "sha": "ca0588e9603d29d74b9c81b8536be941e9a868f4"
+  }
+}

--- a/testdata/script/branch_submit_draft_config_noninteractive.txt
+++ b/testdata/script/branch_submit_draft_config_noninteractive.txt
@@ -1,0 +1,114 @@
+# Test spice.submit.draft configuration with non-interactive submit
+# Tests behavior when spice.submit.draft is set to true
+
+as 'Test <test@example.com>'
+at '2025-07-05T21:28:29Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# Set spice.submit.draft to true
+git config spice.submit.draft true
+
+# Test case 1: non-interactive submit without any flags
+# should create draft PR due to config
+git add feature1.txt
+gs bc -m 'Add feature1' feature1
+gs branch submit --fill
+stderr 'Created #'
+
+shamhub dump change 1
+cmpenvJSON stdout $WORK/golden/draft-default.json
+
+# Test case 2: non-interactive submit with --no-draft flag
+# should override config and create non-draft PR
+git add feature2.txt
+gs bc -m 'Add feature2' feature2
+gs branch submit --fill --no-draft
+stderr 'Created #'
+
+shamhub dump change 2
+cmpenvJSON stdout $WORK/golden/draft-override.json
+
+# Test case 3: non-interactive submit with --draft flag
+# should be explicitly draft (redundant with config but explicit)
+git add feature3.txt
+gs bc -m 'Add feature3' feature3
+gs branch submit --fill --draft
+stderr 'Created #'
+
+shamhub dump change 3
+cmpenvJSON stdout $WORK/golden/draft-explicit.json
+
+-- repo/feature1.txt --
+Contents of feature1
+
+-- repo/feature2.txt --
+Contents of feature2
+
+-- repo/feature3.txt --
+Contents of feature3
+
+-- golden/draft-default.json --
+{
+  "number": 1,
+  "state": "open",
+  "title": "Add feature1",
+  "draft": true,
+  "body": "",
+  "html_url": "$SHAMHUB_URL/alice/example/change/1",
+  "head": {
+    "ref": "feature1",
+    "sha": "dbcf2133e568c7abf343166d32aefb2ecd3ec8be"
+  },
+  "base": {
+    "ref": "main",
+    "sha": "3bcbc80b165d8b4bb7fe792b7ca9effc713b32a5"
+  }
+}
+
+-- golden/draft-override.json --
+{
+  "number": 2,
+  "state": "open",
+  "title": "Add feature2",
+  "body": "",
+  "html_url": "$SHAMHUB_URL/alice/example/change/2",
+  "head": {
+    "ref": "feature2",
+    "sha": "ca0588e9603d29d74b9c81b8536be941e9a868f4"
+  },
+  "base": {
+    "ref": "feature1",
+    "sha": "dbcf2133e568c7abf343166d32aefb2ecd3ec8be"
+  }
+}
+
+-- golden/draft-explicit.json --
+{
+  "number": 3,
+  "state": "open",
+  "title": "Add feature3",
+  "draft": true,
+  "body": "",
+  "html_url": "$SHAMHUB_URL/alice/example/change/3",
+  "head": {
+    "ref": "feature3",
+    "sha": "ae33cf76131b929e42f9e86d80f03aba22aea1b7"
+  },
+  "base": {
+    "ref": "feature2",
+    "sha": "ca0588e9603d29d74b9c81b8536be941e9a868f4"
+  }
+}


### PR DESCRIPTION
Add a spice.submit.draft configuration option
that will control the default value of --draft/--no-draft
when creating new CRs with `gs branch submit` and friends.

In interactive mode, this merely controls the default value
of the prompt that asks for the draft status.
(So a user can just press Enter to accept the default.)

In non-interactive mode, this sets the value that will be used
if the user does not explicitly pass --draft or --no-draft.

Tests include all combinations of:

    { interactive, non-interactive } x { --draft, --no-draft, no flag }

Refs #568