### PR TITLE
ci: Shard script tests

### DIFF
--- a/.github/actions/go-cache/action.yml
+++ b/.github/actions/go-cache/action.yml
@@ -6,6 +6,7 @@
 #     uses: ./.github/actions/go-cache
 
 name: Cache Go
+description: Caches Go build artifacts to speed up subsequent builds.
 
 runs:
   using: "composite"

--- a/.github/actions/install-git/action.yml
+++ b/.github/actions/install-git/action.yml
@@ -10,6 +10,7 @@
 # Must run after checkout and mise-action.
 
 name: Install Git
+description: Installs a specific version of git from source.
 
 inputs:
   version:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,19 +24,42 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - run: mise run lint
 
-  test:
-    runs-on: ${{ matrix.os }}
-    name: Test (${{ matrix.os}}, Git ${{ matrix.git-version }})
+  test-matrix:
+    name: Generate test matrix
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      name: Check out repository
+    - uses: jdx/mise-action@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Go cache
+      uses: ./.github/actions/go-cache
+    - name: Generate test matrix
+      id: generate
+      run: echo "matrix=$(go run ./tools/ci/test-matrix)" >> "$GITHUB_OUTPUT"
+    outputs:
+      matrix: ${{ steps.generate.outputs.matrix }}
 
+  test:
+    needs: [test-matrix]
     strategy:
-      matrix:
-        os: ["ubuntu-latest", "windows-latest"]
-        git-version: ["system"]
-        include:
-          # On Linux, also test against specific versions built from source.
-          - {os: ubuntu-latest, git-version: "2.38.0"}
-          # On Windows, run without coverage.
-          - {os: windows-latest, no-cover: true}
+      fail-fast: true
+      matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}
+    # Schema of matrix:
+    #   name: string
+    #   os: ubuntu-latest | windows-latest
+    #   git-version: system | 2.38.0 | ...
+    #   suite: default | script
+    #   race: bool
+    #   cover: bool
+    #
+    # If suite is 'script', then:
+    #  shard-index: int
+    #  shard-count: int
+
+    runs-on: ${{ matrix.os }}
+    name: Test / ${{ matrix.name }}
 
     steps:
     - uses: actions/checkout@v4
@@ -56,11 +79,13 @@ jobs:
       run:
         git --version
 
+    # TODO: can probably generate the exact test command in the matrix
     - name: Test
+      if: ${{ matrix.suite == 'default' }}
       run: >-  # join lines with spaces
         mise run
-        ${{ (matrix.no-cover == true) && 'test' || 'cover' }}
-        ${{ (matrix.os != 'windows-latest') && '--race' || '' }}
+        ${{ matrix.cover && 'cover:default' || 'test:default' }}
+        ${{ matrix.race && '--race' || '' }}
       # NB:
       # Windows tests are already slow.
       # Run them without race detection to avoid slowing them further.
@@ -68,9 +93,21 @@ jobs:
       env:
         GOTESTSUM_FORMAT: github-actions
 
+    - name: Script tests
+      if: ${{ matrix.suite == 'script' }}
+      run: |
+        mise run \
+          ${{ matrix.cover && 'cover:script' || 'test:script' }} \
+          ${{ matrix.race && '--race' || '' }} \
+          --shard-index "${{ matrix.shard-index || '0' }}" \
+          --shard-count "${{ matrix.shard-count || '1' }}"
+      shell: bash
+      env:
+        GOTESTSUM_FORMAT: github-actions
+
     - name: Upload coverage
       uses: codecov/codecov-action@v5.4.3
-      if: ${{ matrix.no-cover != true }}
+      if: ${{ matrix.os != 'windows-latest' }}
       with:
         files: ./cover.out
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /dist
+/cover
 cover.out
 cover.html
 /.idea

--- a/mise.toml
+++ b/mise.toml
@@ -41,17 +41,54 @@ run = [
 ]
 
 [tasks.test]
-wait_for = ["generate"]
-description = "Run tests"
-run = "gotestsum -- -race={{flag(name='race')}} ./..."
+depends = ["test:*"]
 
-[tasks.cover]
+[tasks."test:default"]
 wait_for = ["generate"]
