### PR TITLE
test(github, gitlab): attempt to unflake PAT auth tests

### DIFF
--- a/internal/forge/github/testdata/auth/pat.txt
+++ b/internal/forge/github/testdata/auth/pat.txt
@@ -1,13 +1,14 @@
 init
 
 await Select an authentication method
-feed -r 3 <Down>
 snapshot
+
+feed -r 3 <Down>
 await
 snapshot
 cmp stdout select
-feed <Enter>
 
+feed <Enter>
 await
 snapshot
 cmp stdout prompt

--- a/internal/forge/gitlab/testdata/auth/pat.txt
+++ b/internal/forge/gitlab/testdata/auth/pat.txt
@@ -1,13 +1,14 @@
 init
 
 await Select an authentication method
-feed <Down>
 snapshot
+
+feed <Down>
 await
 snapshot
 cmp stdout select
-feed <Enter>
 
+feed <Enter>
 await
 snapshot
 cmp stdout prompt


### PR DESCRIPTION
The uitest script here seems to be wrong.
Unclear why we're grabbing the snapshot after sending the keys
instead of before.
I wasn't able to reproduce the flake locally,
but this should fix it.