### PR TITLE
feat: repo restack command

### DIFF
--- a/.changes/unreleased/Added-20250708-201239.yaml
+++ b/.changes/unreleased/Added-20250708-201239.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add 'repo restack' command to restack all tracked branches
+time: 2025-07-08T20:12:39.290928-07:00

--- a/.changes/unreleased/Added-20250708-201239.yaml
+++ b/.changes/unreleased/Added-20250708-201239.yaml
@@ -1,3 +1,3 @@
 kind: Added
-body: Add 'repo restack' command to restack all tracked branches
+body: New 'repo restack' command restacks all tracked branches
 time: 2025-07-08T20:12:39.290928-07:00

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -146,6 +146,19 @@ was not initialized with a remote.
 
 * `--restack`: Restack the current stack after syncing
 
+### gs repo restack
+
+```
+gs repo (r) restack (r)
+```
+
+<span class="mdx-badge"><span class="mdx-badge__icon">:material-tag-hidden:{ title="Released in version" }</span><span class="mdx-badge__text">Unreleased</span>
+
+Restack all tracked branches
+
+All tracked branches in the repository are rebased on top of their
+respective bases in dependency order, ensuring a linear history.
+
 ## Log
 
 ### gs log short

--- a/doc/includes/cli-shorthands.md
+++ b/doc/includes/cli-shorthands.md
@@ -23,6 +23,7 @@
 | gs rba | [gs rebase abort](/cli/reference.md#gs-rebase-abort) |
 | gs rbc | [gs rebase continue](/cli/reference.md#gs-rebase-continue) |
 | gs ri | [gs repo init](/cli/reference.md#gs-repo-init) |
+| gs rr | [gs repo restack](/cli/reference.md#gs-repo-restack) |
 | gs rs | [gs repo sync](/cli/reference.md#gs-repo-sync) |
 | gs sd | [gs stack delete](/cli/reference.md#gs-stack-delete) |
 | gs se | [gs stack edit](/cli/reference.md#gs-stack-edit) |

--- a/repo.go
+++ b/repo.go
@@ -1,6 +1,7 @@
 package main
 
 type repoCmd struct {
-	Init repoInitCmd `cmd:"" aliases:"i" help:"Initialize a repository"`
-	Sync repoSyncCmd `cmd:"" aliases:"s" help:"Pull latest changes from the remote"`
+	Init    repoInitCmd    `cmd:"" aliases:"i" help:"Initialize a repository"`
+	Sync    repoSyncCmd    `cmd:"" aliases:"s" help:"Pull latest changes from the remote"`
+	Restack repoRestackCmd `cmd:"" aliases:"r" help:"Restack all tracked branches" released:"unreleased"`
 }

--- a/repo_restack.go
+++ b/repo_restack.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/graph"
+	"go.abhg.dev/gs/internal/silog"
+	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/state"
+	"go.abhg.dev/gs/internal/text"
+)
+
+type repoRestackCmd struct{}
+
+func (*repoRestackCmd) Help() string {
+	return text.Dedent(`
+		All tracked branches in the repository are rebased on top of their
+		respective bases in dependency order, ensuring a linear history.
+	`)
+}
+
+func (*repoRestackCmd) Run(
+	ctx context.Context,
+	log *silog.Logger,
+	wt *git.Worktree,
+	store *state.Store,
+	svc *spice.Service,
+) error {
+	currentBranch, err := wt.CurrentBranch(ctx)
+	if err != nil {
+		return fmt.Errorf("get current branch: %w", err)
+	}
+
+	branches, err := svc.LoadBranches(ctx)
+	if err != nil {
+		return fmt.Errorf("load branches: %w", err)
+	}
+
+	if len(branches) == 0 {
+		log.Info("Nothing to restack: no tracked branches found")
+		return nil
+	}
+
+	branchNames := make([]string, len(branches))
+	branchesByName := make(map[string]spice.LoadBranchItem, len(branches))
+	for idx, branch := range branches {
+		branchesByName[branch.Name] = branch
+		branchNames[idx] = branch.Name
+	}
+
+	// Topologically sort branches by their dependencies
+	// This ensures we restack branches in the correct order:
+	// branches closer to trunk first, then their dependents
+	topoBranches := graph.Toposort(branchNames, func(branch string) (string, bool) {
+		base := branchesByName[branch].Base
+		_, ok := branchesByName[base]
+		return base, ok
+	})
+
+loop:
+	for _, branch := range topoBranches {
+		// Trunk never needs to be restacked
+		if branch == store.Trunk() {
+			continue loop
+		}
+
+		res, err := svc.Restack(ctx, branch)
+		if err != nil {
+			var rebaseErr *git.RebaseInterruptError
+			switch {
+			case errors.As(err, &rebaseErr):
+				// If the rebase is interrupted by a conflict,
+				// we'll resume by re-running this command.
+				return svc.RebaseRescue(ctx, spice.RebaseRescueRequest{
+					Err:     rebaseErr,
+					Branch:  currentBranch,
+					Command: []string{"repo", "restack"},
+					Message: fmt.Sprintf("interrupted: restack all branches (at %v)", branch),
+				})
+			case errors.Is(err, spice.ErrAlreadyRestacked):
+				log.Infof("%v: branch does not need to be restacked", branch)
+				continue loop
+			default:
+				return fmt.Errorf("restack branch %v: %w", branch, err)
+			}
+		}
+
+		log.Infof("%v: restacked on %v", branch, res.Base)
+	}
+
+	// On success, check out the original branch
+	if err := wt.Checkout(ctx, currentBranch); err != nil {
+		return fmt.Errorf("checkout %v: %w", currentBranch, err)
+	}
+
+	return nil
+}

--- a/testdata/script/repo_restack_already_restacked.txt
+++ b/testdata/script/repo_restack_already_restacked.txt
@@ -1,0 +1,47 @@
+# Test repo restack when branches are already restacked
+
+as 'Test User <test@example.com>'
+at 2025-06-20T21:28:29Z
+
+cd repo
+git init
+git commit -m 'Initial commit' --allow-empty
+
+gs repo init
+
+# Create some branches
+git add feat1.txt
+gs branch create feat1 -m 'feat1 commit'
+
+git add feat2.txt
+gs branch create feat2 -m 'feat2 commit'
+
+git add feat3.txt
+gs branch create feat3 -m 'feat3 commit'
+
+# Branches are already in good state - no restacking needed
+gs repo restack
+stderr 'feat1: branch does not need to be restacked'
+stderr 'feat2: branch does not need to be restacked'
+stderr 'feat3: branch does not need to be restacked'
+
+# Now create a commit on trunk and restack one branch manually
+gs branch checkout main
+git commit --allow-empty -m 'New trunk commit'
+
+# Restack just feat1 manually
+gs branch checkout feat1
+gs branch restack
+
+# Now when we run repo restack, only feat2 and feat3 should be restacked
+gs repo restack
+stderr 'feat1: branch does not need to be restacked'
+stderr 'feat2: restacked on feat1'
+stderr 'feat3: restacked on feat2'
+
+-- repo/feat1.txt --
+feature 1
+-- repo/feat2.txt --
+feature 2
+-- repo/feat3.txt --
+feature 3

--- a/testdata/script/repo_restack_basic.txt
+++ b/testdata/script/repo_restack_basic.txt
@@ -1,0 +1,40 @@
+# Basic repo restack functionality with simple linear dependencies
+
+as 'Test User <test@example.com>'
+at 2025-06-20T21:28:29Z
+
+cd repo
+git init
+git commit -m 'Initial commit' --allow-empty
+
+gs repo init
+git add feat1.txt
+gs branch create feat1 -m 'feat1 commit'
+git add feat2.txt
+gs branch create feat2 -m 'feat2 commit'
+git add feat3.txt
+gs branch create feat3 -m 'feat3 commit'
+
+# Create a new commit on trunk to make branches need restacking
+gs branch checkout main
+git commit --allow-empty -m 'New trunk commit'
+
+# Now restack all branches
+gs repo restack
+
+# Verify all branches are restacked
+git graph --branches
+cmp stdout $WORK/golden/graph.txt
+
+-- repo/feat1.txt --
+feature 1
+-- repo/feat2.txt --
+feature 2
+-- repo/feat3.txt --
+feature 3
+-- golden/graph.txt --
+* f634ce2 (feat3) feat3 commit
+* f5121c8 (feat2) feat2 commit
+* c1f17f5 (feat1) feat1 commit
+* 8e9b73c (HEAD -> main) New trunk commit
+* 91af7b5 Initial commit

--- a/testdata/script/repo_restack_complex.txt
+++ b/testdata/script/repo_restack_complex.txt
@@ -1,0 +1,72 @@
+# Complex repo restack with multiple independent branches and dependencies
+
+as 'Test User <test@example.com>'
+at 2025-06-20T21:28:29Z
+
+cd repo
+git init
+git commit -m 'Initial commit' --allow-empty
+
+gs repo init
+
+# Create first branch stack: feat1 -> feat1-ext
+git add feat1.txt
+gs branch create feat1 -m 'feat1 commit'
+
+git add feat1-ext.txt
+gs branch create feat1-ext -m 'feat1 extension commit'
+
+# Create second independent branch stack: feat2 -> feat2-ext
+gs branch checkout main
+git add feat2.txt
+gs branch create feat2 -m 'feat2 commit'
+
+git add feat2-ext.txt
+gs branch create feat2-ext -m 'feat2 extension commit'
+
+# Create third independent branch
+gs branch checkout main
+git add feat3.txt
+gs branch create feat3 -m 'feat3 commit'
+
+# Create a complex dependency: feat4 depends on feat1
+gs branch checkout feat1
+git add feat4.txt
+gs branch create feat4 -m 'feat4 commit'
+
+# Create a new commit on trunk to make all branches need restacking
+gs branch checkout main
+git commit --allow-empty -m 'New trunk commit'
+
+# Now restack all branches - they should be restacked in topological order
+gs repo restack
+
+# Verify all branches are restacked properly
+git graph --branches
+cmp stdout $WORK/golden/graph.txt
+
+-- repo/feat1.txt --
+feature 1
+-- repo/feat1-ext.txt --
+feature 1 extension
+-- repo/feat2.txt --
+feature 2
+-- repo/feat2-ext.txt --
+feature 2 extension
+-- repo/feat3.txt --
+feature 3
+-- repo/feat4.txt --
+feature 4
+-- golden/graph.txt --
+* 7e864e4 (feat1-ext) feat1 extension commit
+| * 28c4da2 (feat2-ext) feat2 extension commit
+| * cd0a730 (feat2) feat2 commit
+| | * f27266a (feat3) feat3 commit
+| |/  
+| | * 8e2531c (feat4) feat4 commit
+| |/  
+|/|   
+* | c1f17f5 (feat1) feat1 commit
+|/  
+* 8e9b73c (HEAD -> main) New trunk commit
+* 91af7b5 Initial commit

--- a/testdata/script/repo_restack_conflicts.txt
+++ b/testdata/script/repo_restack_conflicts.txt
@@ -1,0 +1,56 @@
+# Test repo restack with conflict resolution
+
+as 'Test User <test@example.com>'
+at 2025-06-20T21:28:29Z
+
+cd repo
+git init
+git commit -m 'Initial commit' --allow-empty
+git add file.txt
+git commit -m 'Add file.txt'
+
+gs repo init
+
+# Create a branch that will conflict
+cp $WORK/other/feat1.txt file.txt
+git add file.txt
+gs branch create feat1 -m 'Modify file.txt in feat1'
+
+# Change trunk to require rebase
+gs branch checkout main
+cp $WORK/other/trunk-change.txt file.txt
+git add file.txt
+git commit -m 'Modify file.txt in trunk'
+
+# Now restack should cause a conflict
+! gs repo restack
+stderr 'rebase of feat1 interrupted by a conflict'
+
+# Check that we're in the rescue state
+git status --porcelain
+cmp stdout $WORK/golden/status_conflict.txt
+
+# Resolve the conflict
+cp ../other/resolved.txt file.txt
+git add file.txt
+gs rebase continue --no-edit
+
+# Command should have been automatically resumed
+git graph --branches
+cmp stdout $WORK/golden/graph_resolved.txt
+
+-- repo/file.txt --
+original content
+-- other/feat1.txt --
+feat1 content
+-- other/trunk-change.txt --
+trunk content
+-- other/resolved.txt --
+resolved content
+-- golden/status_conflict.txt --
+UU file.txt
+-- golden/graph_resolved.txt --
+* 29ec9b8 (feat1) Modify file.txt in feat1
+* 0e4c253 (HEAD -> main) Modify file.txt in trunk
+* c782ce9 Add file.txt
+* 91af7b5 Initial commit

--- a/testdata/script/repo_restack_edge_cases.txt
+++ b/testdata/script/repo_restack_edge_cases.txt
@@ -1,0 +1,37 @@
+# Test repo restack edge cases
+
+as 'Test User <test@example.com>'
+at 2025-06-20T21:28:29Z
+
+cd repo
+git init
+git commit -m 'Initial commit' --allow-empty
+
+gs repo init
+
+# Test case 1: No tracked branches
+gs repo restack
+stderr 'no tracked branches found'
+
+# Test case 2: Single branch
+git add single.txt
+gs branch create single -m 'single commit'
+
+gs branch checkout main
+git commit --allow-empty -m 'trunk commit'
+
+gs repo restack
+stderr 'single: restacked on main'
+
+# Test case 3: Branch that is already on trunk (doesn't need restacking)
+git add already-good.txt
+gs branch create already-good -m 'already good commit'
+
+gs repo restack
+stderr 'already-good: branch does not need to be restacked'
+stderr 'single: branch does not need to be restacked'
+
+-- repo/single.txt --
+single feature
+-- repo/already-good.txt --
+already good feature


### PR DESCRIPTION
Add a 'repo restack' command that restacks all tracked branches.
Branches have to be sorted in topological order
based on their base relationships before being restacked.

Resolves #505