### PR TITLE
branch squash: Add --no-edit flag

### DIFF
--- a/.changes/unreleased/Added-20250718-202010.yaml
+++ b/.changes/unreleased/Added-20250718-202010.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'branch squash: Add --no-edit flag to use generated commit message without opening an editor.'
+time: 2025-07-18T20:20:10.124517-07:00

--- a/branch_squash.go
+++ b/branch_squash.go
@@ -12,7 +12,7 @@ import (
 type branchSquashCmd struct {
 	squash.Options
 
-	Branch string `help:"Branch to squash. Defaults to current branch." predictor:"trackedBranches" placeholder:"NAME"`
+	Branch string `released:"unreleased" help:"Branch to squash. Defaults to current branch." predictor:"trackedBranches" placeholder:"NAME"`
 }
 
 func (*branchSquashCmd) Help() string {

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -754,7 +754,7 @@ Use the -m/--message flag to specify a commit message without editing.
 **Flags**
 
 * `--no-verify`: Bypass pre-commit and commit-msg hooks.
-* `--no-edit`: Do not open an editor to edit the squashed commit message. Only applicable if --message is not used.
+* `--no-edit`: Do not open an editor to edit the squashed commit message. Only applicable if --message is not used. <span class="mdx-badge"><span class="mdx-badge__icon">:material-tag-hidden:{ title="Released in version" }</span><span class="mdx-badge__text">Unreleased</span>
 * `-m`, `--message=MSG`: Use the given message as the commit message.
 * `--branch=NAME`: Branch to squash. Defaults to current branch.
 

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -756,7 +756,7 @@ Use the -m/--message flag to specify a commit message without editing.
 * `--no-verify`: Bypass pre-commit and commit-msg hooks.
 * `--no-edit`: Do not open an editor to edit the squashed commit message. Only applicable if --message is not used. <span class="mdx-badge"><span class="mdx-badge__icon">:material-tag-hidden:{ title="Released in version" }</span><span class="mdx-badge__text">Unreleased</span>
 * `-m`, `--message=MSG`: Use the given message as the commit message.
-* `--branch=NAME`: Branch to squash. Defaults to current branch.
+* `--branch=NAME`: Branch to squash. Defaults to current branch. <span class="mdx-badge"><span class="mdx-badge__icon">:material-tag-hidden:{ title="Released in version" }</span><span class="mdx-badge__text">Unreleased</span>
 
 ### gs branch edit
 

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -754,6 +754,7 @@ Use the -m/--message flag to specify a commit message without editing.
 **Flags**
 
 * `--no-verify`: Bypass pre-commit and commit-msg hooks.
+* `--no-edit`: Do not open an editor to edit the squashed commit message. Only applicable if --message is not used.
 * `-m`, `--message=MSG`: Use the given message as the commit message.
 * `--branch=NAME`: Branch to squash. Defaults to current branch.
 

--- a/internal/handler/squash/handler.go
+++ b/internal/handler/squash/handler.go
@@ -75,7 +75,7 @@ type Options struct {
 	// git.commentString is the prefix for comments in commit messages.
 	CommentPrefix string `hidden:"" config:"@core.commentString" default:"#"`
 
-	NoEdit bool `help:"Do not open an editor to edit the squashed commit message. Only applicable if --message is not used."`
+	NoEdit bool `released:"unreleased" help:"Do not open an editor to edit the squashed commit message. Only applicable if --message is not used."`
 
 	Message string `short:"m" placeholder:"MSG" help:"Use the given message as the commit message."`
 }

--- a/internal/handler/squash/handler_test.go
+++ b/internal/handler/squash/handler_test.go
@@ -108,6 +108,210 @@ func TestHandler_SquashBranch(t *testing.T) {
 		err := handler.SquashBranch(t.Context(), branchName, &Options{})
 		assert.ErrorIs(t, err, commitErr)
 	})
+
+	t.Run("NoEdit", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		branchName := "feature"
+		baseHash := git.Hash("abc123")
+		headHash := git.Hash("def456")
+
+		mockService := NewMockService(ctrl)
+		mockService.EXPECT().
+			VerifyRestacked(t.Context(), branchName).
+			Return(nil)
+		mockService.EXPECT().
+			LookupBranch(t.Context(), branchName).
+			Return(&spice.LookupBranchResponse{
+				Head:     headHash,
+				BaseHash: baseHash,
+			}, nil)
+
+		mockRepo := NewMockGitRepository(ctrl)
+		mockRepo.EXPECT().
+			CommitMessageRange(t.Context(), headHash.String(), baseHash.String()).
+			Return([]git.CommitMessage{
+				{Subject: "Add feature", Body: "Implementation"},
+				{Subject: "Fix bug", Body: "Fixed issue"},
+			}, nil)
+		mockRepo.EXPECT().
+			SetRef(t.Context(), gomock.Any()).
+			Return(nil)
+
+		mockWorktree := NewMockGitWorktree(ctrl)
+		mockWorktree.EXPECT().
+			DetachHead(t.Context(), branchName).
+			Return(nil)
+		mockWorktree.EXPECT().
+			Reset(t.Context(), baseHash.String(), git.ResetOptions{Mode: git.ResetSoft}).
+			Return(nil)
+		mockWorktree.EXPECT().
+			Commit(t.Context(), git.CommitRequest{Message: joinLines(
+				"Fix bug",
+				"",
+				"Fixed issue",
+				"",
+				"Add feature",
+				"",
+				"Implementation",
+			)}).
+			Return(nil)
+		mockWorktree.EXPECT().
+			Head(t.Context()).
+			Return(git.Hash("new123"), nil)
+		mockWorktree.EXPECT().
+			Checkout(t.Context(), branchName).
+			Return(nil)
+
+		mockRestack := NewMockRestackHandler(ctrl)
+		mockRestack.EXPECT().
+			RestackUpstack(t.Context(), branchName, nil).
+			Return(nil)
+
+		handler := &Handler{
+			Log:        silog.Nop(),
+			Repository: mockRepo,
+			Worktree:   mockWorktree,
+			Store:      mockStore,
+			Service:    mockService,
+			Restack:    mockRestack,
+		}
+
+		err := handler.SquashBranch(t.Context(), branchName, &Options{NoEdit: true})
+		assert.NoError(t, err)
+	})
+
+	t.Run("NoEditWithMessage", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		branchName := "feature"
+		baseHash := git.Hash("abc123")
+		headHash := git.Hash("def456")
+
+		mockService := NewMockService(ctrl)
+		mockService.EXPECT().
+			VerifyRestacked(t.Context(), branchName).
+			Return(nil)
+		mockService.EXPECT().
+			LookupBranch(t.Context(), branchName).
+			Return(&spice.LookupBranchResponse{
+				Head:     headHash,
+				BaseHash: baseHash,
+			}, nil)
+
+		mockRepo := NewMockGitRepository(ctrl)
+		mockRepo.EXPECT().
+			SetRef(t.Context(), gomock.Any()).
+			Return(nil)
+
+		explicitMessage := "Custom commit message"
+
+		mockWorktree := NewMockGitWorktree(ctrl)
+		mockWorktree.EXPECT().
+			DetachHead(t.Context(), branchName).
+			Return(nil)
+		mockWorktree.EXPECT().
+			Reset(t.Context(), baseHash.String(), git.ResetOptions{Mode: git.ResetSoft}).
+			Return(nil)
+		mockWorktree.EXPECT().
+			Commit(t.Context(), git.CommitRequest{Message: explicitMessage}).
+			Return(nil)
+		mockWorktree.EXPECT().
+			Head(t.Context()).
+			Return(git.Hash("new123"), nil)
+		mockWorktree.EXPECT().
+			Checkout(t.Context(), branchName).
+			Return(nil)
+
+		mockRestack := NewMockRestackHandler(ctrl)
+		mockRestack.EXPECT().
+			RestackUpstack(t.Context(), branchName, nil).
+			Return(nil)
+
+		handler := &Handler{
+			Log:        silog.Nop(),
+			Repository: mockRepo,
+			Worktree:   mockWorktree,
+			Store:      mockStore,
+			Service:    mockService,
+			Restack:    mockRestack,
+		}
+
+		err := handler.SquashBranch(t.Context(), branchName, &Options{
+			NoEdit:  true,
+			Message: explicitMessage,
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("NoMessage", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		branchName := "feature"
+		baseHash := git.Hash("abc123")
+		headHash := git.Hash("def456")
+
+		mockService := NewMockService(ctrl)
+		mockService.EXPECT().
+			VerifyRestacked(t.Context(), branchName).
+			Return(nil)
+		mockService.EXPECT().
+			LookupBranch(t.Context(), branchName).
+			Return(&spice.LookupBranchResponse{
+				Head:     headHash,
+				BaseHash: baseHash,
+			}, nil)
+
+		mockRepo := NewMockGitRepository(ctrl)
+		mockRepo.EXPECT().
+			CommitMessageRange(t.Context(), headHash.String(), baseHash.String()).
+			Return([]git.CommitMessage{
+				{Subject: "Add feature", Body: "Implementation"},
+			}, nil)
+		mockRepo.EXPECT().
+			SetRef(t.Context(), gomock.Any()).
+			Return(nil)
+
+		expectedTemplate := "Add feature\n\nImplementation\n"
+
+		mockWorktree := NewMockGitWorktree(ctrl)
+		mockWorktree.EXPECT().
+			DetachHead(t.Context(), branchName).
+			Return(nil)
+		mockWorktree.EXPECT().
+			Reset(t.Context(), baseHash.String(), git.ResetOptions{Mode: git.ResetSoft}).
+			Return(nil)
+		mockWorktree.EXPECT().
+			Commit(t.Context(), git.CommitRequest{
+				Message:  "",
+				Template: expectedTemplate,
+				NoVerify: false,
+			}).
+			Return(nil)
+		mockWorktree.EXPECT().
+			Head(t.Context()).
+			Return(git.Hash("new123"), nil)
+		mockWorktree.EXPECT().
+			Checkout(t.Context(), branchName).
+			Return(nil)
+
+		mockRestack := NewMockRestackHandler(ctrl)
+		mockRestack.EXPECT().
+			RestackUpstack(t.Context(), branchName, nil).
+			Return(nil)
+
+		handler := &Handler{
+			Log:        silog.Nop(),
+			Repository: mockRepo,
+			Worktree:   mockWorktree,
+			Store:      mockStore,
+			Service:    mockService,
+			Restack:    mockRestack,
+		}
+
+		err := handler.SquashBranch(t.Context(), branchName, &Options{NoEdit: false})
+		assert.NoError(t, err)
+	})
 }
 
 func TestCommitMessageTemplate(t *testing.T) {
@@ -117,6 +321,7 @@ func TestCommitMessageTemplate(t *testing.T) {
 		want string
 
 		commentPrefix string // defaults to "#"
+		noComments    bool   // if true, no comments are added
 	}{
 		{
 			name: "Empty",
@@ -163,11 +368,38 @@ func TestCommitMessageTemplate(t *testing.T) {
 				"This is the first commit.",
 			),
 		},
+		{
+			name: "TwoNoComments",
+			give: []git.CommitMessage{
+				{
+					Subject: "Initial commit",
+					Body:    "This is the first commit.",
+				},
+				{
+					Subject: "Add feature",
+					Body:    "This adds a new feature.",
+				},
+			},
+			want: joinLines(
+				"Add feature",
+				"",
+				"This adds a new feature.",
+				"",
+				"Initial commit",
+				"",
+				"This is the first commit.",
+			),
+			noComments: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := commitMessageTemplate(tt.commentPrefix, tt.give)
+			got := commitMessageTemplate(
+				tt.give,
+				tt.commentPrefix,
+				!tt.noComments,
+			)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/testdata/script/branch_squash_no_edit.txt
+++ b/testdata/script/branch_squash_no_edit.txt
@@ -1,0 +1,44 @@
+# Test branch squash with --no-edit flag
+
+as 'Test <test@example.com>'
+at '2025-07-19T21:28:29Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# Create a branch with multiple commits
+git add feature1.txt
+gs branch create feature1 -m 'Add feature 1'
+git add feature2.txt
+git commit -m 'Add feature 2'
+
+git graph --branches
+cmp stdout $WORK/golden/graph-before.txt
+
+# Test --no-edit flag: should use combined commit messages without opening editor
+gs branch squash --no-edit
+git log -1 --pretty=format:'%B'
+cmp stdout $WORK/golden/squashed-msg.txt
+
+git graph --branches
+cmp stdout $WORK/golden/graph-after.txt
+
+-- repo/feature1.txt --
+Feature 1
+-- repo/feature2.txt --
+Feature 2
+-- golden/graph-before.txt --
+* a912d4b (HEAD -> feature1) Add feature 2
+* 5c78712 Add feature 1
+* a042ef1 (main) Initial commit
+-- golden/squashed-log.txt --
+6a5b4c3 Add feature 2
+-- golden/squashed-msg.txt --
+Add feature 1
+
+Add feature 2
+-- golden/graph-after.txt --
+* e55dcb7 (HEAD -> feature1) Add feature 1
+* a042ef1 (main) Initial commit


### PR DESCRIPTION
If set, the message will be generated without comments
and be used as the commit message without opening an editor.

Resolves #755