### PR TITLE
repo init: warn if trunk is behind upstream

### DIFF
--- a/.changes/unreleased/Added-20250712-091644.yaml
+++ b/.changes/unreleased/Added-20250712-091644.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: |
+  repo init: Warn when trunk is behind upstream at initialization time.
+  This should catch issues where local branches are rebased
+  on top of an outdated trunk.
+time: 2025-07-12T09:16:44.724231-07:00

--- a/testdata/script/repo_init_trunk_behind.txt
+++ b/testdata/script/repo_init_trunk_behind.txt
@@ -1,0 +1,23 @@
+# Test repo init warns when trunk is behind upstream.
+
+as 'Test <test@example.com>'
+at '2025-07-12T14:00:00Z'
+
+# Set up an upstream repository
+mkdir upstream
+cd upstream
+git init -b main
+git commit --allow-empty -m 'Initial commit'
+git commit --allow-empty -m 'Second commit'
+git commit --allow-empty -m 'Third commit'
+
+# Clone and create a local repository that's behind
+cd $WORK
+git clone upstream repo
+cd repo
+git reset --hard HEAD~2
+
+# Initialize repository - should warn about being behind
+gs repo init
+stderr 'main is behind upstream by 2 commits'
+stderr 'Please run ''gs repo sync'' before other git-spice commands.'


### PR DESCRIPTION
If trunk is behind upstream,
but a local branch is made on top of latest upstream,
and then someone onboards onto git-spice,
restack commands will attempt to replay the upstream commits
when the local branch is rebased on top of trunk.

This guards against that by warning the user
when trunk is behind upstream at initialization time.