### PR TITLE
fix: concurrent Git storage usage, bad base hash after manual rebase

### DIFF
--- a/.changes/unreleased/Fixed-20250711-212136.yaml
+++ b/.changes/unreleased/Fixed-20250711-212136.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fix concurrent updates to git-spice's state causing "cannot lock ref" warnings.
+time: 2025-07-11T21:21:36.546923-07:00

--- a/.changes/unreleased/Fixed-20250711-212236.yaml
+++ b/.changes/unreleased/Fixed-20250711-212236.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'log long: Fix incorrect list of commits following a manual rebase operation.'
+time: 2025-07-11T21:22:36.27471-07:00

--- a/.changes/unreleased/Fixed-20250711-215056.yaml
+++ b/.changes/unreleased/Fixed-20250711-215056.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'branch squash: Fix no-op commit left behind in some scenarios when ''branch squash'' is run after a manual rebase.'
+time: 2025-07-11T21:50:56.884734-07:00

--- a/branch_squash.go
+++ b/branch_squash.go
@@ -46,17 +46,17 @@ func (cmd *branchSquashCmd) Run(
 		return errors.New("cannot squash the trunk branch")
 	}
 
-	branch, err := svc.LookupBranch(ctx, branchName)
-	if err != nil {
-		return fmt.Errorf("lookup branch %q: %w", branchName, err)
-	}
-
 	if err := svc.VerifyRestacked(ctx, branchName); err != nil {
 		var restackErr *spice.BranchNeedsRestackError
 		if errors.As(err, &restackErr) {
 			return fmt.Errorf("branch %v needs to be restacked before it can be squashed", branchName)
 		}
 		return fmt.Errorf("verify restacked: %w", err)
+	}
+
+	branch, err := svc.LookupBranch(ctx, branchName)
+	if err != nil {
+		return fmt.Errorf("lookup branch %q: %w", branchName, err)
 	}
 
 	// If no message was specified,

--- a/branch_submit.go
+++ b/branch_submit.go
@@ -156,11 +156,6 @@ func (cmd *branchSubmitCmd) run(
 		return errors.New("cannot submit trunk")
 	}
 
