### PR TITLE
Add stack delete command

### DIFF
--- a/.changes/unreleased/Added-20250706-165757.yaml
+++ b/.changes/unreleased/Added-20250706-165757.yaml
@@ -1,0 +1,4 @@
+kind: Added
+body: >-
+  New 'stack delete' deletes all branches in the current branch's stack.
+time: 2025-07-06T16:57:57.80202-07:00

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -263,6 +263,28 @@ Branches that are deleted from the list will be ignored.
 * `--editor=STRING`: Editor to use for editing the downstack. Defaults to Git's default editor.
 * `--branch=NAME`: Branch whose stack we're editing. Defaults to current branch.
 
+### gs stack delete
+
+```
+gs stack (s) delete (d) [flags]
+```
+
+Delete all branches in a stack
+
+Deletes all branches in the current branch's stack.
+This includes both upstack and downstack branches.
+
+The deleted branches and their commits are removed from the stack.
+This is a convenient way to clean up completed or abandoned
+feature stacks.
+
+As this is a destructive operation,
+you must use the --force flag to confirm deletion.
+
+**Flags**
+
+* `--force`: Force deletion of the branches
+
 ### gs upstack submit
 
 ```

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -269,6 +269,8 @@ Branches that are deleted from the list will be ignored.
 gs stack (s) delete (d) [flags]
 ```
 
+<span class="mdx-badge"><span class="mdx-badge__icon">:material-tag-hidden:{ title="Released in version" }</span><span class="mdx-badge__text">Unreleased</span>
+
 Delete all branches in a stack
 
 Deletes all branches in the current branch's stack.

