### PR TITLE
cli/config: learn to load Git configuration

### DIFF
--- a/dumpmd.go
+++ b/dumpmd.go
@@ -219,7 +219,8 @@ func (cmd cliDumper) dumpConfigFooter(node *kong.Node) {
 	var configKeys []string
 	for _, flag := range node.Flags {
 		key := flag.Tag.Get("config")
-		if key == "" {
+		if key == "" || key[0] == '@' {
+			// "@" is for git configuration keys.
 			continue
 		}
 		configKeys = append(configKeys, key)

--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -132,11 +132,12 @@ type ConfigEntry struct {
 	Value string
 }
 
-// ListRegexp lists all configuration entries that match the given pattern.
-// If pattern is empty, '.' is used to match all entries.
-func (cfg *Config) ListRegexp(ctx context.Context, pattern string) iter.Seq2[ConfigEntry, error] {
-	if pattern == "" {
-		pattern = "."
+// ListRegexp lists all configuration entries that match the given patterns.
+// If no patterns are provided, it lists all entries.
+func (cfg *Config) ListRegexp(ctx context.Context, patterns ...string) iter.Seq2[ConfigEntry, error] {
+	pattern := "."
+	if len(patterns) > 0 {
+		pattern = strings.Join(patterns, "|")
 	}
 	return cfg.list(ctx, "--get-regexp", pattern)
 }


### PR DESCRIPTION
For some commands to be implemented correctly,
we need to be able to read Git configuration values.

This commit adds support for reading Git configuration values
by using keys in the form `config:"@core.key"`.
This will read the configuration key `core.key` from git-config,
omitting the "spice." prefix.