### PR TITLE
fix(restack): leverage branch graph to avoid reloading

### DIFF
--- a/.changes/unreleased/Fixed-20250722-150705.yaml
+++ b/.changes/unreleased/Fixed-20250722-150705.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'stack restack: Avoid double-loading state information to determine upstack/downstack branches.'
+time: 2025-07-22T15:07:05.944487-07:00

--- a/internal/handler/restack/mocks_test.go
+++ b/internal/handler/restack/mocks_test.go
@@ -94,64 +94,19 @@ func (m *MockService) EXPECT() *MockServiceMockRecorder {
 	return m.recorder
 }
 
-// ListDownstack mocks base method.
-func (m *MockService) ListDownstack(ctx context.Context, branch string) ([]string, error) {
+// BranchGraph mocks base method.
+func (m *MockService) BranchGraph(ctx context.Context, opts *spice.BranchGraphOptions) (*spice.BranchGraph, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListDownstack", ctx, branch)
-	ret0, _ := ret[0].([]string)
+	ret := m.ctrl.Call(m, "BranchGraph", ctx, opts)
+	ret0, _ := ret[0].(*spice.BranchGraph)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListDownstack indicates an expected call of ListDownstack.
-func (mr *MockServiceMockRecorder) ListDownstack(ctx, branch any) *gomock.Call {
+// BranchGraph indicates an expected call of BranchGraph.
+func (mr *MockServiceMockRecorder) BranchGraph(ctx, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDownstack", reflect.TypeOf((*MockService)(nil).ListDownstack), ctx, branch)
-}
-
-// ListStack mocks base method.
-func (m *MockService) ListStack(ctx context.Context, branch string) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListStack", ctx, branch)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListStack indicates an expected call of ListStack.
-func (mr *MockServiceMockRecorder) ListStack(ctx, branch any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStack", reflect.TypeOf((*MockService)(nil).ListStack), ctx, branch)
-}
-
-// ListUpstack mocks base method.
-func (m *MockService) ListUpstack(ctx context.Context, branch string) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListUpstack", ctx, branch)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListUpstack indicates an expected call of ListUpstack.
-func (mr *MockServiceMockRecorder) ListUpstack(ctx, branch any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUpstack", reflect.TypeOf((*MockService)(nil).ListUpstack), ctx, branch)
-}
-
-// LoadBranches mocks base method.
-func (m *MockService) LoadBranches(ctx context.Context) ([]spice.LoadBranchItem, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoadBranches", ctx)
-	ret0, _ := ret[0].([]spice.LoadBranchItem)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// LoadBranches indicates an expected call of LoadBranches.
-func (mr *MockServiceMockRecorder) LoadBranches(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadBranches", reflect.TypeOf((*MockService)(nil).LoadBranches), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BranchGraph", reflect.TypeOf((*MockService)(nil).BranchGraph), ctx, opts)
 }
 
 // RebaseRescue mocks base method.

--- a/internal/iterutil/iterutil.go
+++ b/internal/iterutil/iterutil.go
@@ -1,0 +1,17 @@
+// Package iterutil contains utilities for working with iterators.
+package iterutil
+
+import "iter"
+
+// Enumerate adds 0-indexing to a single value iterator.
+func Enumerate[T any](seq iter.Seq[T]) iter.Seq2[int, T] {
+	return func(yield func(int, T) bool) {
+		var idx int
+		for item := range seq {
+			if !yield(idx, item) {
+				return
+			}
+			idx++
+		}
+	}
+}

--- a/internal/iterutil/iterutil_test.go
+++ b/internal/iterutil/iterutil_test.go
@@ -1,0 +1,98 @@
+package iterutil
+
+import (
+	"iter"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnumerate(t *testing.T) {
+	t.Run("EmptySequence", func(t *testing.T) {
+		give := slices.Values([]string{})
+		got := collectIndexed(Enumerate(give))
+		assert.Empty(t, got)
+	})
+
+	t.Run("SingleItem", func(t *testing.T) {
+		give := slices.Values([]string{"hello"})
+		got := collectIndexed(Enumerate(give))
+		want := []indexed[string]{
+			{0, "hello"},
+		}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("MultipleItems", func(t *testing.T) {
+		give := slices.Values([]string{"foo", "bar", "baz"})
+		got := collectIndexed(Enumerate(give))
+		want := []indexed[string]{
+			{0, "foo"},
+			{1, "bar"},
+			{2, "baz"},
+		}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("EarlyTermination", func(t *testing.T) {
+		give := slices.Values([]int{10, 20, 30, 40, 50})
+
+		var got []indexed[int]
+		for idx, val := range Enumerate(give) {
+			got = append(got, indexed[int]{idx, val})
+			if idx == 2 {
+				break
+			}
+		}
+
+		want := []indexed[int]{
+			{0, 10},
+			{1, 20},
+			{2, 30},
+		}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("DifferentTypes", func(t *testing.T) {
+		give := slices.Values([]int{42, 100, 0})
+		got := collectIndexed(Enumerate(give))
+		want := []indexed[int]{
+			{0, 42},
+			{1, 100},
+			{2, 0},
+		}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("CustomIterator", func(t *testing.T) {
+		give := func(yield func(string) bool) {
+			items := []string{"alpha", "beta", "gamma"}
+			for _, item := range items {
+				if !yield(item) {
+					return
+				}
+			}
+		}
+		got := collectIndexed(Enumerate(iter.Seq[string](give)))
+		want := []indexed[string]{
+			{0, "alpha"},
+			{1, "beta"},
+			{2, "gamma"},
+		}
+		assert.Equal(t, want, got)
+	})
+}
+
+type indexed[T any] struct {
+	Index int
+	Value T
+}
+
+func collectIndexed[T any](seq iter.Seq2[int, T]) []indexed[T] {
+	var results []indexed[T]
+	for idx, val := range seq {
+		results = append(results, indexed[T]{idx, val})
+	}
+	return results
+}


### PR DESCRIPTION
Avoid loading the branch graph for the downstack/upstack traversal
during a restack operation by taking advantage of the branch graph.
This won't be a major difference versus reloading
as we're just going from two to one reload.