--- a/doc/includes/cli-shorthands.md
+++ b/doc/includes/cli-shorthands.md
@@ -24,6 +24,7 @@
 | gs rbc | [gs rebase continue](/cli/reference.md#gs-rebase-continue) |
 | gs ri | [gs repo init](/cli/reference.md#gs-repo-init) |
 | gs rs | [gs repo sync](/cli/reference.md#gs-repo-sync) |
+| gs sd | [gs stack delete](/cli/reference.md#gs-stack-delete) |
 | gs se | [gs stack edit](/cli/reference.md#gs-stack-edit) |
 | gs sr | [gs stack restack](/cli/reference.md#gs-stack-restack) |
 | gs ss | [gs stack submit](/cli/reference.md#gs-stack-submit) |

--- a/stack.go
+++ b/stack.go
@@ -4,5 +4,5 @@ type stackCmd struct {
 	Submit  stackSubmitCmd  `cmd:"" aliases:"s" help:"Submit a stack"`
 	Restack stackRestackCmd `cmd:"" aliases:"r" help:"Restack a stack"`
 	Edit    stackEditCmd    `cmd:"" aliases:"e" help:"Edit the order of branches in a stack"`
-	Delete  stackDeleteCmd  `cmd:"" aliases:"d" help:"Delete all branches in a stack"`
+	Delete  stackDeleteCmd  `cmd:"" aliases:"d" released:"unreleased" help:"Delete all branches in a stack"`
 }

--- a/stack.go
+++ b/stack.go
@@ -4,4 +4,5 @@ type stackCmd struct {
 	Submit  stackSubmitCmd  `cmd:"" aliases:"s" help:"Submit a stack"`
 	Restack stackRestackCmd `cmd:"" aliases:"r" help:"Restack a stack"`
 	Edit    stackEditCmd    `cmd:"" aliases:"e" help:"Edit the order of branches in a stack"`
+	Delete  stackDeleteCmd  `cmd:"" aliases:"d" help:"Delete all branches in a stack"`
 }

--- a/stack_delete.go
+++ b/stack_delete.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/must"
+	"go.abhg.dev/gs/internal/silog"
+	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/state"
+	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
+)
+
+type stackDeleteCmd struct {
+	Force bool `help:"Force deletion of the branches"`
+}
+
+func (*stackDeleteCmd) Help() string {
+	return text.Dedent(`
+		Deletes all branches in the current branch's stack.
+		This includes both upstack and downstack branches.
+
+		The deleted branches and their commits are removed from the stack.
+		This is a convenient way to clean up completed or abandoned
+		feature stacks.
+
+		As this is a destructive operation,
+		you must use the --force flag to confirm deletion.
+	`)
+}
+
+func (cmd *stackDeleteCmd) Run(
+	ctx context.Context,
+	log *silog.Logger,
+	view ui.View,
+	repo *git.Repository,
+	wt *git.Worktree,
+	store *state.Store,
+	svc *spice.Service,
+) error {
+	currentBranch, err := wt.CurrentBranch(ctx)
+	if err != nil {
+		return fmt.Errorf("get current branch: %w", err)
+	}
+
+	if currentBranch == store.Trunk() {
+		return errors.New("this command cannot be run against the trunk branch")
+	}
+
+	stack, err := svc.ListStack(ctx, currentBranch)
+	if err != nil {
+		return fmt.Errorf("list stack: %w", err)
+	}
+	must.NotBeEmptyf(stack, "list stack from non-trunk branch cannot be empty: %s", currentBranch)
+
+	prefix := "WOULD "
+	shouldPrompt := !cmd.Force && ui.Interactive(view)
+	if shouldPrompt {
+		prefix = "WILL "
+	}
+	for _, branch := range stack {
+		log.Infof("%s delete branch: %v", prefix, branch)
+	}
+
+	if shouldPrompt {
+		prompt := ui.NewConfirm().
+			WithTitlef("Delete %d branches", len(stack)).
+			WithDescription("Confirm all these branches should be deleted.").
+			WithValue(&cmd.Force)
+		if err := ui.Run(view, prompt); err != nil {
+			return err
+		}
+	}
+
+	if !cmd.Force {
+		return errors.New("use --force to confirm deletion")
+	}
+
+	return (&branchDeleteCmd{
+		Branches: stack,
+		Force:    true,
+	}).Run(ctx, log, view, repo, wt, store, svc)
+}

--- a/testdata/script/stack_delete.txt
+++ b/testdata/script/stack_delete.txt
@@ -1,0 +1,78 @@
+# Test stack delete command - deletes all branches in a stack
+
+as 'Test <test@example.com>'
+at '2025-07-06T15:30:00Z'
+
+# set up
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# Test 1: Error when running on trunk branch
+gs bco main
+! gs stack delete --force
+stderr 'this command cannot be run against the trunk branch'
+
+git add feature1.txt
+gs branch create feature1 -m 'Add feature 1'
+
+git add feature2.txt
+gs branch create feature2 -m 'Add feature 2'
+
+# Test 2: Force flag requirement when not interactive
+gs bco feature1
+! gs stack delete
+stderr 'use --force to confirm deletion'
+
+# Test 3: Interactive confirmation prompt
+env ROBOT_INPUT=$WORK/robot.golden ROBOT_OUTPUT=$WORK/robot.output
+gs stack delete
+cmp $WORK/robot.output $WORK/robot.golden
+
+# After deletion, should be on main branch
+git branch --show-current
+stdout 'main'
+
+# Verify all branches in the stack are deleted
+gs ls -a
+cmp stderr $WORK/golden/ls-deleted.txt
+
+git add feature3.txt
+gs branch create feature3 -m 'Add feature 3'
+
+git add feature4.txt
+gs branch create feature4 -m 'Add feature 4'
+
+# Test 4: Force flag works without prompting
+env ROBOT_INPUT= ROBOT_OUTPUT=
+gs bco feature3
+gs stack delete --force
+
+# Should be on main and all branches deleted
+git branch --show-current
+stdout 'main'
+
+gs ls -a
+cmp stderr $WORK/golden/ls-deleted.txt
+
+-- repo/feature1.txt --
+Feature 1
+-- repo/feature2.txt --
+Feature 2
+-- repo/feature3.txt --
+Feature 3
+-- repo/feature4.txt --
+Feature 4
+-- repo/feature5.txt --
+Feature 5
+-- repo/unmerged.txt --
+Unmerged change
+
+-- golden/ls-deleted.txt --
+main ◀
+-- robot.golden --
+===
+> Delete 2 branches: [y/N]
+> Confirm all these branches should be deleted.
+true


### PR DESCRIPTION
This command allows users to delete all branches in the current
branch's stack with a single command, providing a convenient way
to clean up completed or abandoned feature stacks.

The implementation leverages the existing branchDeleteCmd
logic while using ListStack() to determine which branches
to delete in the current stack scope.

Closes #629