### PR TITLE
fix(restack): worktree aware restack

### DIFF
--- a/.changes/unreleased/Fixed-20250719-112448.yaml
+++ b/.changes/unreleased/Fixed-20250719-112448.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: >-
+  restack: If a branch planned to be restacked is checked out in another worktree,
+  don't attempt to restack it or its upstacks.
+time: 2025-07-19T11:24:48.507438-07:00

--- a/internal/handler/restack/branch_test.go
+++ b/internal/handler/restack/branch_test.go
@@ -25,10 +25,18 @@ func TestHandler_RestackBranch(t *testing.T) {
 
 		mockService := NewMockService(ctrl)
 		mockService.EXPECT().
+			BranchGraph(gomock.Any(), gomock.Any()).
+			Return(newBranchGraphBuilder("main").
+				Branch("feature", "main").
+				Build(t), nil)
+		mockService.EXPECT().
 			Restack(gomock.Any(), "feature").
 			Return(&spice.RestackResponse{Base: "main"}, nil)
 
 		mockWorktree := NewMockGitWorktree(ctrl)
+		mockWorktree.EXPECT().
+			RootDir().
+			Return(t.TempDir())
 		mockWorktree.EXPECT().
 			Checkout(gomock.Any(), "feature").
 			Return(nil)
@@ -49,6 +57,11 @@ func TestHandler_RestackBranch(t *testing.T) {
 
 		mockService := NewMockService(ctrl)
 		mockService.EXPECT().
+			BranchGraph(gomock.Any(), gomock.Any()).
+			Return(newBranchGraphBuilder("main").
+				Branch("feature", "main").
+				Build(t), nil)
+		mockService.EXPECT().
 			Restack(gomock.Any(), "feature").
 			Return(nil, &git.RebaseInterruptError{
 				Kind: git.RebaseInterruptConflict,
@@ -57,9 +70,14 @@ func TestHandler_RestackBranch(t *testing.T) {
 			RebaseRescue(gomock.Any(), gomock.Any()).
 			Return(nil)
 
+		mockWorktree := NewMockGitWorktree(ctrl)
+		mockWorktree.EXPECT().
+			RootDir().
+			Return(t.TempDir())
+
 		handler := &Handler{
 			Log:      log,
-			Worktree: NewMockGitWorktree(ctrl),
+			Worktree: mockWorktree,
 			Store:    statetest.NewMemoryStore(t, "main", "", log),
 			Service:  mockService,
 		}
@@ -75,12 +93,22 @@ func TestHandler_RestackBranch(t *testing.T) {
 
 		mockService := NewMockService(ctrl)
 		mockService.EXPECT().
+			BranchGraph(gomock.Any(), gomock.Any()).
+			Return(newBranchGraphBuilder("main").
+				Branch("feature", "main").
+				Build(t), nil)
+		mockService.EXPECT().
 			Restack(gomock.Any(), "untracked").
 			Return(nil, state.ErrNotExist)
 
+		mockWorktree := NewMockGitWorktree(ctrl)
+		mockWorktree.EXPECT().
+			RootDir().
+			Return(t.TempDir())
+
 		handler := &Handler{
 			Log:      log,
-			Worktree: NewMockGitWorktree(ctrl),
+			Worktree: mockWorktree,
 			Store:    statetest.NewMemoryStore(t, "main", "", log),
 			Service:  mockService,
 		}
@@ -99,10 +127,18 @@ func TestHandler_RestackBranch(t *testing.T) {
 
 		mockService := NewMockService(ctrl)
 		mockService.EXPECT().
+			BranchGraph(gomock.Any(), gomock.Any()).
+			Return(newBranchGraphBuilder("main").
+				Branch("already-restacked", "main").
+				Build(t), nil)
+		mockService.EXPECT().
 			Restack(gomock.Any(), "already-restacked").
 			Return(nil, spice.ErrAlreadyRestacked)
 
 		mockWorktree := NewMockGitWorktree(ctrl)
+		mockWorktree.EXPECT().
+			RootDir().
+			Return(t.TempDir())
 		mockWorktree.EXPECT().
 			Checkout(gomock.Any(), "already-restacked").
 			Return(nil)
@@ -125,12 +161,22 @@ func TestHandler_RestackBranch(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockService := NewMockService(ctrl)
 		mockService.EXPECT().
+			BranchGraph(gomock.Any(), gomock.Any()).
+			Return(newBranchGraphBuilder("main").
+				Branch("feature", "main").
+				Build(t), nil)
+		mockService.EXPECT().
 			Restack(gomock.Any(), "feature").
 			Return(nil, unexpectedErr)
 
+		mockWorktree := NewMockGitWorktree(ctrl)
+		mockWorktree.EXPECT().
+			RootDir().
+			Return(t.TempDir())
+
 		handler := &Handler{
 			Log:      log,
-			Worktree: NewMockGitWorktree(ctrl),
+			Worktree: mockWorktree,
 			Store:    statetest.NewMemoryStore(t, "main", "", log),
 			Service:  mockService,
 		}

--- a/internal/handler/restack/handler_test.go
+++ b/internal/handler/restack/handler_test.go
@@ -27,10 +27,18 @@ func TestHandler_Restack(t *testing.T) {
 
 			mockService := NewMockService(ctrl)
 			mockService.EXPECT().
+				BranchGraph(gomock.Any(), gomock.Any()).
+				Return(newBranchGraphBuilder("main").
+					Branch("feature", "main").
+					Build(t), nil)
+			mockService.EXPECT().
 				Restack(gomock.Any(), "feature").
 				Return(&spice.RestackResponse{Base: "main"}, nil)
 
 			mockWorktree := NewMockGitWorktree(ctrl)
+			mockWorktree.EXPECT().
+				RootDir().
+				Return(t.TempDir())
 			mockWorktree.EXPECT().
 				Checkout(gomock.Any(), "feature").
 				Return(nil)
@@ -56,26 +64,29 @@ func TestHandler_Restack(t *testing.T) {
 			log := silog.Nop()
 			ctrl := gomock.NewController(t)
 
-			mockWorktree := NewMockGitWorktree(ctrl)
-			mockWorktree.EXPECT().
-				Checkout(gomock.Any(), "main").
-				Return(nil)
+			mockService := NewMockService(ctrl)
+			mockService.EXPECT().
+				BranchGraph(gomock.Any(), gomock.Any()).
+				Return(newBranchGraphBuilder("main").
+					Branch("feature", "main").
+					Build(t), nil)
 
+			mockWorktree := NewMockGitWorktree(ctrl)
 			handler := &Handler{
 				Log:      log,
 				Worktree: mockWorktree,
 				Store:    statetest.NewMemoryStore(t, "main", "", log),
-				Service:  NewMockService(ctrl),
+				Service:  mockService,
 			}
 
-			count, err := handler.Restack(t.Context(), &Request{
+			_, err := handler.Restack(t.Context(), &Request{
 				Branch:          "main",
 				ContinueCommand: []string{"false"},
 				Scope:           ScopeBranch,
 			})
 
-			require.NoError(t, err)
-			assert.Equal(t, 0, count)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "trunk cannot be restacked")
 		})
 	})
 
@@ -105,6 +116,9 @@ func TestHandler_Restack(t *testing.T) {
 				Return(&spice.RestackResponse{Base: "feature2"}, nil)
 
 			mockWorktree := NewMockGitWorktree(ctrl)
+			mockWorktree.EXPECT().
+				RootDir().
+				Return(t.TempDir())
 			mockWorktree.EXPECT().
 				Checkout(gomock.Any(), "feature").
 				Return(nil)
@@ -151,6 +165,9 @@ func TestHandler_Restack(t *testing.T) {
 
 			mockWorktree := NewMockGitWorktree(ctrl)
 			mockWorktree.EXPECT().
+				RootDir().
+				Return(t.TempDir())
+			mockWorktree.EXPECT().
 				Checkout(gomock.Any(), "feature").
 				Return(nil)
 
@@ -189,6 +206,9 @@ func TestHandler_Restack(t *testing.T) {
 				Return(&spice.RestackResponse{Base: "main"}, nil)
 
 			mockWorktree := NewMockGitWorktree(ctrl)
+			mockWorktree.EXPECT().
+				RootDir().
+				Return(t.TempDir())
 			mockWorktree.EXPECT().
 				Checkout(gomock.Any(), "feature").
 				Return(nil)
@@ -237,6 +257,9 @@ func TestHandler_Restack(t *testing.T) {
 
 			mockWorktree := NewMockGitWorktree(ctrl)
 			mockWorktree.EXPECT().
+				RootDir().
+				Return(t.TempDir())
+			mockWorktree.EXPECT().
 				Checkout(gomock.Any(), "feature").
 				Return(nil)
 
@@ -275,6 +298,9 @@ func TestHandler_Restack(t *testing.T) {
 				Return(&spice.RestackResponse{Base: "main"}, nil)
 
 			mockWorktree := NewMockGitWorktree(ctrl)
+			mockWorktree.EXPECT().
+				RootDir().
+				Return(t.TempDir())
 			mockWorktree.EXPECT().
 				Checkout(gomock.Any(), "feature").
 				Return(nil)
@@ -331,6 +357,9 @@ func TestHandler_Restack(t *testing.T) {
 
 			mockWorktree := NewMockGitWorktree(ctrl)
 			mockWorktree.EXPECT().
+				RootDir().
+				Return(t.TempDir())
+			mockWorktree.EXPECT().
 				Checkout(gomock.Any(), "feature").
 				Return(nil)
 
@@ -378,6 +407,9 @@ func TestHandler_Restack(t *testing.T) {
 
 		mockWorktree := NewMockGitWorktree(ctrl)
 		mockWorktree.EXPECT().
+			RootDir().
+			Return(t.TempDir())
+		mockWorktree.EXPECT().
 			Checkout(gomock.Any(), "feature").
 			Return(nil)
 
@@ -410,15 +442,25 @@ func TestHandler_Restack(t *testing.T) {
 
 		mockService := NewMockService(ctrl)
 		mockService.EXPECT().
+			BranchGraph(gomock.Any(), gomock.Any()).
+			Return(newBranchGraphBuilder("main").
+				Branch("feature", "main").
+				Build(t), nil)
+		mockService.EXPECT().
 			Restack(gomock.Any(), "feature").
 			Return(nil, rebaseErr)
 		mockService.EXPECT().
 			RebaseRescue(gomock.Any(), gomock.Any()).
 			Return(nil)
 
+		mockWorktree := NewMockGitWorktree(ctrl)
+		mockWorktree.EXPECT().
+			RootDir().
+			Return(t.TempDir())
+
 		handler := &Handler{
 			Log:      log,
-			Worktree: NewMockGitWorktree(ctrl),
+			Worktree: mockWorktree,
 			Store:    statetest.NewMemoryStore(t, "main", "", log),
 			Service:  mockService,
 		}
@@ -454,6 +496,9 @@ func TestHandler_Restack_trunk(t *testing.T) {
 			Return(&spice.RestackResponse{Base: "feature1"}, nil)
 
 		mockWorktree := NewMockGitWorktree(ctrl)
+		mockWorktree.EXPECT().
+			RootDir().
+			Return(t.TempDir())
 		mockWorktree.EXPECT().
 			Checkout(gomock.Any(), "main").
 			Return(nil)
@@ -491,6 +536,9 @@ func TestHandler_Restack_trunk(t *testing.T) {
 
 		mockWorktree := NewMockGitWorktree(ctrl)
 		mockWorktree.EXPECT().
+			RootDir().
+			Return(t.TempDir())
+		mockWorktree.EXPECT().
 			Checkout(gomock.Any(), "main").
 			Return(nil)
 
@@ -501,14 +549,12 @@ func TestHandler_Restack_trunk(t *testing.T) {
 			Service:  mockService,
 		}
 
-		count, err := handler.Restack(t.Context(), &Request{
+		_, err := handler.Restack(t.Context(), &Request{
 			Branch:          "main",
 			ContinueCommand: []string{"false"},
 			Scope:           ScopeDownstack,
 		})
-
 		require.NoError(t, err)
-		assert.Equal(t, 0, count)
 	})
 
 	t.Run("ScopeUpstackFromTrunk", func(t *testing.T) {
@@ -532,6 +578,9 @@ func TestHandler_Restack_trunk(t *testing.T) {
 
 		mockWorktree := NewMockGitWorktree(ctrl)
 		mockWorktree.EXPECT().
+			RootDir().
+			Return(t.TempDir())
+		mockWorktree.EXPECT().
 			Checkout(gomock.Any(), "main").
 			Return(nil)
 
@@ -553,6 +602,101 @@ func TestHandler_Restack_trunk(t *testing.T) {
 		assert.NotContains(t, logBuffer.String(), "main: restacked")
 		assert.Contains(t, logBuffer.String(), "feature1: restacked on main")
 		assert.Contains(t, logBuffer.String(), "feature2: restacked on feature1")
+	})
+}
+
+func TestHandler_Restack_skipCheckedOut(t *testing.T) {
+	t.Run("Branch", func(t *testing.T) {
+		// Branch-scoped restack operation,
+		// and branch is checked out in another worktree.
+
+		var logBuffer bytes.Buffer
+		log := silog.New(&logBuffer, nil)
+		ctrl := gomock.NewController(t)
+
+		featureWorktree := t.TempDir()
+
+		mockService := NewMockService(ctrl)
+		mockService.EXPECT().
+			BranchGraph(gomock.Any(), gomock.Any()).
+			Return(newBranchGraphBuilder("main").
+				Branch("feature", "main").
+				Worktree("feature", featureWorktree).
+				Build(t), nil)
+
+		mockWorktree := NewMockGitWorktree(ctrl)
+		mockWorktree.EXPECT().
+			RootDir().
+			Return(t.TempDir())
+
+		handler := &Handler{
+			Log:      log,
+			Worktree: mockWorktree,
+			Store:    statetest.NewMemoryStore(t, "main", "", log),
+			Service:  mockService,
+		}
+
+		count, err := handler.Restack(t.Context(), &Request{
+			Branch:          "feature",
+			ContinueCommand: []string{"false"},
+			Scope:           ScopeBranch,
+		})
+		require.NoError(t, err)
+		assert.Zero(t, count, "nothing should've been restacked")
+
+		assert.Regexp(t, `checked out in another worktree \(.*\), skipping`, logBuffer.String())
+		assert.Contains(t, logBuffer.String(), "not checking out here")
+	})
+
+	t.Run("Upstack", func(t *testing.T) {
+		// Upstack-scoped rebase,
+		// one of the upstack branches is
+		// checked out in another worktree.
+		var logBuffer bytes.Buffer
+		log := silog.New(&logBuffer, nil)
+		ctrl := gomock.NewController(t)
+
+		feature2WT := t.TempDir()
+
+		mockService := NewMockService(ctrl)
+		mockService.EXPECT().
+			BranchGraph(gomock.Any(), gomock.Any()).
+			Return(newBranchGraphBuilder("main").
+				Branch("feature1", "main").
+				Branch("feature2", "feature1").
+				Branch("feature3", "feature2").
+				Worktree("feature2", feature2WT).
+				Build(t), nil)
+		mockService.EXPECT().
+			Restack(gomock.Any(), "feature1").
+			Return(&spice.RestackResponse{Base: "main"}, nil)
+
+		mockWorktree := NewMockGitWorktree(ctrl)
+		mockWorktree.EXPECT().
+			RootDir().
+			Return(t.TempDir())
+		mockWorktree.EXPECT().
+			Checkout(gomock.Any(), "feature1").
+			Return(nil)
+
+		handler := &Handler{
+			Log:      log,
+			Worktree: mockWorktree,
+			Store:    statetest.NewMemoryStore(t, "main", "", log),
+			Service:  mockService,
+		}
+
+		count, err := handler.Restack(t.Context(), &Request{
+			Branch:          "feature1",
+			ContinueCommand: []string{"false"},
+			Scope:           ScopeUpstack,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1, count, "feature1 must have been restacked")
+
+		assert.Contains(t, logBuffer.String(), "feature1: restacked on main")
+		assert.Regexp(t, `feature2: checked out in another worktree \(.*\), skipping`, logBuffer.String())
+		assert.Contains(t, logBuffer.String(), "feature3: base branch feature2 was not restacked")
 	})
 }
 
@@ -591,12 +735,20 @@ func TestHandler_Restack_errors(t *testing.T) {
 
 		mockService := NewMockService(ctrl)
 		mockService.EXPECT().
+			BranchGraph(gomock.Any(), gomock.Any()).
+			Return(newBranchGraphBuilder("main").Build(t), nil)
+		mockService.EXPECT().
 			Restack(gomock.Any(), "untracked").
 			Return(nil, state.ErrNotExist)
 
+		mockWorktree := NewMockGitWorktree(ctrl)
+		mockWorktree.EXPECT().
+			RootDir().
+			Return(t.TempDir())
+
 		handler := &Handler{
 			Log:      log,
-			Worktree: NewMockGitWorktree(ctrl),
+			Worktree: mockWorktree,
 			Store:    statetest.NewMemoryStore(t, "main", "", log),
 			Service:  mockService,
 		}
@@ -621,12 +773,22 @@ func TestHandler_Restack_errors(t *testing.T) {
 
 		mockService := NewMockService(ctrl)
 		mockService.EXPECT().
+			BranchGraph(gomock.Any(), gomock.Any()).
+			Return(newBranchGraphBuilder("main").
+				Branch("feature", "main").
+				Build(t), nil)
+		mockService.EXPECT().
 			Restack(gomock.Any(), "feature").
 			Return(nil, unexpectedErr)
 
+		mockWorktree := NewMockGitWorktree(ctrl)
+		mockWorktree.EXPECT().
+			RootDir().
+			Return(t.TempDir())
+
 		handler := &Handler{
 			Log:      log,
-			Worktree: NewMockGitWorktree(ctrl),
+			Worktree: mockWorktree,
 			Store:    statetest.NewMemoryStore(t, "main", "", log),
 			Service:  mockService,
 		}
@@ -651,10 +813,18 @@ func TestHandler_Restack_errors(t *testing.T) {
 
 		mockService := NewMockService(ctrl)
 		mockService.EXPECT().
+			BranchGraph(gomock.Any(), gomock.Any()).
+			Return(newBranchGraphBuilder("main").
+				Branch("feature", "main").
+				Build(t), nil)
+		mockService.EXPECT().
 			Restack(gomock.Any(), "feature").
 			Return(&spice.RestackResponse{Base: "main"}, nil)
 
 		mockWorktree := NewMockGitWorktree(ctrl)
+		mockWorktree.EXPECT().
+			RootDir().
+			Return(t.TempDir())
 		mockWorktree.EXPECT().
 			Checkout(gomock.Any(), "feature").
 			Return(checkoutErr)
@@ -680,13 +850,15 @@ func TestHandler_Restack_errors(t *testing.T) {
 }
 
 type branchGraphBuilder struct {
-	trunk string
-	items []spice.BranchGraphItem
+	trunk     string
+	items     []spice.BranchGraphItem
+	worktrees map[string]string
 }
 
 func newBranchGraphBuilder(trunk string) *branchGraphBuilder {
 	return &branchGraphBuilder{
-		trunk: trunk,
+		trunk:     trunk,
+		worktrees: make(map[string]string),
 	}
 }
 
@@ -698,18 +870,25 @@ func (b *branchGraphBuilder) Branch(name, base string) *branchGraphBuilder {
 	return b
 }
 
+func (b *branchGraphBuilder) Worktree(branch, wt string) *branchGraphBuilder {
+	b.worktrees[branch] = wt
+	return b
+}
+
 func (b *branchGraphBuilder) Build(t testing.TB) *spice.BranchGraph {
 	graph, err := spice.NewBranchGraph(t.Context(), &branchLoaderStub{
-		trunk: b.trunk,
-		items: b.items,
-	}, nil)
+		trunk:     b.trunk,
+		items:     b.items,
+		worktrees: b.worktrees,
+	}, &spice.BranchGraphOptions{IncludeWorktrees: true})
 	require.NoError(t, err)
 	return graph
 }
 
 type branchLoaderStub struct {
-	trunk string
-	items []spice.LoadBranchItem
+	trunk     string
+	items     []spice.LoadBranchItem
+	worktrees map[string]string
 }
 
 var _ spice.BranchLoader = (*branchLoaderStub)(nil)
@@ -720,4 +899,15 @@ func (b *branchLoaderStub) Trunk() string {
 
 func (b *branchLoaderStub) LoadBranches(context.Context) ([]spice.LoadBranchItem, error) {
 	return slices.Clone(b.items), nil
+}
+
+func (b *branchLoaderStub) LookupWorktrees(_ context.Context, branches []string) (map[string]string, error) {
+	wts := make(map[string]string, len(branches))
+	for _, branch := range branches {
+		wt := b.worktrees[branch]
+		if wt != "" {
+			wts[branch] = wt
+		}
+	}
+	return wts, nil
 }

--- a/internal/handler/restack/mocks_test.go
+++ b/internal/handler/restack/mocks_test.go
@@ -70,6 +70,20 @@ func (mr *MockGitWorktreeMockRecorder) CurrentBranch(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentBranch", reflect.TypeOf((*MockGitWorktree)(nil).CurrentBranch), ctx)
 }
 
+// RootDir mocks base method.
+func (m *MockGitWorktree) RootDir() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RootDir")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// RootDir indicates an expected call of RootDir.
+func (mr *MockGitWorktreeMockRecorder) RootDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RootDir", reflect.TypeOf((*MockGitWorktree)(nil).RootDir))
+}
+
 // MockService is a mock of Service interface.
 type MockService struct {
 	ctrl     *gomock.Controller

--- a/testdata/script/stack_restack_skip_worktree.txt
+++ b/testdata/script/stack_restack_skip_worktree.txt
@@ -1,0 +1,85 @@
+# 'stack restack' with a non-linear stack where a branch is checked out in another worktree.
+# Should skip the branch in the worktree and anything stacked on top of it.
+
+as 'Test <test@example.com>'
+at '2025-06-20T21:28:29Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# Create a non-linear stack:
+# main -> feature1 -> feature2 -> feature3
+#              '----> feature4 -> feature5
+
+# Create first stack: feaure1-3
+git add feature1.txt
+gs bc feature1 -m 'Add feature1'
+git add feature2.txt
+gs bc feature2 -m 'Add feature2'
+git add feature3.txt
+gs bc feature3 -m 'Add feature3'
+
+# Go back to feature1 and create 4-5
+gs bco feature1
+git add feature4.txt
+gs bc feature4 -m 'Add feature4'
+git add feature5.txt
+gs bc feature5 -m 'Add feature5'
+
+# Create a worktree for feature2.
+# This will block restacking of feature2 and feature3.
+git worktree add ../wt-feature2 feature2
+
+# Move main to require restacking.
+gs bco main
+git add main-change.txt
+git commit -m 'Change on main that requires restacking'
+
+# Restack the stack.
+gs bco feature1
+gs stack restack
+
+# Verify warnings about skipped branches
+stderr 'WRN feature2: checked out in another worktree \(.+/wt-feature2\), skipping'
+stderr 'WRN feature3: base branch feature2 was not restacked, skipping'
+
+# Verify that feature1, feature4, and feature5 were restacked
+# but feature2 and feature3 were not
+git graph --branches
+cmp stdout $WORK/golden/branches.txt
+
+# Verify we're still on feature1
+git branch --show-current
+stdout '^feature1$'
+
+-- repo/feature1.txt --
+feature1
+
+-- repo/feature2.txt --
+feature2
+
+-- repo/feature3.txt --
+feature3
+
+-- repo/feature4.txt --
+feature4
+
+-- repo/feature5.txt --
+feature5
+
+-- repo/main-change.txt --
+main change
+
+-- golden/branches.txt --
+* 056aa97 (feature3) Add feature3
+* 8a1ddca (feature2) Add feature2
+* 62d71a8 Add feature1
+| * c7b4892 (feature5) Add feature5
+| * 449b09d (feature4) Add feature4
+| * 0166554 (HEAD -> feature1) Add feature1
+| * 28f9688 (main) Change on main that requires restacking
+|/  
+* cb6d6c3 Initial commit


### PR DESCRIPTION
When running stack-scoped operations, if a branch to be restacked
is checked out in another worktree,
skip it instead of failing the command.