### PR TITLE
refac(log): extract into handler

### DIFF
--- a/.changes/unreleased/Fixed-20250830-143837.yaml
+++ b/.changes/unreleased/Fixed-20250830-143837.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: >-
+  log: When used without `--all`, query only requested branches internally.
+  This was wasted work and slowed the command down in repositories
+  with many branches.
+time: 2025-08-30T14:38:37.576813-07:00

--- a/.changes/unreleased/Fixed-20250830-150221.yaml
+++ b/.changes/unreleased/Fixed-20250830-150221.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: >-
+  log: List all tracked branches
+  when run from an untracked branch or detached HEAD.
+  Previously, this behavior was undefined.
+time: 2025-08-30T15:02:21.640757-07:00

--- a/internal/handler/list/handler.go
+++ b/internal/handler/list/handler.go
@@ -1,0 +1,327 @@
+// Package list defines handlers that list the repository state.
+package list
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"runtime"
+	"slices"
+	"strings"
+	"sync"
+
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/silog"
+	"go.abhg.dev/gs/internal/sliceutil"
+	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/state"
+)
+
+// GitRepository lists operations from git.Repository
+// that we need for the log handler.
+type GitRepository interface {
+	RemoteURL(context.Context, string) (string, error)
+	CommitAheadBehind(context.Context, string, string) (int, int, error)
+	ListCommitsDetails(context.Context, git.CommitRange) iter.Seq2[git.CommitDetail, error]
+}
+
+var _ GitRepository = (*git.Repository)(nil)
+
+// Store provides access to git-spice's state store.
+type Store interface {
+	Remote() (string, error)
+	Trunk() string
+}
+
+var _ Store = (*state.Store)(nil)
+
+// Service provides access to git-spice's higher-level operations.
+type Service interface {
+	BranchGraph(context.Context, *spice.BranchGraphOptions) (*spice.BranchGraph, error)
+	CheckRestacked(context.Context, string) (git.Hash, error)
+}
+
+var _ Service = (*spice.Service)(nil)
+
+// Handler implements the business logic for git-spice's log commands.
+type Handler struct {
+	Log        *silog.Logger   // required
+	Repository GitRepository   // required
+	Store      Store           // required
+	Service    Service         // required
+	Forges     *forge.Registry // required
+}
+
+// Options holds command line options for the log command.
+type Options struct {
+	All bool `short:"a" long:"all" config:"log.all" help:"Show all tracked branches, not just the current stack."`
+}
+
+// Include specifies what additional information to include in the response.
+type Include int
+
+const (
+	// IncludeMinimal includes only basic branch information.
+	IncludeMinimal = 1 << iota
+
+	// IncludeCommits includes a list of commits for each branch.
+	IncludeCommits
+
+	// IncludeChangeURL includes the URL for the associated change, if any.
+	IncludeChangeURL
+
+	// IncludePushStatus includes push status information for each branch
+	// (e.g. ahead/behind counts).
+	IncludePushStatus
+)
+
+// BranchesRequest holds the parameters for the log command.
+type BranchesRequest struct {
+	// Branch is the name of the branch to start from.
+	// By default, only branches that are part of this branch's stack
+	// are included.
+	//
+	// If Options.All is set, this is ignored and all tracked branches
+	Branch string // required
+
+	Options *Options
+	Include Include
+}
+
+// BranchesResponse holds the result of the log handler.
+type BranchesResponse struct {
+	Branches []*BranchItem
+	TrunkIdx int
+}
+
+// BranchItem is a single branch in the log output.
+type BranchItem struct {
+	// Name of the branch.
+	Name string
+
+	// Base branch onto which this branch is stacked.
+	// Empty if this branch is trunk.
+	Base string
+
+	// Aboves lists branches that are stacked directly above this branch.
+	Aboves []int
+
+	Commits []git.CommitDetail // only if IncludeCommits is set
+
+	// ChangeID is the ID of the associated change, if any.
+	ChangeID   forge.ChangeID
+	ChangeURL  string      // only if IncludeChangeURL is set
+	PushStatus *PushStatus // only if IncludePushStatus is set
+
+	// NeedsRestack indicates whether this branch needs to be restacked
+	// on top of its base branch.
+	NeedsRestack bool
+}
+
+// PushStatus contains push-related information
+// if the branch has been pushed to a remote.
+type PushStatus struct {
+	// Ahead and Behind specify the number of commits
+	// that the branch is ahead or behind its remote tracking branch.
+	Ahead, Behind int
+
+	// NeedsPush indicates whether the branch has commits
+	// that need to be pushed to the remote.
+	//
+	// This will be false if Ahead and Behind are both zero.
+	NeedsPush bool
+}
+
+// ListBranches logs the branches in the repository
+// according to the request parameters.
+func (h *Handler) ListBranches(ctx context.Context, req *BranchesRequest) (*BranchesResponse, error) {
+	req.Options = cmp.Or(req.Options, &Options{})
+	log := h.Log
+
+	branchGraph, err := h.Service.BranchGraph(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("load branch graph: %w", err)
+	}
+
+	getRemote := sync.OnceValue(func() string {
+		remote, err := h.Store.Remote()
+		if err != nil {
+			return ""
+		}
+		return remote
+	})
+
+	var repoID forge.RepositoryID
+	if req.Include&IncludeChangeURL != 0 {
+		err := func() error {
+			remote := getRemote()
+
+			remoteURL, err := h.Repository.RemoteURL(ctx, remote)
+			if err != nil {
+				return fmt.Errorf("get remote URL: %w", err)
+			}
+
+			var ok bool
+			_, repoID, ok = forge.MatchRemoteURL(h.Forges, remoteURL)
+			if !ok {
+				return fmt.Errorf("no forge matches remote URL %q", remoteURL)
+			}
+
+			return nil
+		}()
+		if err != nil {
+			log.Warn("Could not find information about the remote", "error", err)
+		}
+	}
+
+	// changeURL queries the forge for the URL of a change request.
+	changeURL := func(changeID forge.ChangeID) string {
+		if repoID == nil {
+			// No forge to query against. Just return the change ID.
+			return changeID.String()
+		}
+
+		return repoID.ChangeURL(changeID)
+	}
+
+	var itemsMu sync.Mutex
+	items := make([]*BranchItem, 0, branchGraph.Count()+1)   // +1 for trunk
+	itemByName := make(map[string]*BranchItem, len(items)+1) // name -> item
+
+	type branchLogEntry struct {
+		Name string
+	}
+
+	entryc := make(chan branchLogEntry)
+	var wg sync.WaitGroup
+	for range runtime.GOMAXPROCS(0) {
+		wg.Go(func() {
+			for entry := range entryc {
+				if entry.Name == branchGraph.Trunk() {
+					// Trunk is added at the end manually.
+					continue
+				}
+
+				branch, ok := branchGraph.Lookup(entry.Name)
+				if !ok {
+					log.Warn("Branch disappeared from graph. Skipping.", "branch", entry.Name)
+					continue
+				}
+
+				item := &BranchItem{
+					Name: branch.Name,
+				}
+
+				// NB:
+				// DO NOT 'continue' from this loop
+				// as that will leave unfilled entries in infos,
+				// which will panic down below when consuming
+				// the result.
+
+				// Check restack status /before/ looking up
+				// the branch in git because VerifyRestacked
+				// might update the branch's base hash
+				// if the branch was manually restacked.
+				//
+				// TODO: This is a hack.
+				// The isn't a good abstraction.
+				baseHash, err := h.Service.CheckRestacked(ctx, branch.Name)
+				if err != nil {
+					var needsRestack *spice.BranchNeedsRestackError
+					if errors.As(err, &needsRestack) {
+						// if the branch needs to be restacked,
+						// use the base hash stored in state
+						// so that the log doesn't show duplicated commits.
+						item.NeedsRestack = true
+						baseHash = branch.BaseHash
+					} else {
+						baseHash = git.ZeroHash
+					}
+				}
+
+				item.Base = branch.Base
+
+				if branch.Change != nil {
+					item.ChangeID = branch.Change.ChangeID()
+					if req.Include&IncludeChangeURL != 0 {
+						item.ChangeURL = changeURL(item.ChangeID)
+					}
+				}
+
+				if req.Include&IncludePushStatus != 0 && branch.UpstreamBranch != "" {
+					upstream := getRemote() + "/" + branch.UpstreamBranch
+					ahead, behind, err := h.Repository.CommitAheadBehind(ctx, upstream, string(branch.Head))
+					if err == nil {
+						item.PushStatus = &PushStatus{
+							Ahead:     ahead,
+							Behind:    behind,
+							NeedsPush: ahead > 0 || behind > 0,
+						}
+					}
+				}
+
+				if req.Include&IncludeCommits != 0 && baseHash != git.ZeroHash {
+					commits, err := sliceutil.CollectErr(h.Repository.ListCommitsDetails(ctx,
+						git.CommitRangeFrom(branch.Head).
+							ExcludeFrom(baseHash).
+							FirstParent()))
+					if err != nil {
+						log.Warn("Could not list commits for branch. Skipping.", "branch", branch.Name, "error", err)
+					} else {
+						item.Commits = commits
+					}
+				}
+
+				itemsMu.Lock()
+				items = append(items, item)
+				itemByName[branch.Name] = item
+				itemsMu.Unlock()
+			}
+		})
+	}
+
+	var branchesToLog iter.Seq[string]
+	if req.Options.All {
+		branchesToLog = branchGraph.Names()
+	} else {
+		branchesToLog = branchGraph.Stack(req.Branch)
+	}
+	for branch := range branchesToLog {
+		entryc <- branchLogEntry{Name: branch}
+	}
+	close(entryc)
+	wg.Wait()
+
+	// Add trunk.
+	trunkItem := &BranchItem{Name: h.Store.Trunk()}
+	items = append(items, trunkItem)
+	itemByName[trunkItem.Name] = trunkItem
+
+	slices.SortFunc(items, func(a, b *BranchItem) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	// Connect the Above relationships.
+	var trunkIdx int
+	for idx, item := range items {
+		if item.Name == branchGraph.Trunk() {
+			trunkIdx = idx
+			continue
+		}
+
+		baseItem, ok := itemByName[item.Base]
+		if !ok {
+			continue
+		}
+
+		baseItem.Aboves = append(baseItem.Aboves, idx)
+	}
+
+	return &BranchesResponse{
+		TrunkIdx: trunkIdx,
+		Branches: items,
+	}, nil
+}

--- a/internal/handler/list/handler.go
+++ b/internal/handler/list/handler.go
@@ -287,7 +287,13 @@ func (h *Handler) ListBranches(ctx context.Context, req *BranchesRequest) (*Bran
 	if req.Options.All {
 		branchesToLog = branchGraph.Names()
 	} else {
-		branchesToLog = branchGraph.Stack(req.Branch)
+		// If req.Branch is not tracked,
+		// we still want to list all branches.
+		if _, ok := branchGraph.Lookup(req.Branch); !ok {
+			branchesToLog = branchGraph.Names()
+		} else {
+			branchesToLog = branchGraph.Stack(req.Branch)
+		}
 	}
 	for branch := range branchesToLog {
 		entryc <- branchLogEntry{Name: branch}

--- a/internal/spice/branch_graph.go
+++ b/internal/spice/branch_graph.go
@@ -95,6 +95,17 @@ func (g *BranchGraph) All() iter.Seq[LoadBranchItem] {
 	return slices.Values(g.branches)
 }
 
+// Names returns an iterator over the names of all branches in the graph.
+func (g *BranchGraph) Names() iter.Seq[string] {
+	return func(yield func(string) bool) {
+		for _, branch := range g.branches {
+			if !yield(branch.Name) {
+				return
+			}
+		}
+	}
+}
+
 // Count reports the total number of tracked branches in the graph.
 // The count DOES NOT include trunk.
 func (g *BranchGraph) Count() int {

--- a/log.go
+++ b/log.go
@@ -1,22 +1,20 @@
 package main
 
 import (
+	"cmp"
 	"context"
 	"encoding"
-	"errors"
 	"fmt"
 	"os"
-	"runtime"
 	"strings"
-	"sync"
 
+	"github.com/alecthomas/kong"
 	"github.com/charmbracelet/lipgloss"
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/iterutil"
+	"go.abhg.dev/gs/internal/handler/list"
 	"go.abhg.dev/gs/internal/must"
 	"go.abhg.dev/gs/internal/silog"
-	"go.abhg.dev/gs/internal/sliceutil"
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/ui"
@@ -27,6 +25,24 @@ import (
 type logCmd struct {
 	Short logShortCmd `cmd:"" aliases:"s" help:"List branches"`
 	Long  logLongCmd  `cmd:"" aliases:"l" help:"List branches and commits"`
+}
+
+func (*logCmd) AfterApply(kctx *kong.Context) error {
+	return kctx.BindToProvider(func(
+		log *silog.Logger,
+		repo *git.Repository,
+		store *state.Store,
+		svc *spice.Service,
+		forges *forge.Registry,
+	) (ListHandler, error) {
+		return &list.Handler{
+			Log:        log,
+			Repository: repo,
+			Store:      store,
+			Service:    svc,
+			Forges:     forges,
+		}, nil
+	})
 }
 
 var (
@@ -56,9 +72,13 @@ var (
 			SetString("◀")
 )
 
+type ListHandler interface {
+	ListBranches(context.Context, *list.BranchesRequest) (*list.BranchesResponse, error)
+}
+
 // branchLogCmd is the shared implementation of logShortCmd and logLongCmd.
 type branchLogCmd struct {
-	All bool `short:"a" long:"all" config:"log.all" help:"Show all tracked branches, not just the current stack."`
+	list.Options
 
 	ChangeFormat      string  `config:"log.crFormat" hidden:"" default:"id" enum:"id,url"`
 	ChangeFormatShort *string `config:"logShort.crFormat" hidden:"" enum:"id,url"`
@@ -69,37 +89,25 @@ type branchLogCmd struct {
 
 type branchLogOptions struct {
 	Commits bool
-
-	Log *silog.Logger
 }
 
 func (cmd *branchLogCmd) run(
 	ctx context.Context,
 	opts *branchLogOptions,
-	repo *git.Repository,
 	wt *git.Worktree,
-	store *state.Store,
-	svc *spice.Service,
-	forges *forge.Registry,
+	listHandler ListHandler,
 ) (err error) {
-	log := opts.Log
+	opts = cmp.Or(opts, &branchLogOptions{})
+
 	currentBranch, err := wt.CurrentBranch(ctx)
 	if err != nil {
 		currentBranch = "" // may be detached
 	}
 
-	branchGraph, err := svc.BranchGraph(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("load branch graph: %w", err)
+	req := list.BranchesRequest{
+		Branch:  currentBranch,
+		Options: &cmd.Options,
 	}
-
-	getRemote := sync.OnceValue(func() string {
-		remote, err := store.Remote()
-		if err != nil {
-			return ""
-		}
-		return remote
-	})
 
 	// Determine which ChangeFormat to use: prefer long/short-specific, then fallback to general.
 	changeFormat := cmd.ChangeFormat
@@ -108,188 +116,23 @@ func (cmd *branchLogCmd) run(
 	} else if !opts.Commits && cmd.ChangeFormatShort != nil {
 		changeFormat = *cmd.ChangeFormatShort
 	}
-
-	var repoID forge.RepositoryID
 	if changeFormat == "url" {
-		err := func() error {
-			remote := getRemote()
-
-			remoteURL, err := repo.RemoteURL(ctx, remote)
-			if err != nil {
-				return fmt.Errorf("get remote URL: %w", err)
-			}
-
-			var ok bool
-			_, repoID, ok = forge.MatchRemoteURL(forges, remoteURL)
-			if !ok {
-				return fmt.Errorf("no forge matches remote URL %q", remoteURL)
-			}
-
-			return nil
-		}()
-		if err != nil {
-			log.Warn("Could not find information about the remote", "error", err)
-		}
+		req.Include |= list.IncludeChangeURL
+	}
+	if opts.Commits {
+		req.Include |= list.IncludeCommits
+	}
+	if cmd.PushStatusFormat.Enabled() {
+		req.Include |= list.IncludePushStatus
 	}
 
-	// changeURL queries the forge for the URL of a change request.
-	changeURL := func(changeID forge.ChangeID) string {
-		if repoID == nil {
-			// No forge to query against. Just return the change ID.
-			return changeID.String()
-		}
-
-		return repoID.ChangeURL(changeID)
+	res, err := listHandler.ListBranches(ctx, &req)
+	if err != nil {
+		return fmt.Errorf("log branches: %w", err)
 	}
 
-	type branchInfo struct {
-		Index    int // index in infos
-		Name     string
-		Base     string
-		ChangeID forge.ChangeID
-
-		// Number of commits ahead of the base and behind the head.
-		Ahead, Behind int
-
-		// Whether the branch needs to be pushed to its upstream.
-		NeedsPush bool
-
-		// Whether the branch needs to be restacked.
-		NeedsRestack bool
-
-		Commits []git.CommitDetail
-		Aboves  []int
-	}
-
-	var infoMu sync.Mutex
-	infos := make([]*branchInfo, branchGraph.Count()+1)        // +1 for trunk
-	infoIdxByName := make(map[string]int, branchGraph.Count()) // branch name => index in infos
-
-	type branchLogEntry struct {
-		Branch spice.BranchGraphItem
-		Index  int // index in infos to target
-	}
-
-	entryc := make(chan branchLogEntry)
-	var wg sync.WaitGroup
-	for range runtime.GOMAXPROCS(0) {
-		wg.Go(func() {
-			for entry := range entryc {
-				branch := entry.Branch
-				info := &branchInfo{
-					Name: branch.Name,
-				}
-
-				// NB:
-				// DO NOT 'continue' from this loop
-				// as that will leave unfilled entries in infos,
-				// which will panic down below when consuming
-				// the result.
-
-				// Check restack status /before/ looking up
-				// the branch in git because VerifyRestacked
-				// might update the branch's base hash
-				// if the branch was manually restacked.
-				//
-				// TODO: This is a hack.
-				// The isn't a good abstraction.
-				baseHash, err := svc.CheckRestacked(ctx, branch.Name)
-				if err != nil {
-					var needsRestack *spice.BranchNeedsRestackError
-					if errors.As(err, &needsRestack) {
-						// if the branch needs to be restacked,
-						// use the base hash stored in state
-						// so that the log doesn't show duplicated commits.
-						info.NeedsRestack = true
-						baseHash = branch.BaseHash
-					} else {
-						baseHash = git.ZeroHash
-					}
-				}
-
-				info.Base = branch.Base
-				if branch.Change != nil {
-					info.ChangeID = branch.Change.ChangeID()
-				}
-
-				if cmd.PushStatusFormat.Enabled() && branch.UpstreamBranch != "" {
-					upstream := getRemote() + "/" + branch.UpstreamBranch
-					ahead, behind, err := repo.CommitAheadBehind(ctx, upstream, string(branch.Head))
-					if err == nil {
-						info.Ahead = ahead
-						info.Behind = behind
-						info.NeedsPush = ahead > 0 || behind > 0
-					}
-				}
-
-				if opts.Commits && baseHash != git.ZeroHash {
-					commits, err := sliceutil.CollectErr(repo.ListCommitsDetails(ctx,
-						git.CommitRangeFrom(branch.Head).
-							ExcludeFrom(baseHash).
-							FirstParent()))
-					if err != nil {
-						log.Warn("Could not list commits for branch. Skipping.", "branch", branch.Name, "error", err)
-					} else {
-						info.Commits = commits
-					}
-				}
-
-				infoMu.Lock()
-				info.Index = entry.Index
-				infos[entry.Index] = info
-				infoIdxByName[branch.Name] = info.Index
-				infoMu.Unlock()
-			}
-		})
-	}
-
-	for index, branch := range iterutil.Enumerate(branchGraph.All()) {
-		entryc <- branchLogEntry{
-			Index:  index,
-			Branch: branch,
-		}
-	}
-	close(entryc)
-	wg.Wait()
-
-	trunkIdx := len(infos) - 1
-	infos[trunkIdx] = &branchInfo{
-		Index: trunkIdx,
-		Name:  store.Trunk(),
-	}
-	infoIdxByName[store.Trunk()] = trunkIdx
-
-	// Second pass: Connect the "aboves".
-	for idx, branch := range infos {
-		if branch.Base == "" {
-			continue
-		}
-
-		baseIdx, ok := infoIdxByName[branch.Base]
-		if !ok {
-			continue
-		}
-
-		infos[baseIdx].Aboves = append(infos[baseIdx].Aboves, idx)
-	}
-
-	isVisible := func(*branchInfo) bool { return true }
-	if !cmd.All && currentBranch != "" {
-		visible := make(map[string]struct{})
-
-		// Add the upstack and downstacks of the current branch to the visible set.
-		for branch := range branchGraph.Stack(currentBranch) {
-			visible[branch] = struct{}{}
-		}
-
-		isVisible = func(info *branchInfo) bool {
-			_, ok := visible[info.Name]
-			return ok
-		}
-	}
-
-	treeStyle := fliptree.DefaultStyle[*branchInfo]()
-	treeStyle.NodeMarker = func(b *branchInfo) lipgloss.Style {
+	treeStyle := fliptree.DefaultStyle[*list.BranchItem]()
+	treeStyle.NodeMarker = func(b *list.BranchItem) lipgloss.Style {
 		if b.Name == currentBranch {
 			return fliptree.DefaultNodeMarker.SetString("■")
 		}
@@ -297,10 +140,10 @@ func (cmd *branchLogCmd) run(
 	}
 
 	var s strings.Builder
-	err = fliptree.Write(&s, fliptree.Graph[*branchInfo]{
-		Roots:  []int{trunkIdx},
-		Values: infos,
-		View: func(b *branchInfo) string {
+	err = fliptree.Write(&s, fliptree.Graph[*list.BranchItem]{
+		Roots:  []int{res.TrunkIdx},
+		Values: res.Branches,
+		View: func(b *list.BranchItem) string {
 			var o strings.Builder
 			if b.Name == currentBranch {
 				o.WriteString(_currentBranchStyle.Render(b.Name))
@@ -313,7 +156,7 @@ func (cmd *branchLogCmd) run(
 				case "id", "":
 					_, _ = fmt.Fprintf(&o, " (%v)", cid)
 				case "url":
-					_, _ = fmt.Fprintf(&o, " (%s)", changeURL(cid))
+					_, _ = fmt.Fprintf(&o, " (%s)", b.ChangeURL)
 				default:
 					must.Failf("unknown change format: %v", cmd.ChangeFormat)
 				}
@@ -323,7 +166,9 @@ func (cmd *branchLogCmd) run(
 				o.WriteString(_needsRestackStyle.String())
 			}
 
-			cmd.PushStatusFormat.FormatTo(&o, b.Ahead, b.Behind, b.NeedsPush)
+			if s := b.PushStatus; s != nil {
+				cmd.PushStatusFormat.FormatTo(&o, s.Ahead, s.Behind, s.NeedsPush)
+			}
 
 			if b.Name == currentBranch {
 				o.WriteString(" " + _markerStyle.String())
@@ -345,16 +190,10 @@ func (cmd *branchLogCmd) run(
 
 			return o.String()
 		},
-		Edges: func(bi *branchInfo) []int {
-			aboves := make([]int, 0, len(bi.Aboves))
-			for _, above := range bi.Aboves {
-				if isVisible(infos[above]) {
-					aboves = append(aboves, above)
-				}
-			}
-			return aboves
+		Edges: func(bi *list.BranchItem) []int {
+			return bi.Aboves
 		},
-	}, fliptree.Options[*branchInfo]{Style: treeStyle})
+	}, fliptree.Options[*list.BranchItem]{Style: treeStyle})
 	if err != nil {
 		return fmt.Errorf("write tree: %w", err)
 	}

--- a/log_long.go
+++ b/log_long.go
@@ -3,11 +3,7 @@ package main
 import (
 	"context"
 
-	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/silog"
-	"go.abhg.dev/gs/internal/spice"
-	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
 )
 
@@ -25,15 +21,10 @@ func (*logLongCmd) Help() string {
 
 func (cmd *logLongCmd) Run(
 	ctx context.Context,
-	log *silog.Logger,
-	repo *git.Repository,
 	wt *git.Worktree,
-	store *state.Store,
-	svc *spice.Service,
-	forges *forge.Registry,
+	listHandler ListHandler,
 ) (err error) {
 	return cmd.run(ctx, &branchLogOptions{
-		Log:     log,
 		Commits: true,
-	}, repo, wt, store, svc, forges)
+	}, wt, listHandler)
 }

--- a/log_short.go
+++ b/log_short.go
@@ -3,11 +3,7 @@ package main
 import (
 	"context"
 
-	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/silog"
-	"go.abhg.dev/gs/internal/spice"
-	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
 )
 
@@ -25,14 +21,8 @@ func (*logShortCmd) Help() string {
 
 func (cmd *logShortCmd) Run(
 	ctx context.Context,
-	log *silog.Logger,
-	repo *git.Repository,
 	wt *git.Worktree,
-	store *state.Store,
-	svc *spice.Service,
-	forges *forge.Registry,
+	listHandler ListHandler,
 ) (err error) {
-	return cmd.run(ctx, &branchLogOptions{
-		Log: log,
-	}, repo, wt, store, svc, forges)
+	return cmd.run(ctx, nil, wt, listHandler)
 }

--- a/testdata/script/branch_checkout_remote.txt
+++ b/testdata/script/branch_checkout_remote.txt
@@ -71,4 +71,5 @@ false
 ┏━■ feat1 ◀
 main
 -- golden/ls-feat2.txt --
+┏━□ feat1
 main

--- a/testdata/script/log_from_untracked_and_detached.txt
+++ b/testdata/script/log_from_untracked_and_detached.txt
@@ -1,0 +1,62 @@
+# Test that 'gs log long' and 'gs log short' list all tracked branches
+# when run from untracked branches and detached HEAD.
+
+as 'Test <test@example.com>'
+at '2025-08-30T10:00:00Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# Create a stack of tracked branches: feat1 -> feat2 -> feat3
+gs bc feat1 -m 'Add feature 1'
+gs bc feat2 -m 'Add feature 2'
+gs bc feat3 -m 'Add feature 3'
+
+# Go back and create another stack: feat1 -> feat4 -> feat5
+gs bco feat1
+gs bc feat4 -m 'Add feature 4'
+gs bc feat5 -m 'Add feature 5'
+
+# Create an untracked branch
+git checkout -b untracked_branch main
+git add untracked.txt
+git commit -m 'Add untracked feature'
+
+# Test from untracked branch - should show all tracked branches
+gs log short
+cmp stderr $WORK/golden/log_short.txt
+gs log long
+cmp stderr $WORK/golden/log_long.txt
+
+# Test from detached HEAD - should show all tracked branches
+git checkout --detach main
+gs log short
+cmp stderr $WORK/golden/log_short.txt
+gs log long
+cmp stderr $WORK/golden/log_long.txt
+
+-- repo/untracked.txt --
+untracked content
+
+-- golden/log_short.txt --
+    ┏━□ feat3
+  ┏━┻□ feat2
+  ┃ ┏━□ feat5
+  ┣━┻□ feat4
+┏━┻□ feat1
+main
+-- golden/log_long.txt --
+    ┏━□ feat3
+    ┃   9276838 Add feature 3 (now)
+  ┏━┻□ feat2
+  ┃    588a367 Add feature 2 (now)
+  ┃ ┏━□ feat5
+  ┃ ┃   5b70527 Add feature 5 (now)
+  ┣━┻□ feat4
+  ┃    9037034 Add feature 4 (now)
+┏━┻□ feat1
+┃    f9bce04 Add feature 1 (now)
+main


### PR DESCRIPTION
Continue the slow migration to the Handler pattern.
Move part of the log command's business logic into a handler.
This better draws the boundary for the upcoming JSON flag.

In porting the code over, I realized that the `isVisible` logic
basically meant that we were querying all branches
and then filtering them in memory at render time.

With the branch graph's new stack querying capabilities,
we're able to avoid querying branches we don't need
when `--all` is not specified.

On a test repository with a 100 branches,
if I run this from a branch that's stacked on top of main,
and has nothing else on top of it (so there won't be a lot to query):

```
❯ hyperfine --warmup 5 'gs ll' '../main/bin/gs ll'
Benchmark 1: gs ll
  Time (mean ± σ):     909.0 ms ±  18.0 ms    [User: 2786.6 ms, System: 3248.9 ms]
  Range (min … max):   896.8 ms … 957.5 ms    10 runs

Benchmark 2: ../main/bin/gs ll
  Time (mean ± σ):     347.5 ms ±   3.5 ms    [User: 951.1 ms, System: 1070.6 ms]
  Range (min … max):   343.7 ms … 351.9 ms    10 runs

Summary
  ../main/bin/gs ll ran
    2.62 ± 0.06 times faster than gs ll
```

(Performance unchanged with --all.)