### PR TITLE
refac(upstack restack): extract Handler

### DIFF
--- a/branch_create.go
+++ b/branch_create.go
@@ -94,6 +94,7 @@ func (cmd *branchCreateCmd) Run(
 	wt *git.Worktree,
 	store *state.Store,
 	svc *spice.Service,
+	restackHandler RestackHandler,
 ) (err error) {
 	if cmd.Name == "" && !cmd.Commit {
 		return errors.New("a branch name is required with --no-commit")
@@ -308,9 +309,7 @@ func (cmd *branchCreateCmd) Run(
 	}
 
 	if cmd.Below || cmd.Insert {
-		return (&upstackRestackCmd{}).Run(
-			ctx, log, wt, store, svc,
-		)
+		return restackHandler.RestackUpstack(ctx, branchName, nil)
 	}
 
 	return nil

--- a/branch_edit.go
+++ b/branch_edit.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
@@ -25,10 +24,9 @@ func (*branchEditCmd) Help() string {
 
 func (*branchEditCmd) Run(
 	ctx context.Context,
-	log *silog.Logger,
 	wt *git.Worktree,
-	store *state.Store,
 	svc *spice.Service,
+	restackHandler RestackHandler,
 ) error {
 	currentBranch, err := wt.CurrentBranch(ctx)
 	if err != nil {
@@ -59,5 +57,5 @@ func (*branchEditCmd) Run(
 		})
 	}
 
-	return (&upstackRestackCmd{}).Run(ctx, log, wt, store, svc)
+	return restackHandler.RestackUpstack(ctx, currentBranch, nil)
 }

--- a/branch_onto.go
+++ b/branch_onto.go
@@ -103,8 +103,8 @@ func (cmd *branchOntoCmd) Run(
 	ctx context.Context,
 	log *silog.Logger,
 	wt *git.Worktree,
-	store *state.Store,
 	svc *spice.Service,
+	restackHandler RestackHandler,
 ) error {
 	branch, err := svc.LookupBranch(ctx, cmd.Branch)
 	if err != nil {
@@ -127,7 +127,7 @@ func (cmd *branchOntoCmd) Run(
 		if err := (&upstackOntoCmd{
 			Branch: above,
 			Onto:   branch.Base,
-		}).Run(ctx, log, wt, store, svc); err != nil {
+		}).Run(ctx, log, svc, restackHandler); err != nil {
 			return svc.RebaseRescue(ctx, spice.RebaseRescueRequest{
 				Err:     err,
 				Command: []string{"branch", "onto", cmd.Onto},

--- a/branch_squash.go
+++ b/branch_squash.go
@@ -36,6 +36,7 @@ func (cmd *branchSquashCmd) Run(
 	wt *git.Worktree,
 	store *state.Store,
 	svc *spice.Service,
+	restackHandler RestackHandler,
 ) (err error) {
 	branchName, err := wt.CurrentBranch(ctx)
 	if err != nil {
@@ -138,5 +139,5 @@ func (cmd *branchSquashCmd) Run(
 	}
 	reattachedHead = true
 
-	return (&upstackRestackCmd{}).Run(ctx, log, wt, store, svc)
+	return restackHandler.RestackUpstack(ctx, branchName, nil)
 }

--- a/commit_amend.go
+++ b/commit_amend.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
@@ -45,6 +46,7 @@ func (cmd *commitAmendCmd) Run(
 	wt *git.Worktree,
 	store *state.Store,
 	svc *spice.Service,
+	restackHandler RestackHandler,
 ) error {
 	if cmd.NoEditDeprecated {
 		cmd.NoEdit = true
@@ -114,7 +116,7 @@ func (cmd *commitAmendCmd) Run(
 					NoVerify:           cmd.NoVerify,
 					Message:            cmd.Message,
 					Commit:             true,
-				}).Run(ctx, log, repo, wt, store, svc)
+				}).Run(ctx, log, repo, wt, store, svc, restackHandler)
 			}
 		}
 	}
@@ -192,8 +194,7 @@ func (cmd *commitAmendCmd) Run(
 		return nil
 	}
 
-	return (&upstackRestackCmd{
-		Branch:    currentBranch,
+	return restackHandler.RestackUpstack(ctx, currentBranch, &restack.UpstackOptions{
 		SkipStart: true,
-	}).Run(ctx, log, wt, store, svc)
+	})
 }

--- a/commit_create.go
+++ b/commit_create.go
@@ -6,9 +6,8 @@ import (
 	"fmt"
 
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/silog"
-	"go.abhg.dev/gs/internal/spice"
-	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
 )
 
@@ -33,8 +32,7 @@ func (cmd *commitCreateCmd) Run(
 	ctx context.Context,
 	log *silog.Logger,
 	wt *git.Worktree,
-	store *state.Store,
-	svc *spice.Service,
+	restackHandler RestackHandler,
 ) error {
 	if err := wt.Commit(ctx, git.CommitRequest{
 		Message:    cmd.Message,
@@ -63,8 +61,7 @@ func (cmd *commitCreateCmd) Run(
 		return fmt.Errorf("get current branch: %w", err)
 	}
 
-	return (&upstackRestackCmd{
-		Branch:    currentBranch,
+	return restackHandler.RestackUpstack(ctx, currentBranch, &restack.UpstackOptions{
 		SkipStart: true,
-	}).Run(ctx, log, wt, store, svc)
+	})
 }

--- a/commit_split.go
+++ b/commit_split.go
@@ -6,9 +6,8 @@ import (
 	"fmt"
 
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/silog"
-	"go.abhg.dev/gs/internal/spice"
-	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
 )
 
@@ -30,8 +29,7 @@ func (cmd *commitSplitCmd) Run(
 	log *silog.Logger,
 	repo *git.Repository,
 	wt *git.Worktree,
-	store *state.Store,
-	svc *spice.Service,
+	restackHandler RestackHandler,
 ) (err error) {
 	head, err := wt.Head(ctx)
 	if err != nil {
@@ -110,8 +108,7 @@ func (cmd *commitSplitCmd) Run(
 		return fmt.Errorf("get current branch: %w", err)
 	}
 
-	return (&upstackRestackCmd{
-		Branch:    currentBranch,
+	return restackHandler.RestackUpstack(ctx, currentBranch, &restack.UpstackOptions{
 		SkipStart: true,
-	}).Run(ctx, log, wt, store, svc)
+	})
 }

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -366,8 +366,8 @@ all managed branches will be restacked.
 
 **Flags**
 
-* `--branch=NAME`: Branch to restack the upstack of
 * `--skip-start`: Do not restack the starting branch
+* `--branch=NAME`: Branch to restack the upstack of
 
 ### gs upstack onto
 

--- a/internal/git/wt.go
+++ b/internal/git/wt.go
@@ -32,18 +32,18 @@ func newWorktree(gitDir, rootDir string, repo *Repository, log *silog.Logger, ex
 	}
 }
 
-func (r *Worktree) gitCmd(ctx context.Context, args ...string) *gitCmd {
-	return newGitCmd(ctx, r.log, args...).Dir(r.rootDir)
+func (w *Worktree) gitCmd(ctx context.Context, args ...string) *gitCmd {
+	return newGitCmd(ctx, w.log, args...).Dir(w.rootDir)
 }
 
 // RootDir returns the absolute path to the root directory of the worktree.
-func (r *Worktree) RootDir() string {
-	return r.rootDir
+func (w *Worktree) RootDir() string {
+	return w.rootDir
 }
 
 // Repository returns the Git repository that this worktree belongs to.
-func (r *Worktree) Repository() *Repository {
-	return r.repo
+func (w *Worktree) Repository() *Repository {
+	return w.repo
 }
 
 // OpenWorktree opens a worktree of this repository at the given directory.

--- a/internal/handler/restack/handler.go
+++ b/internal/handler/restack/handler.go
@@ -1,0 +1,34 @@
+// Package restack implements business logic for high-level restack operations.
+package restack
+
+import (
+	"context"
+
+	"go.abhg.dev/gs/internal/silog"
+	"go.abhg.dev/gs/internal/spice"
+)
+
+// GitWorktree is a subet of the git.Worktree interface.
+type GitWorktree interface {
+	Checkout(ctx context.Context, branch string) error
+}
+
+// Store is a subset of the state.Store interface.
+type Store interface {
+	Trunk() string
+}
+
+// Service is a subset of the spice.Service interface.
+type Service interface {
+	ListUpstack(ctx context.Context, branch string) ([]string, error)
+	Restack(ctx context.Context, name string) (*spice.RestackResponse, error)
+	RebaseRescue(ctx context.Context, req spice.RebaseRescueRequest) error
+}
+
+// Handler implements various restack operations.
+type Handler struct {
+	Log      *silog.Logger // required
+	Worktree GitWorktree   // required
+	Store    Store         // required
+	Service  Service       // required
+}

--- a/internal/handler/restack/upstack.go
+++ b/internal/handler/restack/upstack.go
@@ -1,0 +1,76 @@
+package restack
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/spice"
+)
+
+// UpstackOptions holds options for restacking the upstack of a branch.
+type UpstackOptions struct {
+	// SkipStart indicates that the starting branch should not be restacked.
+	SkipStart bool `help:"Do not restack the starting branch"`
+}
+
+// RestackUpstack restacks the upstack of the given branch,
+// including the branch itself, unless SkipStart is set.
+func (h *Handler) RestackUpstack(ctx context.Context, branch string, opts *UpstackOptions) error {
+	log := h.Log
+	opts = cmp.Or(opts, &UpstackOptions{})
+	upstacks, err := h.Service.ListUpstack(ctx, branch)
+	if err != nil {
+		return fmt.Errorf("get upstack branches: %w", err)
+	}
+	if opts.SkipStart && len(upstacks) > 0 && upstacks[0] == branch {
+		upstacks = upstacks[1:]
+		if len(upstacks) == 0 {
+			return nil
+		}
+	}
+
+loop:
+	for _, upstack := range upstacks {
+		// Trunk never needs to be restacked.
+		if upstack == h.Store.Trunk() {
+			continue loop
+		}
+
+		res, err := h.Service.Restack(ctx, upstack)
+		if err != nil {
+			var rebaseErr *git.RebaseInterruptError
+			switch {
+			case errors.As(err, &rebaseErr):
+				// If the rebase is interrupted by a conflict,
+				// we'll resume by re-running this command.
+				return h.Service.RebaseRescue(ctx, spice.RebaseRescueRequest{
+					Err:     rebaseErr,
+					Command: []string{"upstack", "restack"},
+					Branch:  branch,
+					Message: fmt.Sprintf("interrupted: restack upstack of %v", branch),
+				})
+			case errors.Is(err, spice.ErrAlreadyRestacked):
+				// Log the "does not need to be restacked" message
+				// only for branches that are not the base branch.
+				if upstack != branch {
+					log.Infof("%v: branch does not need to be restacked.", upstack)
+				}
+				continue loop
+			default:
+				return fmt.Errorf("restack branch: %w", err)
+			}
+		}
+
+		log.Infof("%v: restacked on %v", upstack, res.Base)
+	}
+
+	// On success, check out the original branch.
+	if err := h.Worktree.Checkout(ctx, branch); err != nil {
+		return fmt.Errorf("checkout branch %v: %w", branch, err)
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/handler/checkout"
 	"go.abhg.dev/gs/internal/handler/delete"
+	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/handler/submit"
 	"go.abhg.dev/gs/internal/handler/track"
 	"go.abhg.dev/gs/internal/secret"
@@ -388,6 +389,19 @@ func (cmd *mainCmd) AfterApply(ctx context.Context, kctx *kong.Context, logger *
 				OpenRemoteRepository: func(ctx context.Context, remote string) (forge.Repository, error) {
 					return openRemoteRepository(ctx, log, secretStash, forges, wt.Repository(), remote)
 				},
+			}, nil
+		}),
+		kctx.BindSingletonProvider(func(
+			log *silog.Logger,
+			worktree *git.Worktree,
+			store *state.Store,
+			svc *spice.Service,
+		) (RestackHandler, error) {
+			return &restack.Handler{
+				Log:      log,
+				Worktree: worktree,
+				Store:    store,
+				Service:  svc,
 			}, nil
 		}),
 		kctx.BindSingletonProvider(func(

--- a/upstack_onto.go
+++ b/upstack_onto.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
@@ -111,9 +112,8 @@ func (cmd *upstackOntoCmd) AfterApply(
 func (cmd *upstackOntoCmd) Run(
 	ctx context.Context,
 	log *silog.Logger,
-	wt *git.Worktree,
-	store *state.Store,
 	svc *spice.Service,
+	restackHandler RestackHandler,
 ) error {
 	// Implementation note:
 	// This is a pretty straightforward operation despite the large scope.
@@ -136,7 +136,7 @@ func (cmd *upstackOntoCmd) Run(
 	}
 	log.Infof("%v: moved upstack onto %v", cmd.Branch, cmd.Onto)
 
-	return (&upstackRestackCmd{
-		SkipStart: true, // we've already moved the current branch
-	}).Run(ctx, log, wt, store, svc)
+	return restackHandler.RestackUpstack(ctx, cmd.Branch, &restack.UpstackOptions{
+		SkipStart: true,
+	})
 }


### PR DESCRIPTION
Add a Handler that implements the high-level restack operations.
Start with the upstack restack command, which is used heavily
across the other commands.

With this change, no command invokes upstackRestackCmd directly anymore.

[skip changelog]: no user facing changes
