### PR TITLE
stack restack: extract Handler, add --branch flag

### DIFF
--- a/.changes/unreleased/Added-20250713-101839.yaml
+++ b/.changes/unreleased/Added-20250713-101839.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'stack restack: Add --branch flag to restack the stack of a different branch.'
+time: 2025-07-13T10:18:39.260341-07:00

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -243,13 +243,19 @@ or --nav-comment=multiple to post those comments only if there are multiple CRs 
 ### gs stack restack
 
 ```
-gs stack (s) restack (r)
+gs stack (s) restack (r) [flags]
 ```
 
 Restack a stack
 
 All branches in the current stack are rebased on top of their
 respective bases, ensuring a linear history.
+
+Use --branch to rebase the stack of a different branch.
+
+**Flags**
+
+* `--branch=NAME`: Branch to restack the stack of
 
 ### gs stack edit
 

--- a/internal/handler/restack/handler.go
+++ b/internal/handler/restack/handler.go
@@ -21,6 +21,7 @@ type Store interface {
 // Service is a subset of the spice.Service interface.
 type Service interface {
 	ListUpstack(ctx context.Context, branch string) ([]string, error)
+	ListStack(ctx context.Context, branch string) ([]string, error)
 	Restack(ctx context.Context, name string) (*spice.RestackResponse, error)
 	RebaseRescue(ctx context.Context, req spice.RebaseRescueRequest) error
 }

--- a/internal/handler/restack/stack.go
+++ b/internal/handler/restack/stack.go
@@ -1,0 +1,62 @@
+package restack
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/spice"
+)
+
+// RestackStack restacks the stack of the given branch.
+// This includes all upstack and downtrack branches,
+// as well as the branch itself.
+func (h *Handler) RestackStack(ctx context.Context, branch string) error {
+	stack, err := h.Service.ListStack(ctx, branch)
+	if err != nil {
+		return fmt.Errorf("list stack: %w", err)
+	}
+
+loop:
+	for _, stackBranch := range stack {
+		// Trunk never needs to be restacked.
+		if stackBranch == h.Store.Trunk() {
+			continue loop
+		}
+
+		res, err := h.Service.Restack(ctx, stackBranch)
+		if err != nil {
+			var rebaseErr *git.RebaseInterruptError
+			switch {
+			case errors.As(err, &rebaseErr):
+				// If the rebase is interrupted by a conflict,
+				// we'll resume by re-running this command.
+				return h.Service.RebaseRescue(ctx, spice.RebaseRescueRequest{
+					Err:     rebaseErr,
+					Command: []string{"stack", "restack"},
+					Branch:  branch,
+					Message: "interrupted: restack stack for " + stackBranch,
+				})
+			case errors.Is(err, spice.ErrAlreadyRestacked):
+				// Log the "does not need to be restacked" message
+				// only for branches that are not the current branch.
+				if stackBranch != branch {
+					h.Log.Infof("%v: branch does not need to be restacked.", stackBranch)
+				}
+				continue loop
+			default:
+				return fmt.Errorf("restack branch: %w", err)
+			}
+		}
+
+		h.Log.Infof("%v: restacked on %v", stackBranch, res.Base)
+	}
+
+	// On success, check out the original branch.
+	if err := h.Worktree.Checkout(ctx, branch); err != nil {
+		return fmt.Errorf("checkout branch %v: %w", branch, err)
+	}
+
+	return nil
+}

--- a/upstack_restack.go
+++ b/upstack_restack.go
@@ -33,6 +33,7 @@ func (*upstackRestackCmd) Help() string {
 // RestackHandler implements high level restack operations.
 type RestackHandler interface {
 	RestackUpstack(ctx context.Context, branch string, opts *restack.UpstackOptions) error
+	RestackStack(ctx context.Context, branch string) error
 }
 
 func (cmd *upstackRestackCmd) AfterApply(ctx context.Context, wt *git.Worktree) error {


### PR DESCRIPTION
Extracts stack restack logic into the restack.Handler.
Adds a --branch flag to the operation for consistency
with upstack restack, and for ease of implementation of handler.