### PR TITLE
submit/web: set to 'created' to open new CRs only

### DIFF
--- a/.changes/unreleased/Changed-20250706-152414.yaml
+++ b/.changes/unreleased/Changed-20250706-152414.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: >-
+  submit: The --web flag and the spice.submit.web configuration option
+  may now be set to 'created' to only open new CRs in a browser.
+  Updates to existing CRs will not be opened in a browser.
+time: 2025-07-06T15:24:14.921298-07:00

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -218,7 +218,8 @@ or --nav-comment=multiple to post those comments only if there are multiple CRs 
 * `-c`, `--fill`: Fill in the change title and body from the commit messages
 * `--[no-]draft`: Whether to mark change requests as drafts
 * `--[no-]publish` ([:material-wrench:{ .middle title="spice.submit.publish" }](/cli/config.md#spicesubmitpublish)): Whether to create CRs for pushed branches. Defaults to true.
-* `-w`, `--[no-]web` ([:material-wrench:{ .middle title="spice.submit.web" }](/cli/config.md#spicesubmitweb)): Open submitted changes in a web browser
+* `-w`, `--web` ([:material-wrench:{ .middle title="spice.submit.web" }](/cli/config.md#spicesubmitweb)): Open submitted changes in a web browser. Accepts an optional argument: 'true', 'false', 'created'.
+* `--no-web`: Alias for --web=false.
 * `--nav-comment=true` ([:material-wrench:{ .middle title="spice.submit.navigationComment" }](/cli/config.md#spicesubmitnavigationcomment)): Whether to add a navigation comment to the change request. Must be one of: true, false, multiple.
 * `--force`: Force push, bypassing safety checks
 * `--no-verify`: Bypass pre-push hooks when pushing to the remote. <span class="mdx-badge"><span class="mdx-badge__icon">:material-tag:{ title="Released in version" }</span><span class="mdx-badge__text">[v0.15.0](/changelog.md#v0.15.0)</span>
@@ -297,7 +298,8 @@ or --nav-comment=multiple to post those comments only if there are multiple CRs 
 * `-c`, `--fill`: Fill in the change title and body from the commit messages
 * `--[no-]draft`: Whether to mark change requests as drafts
 * `--[no-]publish` ([:material-wrench:{ .middle title="spice.submit.publish" }](/cli/config.md#spicesubmitpublish)): Whether to create CRs for pushed branches. Defaults to true.
-* `-w`, `--[no-]web` ([:material-wrench:{ .middle title="spice.submit.web" }](/cli/config.md#spicesubmitweb)): Open submitted changes in a web browser
+* `-w`, `--web` ([:material-wrench:{ .middle title="spice.submit.web" }](/cli/config.md#spicesubmitweb)): Open submitted changes in a web browser. Accepts an optional argument: 'true', 'false', 'created'.
+* `--no-web`: Alias for --web=false.
 * `--nav-comment=true` ([:material-wrench:{ .middle title="spice.submit.navigationComment" }](/cli/config.md#spicesubmitnavigationcomment)): Whether to add a navigation comment to the change request. Must be one of: true, false, multiple.
 * `--force`: Force push, bypassing safety checks
 * `--no-verify`: Bypass pre-push hooks when pushing to the remote. <span class="mdx-badge"><span class="mdx-badge__icon">:material-tag:{ title="Released in version" }</span><span class="mdx-badge__text">[v0.15.0](/changelog.md#v0.15.0)</span>
@@ -404,7 +406,8 @@ or --nav-comment=multiple to post those comments only if there are multiple CRs 
 * `-c`, `--fill`: Fill in the change title and body from the commit messages
 * `--[no-]draft`: Whether to mark change requests as drafts
 * `--[no-]publish` ([:material-wrench:{ .middle title="spice.submit.publish" }](/cli/config.md#spicesubmitpublish)): Whether to create CRs for pushed branches. Defaults to true.
-* `-w`, `--[no-]web` ([:material-wrench:{ .middle title="spice.submit.web" }](/cli/config.md#spicesubmitweb)): Open submitted changes in a web browser
+* `-w`, `--web` ([:material-wrench:{ .middle title="spice.submit.web" }](/cli/config.md#spicesubmitweb)): Open submitted changes in a web browser. Accepts an optional argument: 'true', 'false', 'created'.
+* `--no-web`: Alias for --web=false.
 * `--nav-comment=true` ([:material-wrench:{ .middle title="spice.submit.navigationComment" }](/cli/config.md#spicesubmitnavigationcomment)): Whether to add a navigation comment to the change request. Must be one of: true, false, multiple.
 * `--force`: Force push, bypassing safety checks
 * `--no-verify`: Bypass pre-push hooks when pushing to the remote. <span class="mdx-badge"><span class="mdx-badge__icon">:material-tag:{ title="Released in version" }</span><span class="mdx-badge__text">[v0.15.0](/changelog.md#v0.15.0)</span>
@@ -819,7 +822,8 @@ or --nav-comment=multiple to post those comments only if there are multiple CRs 
 * `-c`, `--fill`: Fill in the change title and body from the commit messages
 * `--[no-]draft`: Whether to mark change requests as drafts
 * `--[no-]publish` ([:material-wrench:{ .middle title="spice.submit.publish" }](/cli/config.md#spicesubmitpublish)): Whether to create CRs for pushed branches. Defaults to true.
-* `-w`, `--[no-]web` ([:material-wrench:{ .middle title="spice.submit.web" }](/cli/config.md#spicesubmitweb)): Open submitted changes in a web browser
+* `-w`, `--web` ([:material-wrench:{ .middle title="spice.submit.web" }](/cli/config.md#spicesubmitweb)): Open submitted changes in a web browser. Accepts an optional argument: 'true', 'false', 'created'.
+* `--no-web`: Alias for --web=false.
 * `--nav-comment=true` ([:material-wrench:{ .middle title="spice.submit.navigationComment" }](/cli/config.md#spicesubmitnavigationcomment)): Whether to add a navigation comment to the change request. Must be one of: true, false, multiple.
 * `--force`: Force push, bypassing safety checks
 * `--no-verify`: Bypass pre-push hooks when pushing to the remote. <span class="mdx-badge"><span class="mdx-badge__icon">:material-tag:{ title="Released in version" }</span><span class="mdx-badge__text">[v0.15.0](/changelog.md#v0.15.0)</span>

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -322,7 +322,12 @@ on a case-by-case basis.
 Whether submission commands ($$gs branch submit$$ and friends)
 should open a web browser with submitted CRs.
 
+<!-- gs:version unreleased --> If set to `created`,
+git-spice will open the web browser only for newly created CRs,
+and not for existing ones that were updated.
+
 **Accepted values:**
 
 - `true`
 - `false` (default)
+- `created` (<!-- gs:version unreleased -->)

--- a/testdata/script/branch_submit_web_created.txt
+++ b/testdata/script/branch_submit_web_created.txt
@@ -1,0 +1,61 @@
+# branch submit with spice.submit.web='created' only opens browser for new CRs
+
+as 'Test <test@example.com>'
+at '2025-07-06T21:28:29Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+git config spice.submit.web created
+
+# set up a fake GitHub remote
+shamhub init
+shamhub register alice
+shamhub new origin alice/example.git
+git push origin main
+
+env BROWSER_RECORDER_FILE=$WORK/browser.txt
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# create a branch and submit it - should open browser for new CR
+git add feature1.txt
+gs bc -m 'Add feature1' feature1
+gs branch submit --fill
+grep -count=1 $SHAMHUB_URL/alice/example/change/1 $WORK/browser.txt
+
+# update the CR - should NOT open browser (not a new CR)
+cp $WORK/extra/feature1-new.txt feature1.txt
+git add feature1.txt
+gs cc -m 'Update feature1'
+gs branch submit --fill
+grep -count=1 $SHAMHUB_URL/alice/example/change/1 $WORK/browser.txt
+
+# create another branch and submit the stack - should open browser for new CR
+git checkout main
+git add feature2.txt
+gs bc -m 'Add feature2' feature2
+gs stack submit --fill
+grep -count=1 $SHAMHUB_URL/alice/example/change/1 $WORK/browser.txt
+grep -count=1 $SHAMHUB_URL/alice/example/change/2 $WORK/browser.txt
+
+# update second CR - should NOT open browser
+cp $WORK/extra/feature2-new.txt feature2.txt
+git add feature2.txt
+gs cc -m 'Update feature2'
+gs stack submit --fill
+grep -count=1 $SHAMHUB_URL/alice/example/change/1 $WORK/browser.txt
+grep -count=1 $SHAMHUB_URL/alice/example/change/2 $WORK/browser.txt
+
+-- repo/feature1.txt --
+Contents of feature1
+
+-- extra/feature1-new.txt --
+New contents of feature1
+
+-- repo/feature2.txt --
+Contents of feature2
+
+-- extra/feature2-new.txt --
+New contents of feature2

--- a/testdata/script/branch_submit_web_flag_overrides.txt
+++ b/testdata/script/branch_submit_web_flag_overrides.txt
@@ -1,0 +1,56 @@
+# branch submit with --web and --no-web flags override default behavior
+
+as 'Test <test@example.com>'
+at '2025-07-06T21:28:29Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub register alice
+shamhub new origin alice/example.git
+git push origin main
+
+env BROWSER_RECORDER_FILE=$WORK/browser.txt
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# create a branch and submit it - should NOT open browser (default behavior)
+git add feature1.txt
+gs bc -m 'Add feature1' feature1
+gs branch submit --fill
+! exists $WORK/browser.txt
+
+# submit with --web flag - should open browser (flag overrides default)
+gs branch submit --web
+grep -count=1 $SHAMHUB_URL/alice/example/change/1 $WORK/browser.txt
+
+# submit with --web=created flag - should NOT open browser (updating existing CR)
+cp $WORK/extra/feature1-last.txt feature1.txt
+git add feature1.txt
+gs cc -m 'Last update to feature1'
+gs branch submit --web=created
+grep -count=1 $SHAMHUB_URL/alice/example/change/1 $WORK/browser.txt
+
+# create new branch with --web=created flag - should open browser (new CR)
+git checkout main
+git add feature2.txt
+gs bc -m 'Add feature2' feature2
+gs branch submit --fill --web=created
+grep -count=1 $SHAMHUB_URL/alice/example/change/1 $WORK/browser.txt
+grep -count=1 $SHAMHUB_URL/alice/example/change/2 $WORK/browser.txt
+
+-- repo/feature1.txt --
+Contents of feature1
+
+-- extra/feature1-new.txt --
+New contents of feature1
+
+-- extra/feature1-last.txt --
+Last contents of feature1
+
+-- repo/feature2.txt --
+Contents of feature2

--- a/testdata/script/stack_submit_web_created_mixed.txt
+++ b/testdata/script/stack_submit_web_created_mixed.txt
@@ -1,0 +1,90 @@
+# stack submit with --web=created opens browser only for new CRs in stack
+
+as 'Test <test@example.com>'
+at '2025-07-06T21:28:29Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub register alice
+shamhub new origin alice/example.git
+git push origin main
+
+env BROWSER_RECORDER_FILE=$WORK/browser.txt
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# create a stack with 3 branches
+git add feat1.txt
+gs bc -m 'Add feat1' feat1
+git add feat2.txt
+gs bc -m 'Add feat2' feat2
+git add feat3.txt
+gs bc -m 'Add feat3' feat3
+
+# submit the entire stack with --web=created - should open browser for all 3 new CRs
+gs trunk
+gs stack submit --fill --web=created
+grep -count=1 $SHAMHUB_URL/alice/example/change/1 $WORK/browser.txt
+grep -count=1 $SHAMHUB_URL/alice/example/change/2 $WORK/browser.txt
+grep -count=1 $SHAMHUB_URL/alice/example/change/3 $WORK/browser.txt
+
+# make changes to feat1 and feat3
+git checkout feat1
+cp $WORK/extra/feat1-new.txt feat1.txt
+git add feat1.txt
+gs cc -m 'Update feat1'
+
+git checkout feat3
+cp $WORK/extra/feat3-new.txt feat3.txt
+git add feat3.txt
+gs cc -m 'Update feat3'
+
+# submit the stack again with --web=created - should NOT open browser (all existing CRs)
+gs trunk
+gs stack submit --fill --web=created
+grep -count=1 $SHAMHUB_URL/alice/example/change/1 $WORK/browser.txt
+grep -count=1 $SHAMHUB_URL/alice/example/change/2 $WORK/browser.txt
+grep -count=1 $SHAMHUB_URL/alice/example/change/3 $WORK/browser.txt
+
+# add a new branch to the stack
+git checkout feat3
+git add feat4.txt
+gs bc -m 'Add feat4' feat4
+
+# submit the stack with --web=created - should open browser only for new CR (feat4)
+gs trunk
+gs stack submit --fill --web=created
+grep -count=1 $SHAMHUB_URL/alice/example/change/1 $WORK/browser.txt
+grep -count=1 $SHAMHUB_URL/alice/example/change/2 $WORK/browser.txt
+grep -count=1 $SHAMHUB_URL/alice/example/change/3 $WORK/browser.txt
+grep -count=1 $SHAMHUB_URL/alice/example/change/4 $WORK/browser.txt
+
+# submit the stack with --web=true - should open browser for all CRs
+gs stack submit --fill --web=true
+grep -count=2 $SHAMHUB_URL/alice/example/change/1 $WORK/browser.txt
+grep -count=2 $SHAMHUB_URL/alice/example/change/2 $WORK/browser.txt
+grep -count=2 $SHAMHUB_URL/alice/example/change/3 $WORK/browser.txt
+grep -count=2 $SHAMHUB_URL/alice/example/change/4 $WORK/browser.txt
+
+-- repo/feat1.txt --
+This is feature 1
+
+-- extra/feat1-new.txt --
+This is updated feature 1
+
+-- repo/feat2.txt --
+This is feature 2
+
+-- repo/feat3.txt --
+This is feature 3
+
+-- extra/feat3-new.txt --
+This is updated feature 3
+
+-- repo/feat4.txt --
+This is feature 4


### PR DESCRIPTION
The --web flag now accepts an argument,
which can be 'true', 'false', or 'created'.
true and false match today's behavior, while 'created'
means that only newly created CRs will be opened in a browser.

For backwards compatibility, the argument is optional:

    --web    # equivalent to --web=true
    --no-web # equivalent to --web=false

The configuration option `spice.submit.web` also accepts the same values.

Resolves #649