-	branch, err := svc.LookupBranch(ctx, cmd.Branch)
-	if err != nil {
-		return fmt.Errorf("lookup branch: %w", err)
-	}
-
 	// Refuse to submit if the branch is not restacked.
 	if !cmd.Force {
 		if err := svc.VerifyRestacked(ctx, cmd.Branch); err != nil {
@@ -170,6 +165,11 @@ func (cmd *branchSubmitCmd) run(
 			log.Errorf("Or, try again with --force to submit anyway.")
 			return errors.New("refusing to submit outdated branch")
 		}
+	}
+
+	branch, err := svc.LookupBranch(ctx, cmd.Branch)
+	if err != nil {
+		return fmt.Errorf("lookup branch: %w", err)
 	}
 
 	// Various code paths down below should call this

--- a/internal/spice/state/storage/git_test.go
+++ b/internal/spice/state/storage/git_test.go
@@ -1,11 +1,19 @@
 package storage
 
 import (
+	cryptorand "crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"os"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/silog/silogtest"
 )
 
@@ -37,4 +45,144 @@ func TestGitBackendUpdateNoChanges(t *testing.T) {
 
 	assert.Equal(t, start, end,
 		"there should be no changes in the repository")
+}
+
+func TestGitBackend_ConcurrentOperations(t *testing.T) {
+	var seed [32]byte
+	if seedstr := os.Getenv("GIT_BACKEND_CONCURRENT_SEED"); seedstr != "" {
+		bs, err := hex.DecodeString(seedstr)
+		require.NoError(t, err)
+		require.Len(t, bs, 32)
+		copy(seed[:], bs)
+	} else {
+		_, _ = cryptorand.Read(seed[:]) // cannot fail
+		t.Logf("GIT_BACKEND_CONCURRENT_SEED=%s", hex.EncodeToString(seed[:]))
+	}
+	testRand := rand.New(rand.NewChaCha8(seed))
+
+	ctx := t.Context()
+	repo, _, err := git.Init(ctx, t.TempDir(), git.InitOptions{
+		Log: silog.Nop(),
+	})
+	require.NoError(t, err)
+
+	backend := NewGitBackend(GitConfig{
+		Repo:        repo,
+		Ref:         "refs/data",
+		AuthorName:  "Test Author",
+		AuthorEmail: "test@example.com",
+		Log:         silogtest.New(t),
+	})
+
+	const (
+		NumWorkers   = 10
+		OpsPerWorker = 10
+		NumKeys      = 1000
+	)
+
+	db := NewDB(backend)
+
+	// Pre-populate some data
+	require.NoError(t, db.Set(ctx, "initial/key1", "value1", "initial data"))
+	require.NoError(t, db.Set(ctx, "initial/key2", "value2", "initial data"))
+
+	ops := []struct {
+		name   string
+		op     func(*rand.Rand)
+		weight float64 // weight for random selection
+	}{
+		{
+			name:   "Keys",
+			weight: 1,
+			op: func(*rand.Rand) {
+				_, err := backend.Keys(ctx, "")
+				assert.NoError(t, err, "Keys operation failed")
+			},
+		},
+		{
+			name:   "Get",
+			weight: 1,
+			op: func(*rand.Rand) {
+				var value string
+				err := backend.Get(ctx, "initial/key1", &value)
+				if !errors.Is(err, ErrNotExist) {
+					assert.NoError(t, err, "Get operation failed")
+				}
+			},
+		},
+		{
+			name:   "Update",
+			weight: 1,
+			op: func(rand *rand.Rand) {
+				key := fmt.Sprintf("key%d", rand.IntN(NumKeys))
+				value := rand.Int()
+				err := backend.Update(ctx, UpdateRequest{
+					Sets: []SetRequest{{
+						Key:   key,
+						Value: value,
+					}},
+					Message: "concurrent update",
+				})
+				assert.NoError(t, err, "Update operation failed")
+			},
+		},
+		{
+			name:   "Clear",
+			weight: 0.3, // Less frequent
+			op: func(*rand.Rand) {
+				err := backend.Clear(ctx, "concurrent clear operation")
+				assert.NoError(t, err, "Clear operation failed")
+			},
+		},
+	}
+
+	var totalWeight float64
+	for _, op := range ops {
+		totalWeight += op.weight
+	}
+
+	selectOp := func(rand *rand.Rand) (name string, f func(*rand.Rand)) {
+		// Generate a random value in [0, totalWeight)
+		// and then search through the operations
+		// to find where it falls.
+		target := rand.Float64() * totalWeight // [0, totalWeight)
+
+		var cursor float64
+		for _, op := range ops {
+			cursor += op.weight
+			if cursor >= target {
+				return op.name, op.op
+			}
+		}
+
+		panic("should never reach here, totalWeight is not zero")
+	}
+
+	var wg sync.WaitGroup
+	for workerIdx := range NumWorkers {
+		wg.Add(1)
+
+		seed1, seed2 := testRand.Uint64(), testRand.Uint64()
+		go func() {
+			defer wg.Done()
+
+			rand := rand.New(rand.NewPCG(seed1, seed2))
+			for opIdx := range OpsPerWorker {
+				name, op := selectOp(rand)
+				t.Logf("[worker %d, op %d] %s", workerIdx, opIdx, name)
+				op(rand)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Verify the backend is still functional after concurrent operations
+	err = db.Set(ctx, "post_test", "final_value", "post-test verification")
+	require.NoError(t, err)
+
+	var finalValue string
+	err = backend.Get(ctx, "post_test", &finalValue)
+	require.NoError(t, err)
+	assert.Equal(t, "final_value", finalValue)
 }

--- a/testdata/script/branch_squash_after_manual_rebase.txt
+++ b/testdata/script/branch_squash_after_manual_rebase.txt
@@ -1,0 +1,76 @@
+# Test squash after manual rebase uses correct base hash
+
+as 'Test <test@example.com>'
+at '2025-07-12T21:28:29Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+git add main-change.txt
+git commit -m 'main change'
+
+# Create feat1 branch with 3 commits stacked on main
+git add feature1.txt
+gs branch create feat1 -m 'Add feature1 first commit'
+git add feature2.txt
+git commit -m 'Add feature1 second commit'
+git add feature3.txt
+git commit -m 'Add feature1 third commit'
+
+git graph --branches
+cmp stdout $WORK/golden/graph-before-main-change.txt
+
+# Go back to main and change HEAD significantly
+git checkout main
+git reset --hard HEAD~
+
+git graph --branches
+cmp stdout $WORK/golden/graph-after-main-change.txt
+
+# Now feat1 needs to be restacked, but we'll do it manually
+git checkout feat1
+git rebase --onto main cb2e344 feat1
+
+git graph --branches
+cmp stdout $WORK/golden/graph-after-manual-rebase.txt
+
+# Now run 'gs branch squash' with a commit message
+gs branch squash -m 'Squashed feat1 into single commit'
+
+git graph --branches
+cmp stdout $WORK/golden/graph-after-squash.txt
+
+# feat1 must not have main-change
+# because that commit was removed.
+git checkout feat1
+! exists main-change.txt
+
+-- repo/feature1.txt --
+Feature 1 content
+-- repo/feature2.txt --
+Feature 2 content
+-- repo/feature3.txt --
+Feature 3 content
+-- repo/main-change.txt --
+Main change content
+-- golden/graph-before-main-change.txt --
+* 2179516 (HEAD -> feat1) Add feature1 third commit
+* 3e313fc Add feature1 second commit
+* 0ddeaa0 Add feature1 first commit
+* cb2e344 (main) main change
+* a17206f Initial commit
+-- golden/graph-after-main-change.txt --
+* 2179516 (feat1) Add feature1 third commit
+* 3e313fc Add feature1 second commit
+* 0ddeaa0 Add feature1 first commit
+* cb2e344 main change
+* a17206f (HEAD -> main) Initial commit
+-- golden/graph-after-manual-rebase.txt --
+* b288894 (HEAD -> feat1) Add feature1 third commit
+* 5b8dc68 Add feature1 second commit
+* 1c7b5e0 Add feature1 first commit
+* a17206f (main) Initial commit
+-- golden/graph-after-squash.txt --
+* d36334c (HEAD -> feat1) Squashed feat1 into single commit
+* a17206f (main) Initial commit

--- a/testdata/script/issue731_rebase_update_refs_warnings.txt
+++ b/testdata/script/issue731_rebase_update_refs_warnings.txt
@@ -1,0 +1,76 @@
+# Reproduces issue #731: ref update warnings during git rebase --update-refs
+# https://github.com/abhinav/git-spice/issues/731
+
+at 2025-07-09T20:00:29Z
+as 'Test User <test@example.com>'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# Create a branch stack A -> B -> C -> D
+git add featA.txt
+gs bc featA -m 'commit A'
+git add featB.txt
+gs bc featB -m 'commit B'
+git add featC.txt
+gs bc featC -m 'commit C'
+git add featD.txt
+gs bc featD -m 'commit D'
+
+gs ll -a
+cmp stderr $WORK/golden/ll-before.txt
+
+# Go back to A and add a new commit.
+gs bottom
+cp $WORK/extra/featA-new.txt featA.txt
+git add featA.txt
+git commit -m 'additional commit in A'
+
+# Trigger the rebase with --update-refs.
+# This should update all intermediate branches automatically.
+gs top
+git rebase featA --update-refs
+
+# Verify the final state
+gs ll -a
+cmp stderr $WORK/golden/ll-after.txt
+
+-- repo/featA.txt --
+change A
+
+-- repo/featB.txt --
+change B
+
+-- repo/featC.txt --
+change C
+
+-- repo/featD.txt --
+change D
+
+-- extra/featA-new.txt --
+change A
+additional change in A
+
+-- golden/ll-before.txt --
+      ┏━■ featD ◀
+      ┃   dab4857 commit D (now)
+    ┏━┻□ featC
+    ┃    f56fce0 commit C (now)
+  ┏━┻□ featB
+  ┃    e6addcd commit B (now)
+┏━┻□ featA
+┃    eb56755 commit A (now)
+main
+-- golden/ll-after.txt --
+      ┏━■ featD ◀
+      ┃   285a1b7 commit D (now)
+    ┏━┻□ featC
+    ┃    f21feba commit C (now)
+  ┏━┻□ featB
+  ┃    29fe805 commit B (now)
+┏━┻□ featA
+┃    25c3f92 additional commit in A (now)
+┃    eb56755 commit A (now)
+main


### PR DESCRIPTION
This PR fixes a couple issues discovered in trying to fix #731.

First, there's a data race in the Git backend:
when multiple processes try to write to it,
the `update ref` operation can fail.
We accounted for this and retry, but with enough updates,
the operation can actually fail.

To fix this, add locking around the Git backend's read/write operations,
ensuring that only one process can write at a time.
The included test tries to run a bunch of operations on it concurrently,
and fails without the fix.

Secondly, we discovered that in a couple places, including `log long`,
we did `LookupBranch`/`LoadBranches` before calling `VerifyRestacked`.
This means we loaded the branch information (including the base hash)
and then called `VerifyRestacked`, which, despite the read-only-looking name
may change the branch's base hash if the branch was manually restacked
by the user (using `git rebase` instead of `gs branch restack`).
This would result in the operation using the wrong base hash.

The following commands were affected:

- `log long` would show the wrong list of commits
  for the first run after a manual rebase.
- `branch squash` would use the wrong base hash when squashing the commits,
  resulting in an extraneous no-op commit.
- `branch submit` was not negatively affected, but it was updated nonetheless

(Test cases included for `log long` and `branch squash`.)

Resolves #731
