### PR TITLE
Add upstack delete command

### DIFF
--- a/.changes/unreleased/Added-20250706-165936.yaml
+++ b/.changes/unreleased/Added-20250706-165936.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: >-
+  New 'upstack delete' command to delete all branches
+  upstack from the current branch, not including the current branch.
+time: 2025-07-06T16:59:36.896784-07:00

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -373,6 +373,28 @@ Provide the new base name as an argument to skip the prompt.
 
 **Configuration**: [spice.branchPrompt.sort](/cli/config.md#spicebranchpromptsort)
 
+### gs upstack delete
+
+```
+gs upstack (us) delete (d) [flags]
+```
+
+Delete all branches above the current branch
+
+Deletes all branches above the current branch in the stack,
+not including the current branch.
+The current branch remains unchanged.
+
+This is a convenient way to clean up abandoned or completed
+parts of a feature stack.
+
+As this is a destructive operation,
+you must use the --force flag to confirm deletion.
+
+**Flags**
+
+* `--force`: Force deletion of the branches
+
 ### gs downstack submit
 
 ```

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -379,6 +379,8 @@ Provide the new base name as an argument to skip the prompt.
 gs upstack (us) delete (d) [flags]
 ```
 
+<span class="mdx-badge"><span class="mdx-badge__icon">:material-tag-hidden:{ title="Released in version" }</span><span class="mdx-badge__text">Unreleased</span>
+
 Delete all branches above the current branch
 
 Deletes all branches above the current branch in the stack,

--- a/doc/includes/cli-shorthands.md
+++ b/doc/includes/cli-shorthands.md
@@ -27,6 +27,7 @@
 | gs se | [gs stack edit](/cli/reference.md#gs-stack-edit) |
 | gs sr | [gs stack restack](/cli/reference.md#gs-stack-restack) |
 | gs ss | [gs stack submit](/cli/reference.md#gs-stack-submit) |
+| gs usd | [gs upstack delete](/cli/reference.md#gs-upstack-delete) |
 | gs uso | [gs upstack onto](/cli/reference.md#gs-upstack-onto) |
 | gs usr | [gs upstack restack](/cli/reference.md#gs-upstack-restack) |
 | gs uss | [gs upstack submit](/cli/reference.md#gs-upstack-submit) |

--- a/testdata/script/upstack_delete.txt
+++ b/testdata/script/upstack_delete.txt
@@ -1,0 +1,88 @@
+# Test upstack delete command - deletes all branches above current branch
+
+as 'Test <test@example.com>'
+at '2025-07-06T15:30:00Z'
+
+# set up
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# Test 1: Error when running on trunk branch
+gs bco main
+! gs upstack delete --force
+stderr 'this command cannot be run against the trunk branch'
+
+# Test 2: Force flag requirement when not interactive
+git add feature1.txt
+gs branch create feature1 -m 'Add feature 1'
+
+git add feature2.txt
+gs branch create feature2 -m 'Add feature 2'
+
+gs bco feature1
+! gs upstack delete
+stderr 'use --force to confirm deletion'
+
+# Test 3: Interactive confirmation prompt
+env ROBOT_INPUT=$WORK/robot.golden ROBOT_OUTPUT=$WORK/robot.output
+gs upstack delete
+cmp $WORK/robot.output $WORK/robot.golden
+
+# After deletion, should still be on feature1
+git branch --show-current
+stdout 'feature1'
+
+# Verify upstack branches are deleted, but feature1 remains
+gs ls -a
+cmp stderr $WORK/golden/ls-after-interactive.txt
+
+# Test 4: Force flag works without prompting
+env ROBOT_INPUT= ROBOT_OUTPUT=
+git add feature3.txt
+gs branch create feature3 -m 'Add feature 3'
+
+git add feature4.txt
+gs branch create feature4 -m 'Add feature 4'
+
+gs bco feature3
+gs upstack delete --force
+
+# Should still be on feature3
+git branch --show-current
+stdout 'feature3'
+
+# Verify only feature4 was deleted, feature3 remains
+gs ls -a
+cmp stderr $WORK/golden/ls-final.txt
+
+# Test 5: No upstack branches to delete
+gs upstack delete --force
+stderr 'no upstack branches to delete'
+
+-- repo/feature1.txt --
+Feature 1
+-- repo/feature2.txt --
+Feature 2
+-- repo/feature3.txt --
+Feature 3
+-- repo/feature4.txt --
+Feature 4
+-- repo/feature5.txt --
+Feature 5
+-- repo/unmerged.txt --
+Unmerged change
+
+-- golden/ls-after-interactive.txt --
+┏━■ feature1 ◀
+main
+-- golden/ls-final.txt --
+  ┏━■ feature3 ◀
+┏━┻□ feature1
+main
+-- robot.golden --
+===
+> Delete 1 upstack branches: [y/N]
+> Confirm all these branches should be deleted.
+true

--- a/upstack.go
+++ b/upstack.go
@@ -4,5 +4,5 @@ type upstackCmd struct {
 	Submit  upstackSubmitCmd  `cmd:"" aliases:"s" help:"Submit a branch and those above it"`
 	Restack upstackRestackCmd `cmd:"" aliases:"r" help:"Restack a branch and its upstack"`
 	Onto    upstackOntoCmd    `cmd:"" aliases:"o" help:"Move a branch onto another branch"`
-	Delete  upstackDeleteCmd  `cmd:"" aliases:"d" help:"Delete all branches above the current branch"`
+	Delete  upstackDeleteCmd  `cmd:"" aliases:"d" released:"unreleased" help:"Delete all branches above the current branch"`
 }

--- a/upstack.go
+++ b/upstack.go
@@ -4,4 +4,5 @@ type upstackCmd struct {
 	Submit  upstackSubmitCmd  `cmd:"" aliases:"s" help:"Submit a branch and those above it"`
 	Restack upstackRestackCmd `cmd:"" aliases:"r" help:"Restack a branch and its upstack"`
 	Onto    upstackOntoCmd    `cmd:"" aliases:"o" help:"Move a branch onto another branch"`
+	Delete  upstackDeleteCmd  `cmd:"" aliases:"d" help:"Delete all branches above the current branch"`
 }

--- a/upstack_delete.go
+++ b/upstack_delete.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/silog"
+	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/state"
+	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
+)
+
+type upstackDeleteCmd struct {
+	Force bool `help:"Force deletion of the branches"`
+}
+
+func (*upstackDeleteCmd) Help() string {
+	return text.Dedent(`
+		Deletes all branches above the current branch in the stack,
+		not including the current branch.
+		The current branch remains unchanged.
+
+		This is a convenient way to clean up abandoned or completed
+		parts of a feature stack.
+
+		As this is a destructive operation,
+		you must use the --force flag to confirm deletion.
+	`)
+}
+
+func (cmd *upstackDeleteCmd) Run(
+	ctx context.Context,
+	log *silog.Logger,
+	view ui.View,
+	repo *git.Repository,
+	wt *git.Worktree,
+	store *state.Store,
+	svc *spice.Service,
+) error {
+	currentBranch, err := wt.CurrentBranch(ctx)
+	if err != nil {
+		return fmt.Errorf("get current branch: %w", err)
+	}
+
+	if currentBranch == store.Trunk() {
+		return errors.New("this command cannot be run against the trunk branch")
+	}
+
+	upstack, err := svc.ListUpstack(ctx, currentBranch)
+	if err != nil {
+		return fmt.Errorf("list upstack: %w", err)
+	}
+	// upstack[0] is always the current branch, so skip it.
+	upstack = upstack[1:]
+	if len(upstack) == 0 {
+		log.Infof("%v: no upstack branches to delete", currentBranch)
+		return nil
+	}
+
+	prefix := "WOULD "
+	shouldPrompt := !cmd.Force && ui.Interactive(view)
+	if shouldPrompt {
+		prefix = "WILL "
+	}
+	for _, branch := range upstack {
+		log.Infof("%s delete branch: %v", prefix, branch)
+	}
+
+	if shouldPrompt {
+		prompt := ui.NewConfirm().
+			WithTitlef("Delete %d upstack branches", len(upstack)).
+			WithDescription("Confirm all these branches should be deleted.").
+			WithValue(&cmd.Force)
+		if err := ui.Run(view, prompt); err != nil {
+			return err
+		}
+	}
+
+	if !cmd.Force {
+		return errors.New("use --force to confirm deletion")
+	}
+
+	return (&branchDeleteCmd{
+		Branches: upstack,
+		Force:    true,
+	}).Run(ctx, log, view, repo, wt, store, svc)
+}


### PR DESCRIPTION
This command allows users to delete all branches above
the current branch in the stack, providing a convenient
way to clean up completed upstack branches.

The implementation leverages the existing branchDeleteCmd
logic while using ListUpstack() to determine which branches
to delete in the upstack scope.

Closes #629