### PR TITLE
fix(log): Fix regression in deleted branch detection

### DIFF
--- a/internal/spice/branch_graph.go
+++ b/internal/spice/branch_graph.go
@@ -95,6 +95,12 @@ func (g *BranchGraph) All() iter.Seq[LoadBranchItem] {
 	return slices.Values(g.branches)
 }
 
+// Count reports the total number of tracked branches in the graph.
+// The count DOES NOT include trunk.
+func (g *BranchGraph) Count() int {
+	return len(g.branches)
+}
+
 // Lookup returns information about the given branch,
 // or false if the branch is not known to the graph.
 // trunk also results in a value of false.

--- a/testdata/script/log_short_branch_deleted_out_of_band.txt
+++ b/testdata/script/log_short_branch_deleted_out_of_band.txt
@@ -1,0 +1,36 @@
+# gs ls after deleting a branch out of band
+# should print a log message but be no-op otherwise.
+
+as 'Test <test@example.com>'
+at '2025-07-22T21:25:04Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# create a stack: feat1 -> feat2 -> feat3
+gs bc feat1 -m 'feat1'
+gs bc feat2 -m 'feat2'
+gs bc feat3 -m 'feat3'
+gs trunk
+
+gs ls
+cmp stderr $WORK/golden/ls-before.txt
+
+git branch -D feat3
+
+gs ls
+cmp stderr $WORK/golden/ls-after.txt
+
+-- golden/ls-before.txt --
+    ┏━□ feat3
+  ┏━┻□ feat2
+┏━┻□ feat1
+main ◀
+-- golden/ls-after.txt --
+INF tracked branch feat3 was deleted out of band: removing...
+  ┏━□ feat2
+┏━┻□ feat1
+main ◀


### PR DESCRIPTION
Fixes a regression introduced in a prior commit
where 'gs ls' would panic if a branch was deleted out of band.
To fix the issue, switch to using the branch graph
which will get rid of out-of-band deleted branches during load.

No changelog entry needed as the regression wasn't released to users yet.