### PR TITLE
bco/prompt: don't disable options with --detach

### DIFF
--- a/.changes/unreleased/Changed-20250823-063903.yaml
+++ b/.changes/unreleased/Changed-20250823-063903.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: >-
+  branch checkout:
+  With --detach, prompt now allows selecting any branch,
+  including those checked out in other worktrees.
+time: 2025-08-23T06:39:03.005085-07:00

--- a/branch_checkout.go
+++ b/branch_checkout.go
@@ -60,6 +60,12 @@ func (cmd *branchCheckoutCmd) AfterApply(
 
 		cmd.Branch, err = branchPrompt.Prompt(ctx, &branchPromptRequest{
 			Disabled: func(b git.LocalBranch) bool {
+				// If detaching, allow selecting any branch,
+				// including the current branch
+				// or branches checked out elsewhere.
+				if cmd.Detach {
+					return false
+				}
 				return b.Name != currentBranch && b.Worktree != ""
 			},
 			Default:     currentBranch,

--- a/testdata/script/branch_checkout_prompt_detach_worktrees.txt
+++ b/testdata/script/branch_checkout_prompt_detach_worktrees.txt
@@ -1,0 +1,50 @@
+# branch checkout --detach with prompt across worktrees.
+#
+# Verify that it's possible to checkout a branch in detached HEAD state
+# if it's already checked out in another worktree.
+#
+# https://github.com/abhinav/git-spice/issues/812
+
+as 'Test <test@example.com>'
+at '2025-08-23T14:30:00Z'
+
+# setup main repo
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# create a feature branch with some commits
+git add feat1.txt
+gs bc feat1 -m 'Add feat1 feature'
+
+# get the commit hash of feat1
+git rev-parse HEAD
+cmp stdout $WORK/golden/feat1-hash.txt
+
+# create a second worktree
+git worktree add ../wt main
+
+# Attempt to checkout feat1 in detached HEAD state
+# from the other worktree.
+cd ../wt
+env ROBOT_INPUT=$WORK/robot.golden ROBOT_OUTPUT=$WORK/robot.actual
+gs branch checkout --detach
+cmp $WORK/robot.actual $WORK/robot.golden
+
+# verify both worktrees are on the same commit hash
+git rev-parse HEAD
+cmp stdout $WORK/golden/feat1-hash.txt
+
+-- repo/feat1.txt --
+feature content
+
+-- golden/feat1-hash.txt --
+121498bab12f8ac31e38043ac0b475ccfdcf7769
+-- robot.golden --
+===
+> Select a branch to checkout: 
+> ┏━□ feat1
+> main ◀
+"feat1"


### PR DESCRIPTION
If `gs bco --detach` is invoked with a prompt,
allow selecting branches that are checked out in other worktrees
as well as the current branch.

Resolves #812.