### PR TITLE
fix(resack): don't switch branches if nothing restacked

### DIFF
--- a/.changes/unreleased/Fixed-20250823-064300.yaml
+++ b/.changes/unreleased/Fixed-20250823-064300.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: >-
+  restack:
+  Fix issue where restack opreations would leave the target branch
+  checked out instead of the previously checked out branch,
+  even when no restack operations were performed.
+time: 2025-08-23T06:43:00.323065-07:00

--- a/internal/handler/restack/branch_test.go
+++ b/internal/handler/restack/branch_test.go
@@ -139,9 +139,6 @@ func TestHandler_RestackBranch(t *testing.T) {
 		mockWorktree.EXPECT().
 			RootDir().
 			Return(t.TempDir())
-		mockWorktree.EXPECT().
-			Checkout(gomock.Any(), "already-restacked").
-			Return(nil)
 
 		handler := &Handler{
 			Log:      log,

--- a/internal/handler/restack/handler.go
+++ b/internal/handler/restack/handler.go
@@ -227,7 +227,7 @@ loop:
 
 	if requestBranchWT != "" && requestBranchWT != currentWT {
 		h.Log.Warnf("%v: checked out in another worktree (%v), not checking out here", req.Branch, requestBranchWT)
-	} else {
+	} else if restackCount > 0 {
 		if err := h.Worktree.Checkout(ctx, req.Branch); err != nil {
 			return 0, fmt.Errorf("checkout branch %v: %w", req.Branch, err)
 		}

--- a/internal/handler/restack/handler_test.go
+++ b/internal/handler/restack/handler_test.go
@@ -538,9 +538,6 @@ func TestHandler_Restack_trunk(t *testing.T) {
 		mockWorktree.EXPECT().
 			RootDir().
 			Return(t.TempDir())
-		mockWorktree.EXPECT().
-			Checkout(gomock.Any(), "main").
-			Return(nil)
 
 		handler := &Handler{
 			Log:      log,

--- a/testdata/script/issue803_repo_restack_stay_on_current_branch.txt
+++ b/testdata/script/issue803_repo_restack_stay_on_current_branch.txt
@@ -1,0 +1,39 @@
+# Test that restack stays on current branch when nothing needs restacking
+
+as 'Test User <test@example.com>'
+at 2025-08-23T21:28:29Z
+
+cd repo
+git init
+git commit -m 'Initial commit' --allow-empty
+
+gs repo init
+
+# Create some branches that are already properly stacked
+git add feat1.txt
+gs branch create feat1 -m 'feat1 commit'
+
+git add feat2.txt
+gs branch create feat2 -m 'feat2 commit'
+
+# restack from feat2 should remain on feat2.
+gs repo restack
+git branch --show-current
+stdout 'feat2'
+
+# upstack restack of feat1 from feat2 should remain on feat2.
+gs upstack restack --branch feat1
+git branch --show-current
+stdout 'feat2'
+
+# Test:
+# restack from untracked branch should remain on untracked branch.
+git checkout -b untracked-branch
+gs repo restack
+git branch --show-current
+stdout 'untracked-branch'
+
+-- repo/feat1.txt --
+feature 1
+-- repo/feat2.txt --
+feature 2


### PR DESCRIPTION
While the original issue was about 'repo restack',
this was a larger problem with restack in general.
We always switched to the target branch if it was not checked out,
but that's not really necessary if nothing was restacked.

Resolves #803