### PR TITLE
doc: add Get Started subsections to sidebar

### DIFF
--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -110,6 +110,8 @@ nav:
   - Get started:
     - start/index.md
     - start/install.md
+    - start/stack.md
+    - start/submit.md
   - User Guide:
     - guide/index.md
     - guide/concepts.md
@@ -129,11 +131,6 @@ nav:
   - Recipes: recipes.md
   - FAQ: faq.md
   - Changelog: changelog.md
-
-not_in_nav: |
-  # Listed manually
-  start/stack.md
-  start/submit.md
 
 watch:
   - includes

--- a/doc/src/start/submit.md
+++ b/doc/src/start/submit.md
@@ -8,7 +8,7 @@ prev_page: stack.md
 next_page: ../guide/index.md
 ---
 
-# Your first stacked Pull Requests
+# Your first stacked Change Requests
 
 This page will walk you through creating and updating
 *GitHub Pull Requests* or *GitLab Merge Requests* with git-spice.


### PR DESCRIPTION
These were originally kept out of the sidebar
because I expected them to have verbose titles
and wanted more flexibility with content and subsections.

I think it's fine to keep them in the sidebar now
as the expected UX of the site is now to have subsections
clearly visible in the sidebar.

Resolves #792