### PR TITLE
rebase: use -z flag to handle special characters in file paths

### DIFF
--- a/.changes/unreleased/Fixed-20250911-094458.yaml
+++ b/.changes/unreleased/Fixed-20250911-094458.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: >-
+  Fix incorrect paths being logged
+  when autostashed changes fail to reapply
+  after a rebase operation.
+time: 2025-09-11T09:44:58.625909-07:00

--- a/internal/git/rebase_wt.go
+++ b/internal/git/rebase_wt.go
@@ -131,7 +131,7 @@ func (w *Worktree) Rebase(ctx context.Context, req RebaseRequest) (err error) {
 			w.log.Error("Dirty changes in the worktree were stashed, but could not be re-applied.")
 			w.log.Error("The following files were left unmerged:")
 			for _, file := range unmergedFiles {
-				w.log.Error("  - " + file)
+				w.log.Error("  - " + silog.MaybeQuote(file))
 			}
 			w.log.Error("Resolve the conflict and run 'git stash drop' to remove the stash entry.")
 			w.log.Error("Or change to a branch where the stash can apply, and run 'git stash pop'.")

--- a/internal/silog/escape.go
+++ b/internal/silog/escape.go
@@ -1,0 +1,39 @@
+package silog
+
+import (
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+// MaybeQuote quotes the given string and escapes special characters
+// if it would benefit from quoting.
+// Otherwise, it returns the string unchanged.
+func MaybeQuote(s string) string {
+	if needsQuoting(s) {
+		return strconv.Quote(s)
+	}
+	return s
+}
+
+// needsQuoting returns true if the string contains invisible characters
+// or characters that don't fit on the same line.
+func needsQuoting(s string) bool {
+	if s == "" {
+		return false
+	}
+
+	// Quote strings that are only whitespace (like " " or "  ")
+	if strings.TrimSpace(s) == "" {
+		return true
+	}
+
+	// Quote strings with control characters or non-printable characters
+	for _, r := range s {
+		if unicode.IsControl(r) || !unicode.IsPrint(r) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/silog/escape_test.go
+++ b/internal/silog/escape_test.go
@@ -1,0 +1,52 @@
+package silog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMaybeQuote(t *testing.T) {
+	tests := []struct {
+		give string
+		want string
+	}{
+		// Empty string should not be quoted
+		{"", ""},
+
+		// Normal strings should not be quoted
+		{"hello", "hello"},
+		{"world123", "world123"},
+		{"foo-bar_baz", "foo-bar_baz"},
+		{"unicode文字", "unicode文字"},
+		{"emoji👍", "emoji👍"},
+
+		// Whitespace-only strings should be quoted
+		{" ", `" "`},
+		{"  ", `"  "`},
+		{"\t", `"\t"`},
+		{" \t ", `" \t "`},
+
+		// Strings with control characters should be quoted
+		{"hello\nworld", `"hello\nworld"`},
+		{"tab\there", `"tab\there"`},
+		{"carriage\rreturn", `"carriage\rreturn"`},
+		{"vertical\vtab", `"vertical\vtab"`},
+		{"form\ffeed", `"form\ffeed"`},
+
+		// Mixed content with control chars should be quoted
+		{"normal text\nwith newline", `"normal text\nwith newline"`},
+		{"text with\ttab", `"text with\ttab"`},
+
+		// Normal strings with spaces should not be quoted
+		{"hello world", "hello world"},
+		{"multiple word string", "multiple word string"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.give, func(t *testing.T) {
+			got := MaybeQuote(tt.give)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
`git ls-files` will escape file paths with special characters in them.
We were only splitting on newline, which isn't good enough.

Use the -z flag, and split on null bytes instead
to obviate any escaping concerns.

Also, when logging the list of files, escape paths for readability
so if there are files literally " ", they are quoted in the log output.

Refs #849