### PR TITLE
fix(submit): capture and surface stdout on push

### DIFF
--- a/.changes/unreleased/Fixed-20250823-052118.yaml
+++ b/.changes/unreleased/Fixed-20250823-052118.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'submit: If a pre-push hook fails, surface messages printed to stdout in the error.'
+time: 2025-08-23T05:21:18.251284-07:00

--- a/internal/git/push_wt.go
+++ b/internal/git/push_wt.go
@@ -63,7 +63,8 @@ func (w *Worktree) Push(ctx context.Context, opts PushOptions) error {
 		args = append(args, opts.Refspec.String())
 	}
 
-	if err := w.gitCmd(ctx, args...).Run(w.exec); err != nil {
+	cmd := w.gitCmd(ctx, args...).CaptureStdout()
+	if err := cmd.Run(w.exec); err != nil {
 		return fmt.Errorf("push: %w", err)
 	}
 

--- a/testdata/script/issue808_stack_submit_prepush_hook_stdout_stderr.txt
+++ b/testdata/script/issue808_stack_submit_prepush_hook_stdout_stderr.txt
@@ -1,0 +1,48 @@
+# pre-push hook failure should surface messages from both stdout and stderr.
+# https://github.com/abhinav/git-spice/issues/808
+
+as 'Test User <test@example.com>'
+at 2025-08-19T12:00:00Z
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+shamhub init
+shamhub register alice
+shamhub new origin alice/example.git
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# feature1 -> feature2
+git add feature1.txt
+gs branch create feature1 -m 'Add feature 1'
+git add feature2.txt
+gs branch create feature2 -m 'Add feature 2'
+
+# Pre-push hook that prints to both stdout and stderr.
+mkdir -p .git/hooks
+cp $WORK/extra/pre-push .git/hooks/pre-push
+chmod 755 .git/hooks/pre-push
+
+! gs stack submit --fill
+
+# The error should contain both the stdout and stderr messages from the hook
+stderr 'Error from stderr: Hook validation failed'
+stderr 'Info from stdout: Running pre-push validation'
+
+-- repo/feature1.txt --
+This is feature 1
+
+-- repo/feature2.txt --
+This is feature 2
+
+-- extra/pre-push --
+#!/bin/sh
+# This hook outputs to both stdout and stderr before failing
+echo "Info from stdout: Running pre-push validation"
+echo "Error from stderr: Hook validation failed" >&2
+exit 1


### PR DESCRIPTION
If a pre-push hook fails and prints messages to stdout and stderr,
we currently only surface stderr in the error message.
This change captures stdout as well and includes it in the error.

Note that the message is surfaced only when the command fails
(except in --verbose mode which logs them both live).

There may be need for an option in the future
where users want to always surface stdout/stderr directly,
rather than logging it/capturing it for errors only.

Resolves: #808