-description = "Run tests with coverage"
-run = [
-  "gotestsum -- '-coverprofile=cover.out' '-coverpkg=./...' -race={{flag(name='race')}} ./...",
-  "go tool cover '-html=cover.out' -o cover.html",
-]
+description = "Run default tests"
+run = "gotestsum -- ./... -race={{flag(name='race')}}"
+
+[tasks."test:script"]
+wait_for = ["generate"]
+description = "Run script tests"
+run = """
+gotestsum -- {# -#}
+  -tags=script {# enable script tests -#}
+  -run '^TestScript$' {# run only script tests -#}
+  -race={{flag(name='race')}} {# race detection -#}
+  -shard-index={{option(name='shard-index', default='0')}} {# shard index -#}
+  -shard-count={{option(name='shard-count', default='1')}} {# shard count -#}
+"""
+
+[tasks."_cover_report"]
+run = "go tool cover -html=cover.out -o cover.html"
+
+[tasks."cover:default"]
+wait_for = ["generate"]
+depends_post = ["_cover_report"]
+description = "Run default tests with coverage"
+run = """
+gotestsum -- {# -#}
+  ./... {# run all tests -#}
+  -race={{flag(name='race')}} {# race detection -#}
+  -coverpkg=./... {# cover all packages -#}
+  -coverprofile=cover.out {# -#}
+"""
+
+[tasks."cover:script"]
+wait_for = ["generate"]
+depends_post = ["_cover_report"]
+description = "Run script tests with coverage"
+run = """
+gotestsum -- {# -#}
+  -tags=script {# enable script tests -#}
+  -run '^TestScript$' {# run only script tests -#}
+  -race={{flag(name='race')}} {# race detection -#}
+  -coverpkg=./... {# cover all packages -#}
+  -coverprofile=cover.out {# -#}
+  -shard-index={{option(name='shard-index', default='0')}} {# shard index -#}
+  -shard-count={{option(name='shard-count', default='1')}} {# shard count -#}
+"""
 
 [tasks.tidy]
 run = "go mod tidy"

--- a/tools/ci/test-matrix/config.go
+++ b/tools/ci/test-matrix/config.go
@@ -1,0 +1,28 @@
+package main
+
+var (
+	_linuxConfig = testConfig{
+		OS:           "ubuntu-latest",
+		GitVersions:  []string{"system", "2.38.0"},
+		ScriptShards: 4,
+		Race:         true,
+		Cover:        true,
+	}
+
+	_windowsConfig = testConfig{
+		OS: "windows-latest",
+		// We won't compile Git from source on Windows,
+		GitVersions: []string{"system"},
+
+		// Windows workers are limited so don't take too many up.
+		ScriptShards: 2,
+
+		// Windows tests are quite slow, so we don't enable
+		// race detection or coverage tracking for them.
+	}
+
+	_configs = []testConfig{
+		_linuxConfig,
+		_windowsConfig,
+	}
+)

--- a/tools/ci/test-matrix/main.go
+++ b/tools/ci/test-matrix/main.go
@@ -1,0 +1,105 @@
+// test-matrix generates the matrix for the "test" job in the CI pipeline.
+package main
+
+import (
+	"cmp"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+)
+
+var _indent = flag.Bool("indent", false, "indent JSON output")
+
+type testConfig struct {
+	// GitVersion is the list of Git versions
+	// against which this test job should run.
+	OS string
+
+	// GitVersions is the list of Git versions
+	// against which this test job should run.
+	GitVersions []string
+
+	// ScriptShards is the number of shards to use for script tests.
+	ScriptShards int
+
+	// Whether to run with race detector and coverage.
+	Race, Cover bool
+}
+
+type testSuite string
+
+const (
+	defaultTests testSuite = "default"
+	scriptTests  testSuite = "script"
+)
+
+type matrixEntry struct {
+	Name string `json:"name"`
+	OS   string `json:"os"`
+
+	GitVersion string    `json:"git-version"`
+	Suite      testSuite `json:"suite"`
+
+	Race  bool `json:"race"`
+	Cover bool `json:"cover"`
+
+	// ShardIndex and ShardCount are set only for script tests.
+	ShardIndex int `json:"shard-index"`
+	ShardCount int `json:"shard-count"`
+}
+
+func main() {
+	log.SetFlags(0)
+	flag.Parse()
+
+	var entries []matrixEntry
+	for _, cfg := range _configs {
+		for _, gitVersion := range cfg.GitVersions {
+			var name strings.Builder
+			_, _ = fmt.Fprintf(&name, "os=%s git=%s", cfg.OS, gitVersion)
+
+			// Always run the default tests.
+			entries = append(entries, matrixEntry{
+				Name:       name.String() + " suite=" + string(defaultTests),
+				OS:         cfg.OS,
+				GitVersion: gitVersion,
+				Suite:      defaultTests,
+				Race:       cfg.Race,
+				Cover:      cfg.Cover,
+			})
+
+			scriptShards := cmp.Or(cfg.ScriptShards, 1)
+			name.WriteString(" suite=" + string(scriptTests))
+			for shardIndex := range scriptShards {
+				name := name.String()
+				name += fmt.Sprintf(" shard=[%d/%d]", shardIndex+1, scriptShards)
+
+				entries = append(entries, matrixEntry{
+					Name:       name,
+					OS:         cfg.OS,
+					GitVersion: gitVersion,
+					Suite:      scriptTests,
+					Race:       cfg.Race,
+					Cover:      cfg.Cover,
+					ShardIndex: shardIndex,
+					ShardCount: scriptShards,
+				})
+			}
+		}
+	}
+
+	var output struct {
+		Include []matrixEntry `json:"include"`
+	}
+	output.Include = entries
+	enc := json.NewEncoder(os.Stdout)
+	if *_indent {
+		enc.SetIndent("", "  ")
+	}
+	if err := enc.Encode(output); err != nil {
+		log.Fatalf("failed to encode JSON: %v", err)
+	}
+}


### PR DESCRIPTION
Running all script tests in one job takes quite a while.
Try sharding them across multiple jobs to speed up CI.