### PR TITLE
git: add MergeTree method

### DIFF
--- a/internal/git/gittest/script.go
+++ b/internal/git/gittest/script.go
@@ -2,10 +2,8 @@
 package gittest
 
 import (
-	"bytes"
 	"fmt"
 	"net/mail"
-	"os/exec"
 	"time"
 
 	"github.com/rogpeppe/go-internal/testscript"
@@ -33,13 +31,9 @@ func CondGitVersion(wantStr string) (bool, error) {
 		return false, fmt.Errorf("parse wanted Git version: %w", err)
 	}
 
-	raw, err := exec.Command("git", "--version").Output()
+	got, err := CurrentVersion()
 	if err != nil {
 		return false, fmt.Errorf("get Git version: %w", err)
-	}
-	got, err := ParseVersion(string(bytes.TrimSpace(raw)))
-	if err != nil {
-		return false, fmt.Errorf("parse Git version output: %w", err)
 	}
 
 	return got.Compare(want) >= 0, nil

--- a/internal/git/gittest/version.go
+++ b/internal/git/gittest/version.go
@@ -44,17 +44,24 @@ func SkipUnlessVersionAtLeast(t testing.TB, want Version) {
 // This must be in one of the following formats:
 //
 //	git version X.Y.Z (...)
+//	git version X.Y.Z.windows.N
 //	git version X.Y.Z
 //	X.Y.Z
 //	X.Y
 //	X
 //
 // Where X, Y, and Z are integers.
+// Windows versions like "2.51.0.windows.1" are parsed as "2.51.0".
 func ParseVersion(orig string) (Version, error) {
 	s := orig
 	s = strings.TrimPrefix(s, "git version ")
 	if i := strings.Index(s, " "); i >= 0 {
 		s = s[:i] // "X.Y.Z (...)" => "X.Y.Z"
+	}
+
+	// Handle Windows versions: "2.51.0.windows.1" => "2.51.0"
+	if i := strings.Index(s, ".windows."); i >= 0 {
+		s = s[:i]
 	}
 
 	var (

--- a/internal/git/gittest/version_test.go
+++ b/internal/git/gittest/version_test.go
@@ -21,6 +21,30 @@ func TestParseVersion(t *testing.T) {
 			str:  "2.39.3",
 		},
 		{
+			name: "Windows",
+			give: "git version 2.51.0.windows.1",
+			want: Version{2, 51, 0},
+			str:  "2.51.0",
+		},
+		{
+			name: "WindowsOlder",
+			give: "git version 2.39.2.windows.1",
+			want: Version{2, 39, 2},
+			str:  "2.39.2",
+		},
+		{
+			name: "WindowsNewer",
+			give: "git version 2.60.1.windows.5",
+			want: Version{2, 60, 1},
+			str:  "2.60.1",
+		},
+		{
+			name: "WindowsJustVersion",
+			give: "2.45.2.windows.2",
+			want: Version{2, 45, 2},
+			str:  "2.45.2",
+		},
+		{
 			name: "NoCustom",
 			give: "git version 2.46.0",
 			want: Version{2, 46, 0},
@@ -60,6 +84,7 @@ func TestParseVersion(t *testing.T) {
 func FuzzParseVersion(f *testing.F) {
 	f.Add("git version 2.39.3 (Apple Git-128)")
 	f.Add("git version 2.46.0")
+	f.Add("git version 2.51.0.windows.1")
 	f.Add("2.39.3")
 	f.Add("2.39")
 	f.Add("2")

--- a/internal/git/merge_tree.go
+++ b/internal/git/merge_tree.go
@@ -1,0 +1,247 @@
+package git
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"go.abhg.dev/gs/internal/scanutil"
+)
+
+// MergeTreeRequest specifies the parameters for a merge-tree operation.
+type MergeTreeRequest struct {
+	// Branch1 is the first branch or commit to merge.
+	//
+	// This must be a commit-ish value if MergeBase is not provided.
+	// Otherwise, it can be any tree-ish value.
+	Branch1 string // required
+
+	// Branch2 is the second branch or commit to merge.
+	//
+	// This must be a commit-ish value if MergeBase is not provided.
+	// Otherwise, it can be any tree-ish value.
+	Branch2 string // required
+
+	// MergeBase optionally specifies an explicit merge base for the merge.
+	// If provided, Branch1 and Branch2 can be any tree-ish values.
+	// The difference between this and Branch1 will be applied to Branch2.
+	//
+	// Use of this parameter requires Git 2.40 or later.
+	MergeBase string
+}
+
+// MergeTreeConflictError is returned from the MergeTree operation
+// when a conflict is encountered.
+type MergeTreeConflictError struct {
+	Files   []string
+	Details []MergeTreeConflictDetails
+}
+
+func (e *MergeTreeConflictError) Error() string {
+	var msg strings.Builder
+	msg.WriteString("conflicting files: ")
+	for i, f := range e.Files {
+		if i > 0 {
+			msg.WriteString(",")
+		}
+		msg.WriteString(" ")
+		msg.WriteString(f)
+	}
+	return msg.String()
+}
+
+// MergeTree performs a merge without touching the index or working tree,
+// returning the hash of the resulting tree.
+//
+// For conflicts, this method returns a [MergeTreeConflictError]
+// that reports information about the conflicting files.
+func (r *Repository) MergeTree(ctx context.Context, req MergeTreeRequest) (_ Hash, retErr error) {
+	// TODO: support multiple requests now that we're using stdin
+	args := []string{
+		"merge-tree",
+		"--write-tree", // other mode is deprecated
+		"--stdin",      // pass input on stdin
+		"--name-only",  // only mention conflicting file names instead of stages and objects
+		"-z",
+	}
+
+	var stdin strings.Builder
+	// Input is in the form:
+	//   [<base-commit> -- ]<branch1> <branch2> NL
+	if req.MergeBase != "" {
+		_, _ = fmt.Fprintf(&stdin, "%v -- ", req.MergeBase)
+	}
+	_, _ = fmt.Fprintf(&stdin, "%v %v\n", req.Branch1, req.Branch2)
+
+	cmd := r.gitCmd(ctx, args...).StdinString(stdin.String())
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", fmt.Errorf("create stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(r.exec); err != nil {
+		return "", fmt.Errorf("start git-merge-tree: %w", err)
+	}
+
+	outputs, err := parseMergeTreeOutput(stdout)
+	if err != nil {
+		return "", fmt.Errorf("bad git-merge-tree output: %w", err)
+	}
+	if len(outputs) != 1 {
+		return "", fmt.Errorf("expected one result from git-merge-tree, got %d", len(outputs))
+	}
+
+	waitErr := cmd.Wait(r.exec) // will use below
+	if waitErr != nil {
+		waitErr = fmt.Errorf("git merge-tree: %w", err)
+	}
+
+	output := outputs[0]
+	if len(output.ConflictFiles) == 0 && len(output.ConflictMessages) == 0 {
+		return output.TreeHash, waitErr
+	}
+
+	return output.TreeHash, errors.Join(&MergeTreeConflictError{
+		Files:   output.ConflictFiles,
+		Details: output.ConflictMessages,
+	}, waitErr)
+}
+
+// mergeTreeOutput holds the output of a git-merge-tree operation
+// run with the --write-tree option (this is the non-deprecated variant).
+//
+// If a conflict was resolved with an auto-merge in Git,
+// the output will report as conflicted even though no user action is required.
+// So DO NOT assume that there's a blocking conflict without checking for
+// Auto-merge messages. Per git-merge-tree documentation:
+//
+//	Do NOT assume all filenames listed in the Informational messages section had conflicts.
+//	Messages can be included for files that have no conflicts, such as "Auto-merging <file>".
+type mergeTreeOutput struct {
+	// TreeHash is the hash of the resulting tree.
+	// There is no other output if there are no conflicts.
+	//
+	TreeHash Hash
+
+	ConflictFiles    []string
+	ConflictMessages []MergeTreeConflictDetails
+}
+
+// MergeTreeConflictDetails represents an informational message about a conflict.
+type MergeTreeConflictDetails struct {
+	// Paths is a list of files affected by this message/kind of conflict.
+	Paths []string
+
+	// Type is the type of conflict.
+	// This is a stable string like
+	// "CONFLICT (rename/delete)", "CONFLICT (binary)", etc.
+	// This may be consumed programmatically.
+	Type string // TODO: don't surface Auto-merging to users
+
+	// Message is a detailed user-readable message explaining the conflict.
+	// This string is not stable and may change between Git versions.
+	Message string
+}
+
+// parseMergeTreeOutput parses the output of a git merge-tree operation.
+func parseMergeTreeOutput(r io.Reader) (_ []*mergeTreeOutput, retErr error) {
+	scan := bufio.NewScanner(r)
+	scan.Split(scanutil.SplitNull)
+	var (
+		current *mergeTreeOutput
+		outputs []*mergeTreeOutput
+	)
+	defer func() {
+		if err := scan.Err(); err != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("scan: %w", err))
+		}
+	}()
+	for scan.Scan() && len(scan.Bytes()) > 0 {
+		// With --stdin flag, output is always preceded by
+		// a "merge status section in the form:
+		//   Merge status
+		//       This is an integer status followed by a NUL character. The integer status is:
+		//           0: merge had conflicts
+		//           1: merge was clean
+		var clean bool
+		switch tok := scan.Text(); tok {
+		case "0":
+			clean = false
+		case "1":
+			clean = true
+		default:
+			return outputs, fmt.Errorf("expected '0' or '1', got %q", tok)
+		}
+
+		// Next token is always OID of tree.
+		if !scan.Scan() {
+			return outputs, errors.New("expected OID of tree, got EOF")
+		}
+
+		current = &mergeTreeOutput{TreeHash: Hash(scan.Text())}
+		outputs = append(outputs, current)
+		if clean {
+			// If the merge was clean,
+			// no more output is expected for this merge.
+			continue
+		}
+
+		// Otherwise, we expect two more sections:
+		//   <Conflicted file info>
+		//   <Informational messages>
+		// Because we use --name-only,
+		// conflicted file info contains just the file names.
+		// Empty file name marks end of that section.
+		for scan.Scan() && len(scan.Bytes()) > 0 {
+			current.ConflictFiles = append(current.ConflictFiles, scan.Text())
+		}
+
+		// Informational messages are in the form:
+		//
+		//    <paths> <conflict-type> NUL <conflict-message> NUL
+		//
+		// Where:
+		//
+		//    paths = <N:int> NUL <path1> NUL <path2> NUL ... <pathN> NUL
+		//    conflict-type = [set of stable strings], including "Auto-merging"
+		//    conflict-message = [unstable informational strings]
+		//
+		// An empty token indicates end of conflict information.
+		for scan.Scan() && len(scan.Bytes()) > 0 {
+			numPaths, err := strconv.Atoi(scan.Text())
+			if err != nil {
+				return outputs, fmt.Errorf("expected <number-of-paths>, got %q", scan.Text())
+			}
+
+			paths := make([]string, 0, numPaths)
+			for idx := range numPaths {
+				if !scan.Scan() {
+					return outputs, fmt.Errorf("expected path #%d, got EOF", idx+1)
+				}
+				paths = append(paths, scan.Text())
+			}
+
+			if !scan.Scan() {
+				return outputs, errors.New("expected <conflict-type>, got EOF")
+			}
+			conflictType := scan.Text()
+
+			if !scan.Scan() {
+				return outputs, errors.New("expected <conflict-message>, got EOF")
+			}
+			msg := scan.Text()
+
+			current.ConflictMessages = append(current.ConflictMessages, MergeTreeConflictDetails{
+				Type:    conflictType,
+				Message: msg,
+				Paths:   paths,
+			})
+		}
+	}
+
+	return outputs, nil
+}

--- a/internal/git/merge_tree.go
+++ b/internal/git/merge_tree.go
@@ -30,8 +30,10 @@ type MergeTreeRequest struct {
 	// If provided, Branch1 and Branch2 can be any tree-ish values.
 	// The difference between this and Branch1 will be applied to Branch2.
 	//
-	// Use of this parameter requires Git 2.40 or later.
+	// Use of this parameter requires Git 2.45 or later.
 	MergeBase string
+	// NB: The parameter was added in 2.40,
+	// but support for tree-ish values was added in 2.45.
 }
 
 // MergeTreeConflictError is returned from the MergeTree operation

--- a/internal/git/merge_tree_test.go
+++ b/internal/git/merge_tree_test.go
@@ -1,0 +1,350 @@
+package git_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/git/gittest"
+	"go.abhg.dev/gs/internal/silog/silogtest"
+	"go.abhg.dev/gs/internal/text"
+)
+
+var gitMergeBaseVersion = gittest.Version{Major: 2, Minor: 40, Patch: 0}
+
+func TestRepository_MergeTree(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NoMergeBase", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+			at '2025-06-21T00:00:00Z'
+			git init
+			git add file.txt
+			git commit -m 'Initial commit'
+
+			git checkout -b branch1 main
+			git add file1.txt
+			git commit -m 'Add file1'
+
+			git checkout -b branch2 main
+			git add file2.txt
+			git commit -m 'Add file2'
+
+			-- file.txt --
+			initial content
+
+			-- file1.txt --
+			branch1 content
+
+			-- file2.txt --
+			branch2 content
+		`)))
+		require.NoError(t, err)
+		t.Cleanup(fixture.Cleanup)
+
+		repo, err := git.Open(ctx, fixture.Dir(), git.OpenOptions{
+			Log: silogtest.New(t),
+		})
+		require.NoError(t, err)
+
+		treeHash, err := repo.MergeTree(ctx, git.MergeTreeRequest{
+			Branch1: "branch1",
+			Branch2: "branch2",
+		})
+		require.NoError(t, err)
+
+		// Verify the merged tree contains files from both branches.
+		entries := make(map[string]git.Hash)
+		for entry, err := range repo.ListTree(ctx, treeHash, git.ListTreeOptions{Recurse: true}) {
+			require.NoError(t, err)
+			entries[entry.Name] = entry.Hash
+		}
+
+		var buf bytes.Buffer
+		if assert.Contains(t, entries, "file.txt") {
+			require.NoError(t, repo.ReadObject(ctx, git.BlobType, entries["file.txt"], &buf))
+			assert.Equal(t, "initial content\n\n", buf.String())
+		}
+
+		buf.Reset()
+		if assert.Contains(t, entries, "file1.txt") {
+			require.NoError(t, repo.ReadObject(ctx, git.BlobType, entries["file1.txt"], &buf))
+			assert.Equal(t, "branch1 content\n\n", buf.String())
+		}
+
+		buf.Reset()
+		if assert.Contains(t, entries, "file2.txt") {
+			require.NoError(t, repo.ReadObject(ctx, git.BlobType, entries["file2.txt"], &buf))
+			assert.Equal(t, "branch2 content\n", buf.String())
+		}
+	})
+
+	t.Run("MergeBase", func(t *testing.T) {
+		t.Parallel()
+		gittest.SkipUnlessVersionAtLeast(t, gitMergeBaseVersion)
+
+		ctx := t.Context()
+		fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+			at '2025-06-21T00:00:00Z'
+			git init
+			git add file.txt
+			git commit -m 'Initial commit'
+
+			git checkout -b branch1
+			git add file1.txt
+			git commit -m 'Add file1'
+
+			git checkout -b branch2
+			git add file2.txt
+			git commit -m 'Add file2'
+
+			-- file.txt --
+			initial content
+
+			-- file1.txt --
+			branch1 content
+
+			-- file2.txt --
+			branch2 content
+		`)))
+		require.NoError(t, err)
+		t.Cleanup(fixture.Cleanup)
+
+		repo, err := git.Open(ctx, fixture.Dir(), git.OpenOptions{
+			Log: silogtest.New(t),
+		})
+		require.NoError(t, err)
+
+		// Merge branch2 and main, using branch1 as the merge base.
+		// This should exclude changes from branch1
+		// in the resulting tree.
+		treeHash, err := repo.MergeTree(ctx, git.MergeTreeRequest{
+			Branch1:   "branch2",
+			Branch2:   "main",
+			MergeBase: "branch1",
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, treeHash)
+
+		entries := make(map[string]git.Hash)
+		for entry, err := range repo.ListTree(ctx, treeHash, git.ListTreeOptions{Recurse: true}) {
+			require.NoError(t, err)
+			entries[entry.Name] = entry.Hash
+		}
+
+		assert.NotContains(t, entries, "file1.txt",
+			"files from branch1 should not be included")
+
+		var buf bytes.Buffer
+		if assert.Contains(t, entries, "file.txt") {
+			err = repo.ReadObject(ctx, git.BlobType, entries["file.txt"], &buf)
+			require.NoError(t, err)
+			assert.Equal(t, "initial content\n\n", buf.String())
+		}
+
+		buf.Reset()
+		if assert.Contains(t, entries, "file2.txt") {
+			err = repo.ReadObject(ctx, git.BlobType, entries["file2.txt"], &buf)
+			require.NoError(t, err)
+			assert.Equal(t, "branch2 content\n", buf.String())
+		}
+	})
+
+	t.Run("Conflict", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+			at '2025-06-21T00:00:00Z'
+			git init
+			git add conflict.txt
+			git commit -m 'Initial commit'
+
+			git checkout -b branch1
+			cp $WORK/branch1.txt conflict.txt
+			git add conflict.txt
+			git commit -m 'Branch1 change'
+
+			git checkout -b branch2 main
+			cp $WORK/branch2.txt conflict.txt
+			git add conflict.txt
+			git commit -m 'Branch2 change'
+
+			-- conflict.txt --
+			initial content
+
+			-- branch1.txt --
+			branch1 content
+
+			-- branch2.txt --
+			branch2 content
+		`)))
+		require.NoError(t, err)
+		t.Cleanup(fixture.Cleanup)
+
+		repo, err := git.Open(ctx, fixture.Dir(), git.OpenOptions{
+			Log: silogtest.New(t),
+		})
+		require.NoError(t, err)
+
+		_, err = repo.MergeTree(ctx, git.MergeTreeRequest{
+			Branch1: "branch1",
+			Branch2: "branch2",
+		})
+		require.Error(t, err)
+
+		var conflictErr *git.MergeTreeConflictError
+		require.ErrorAs(t, err, &conflictErr)
+
+		assert.Equal(t, []string{"conflict.txt"}, conflictErr.Files)
+		conflictTypes := make([]string, 0, len(conflictErr.Details))
+		for _, d := range conflictErr.Details {
+			conflictTypes = append(conflictTypes, d.Type)
+		}
+		assert.Contains(t, conflictTypes, "CONFLICT (contents)")
+	})
+
+	t.Run("MergeBaseTreeIsh", func(t *testing.T) {
+		t.Parallel()
+		gittest.SkipUnlessVersionAtLeast(t, gitMergeBaseVersion)
+
+		ctx := t.Context()
+		fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+			at '2025-06-21T00:00:00Z'
+			git init
+			git add file.txt
+			git commit -m 'Initial commit'
+
+			git checkout -b branch1
+			git add file1.txt
+			git commit -m 'Add file1'
+
+			git checkout -b branch2 main
+			git add file2.txt
+			git commit -m 'Add file2'
+
+			-- file.txt --
+			initial content
+
+			-- file1.txt --
+			branch1 content
+
+			-- file2.txt --
+			branch2 content
+		`)))
+		require.NoError(t, err)
+		t.Cleanup(fixture.Cleanup)
+		repo, err := git.Open(ctx, fixture.Dir(), git.OpenOptions{
+			Log: silogtest.New(t),
+		})
+		require.NoError(t, err)
+
+		branch1Tree, err := repo.PeelToTree(ctx, "branch1")
+		require.NoError(t, err)
+		branch2Tree, err := repo.PeelToTree(ctx, "branch2")
+		require.NoError(t, err)
+
+		treeHash, err := repo.MergeTree(ctx, git.MergeTreeRequest{
+			Branch1:   branch1Tree.String(),
+			Branch2:   branch2Tree.String(),
+			MergeBase: "main",
+		})
+		require.NoError(t, err)
+
+		// Verify the merged tree contains files from both branches
+		entries := make(map[string]struct{})
+		for entry, err := range repo.ListTree(ctx, treeHash, git.ListTreeOptions{Recurse: true}) {
+			require.NoError(t, err)
+			entries[entry.Name] = struct{}{}
+		}
+
+		assert.Contains(t, entries, "file.txt")
+		assert.Contains(t, entries, "file1.txt")
+		assert.Contains(t, entries, "file2.txt")
+	})
+
+	t.Run("MergeBaseSameFile", func(t *testing.T) {
+		t.Parallel()
+		gittest.SkipUnlessVersionAtLeast(t, gitMergeBaseVersion)
+
+		ctx := t.Context()
+		fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+			at '2025-06-21T12:22:23Z'
+			git init
+			git add file.txt
+			git commit -m 'Initial commit'
+
+			git checkout -b branch1
+			mv branch1.txt file.txt
+			git add file.txt
+			git commit -m 'Branch1 change'
+
+			git checkout -b branch2
+			mv branch2.txt file.txt
+			git add file.txt
+			git commit -m 'Branch2 change'
+
+			-- file.txt --
+			file
+			spans
+			multiple
+			lines
+			-- branch1.txt --
+			file
+			spans
+			multiple
+			lines
+			and expands
+			-- branch2.txt --
+			this is a
+			file that
+			spans
+			multiple
+			lines
+			and expands
+		`)))
+		require.NoError(t, err)
+		t.Cleanup(fixture.Cleanup)
+
+		repo, err := git.Open(ctx, fixture.Dir(), git.OpenOptions{
+			Log: silogtest.New(t),
+		})
+		require.NoError(t, err)
+
+		// main -> branch1 -> branch2,
+		// where all branches modify the same file.
+		// We'll try to replay only branch2's changes on top of main.
+		treeHash, err := repo.MergeTree(ctx, git.MergeTreeRequest{
+			Branch1:   "branch2",
+			Branch2:   "main",
+			MergeBase: "branch1",
+		})
+		require.NoError(t, err)
+
+		entries := make(map[string]git.Hash)
+		for entry, err := range repo.ListTree(ctx, treeHash, git.ListTreeOptions{Recurse: true}) {
+			require.NoError(t, err)
+			entries[entry.Name] = entry.Hash
+		}
+
+		require.Contains(t, entries, "file.txt",
+			"file.txt should be present in the merged tree")
+
+		var buf bytes.Buffer
+		err = repo.ReadObject(ctx, git.BlobType, entries["file.txt"], &buf)
+		require.NoError(t, err)
+		assert.Equal(t,
+			"this is a\n"+
+				"file that\n"+
+				"spans\n"+
+				"multiple\n"+
+				"lines\n",
+			buf.String(),
+			"file.txt should contain main+branch2 changes only")
+	})
+}

--- a/internal/git/merge_tree_test.go
+++ b/internal/git/merge_tree_test.go
@@ -12,7 +12,7 @@ import (
 	"go.abhg.dev/gs/internal/text"
 )
 
-var gitMergeBaseVersion = gittest.Version{Major: 2, Minor: 40, Patch: 0}
+var gitMergeBaseVersion = gittest.Version{Major: 2, Minor: 45, Patch: 0}
 
 func TestRepository_MergeTree(t *testing.T) {
 	t.Parallel()

--- a/tools/ci/test-matrix/config.go
+++ b/tools/ci/test-matrix/config.go
@@ -3,8 +3,8 @@ package main
 var (
 	_linuxConfig = testConfig{
 		OS:           "ubuntu-latest",
-		GitVersions:  []string{"system", "2.38.0"},
-		ScriptShards: 3,
+		GitVersions:  []string{"system", "2.38.0", "2.40.0"},
+		ScriptShards: 2,
 		Race:         true,
 		Cover:        true,
 	}

--- a/tools/ci/test-matrix/config.go
+++ b/tools/ci/test-matrix/config.go
@@ -3,7 +3,7 @@ package main
 var (
 	_linuxConfig = testConfig{
 		OS:           "ubuntu-latest",
-		GitVersions:  []string{"system", "2.38.0", "2.40.0"},
+		GitVersions:  []string{"system", "2.38.0", "2.45.0"},
 		ScriptShards: 2,
 		Race:         true,
 		Cover:        true,


### PR DESCRIPTION
This adds a new method `MergeTree` to the `git.Repository` type.
This allows performing merge operations between two branches or trees
without affecting the index or working tree.

In particular, with the --merge-base option (added in Git 2.40),
this allows a differential application of a commit's changes
to another commit or tree.
This feature in particular is useful for implementing
functionality similar to the experimental `git replay` command.