### PR TITLE
release/homebrew: Publish Cask instead of Formula

### DIFF
--- a/.changes/unreleased/Changed-20250824-204137.yaml
+++ b/.changes/unreleased/Changed-20250824-204137.yaml
@@ -1,0 +1,8 @@
+kind: Changed
+body: >-
+  Homebrew Tap now publishes the package as a Cask.
+  If you previously installed with 'brew install abhinav/tap/git-spice`,
+  switch to the cask with `brew install --cask abhinav/tap/git-spice`.
+  You can ignore this if you installed from homebrew-core
+  (`brew install git-spice`).
+time: 2025-08-24T20:41:37.103982-07:00

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,7 +55,7 @@ aurs:
       name: Abhinav Gupta
       email: mail@abhinavg.net
 
-brews:
+homebrew_casks:
   - repository:
       owner: abhinav
       name: homebrew-tap
@@ -68,11 +68,16 @@ brews:
     description: "A tool for stacking Git branches."
     license: "GPL-3.0-or-later"
     skip_upload: auto
-    install: |
-      bin.install "gs"
-      generate_completions_from_executable(bin/"gs", "shell", "completion")
-    test: |
-      system "#{bin}/gs --version"
+    conflicts:
+      - formula: git-spice
+      - formula: ghostscript
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/gs"]
+          end
+
 
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
goreleaser is phasing out formula support in favor of Casks.
Switch to Cask for Homebrew Tap releases.

Ref: https://goreleaser.com/deprecations/#brews

Per docs, should add the following manually to the old formula:

```
disable! date: "2025-11-08", because: "was migrated to a cask", replacement_cask: "abhinav/tap/git-spice"
```