### PR TITLE
up: Use branch graph to avoid reloading state

### DIFF
--- a/.changes/unreleased/Fixed-20250722-102117.yaml
+++ b/.changes/unreleased/Fixed-20250722-102117.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'up: Don''t re-load state repeatedly when going up >1 branches. This is >8x faster in degenerate cases.'
+time: 2025-07-22T10:21:17.543993-07:00

--- a/internal/spice/branch_graph.go
+++ b/internal/spice/branch_graph.go
@@ -12,10 +12,15 @@ import (
 // BranchGraph is a full view of the graph of branches in the repository.
 type BranchGraph struct {
 	trunk    string
-	branches []LoadBranchItem // all tracked branches
-	byName   map[string]int   // name -> index in branches
-	byBase   map[string][]int // name -> [indices in branches]
+	branches []BranchGraphItem // all tracked branches
+	byName   map[string]int    // name -> index in branches
+	byBase   map[string][]int  // name -> [indices in branches]
 }
+
+// BranchGraphItem is a single item in the branch graph.
+type BranchGraphItem = LoadBranchItem
+
+// TODO: maybe we kill LoadBranchItem?
 
 // BranchGraphOptions specifies options for the BranchGraph method.
 type BranchGraphOptions struct{}
@@ -48,6 +53,17 @@ func NewBranchGraph(ctx context.Context, loader BranchLoader, _ *BranchGraphOpti
 		byName:   byName,
 		byBase:   byBase,
 	}, nil
+}
+
+// Trunk reports the name of the trunk branch in the repository.
+func (g *BranchGraph) Trunk() string {
+	return g.trunk
+}
+
+// All returns an iterator over all branches in the graph
+// with detailed per-branch information.
+func (g *BranchGraph) All() iter.Seq[LoadBranchItem] {
+	return slices.Values(g.branches)
 }
 
 // Aboves returns branches directly above the given branch,

--- a/up.go
+++ b/up.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/handler/checkout"
@@ -42,14 +43,15 @@ func (cmd *upCmd) Run(
 		return fmt.Errorf("get current branch: %w", err)
 	}
 
+	graph, err := svc.BranchGraph(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("load branch graph: %w", err)
+	}
+
 	var branch string
 outer:
 	for range cmd.N {
-		aboves, err := svc.ListAbove(ctx, current)
-		if err != nil {
-			return fmt.Errorf("list branches above %v: %w", current, err)
-		}
-
+		aboves := slices.Collect(graph.Aboves(current))
 		switch len(aboves) {
 		case 0:
 			if branch != "" {


### PR DESCRIPTION
Instead of calling ListAbove in each iteration of the up command,
load the branch graph once and use it to iterate through the branches.

With a 10-level deep stack, the new version is >8x faster.

```
❯ hyperfine --warmup 5 'gs up -n 10' '../main/bin/gs up -n 10'
Benchmark 1: gs up -n 10
  Time (mean ± σ):      3.061 s ±  0.012 s    [User: 9.172 s, System: 10.825 s]
  Range (min … max):    3.048 s …  3.091 s    10 runs

Benchmark 2: ../main/bin/gs up -n 10
  Time (mean ± σ):     347.1 ms ±   3.5 ms    [User: 940.8 ms, System: 1078.6 ms]
  Range (min … max):   343.5 ms … 353.5 ms    10 runs

Summary
  ../main/bin/gs up -n 10 ran
    8.82 ± 0.10 times faster than gs up -n 10
```