### PR TITLE
internal/spice: unify branch traversals

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/vito/midterm v0.2.2
 	github.com/zalando/go-keyring v0.2.6
 	gitlab.com/gitlab-org/api/client-go v0.134.0
+	go.abhg.dev/container/ring v0.3.0
 	go.abhg.dev/io/ioutil v0.1.0
 	go.abhg.dev/komplete v0.1.0
 	go.abhg.dev/log/silog v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/zalando/go-keyring v0.2.6 h1:r7Yc3+H+Ux0+M72zacZoItR3UDxeWfKTcabvkI8u
 github.com/zalando/go-keyring v0.2.6/go.mod h1:2TCrxYrbUNYfNS/Kgy/LSrkSQzZ5UPVH85RwfczwvcI=
 gitlab.com/gitlab-org/api/client-go v0.134.0 h1:J4i6qPN5hRLsqatPxVbe9w2C0A3JEItyCQrzsP52S2k=
 gitlab.com/gitlab-org/api/client-go v0.134.0/go.mod h1:crkp9sCwMQ8gDwuMLgk11sDT336t6U3kESBT0BGsOBo=
+go.abhg.dev/container/ring v0.3.0 h1:sEYgxqyAsT2X1NkUEPQecR4WY7cZCbKZSGUsERhHyDI=
+go.abhg.dev/container/ring v0.3.0/go.mod h1:GoB+vof3ofHqP2h2S97aJkmrMLK/Dyn7UEupDTgfWV8=
 go.abhg.dev/io/ioutil v0.1.0 h1:YGGMzh9HT52JYuVWbnr/E5GkYHbL3yRNDjcxFDaUHNk=
 go.abhg.dev/io/ioutil v0.1.0/go.mod h1:79IIyZVWxNZE8hBxMtubM8zJFPs+2NCqHYfWeH3X6hM=
 go.abhg.dev/komplete v0.1.0 h1:OE/uazFmWxrYYxttaKri9UpVr/i3J2Iv1vh21mYVom8=

