### PR TITLE
all: WaitGroup.{Add+Done} => WaitGroup.Go

### DIFF
--- a/internal/forge/github/label.go
+++ b/internal/forge/github/label.go
@@ -65,9 +65,7 @@ func (r *Repository) ensureLabels(ctx context.Context, labelNames []string) ([]g
 	// One query instead of many.
 	labelIDs := make([]githubv4.ID, len(labelNames)) // pre-allocate to fill without locking
 	for range runtime.GOMAXPROCS(0) {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 
 			for idx := range idxc {
 				labelName := labelNames[idx]
@@ -83,7 +81,7 @@ func (r *Repository) ensureLabels(ctx context.Context, labelNames []string) ([]g
 				r.log.Debug("Resolved label ID", "name", labelName, "id", labelID)
 				labelIDs[idx] = labelID
 			}
-		}()
+		})
 	}
 
 	for idx := range labelNames {

--- a/internal/forge/github/label.go
+++ b/internal/forge/github/label.go
@@ -66,7 +66,6 @@ func (r *Repository) ensureLabels(ctx context.Context, labelNames []string) ([]g
 	labelIDs := make([]githubv4.ID, len(labelNames)) // pre-allocate to fill without locking
 	for range runtime.GOMAXPROCS(0) {
 		wg.Go(func() {
-
 			for idx := range idxc {
 				labelName := labelNames[idx]
 

--- a/internal/git/remote_test.go
+++ b/internal/git/remote_test.go
@@ -25,7 +25,6 @@ func TestRepositoryListRemoteRefs(t *testing.T) {
 		Start(gomock.Any()).
 		Do(func(cmd *exec.Cmd) error {
 			wg.Go(func() {
-
 				_, _ = io.WriteString(cmd.Stdout, "abc123\trefs/heads/main\n")
 				_, _ = io.WriteString(cmd.Stdout, "malformed entry is ignored\n")
 				_, _ = io.WriteString(cmd.Stdout, "def456\trefs/heads/feature\n")
@@ -69,7 +68,6 @@ func TestRepositoryListRemoteRefsOptions(t *testing.T) {
 			}, cmd.Args[1:])
 
 			wg.Go(func() {
-
 				_, _ = io.WriteString(cmd.Stdout, "abc123\trefs/heads/feat1\n")
 				_, _ = io.WriteString(cmd.Stdout, "def456\trefs/heads/feat2\n")
 				_, _ = io.WriteString(cmd.Stdout, "ghi789\trefs/heads/feat3\n")

--- a/internal/git/remote_test.go
+++ b/internal/git/remote_test.go
@@ -24,15 +24,13 @@ func TestRepositoryListRemoteRefs(t *testing.T) {
 	mockExecer.EXPECT().
 		Start(gomock.Any()).
 		Do(func(cmd *exec.Cmd) error {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 
 				_, _ = io.WriteString(cmd.Stdout, "abc123\trefs/heads/main\n")
 				_, _ = io.WriteString(cmd.Stdout, "malformed entry is ignored\n")
 				_, _ = io.WriteString(cmd.Stdout, "def456\trefs/heads/feature\n")
 				assert.NoError(t, cmd.Stdout.(io.Closer).Close())
-			}()
+			})
 			return nil
 		})
 	mockExecer.EXPECT().
@@ -70,15 +68,13 @@ func TestRepositoryListRemoteRefsOptions(t *testing.T) {
 				"--heads", "origin", "refs/heads/feat*",
 			}, cmd.Args[1:])
 
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 
 				_, _ = io.WriteString(cmd.Stdout, "abc123\trefs/heads/feat1\n")
 				_, _ = io.WriteString(cmd.Stdout, "def456\trefs/heads/feat2\n")
 				_, _ = io.WriteString(cmd.Stdout, "ghi789\trefs/heads/feat3\n")
 				assert.NoError(t, cmd.Stdout.(io.Closer).Close())
-			}()
+			})
 			return nil
 		})
 	mockExecer.EXPECT().

--- a/internal/handler/submit/nav_comment.go
+++ b/internal/handler/submit/nav_comment.go
@@ -263,7 +263,6 @@ func updateNavigationComments(
 	)
 	for range min(runtime.GOMAXPROCS(0), len(branchesToSync)) {
 		wg.Go(func() {
-
 			postc := postc
 			updatec := updatec
 			for postc != nil || updatec != nil {

--- a/internal/handler/submit/nav_comment.go
+++ b/internal/handler/submit/nav_comment.go
@@ -262,9 +262,7 @@ func updateNavigationComments(
 		upserted []string
 	)
 	for range min(runtime.GOMAXPROCS(0), len(branchesToSync)) {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 
 			postc := postc
 			updatec := updatec
@@ -327,7 +325,7 @@ func updateNavigationComments(
 					}
 				}
 			}
-		}()
+		})
 	}
 
 	// Concurrently post and update comments.

--- a/internal/handler/sync/handler.go
+++ b/internal/handler/sync/handler.go
@@ -478,7 +478,6 @@ func (h *Handler) findForgeFinishedBranches(
 	var wg sync.WaitGroup
 	if len(submittedBranches) > 0 {
 		wg.Go(func() {
-
 			changeIDs := make([]forge.ChangeID, len(submittedBranches))
 			for i, b := range submittedBranches {
 				changeIDs[i] = b.Change
@@ -500,7 +499,6 @@ func (h *Handler) findForgeFinishedBranches(
 		trackedch := make(chan *trackedBranch)
 		for range min(runtime.GOMAXPROCS(0), len(trackedBranches)) {
 			wg.Go(func() {
-
 				for b := range trackedch {
 					changes, err := h.RemoteRepository.FindChangesByBranch(ctx, b.Name, forge.FindChangesOptions{
 						Limit: 3,

--- a/internal/handler/sync/handler.go
+++ b/internal/handler/sync/handler.go
@@ -477,9 +477,7 @@ func (h *Handler) findForgeFinishedBranches(
 
 	var wg sync.WaitGroup
 	if len(submittedBranches) > 0 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 
 			changeIDs := make([]forge.ChangeID, len(submittedBranches))
 			for i, b := range submittedBranches {
@@ -495,15 +493,13 @@ func (h *Handler) findForgeFinishedBranches(
 			for i, state := range states {
 				submittedBranches[i].State = state
 			}
-		}()
+		})
 	}
 
 	if len(trackedBranches) > 0 {
 		trackedch := make(chan *trackedBranch)
 		for range min(runtime.GOMAXPROCS(0), len(trackedBranches)) {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 
 				for b := range trackedch {
 					changes, err := h.RemoteRepository.FindChangesByBranch(ctx, b.Name, forge.FindChangesOptions{
@@ -533,7 +529,7 @@ func (h *Handler) findForgeFinishedBranches(
 					}
 
 				}
-			}()
+			})
 		}
 
 		for _, b := range trackedBranches {

--- a/internal/spice/branch.go
+++ b/internal/spice/branch.go
@@ -430,9 +430,7 @@ func (s *Service) LoadBranches(ctx context.Context) ([]LoadBranchItem, error) {
 	)
 	namec := make(chan string)
 	for range runtime.GOMAXPROCS(0) {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 
 			for name := range namec {
 				resp, err := s.LookupBranch(ctx, name)
@@ -462,7 +460,7 @@ func (s *Service) LoadBranches(ctx context.Context) ([]LoadBranchItem, error) {
 				})
 				mu.Unlock()
 			}
-		}()
+		})
 	}
 
 	for name, err := range s.store.ListBranches(ctx) {

--- a/internal/spice/branch.go
+++ b/internal/spice/branch.go
@@ -431,7 +431,6 @@ func (s *Service) LoadBranches(ctx context.Context) ([]LoadBranchItem, error) {
 	namec := make(chan string)
 	for range runtime.GOMAXPROCS(0) {
 		wg.Go(func() {
-
 			for name := range namec {
 				resp, err := s.LookupBranch(ctx, name)
 				if err != nil {

--- a/log.go
+++ b/log.go
@@ -174,7 +174,6 @@ func (cmd *branchLogCmd) run(
 	var wg sync.WaitGroup
 	for range runtime.GOMAXPROCS(0) {
 		wg.Go(func() {
-
 			for entry := range entryc {
 				branch := entry.Branch
 				info := &branchInfo{

--- a/log.go
+++ b/log.go
@@ -173,9 +173,7 @@ func (cmd *branchLogCmd) run(
 	entryc := make(chan branchLogEntry)
 	var wg sync.WaitGroup
 	for range runtime.GOMAXPROCS(0) {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 
 			for entry := range entryc {
 				branch := entry.Branch
@@ -243,7 +241,7 @@ func (cmd *branchLogCmd) run(
 				infoIdxByName[branch.Name] = info.Index
 				infoMu.Unlock()
 			}
-		}()
+		})
 	}
 
 	for index, branch := range iterutil.Enumerate(branchGraph.All()) {


### PR DESCRIPTION
Switch to the new WaitGroup.Go method added in Go 1.25.

[skip changelog]: no user facing changes