### PR TITLE
ci: reduce number of linux script tests shards

### DIFF
--- a/tools/ci/test-matrix/config.go
+++ b/tools/ci/test-matrix/config.go
@@ -4,7 +4,7 @@ var (
 	_linuxConfig = testConfig{
 		OS:           "ubuntu-latest",
 		GitVersions:  []string{"system", "2.38.0"},
-		ScriptShards: 4,
+		ScriptShards: 3,
 		Race:         true,
 		Cover:        true,
 	}


### PR DESCRIPTION
We're still waiting for Windows most of the time
so no need to rip through the linux tests in 2 minutse.

[skip changelog]: no user facing changes