--- a/internal/spice/branch_graph.go
+++ b/internal/spice/branch_graph.go
@@ -1,0 +1,259 @@
+package spice
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"slices"
+
+	"go.abhg.dev/container/ring"
+)
+
+// BranchGraph is a full view of the graph of branches in the repository.
+type BranchGraph struct {
+	trunk    string
+	branches []LoadBranchItem // all tracked branches
+	byName   map[string]int   // name -> index in branches
+	byBase   map[string][]int // name -> [indices in branches]
+}
+
+// BranchGraphOptions specifies options for the BranchGraph method.
+type BranchGraphOptions struct{}
+
+// BranchLoader is a source of branch information in the repository.
+type BranchLoader interface {
+	Trunk() string
+
+	// LoadBranches loads all branches in the repository.
+	LoadBranches(ctx context.Context) ([]LoadBranchItem, error)
+}
+
+// NewBranchGraph returns a full view of the graph of branches in the repository.
+func NewBranchGraph(ctx context.Context, loader BranchLoader, _ *BranchGraphOptions) (*BranchGraph, error) {
+	branches, err := loader.LoadBranches(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load branches: %w", err)
+	}
+
+	byName := make(map[string]int, len(branches))
+	byBase := make(map[string][]int, len(branches))
+	for idx, branch := range branches {
+		byName[branch.Name] = idx
+		byBase[branch.Base] = append(byBase[branch.Base], idx)
+	}
+
+	return &BranchGraph{
+		trunk:    loader.Trunk(),
+		branches: branches,
+		byName:   byName,
+		byBase:   byBase,
+	}, nil
+}
+
+// Aboves returns branches directly above the given branch,
+func (g *BranchGraph) Aboves(branch string) iter.Seq[string] {
+	return func(yield func(string) bool) {
+		for _, idx := range g.byBase[branch] {
+			if !yield(g.branches[idx].Name) {
+				return
+			}
+		}
+	}
+}
+
+// Upstack returns all branches that are upstack from the given branch:
+// branches that are directly above it, those above those branches,
+// and so on.
+//
+// The first element in the returned sequence is always the branch itself.
+// The remaining elements are the branches above it, in toplogical order:
+// it is guaranteed that a branch seen earlier in the sequence
+// does not use a branch seen later as its base.
+//
+// If branch is trunk, this reports all branches in the repository,
+// including trunk itself.
+func (g *BranchGraph) Upstack(branch string) iter.Seq[string] {
+	return func(yield func(string) bool) {
+		// Use a queue to traverse the upstack branches.
+		var q ring.Q[string]
+		q.Push(branch)
+		for !q.Empty() {
+			current := q.Pop()
+			if !yield(current) {
+				return
+			}
+
+			// Add all branches above the current branch to the queue.
+			for above := range g.Aboves(current) {
+				q.Push(above)
+			}
+		}
+	}
+}
+
+// Tops returns all topmost branches in the upstack chain
+// starting at the given branch.
+//
+// A topmost branch is a branch that has no branches above it,
+// i.e. no other branch has it as a base.
+// branch may be trunk.
+func (g *BranchGraph) Tops(branch string) iter.Seq[string] {
+	return func(yield func(string) bool) {
+		var remaining ring.Q[string]
+		remaining.Push(branch)
+		for !remaining.Empty() {
+			branch := remaining.Pop()
+			var hasAboves bool
+			for above := range g.Aboves(branch) {
+				hasAboves = true
+				remaining.Push(above)
+			}
+
+			if !hasAboves {
+				if !yield(branch) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// Downstack returns all branches that are downstack from the given branch:
+// branches that are directly below it, those below those branches,
+// and so on.
+//
+// The first element in the returned sequence is always the branch itself,
+// followed by remaining branches in the downstack chain
+// in reverse topological order:
+// it is guaranteed that a branch seen earlier in the sequence
+// is not used as a base by a branch seen later.
+//
+// trunk is never included in the downstack list.
+// If the given branch is trunk, the returned sequence is empty.
+func (g *BranchGraph) Downstack(branch string) iter.Seq[string] {
+	return func(yield func(string) bool) {
+		current := branch
+		for {
+			if current == g.trunk {
+				// Reached trunk, stop traversing downstack.
+				return
+			}
+
+			idx, ok := g.byName[current]
+			if !ok {
+				// Branch does not exist in the graph.
+				return
+			}
+
+			if !yield(current) {
+				return
+			}
+
+			// Move to the base of the current branch.
+			current = g.branches[idx].Base
+		}
+	}
+}
+
+// Bottom returns the bottom-most branch in the downstack chain
+// of the given branch.
+//
+// The bottom-most branch is the last branch in the downstack chain,
+// i.e. the last branch before trunk.
+//
+// Returns an empty string if the given branch is trunk.
+func (g *BranchGraph) Bottom(branch string) string {
+	for idx, ok := g.byName[branch]; ok; idx, ok = g.byName[branch] {
+		base := g.branches[idx].Base
+		if base == g.trunk {
+			return branch
+		}
+		branch = base
+	}
+
+	return ""
+}
+
+// Stack returns the full stack of branches that the given branch is in.
+//
+// This includes all downstack branches and all upstack branches,
+// with the given branch itself in the middle.
+// Branches are reversed in topological order:
+// it is guaranteed that a branch seen earlier in the sequence
+// does not use a branch seen later as its base.
+//
+// The branch itself is always included in the stack,
+// but its position is based on the number of downstack branches
+// (its distance from the trunk).
+func (g *BranchGraph) Stack(branch string) iter.Seq[string] {
+	return func(yield func(string) bool) {
+		// Downstack is in the reverse order than what we want,
+		// so we have to collect it first.
+		downstack := slices.Collect(g.Downstack(branch))
+		// Drop the branch itself from the downstack.
+		if len(downstack) > 0 && downstack[0] == branch {
+			downstack = downstack[1:]
+		}
+		slices.Reverse(downstack)
+		for _, b := range downstack {
+			if !yield(b) {
+				return
+			}
+		}
+
+		// Upstack branches includes the branch itself
+		// as the first element,
+		for up := range g.Upstack(branch) {
+			if !yield(up) {
+				return
+			}
+		}
+	}
+}
+
+// NonLinearStackError is returned when a stack is not linear.
+// This means that a branch has more than one upstack branch.
+type NonLinearStackError struct {
+	Branch string
+	Aboves []string
+}
+
+func (e *NonLinearStackError) Error() string {
+	return fmt.Sprintf("%v has %d branches above it", e.Branch, len(e.Aboves))
+}
+
+// StackLinear returns the full stack of branches that the given branch is in,
+// but only if the stack is linear: each branch has only one upstack branch.
+//
+// Returns [NonLinearStackError] if the stack is not linear.
+func (g *BranchGraph) StackLinear(branch string) ([]string, error) {
+	// TODO: probably don't need this on the graph itself
+	downstacks := slices.Collect(g.Downstack(branch))
+	if len(downstacks) > 0 && downstacks[0] == branch {
+		downstacks = downstacks[1:] // drop the branch itself
+	}
+	slices.Reverse(downstacks)
+
+	upstacks := []string{branch}
+	current := branch
+	for aboves := g.byBase[current]; len(aboves) > 0; {
+		if len(aboves) > 1 {
+			aboveNames := make([]string, len(aboves))
+			for i, idx := range aboves {
+				aboveNames[i] = g.branches[idx].Name
+			}
+
+			return nil, &NonLinearStackError{
+				Branch: current,
+				Aboves: aboveNames,
+			}
+		}
+
+		above := g.branches[aboves[0]]
+		current = above.Name
+		upstacks = append(upstacks, current)
+		aboves = g.byBase[current]
+	}
+
+	return slices.Concat(downstacks, upstacks), nil
+}

--- a/internal/spice/branch_graph_test.go
+++ b/internal/spice/branch_graph_test.go
@@ -1,0 +1,132 @@
+package spice
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/git"
+	"pgregory.net/rapid"
+)
+
+func TestBranchGraphRapid(t *testing.T) {
+	rapid.Check(t, testBranchGraphRapid)
+}
+
+func testBranchGraphRapid(t *rapid.T) {
+	branchNameGen := rapid.StringMatching(`[a-zA-Z0-9]{1,}`)
+	gitHashGen := rapid.StringOfN(rapid.RuneFrom([]rune("0123456789abcdef")), 40, 40, 40)
+
+	trunk := branchNameGen.Draw(t, "trunk")
+	allBranches := []string{trunk}
+
+	// To guarantee no cycles in generated graph,
+	// we'll only use previously generated branches as bases.
+	var branchItems []LoadBranchItem
+	for range rapid.IntRange(0, 100).Draw(t, "numBranches") {
+		name := branchNameGen.Filter(func(name string) bool {
+			// Requested name must be unused.
+			return !slices.Contains(allBranches, name)
+		}).Draw(t, "branchName")
+		base := rapid.SampledFrom(allBranches).Draw(t, "baseBranch")
+		allBranches = append(allBranches, name)
+		branchItems = append(branchItems, LoadBranchItem{
+			Name:           name,
+			Base:           base,
+			Head:           git.Hash(gitHashGen.Draw(t, "headHash")),
+			BaseHash:       git.Hash(gitHashGen.Draw(t, "baseHash")),
+			UpstreamBranch: name,
+		})
+	}
+
+	graph, err := NewBranchGraph(t.Context(), &branchLoaderStub{
+		trunk:    trunk,
+		branches: branchItems,
+	}, nil)
+	require.NoError(t, err)
+
+	t.Repeat(map[string]func(*rapid.T){
+		"Aboves": func(t *rapid.T) {
+			branch := rapid.SampledFrom(allBranches).Draw(t, "branch")
+			_ = slices.Collect(graph.Aboves(branch))
+			// no validation, just don't panic
+		},
+		"Upstack": func(t *rapid.T) {
+			branch := rapid.SampledFrom(allBranches).Draw(t, "branch")
+			upstack := slices.Collect(graph.Upstack(branch))
+			if assert.NotEmpty(t, upstack, "upstack should not be empty for tracked branches") {
+				assert.Equal(t, branch, upstack[0], "upstack should start with the branch itself")
+			}
+		},
+		"Tops": func(t *rapid.T) {
+			branch := rapid.SampledFrom(allBranches).Draw(t, "branch")
+			tops := slices.Collect(graph.Tops(branch))
+			assert.NotEmpty(t, tops, "tops should not be empty for any branch")
+			for _, top := range tops {
+				// There must be no branches above the top.
+				upstack := slices.Collect(graph.Upstack(top))[1:] // skip top
+				assert.Empty(t, upstack, "top branch should not have any branches above it")
+			}
+		},
+		"Downstack": func(t *rapid.T) {
+			branch := rapid.SampledFrom(allBranches).Draw(t, "branch")
+			downstack := slices.Collect(graph.Downstack(branch))
+			assert.NotContains(t, downstack, trunk, "downstack should not contain trunk branch")
+			if branch == trunk {
+				assert.Empty(t, downstack, "downstack should be empty for trunk branch")
+			} else if assert.NotEmpty(t, downstack, "downstack should not be empty for tracked branches") {
+				assert.Equal(t, branch, downstack[0], "downstack should start with the branch itself")
+			}
+		},
+		"Bottom": func(t *rapid.T) {
+			branch := rapid.SampledFrom(allBranches).Draw(t, "branch")
+			bottom := graph.Bottom(branch)
+			if branch == trunk {
+				assert.Empty(t, bottom, "bottom should be empty for trunk branch")
+			} else {
+				assert.NotEmpty(t, bottom, "bottom should not be empty for tracked branches")
+				assert.NotEqual(t, trunk, bottom, "bottom should not be trunk for tracked branches")
+
+				// TODO: don't look at internals
+				assert.Equal(t, trunk, graph.branches[graph.byName[bottom]].Base,
+					"base of bottom branch should be trunk")
+			}
+		},
+		"Stack": func(t *rapid.T) {
+			branch := rapid.SampledFrom(allBranches).Draw(t, "branch")
+			stack := slices.Collect(graph.Stack(branch))
+			if assert.NotEmpty(t, stack, "stack should not be empty for tracked branches") {
+				assert.Contains(t, stack, branch, "stack should contain the branch itself")
+			}
+		},
+		"StackLinear": func(t *rapid.T) {
+			branch := rapid.SampledFrom(allBranches).Draw(t, "branch")
+			stack, err := graph.StackLinear(branch)
+			if err != nil {
+				// That's okay, the stack isn't linear.
+				return
+			}
+
+			if assert.NotEmpty(t, stack, "linear stack should not be empty for tracked branches") {
+				assert.Contains(t, stack, branch, "linear stack should contain the branch itself")
+			}
+		},
+	})
+}
+
+type branchLoaderStub struct {
+	trunk    string
+	branches []LoadBranchItem
+}
+
+var _ BranchLoader = (*branchLoaderStub)(nil)
+
+func (s *branchLoaderStub) Trunk() string {
+	return s.trunk
+}
+
+func (s *branchLoaderStub) LoadBranches(_ context.Context) ([]LoadBranchItem, error) {
+	return slices.Clone(s.branches), nil
+}

--- a/internal/spice/service.go
+++ b/internal/spice/service.go
@@ -128,3 +128,14 @@ func newService(
 		forges: forges,
 	}
 }
+
+// Trunk reports the name of the trunk branch.
+func (s *Service) Trunk() string {
+	return s.store.Trunk()
+}
+
+// BranchGraph builds a full view of the graph of branches in the repository.
+func (s *Service) BranchGraph(ctx context.Context, opts *BranchGraphOptions) (*BranchGraph, error) {
+	// TODO: cache branch graph based on hash of store contents
+	return NewBranchGraph(ctx, s, opts)
+}


### PR DESCRIPTION
The branch graph traversals end up loading the same data from disk
several times to try to look up or down the stack.

This introduces a BranchGraph abstraction that loads that data once
and provides read-only access to the graph as iterables.

For backwards compatiblity, the old methods are still available for now.
We may remove them in the future and pass the graph around.

The graph can also be cached using a hash of the store's Git hash,
so the same process can re-use the graph if the store hasn't changed.
(This is not implemented yet.)