### PR TITLE
repo sync: add closed PR handling opt-out

### DIFF
--- a/.changes/unreleased/Added-20250809-105418.yaml
+++ b/.changes/unreleased/Added-20250809-105418.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: >-
+  repo sync: Add 'spice.repoSync.closedChanges' configuration option
+  to control how git-spice handles closed change requests.
+time: 2025-08-09T10:54:18.593124-07:00

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -146,6 +146,8 @@ was not initialized with a remote.
 
 * `--restack`: Restack the current stack after syncing
 
+**Configuration**: [spice.repoSync.closedChanges](/cli/config.md#spicereposyncclosedchanges)
+
 ### gs repo restack
 
 ```

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -401,6 +401,23 @@ This option has no effect on $$gs branch submit$$,
 - `true`
 - `false` (default)
 
+### spice.repoSync.closedChanges
+
+<!-- gs:version unreleased -->
+
+How to handle closed Change Requests that have not been merged
+when running $$gs repo sync$$.
+
+**Accepted values:**
+
+- `ask` (default): prompt the user whether to delete the branch
+- `ignore`: ignore closed CRs without prompting and leave the branch intact
+
+When set to `ignore`,
+$$gs repo sync$$ will skip closed CRs entirely
+and log an informational message about the closed CR being ignored.
+The branch will remain on the system.
+
 ### spice.submit.web
 
 <!-- gs:version v0.8.0 -->

--- a/doc/src/guide/cr.md
+++ b/doc/src/guide/cr.md
@@ -198,6 +198,21 @@ This will update the trunk branch (e.g. `main`)
 with the latest changes from the upstream repository,
 and delete any local branches whose PRs have been merged.
 
+### Handling closed Change Requests
+
+When running $$gs repo sync$$, if a Change Request was closed
+(but not merged), git-spice will detect this
+and offer you the choice of deleting that branch locally.
+
+If you prefer not to be prompted about closed CRs,
+you can set the configuration option to ignore them:
+
+```freeze language="terminal"
+{green}${reset} git config {red}spice.repoSync.closedChanges{reset} {mag}ignore{reset}
+```
+
+For more details, see the [configuration reference](../cli/config.md#spicereposyncclosedchanges).
+
 ## Importing open CRs
 
 You can import an existing open CR into git-spice

--- a/internal/handler/sync/closed_change_behavior_test.go
+++ b/internal/handler/sync/closed_change_behavior_test.go
@@ -1,0 +1,103 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClosedChanges_UnmarshalText(t *testing.T) {
+	tests := []struct {
+		give string
+		want ClosedChanges
+	}{
+		{"ask", ClosedChangesAsk},
+		{"ignore", ClosedChangesIgnore},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.give, func(t *testing.T) {
+			var got ClosedChanges
+			require.NoError(t, got.UnmarshalText([]byte(tt.give)))
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	t.Run("Invalid", func(t *testing.T) {
+		var c ClosedChanges
+		err := c.UnmarshalText([]byte("invalid"))
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "invalid value")
+		assert.ErrorContains(t, err, "expected 'ask' or 'ignore'")
+	})
+}
+
+func TestClosedChanges_MarshalText(t *testing.T) {
+	tests := []struct {
+		give ClosedChanges
+		want string
+	}{
+		{ClosedChangesAsk, "ask"},
+		{ClosedChangesIgnore, "ignore"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got, err := tt.give.MarshalText()
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, string(got))
+		})
+	}
+
+	t.Run("Unknown", func(t *testing.T) {
+		c := ClosedChanges(42)
+		_, err := c.MarshalText()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid value: 42")
+	})
+}
+
+func TestClosedChanges_String(t *testing.T) {
+	tests := []struct {
+		give ClosedChanges
+		want string
+	}{
+		{ClosedChangesAsk, "ask"},
+		{ClosedChangesIgnore, "ignore"},
+		{42, "ClosedChanges(42)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.give.String())
+		})
+	}
+}
+
+func TestClosedChanges_RoundTrip(t *testing.T) {
+	tests := []struct {
+		give string
+		want ClosedChanges
+	}{
+		{"ask", ClosedChangesAsk},
+		{"ignore", ClosedChangesIgnore},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.give, func(t *testing.T) {
+			// Unmarshal -> Marshal -> Unmarshal
+			var c1 ClosedChanges
+			require.NoError(t, c1.UnmarshalText([]byte(tt.give)))
+			assert.Equal(t, tt.want, c1)
+
+			marshaled, err := c1.MarshalText()
+			require.NoError(t, err)
+			assert.Equal(t, tt.give, string(marshaled))
+
+			var c2 ClosedChanges
+			require.NoError(t, c2.UnmarshalText(marshaled))
+			assert.Equal(t, c1, c2)
+		})
+	}
+}

--- a/testdata/script/repo_sync_closed_cr_ignore.txt
+++ b/testdata/script/repo_sync_closed_cr_ignore.txt
@@ -1,0 +1,75 @@
+# 'repo sync' ignores closed CRs when repoSync.closedChanges is set to 'ignore'.
+
+as 'Test <test@example.com>'
+at '2025-08-09T10:00:00Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+git add feature1.txt
+gs bc -m 'Add feature1' feature1
+
+git add feature2.txt
+gs bc -m 'Add feature2' feature2
+
+gs ss --fill
+
+gs ls -a
+cmp stderr $WORK/golden/open.txt
+
+# Close the PR server-side
+shamhub reject alice/example 1
+
+# Test 1: Ignore closed changes and repo sync.
+git config spice.repoSync.closedChanges ignore
+gs repo sync
+stderr 'feature1: #1 was closed but not merged, ignoring'
+
+# Branch still exists.
+gs ls -a
+cmp stderr $WORK/golden/ls-first-submit.txt
+
+# Test 2:
+# Same as above, but non-interactive mode.
+git add feature3.txt
+gs bc -m 'Add feature3' feature3
+gs bs --fill
+shamhub reject alice/example 3
+gs repo sync --no-prompt
+stderr 'feature1: #1 was closed but not merged, ignoring'
+stderr 'feature3: #3 was closed but not merged, ignoring'
+gs ls -a
+cmp stderr $WORK/golden/ls-second-submit.txt
+
+-- repo/feature1.txt --
+Contents of feature1
+
+-- repo/feature2.txt --
+Contents of feature2
+
+-- repo/feature3.txt --
+Contents of feature3
+
+-- golden/open.txt --
+  ┏━■ feature2 (#2) ◀
+┏━┻□ feature1 (#1)
+main
+-- golden/ls-first-submit.txt --
+  ┏━■ feature2 (#2) ◀
+┏━┻□ feature1 (#1)
+main
+-- golden/ls-second-submit.txt --
+    ┏━■ feature3 (#3) ◀
+  ┏━┻□ feature2 (#2)
+┏━┻□ feature1 (#1)
+main


### PR DESCRIPTION
Introduces a 'spice.repoSync.closedChanges' configuration option
that allows users to opt out of the closed PR detection
added in the previous release
as some users prefer not to delete branches for closed PRs.

Resolves #793