### PR TITLE
fix(submit): panic when there are merged downstack nodes

### DIFF
--- a/.changes/unreleased/Fixed-20250808-173411.yaml
+++ b/.changes/unreleased/Fixed-20250808-173411.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fix panic when the 'spice.submit.navigationCommentSync' configuration option is set to 'downstack', and one of the downstacks has already been merged.
+time: 2025-08-08T17:34:11.809985-07:00

--- a/internal/handler/submit/nav_comment.go
+++ b/internal/handler/submit/nav_comment.go
@@ -224,7 +224,13 @@ func updateNavigationComments(
 
 			baseIdx := nodes[nodeIdx].Base
 			for baseIdx != -1 {
-				updateBranches[baseIdx] = struct{}{}
+				// Only add tracked branches
+				// that have corresponding infos entries.
+				// Merged downstack nodes don't have info
+				// and can't be commented on.
+				if baseIdx < len(infos) {
+					updateBranches[baseIdx] = struct{}{}
+				}
 				baseIdx = nodes[baseIdx].Base
 			}
 		}


### PR DESCRIPTION
When the 'spice.submit.navigationCommentSync' is set to 'downstack',
we traverse the downstack nodes to update their navigation comments.
This logic did not account for the possibility of some downstack nodes
being already merged, which means they do not have corresponding
infos entries.

Resolves #788