### PR TITLE
Support experimental commands

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"maps"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/spice"
+)
+
+// List of Git configuration sections besides "spice."
+// that we read is hard-coded in spice/config.go.
+// This tests that all sections that we need are covered.
+func TestGitSectionsRequested(t *testing.T) {
+	app, err := kong.New(
+		new(mainCmd),
+		kong.Vars{"defaultPrompt": "false"},
+	)
+	require.NoError(t, err)
+
+	nodes := []*kong.Node{app.Model.Node}
+	sections := make(map[string]struct{})
+	for len(nodes) > 0 {
+		node := nodes[0]
+		nodes = append(nodes[1:], node.Children...)
+
+		for _, flag := range node.Flags {
+			key := flag.Tag.Get("config")
+			gitKey, ok := strings.CutPrefix(key, "@")
+			if !ok {
+				continue
+			}
+
+			section, _, _ := git.ConfigKey(gitKey).Split()
+			sections[section] = struct{}{}
+		}
+	}
+
+	want := slices.Sorted(maps.Keys(sections))
+	assert.ElementsMatch(t, want, spice.GitSections)
+}

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -154,7 +154,7 @@ was not initialized with a remote.
 gs repo (r) restack (r)
 ```
 
-<span class="mdx-badge"><span class="mdx-badge__icon">:material-tag:{ title="Released in version" }</span><span class="mdx-badge__text">[v0.16.0](/changelog.md#v0.16.0)</span>
+<span class="mdx-badge"><span class="mdx-badge__icon">:material-tag:{ title="Released in version" }</span><span class="mdx-badge__text">[v0.16.0](/changelog.md#v0.16.0)</span></span>
 
 Restack all tracked branches
 
@@ -291,7 +291,7 @@ Branches that are deleted from the list will be ignored.
 gs stack (s) delete (d) [flags]
 ```
 
-<span class="mdx-badge"><span class="mdx-badge__icon">:material-tag:{ title="Released in version" }</span><span class="mdx-badge__text">[v0.16.0](/changelog.md#v0.16.0)</span>
+<span class="mdx-badge"><span class="mdx-badge__icon">:material-tag:{ title="Released in version" }</span><span class="mdx-badge__text">[v0.16.0](/changelog.md#v0.16.0)</span></span>
 
 Delete all branches in a stack
 
@@ -426,7 +426,7 @@ Provide the new base name as an argument to skip the prompt.
 gs upstack (us) delete (d) [flags]
 ```
 
-<span class="mdx-badge"><span class="mdx-badge__icon">:material-tag:{ title="Released in version" }</span><span class="mdx-badge__text">[v0.16.0](/changelog.md#v0.16.0)</span>
+<span class="mdx-badge"><span class="mdx-badge__icon">:material-tag:{ title="Released in version" }</span><span class="mdx-badge__text">[v0.16.0](/changelog.md#v0.16.0)</span></span>
 
 Delete all branches above the current branch
 
@@ -746,7 +746,7 @@ For example:
 gs branch (b) squash (sq) [flags]
 ```
 
-<span class="mdx-badge"><span class="mdx-badge__icon">:material-tag:{ title="Released in version" }</span><span class="mdx-badge__text">[v0.11.0](/changelog.md#v0.11.0)</span>
+<span class="mdx-badge"><span class="mdx-badge__icon">:material-tag:{ title="Released in version" }</span><span class="mdx-badge__text">[v0.11.0](/changelog.md#v0.11.0)</span></span>
 
 Squash a branch into one commit
 

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -128,6 +128,7 @@ nav:
     - cli/index.md
     - cli/reference.md
     - cli/config.md
+    - cli/experiments.md
     - cli/shorthand.md
   - Recipes: recipes.md
   - FAQ: faq.md

--- a/doc/src/cli/experiments.md
+++ b/doc/src/cli/experiments.md
@@ -1,0 +1,36 @@
+---
+title: Experiments
+icon: material/test-tube
+description: >-
+  Enabling experimental features in git-spice.
+---
+
+# Experiments
+
+git-spice includes experimental features
+that can be enabled on an opt-in basis.
+
+!!! warning "Before you use experiments"
+
+    Be aware that experimental features:
+
+    - may be incomplete or buggy
+    - may change or be removed in future releases
+    - may not be well-documented
+    - may destroy your work
+
+```freeze language="terminal" float="right"
+{gray}# Enable an experiment{reset}
+{green}${reset} git config {red}spice.experiment.<name>{reset} {mag}true{reset}
+
+{gray}# Disable an experiment{reset}
+{green}${reset} git config {red}spice.experiment.<name>{reset} {mag}false{reset}
+```
+
+Experiments are enabled with `git config`,
+by setting `spice.experiment.<name>` to `true` or `false`.
+
+If you use an experimental feature,
+feel free to report issues and provide feedback about them.
+
+## Available experiments

--- a/dumpmd.go
+++ b/dumpmd.go
@@ -158,7 +158,10 @@ func (cmd cliDumper) dumpCommand(node *kong.Node, level int) {
 	cmd.println("```")
 	cmd.println()
 
+	// Badges all on one line:
+	var hasBadge bool
 	if version := node.Tag.Get("released"); version != "" {
+		hasBadge = true
 		icon := ":material-tag:"
 		text := version
 		href := fmt.Sprintf("/changelog.md#%s", version)
@@ -179,7 +182,26 @@ func (cmd cliDumper) dumpCommand(node *kong.Node, level int) {
 			cmd.printf("%s", text)
 		}
 		cmd.printf(`</span>`)
-		cmd.printf("\n\n")
+		cmd.printf("</span>")
+	}
+	if experiment := node.Tag.Get("experiment"); experiment != "" {
+		hasBadge = true
+		icon := ":material-test-tube:"
+		text := experiment
+		href := fmt.Sprintf("/cli/experiments.md#%s", strings.ToLower(experiment))
+
+		cmd.printf(`<span class="mdx-badge mdx-badge--experiment">`)
+		cmd.printf(`<span class="mdx-badge__icon">`)
+		cmd.printf(`%s{ title="Experimental" }`, icon)
+		cmd.printf(`</span>`)
+		cmd.printf(`<span class="mdx-badge__text">`)
+		cmd.printf("[%s](%s)", text, href)
+		cmd.printf(`</span>`)
+		cmd.printf(`</span>`)
+	}
+	if hasBadge {
+		cmd.println()
+		cmd.println()
 	}
 
 	if node.Help != "" {

--- a/internal/cli/experiment/check.go
+++ b/internal/cli/experiment/check.go
@@ -1,0 +1,69 @@
+// Package experiment adds support to the Kong CLI
+// for marking commands as experimental.
+//
+// # Usage
+//
+// Embed [Check] in the root command struct.
+//
+//	type mainCmd struct {
+//		experiment.Check
+//
+//		// ...
+//	}
+//
+// Annotate experimental commands with `experiment:"name"` tags.
+//
+//	type mainCmd struct {
+//		// ...
+//
+//		MyCmd myCmd `cmd:"" experiment:"my-experiment"`
+//	}
+//
+// An [Enabler] must be bound to the Kong Context
+// for us to check if the experiment is enabled.
+package experiment
+
+import (
+	"fmt"
+
+	"github.com/alecthomas/kong"
+	"go.abhg.dev/gs/internal/silog"
+)
+
+// Enabler reports whether an experiment is enabled.
+type Enabler interface {
+	ExperimentEnabled(string) bool
+}
+
+// Check is embedded into a Kong command
+// to check for experimental commands.
+type Check struct{}
+
+// AfterApply is called by Kong after parsing the command line.
+func (*Check) AfterApply(kctx *kong.Context, log *silog.Logger, enabler Enabler) error {
+	// If any of the commands in the path are experimental,
+	// make sure that the experiment is enabled.
+	for _, path := range kctx.Path {
+		cmd := path.Command
+		if cmd == nil {
+			continue
+		}
+
+		experiment := cmd.Tag.Get("experiment")
+		if experiment == "" {
+			continue
+		}
+
+		if enabler.ExperimentEnabled(experiment) {
+			continue
+		}
+
+		log.Errorf("Command is experimental: %s", cmd.FullPath())
+		log.Error("Enable the experiment to use it:")
+		log.Errorf("  git config spice.experiment.%s true", experiment)
+		log.Errorf("Before you enable the experiment, please read:")
+		log.Errorf("  https://abhinav.github.io/git-spice/cli/experiments/")
+		return fmt.Errorf("experiment not enabled: %v", experiment)
+	}
+	return nil
+}

--- a/internal/cli/experiment/check_test.go
+++ b/internal/cli/experiment/check_test.go
@@ -1,0 +1,68 @@
+package experiment_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/cli/experiment"
+	"go.abhg.dev/gs/internal/silog"
+)
+
+func TestCheck(t *testing.T) {
+	var cmd struct {
+		experiment.Check
+
+		Cmd      mustNotRunCmd `cmd:"" experiment:"my-experiment"`
+		OtherCmd mustNotRunCmd `cmd:""`
+	}
+
+	cfg := make(mapEnabler)
+	var logBuffer strings.Builder
+	app, err := kong.New(
+		&cmd,
+		kong.Writers(t.Output(), t.Output()),
+		kong.Name("my-cli"),
+		kong.BindTo(cfg, (*experiment.Enabler)(nil)),
+		kong.Bind(silog.New(&logBuffer, nil)),
+	)
+	require.NoError(t, err)
+
+	t.Run("NotEnabled", func(t *testing.T) {
+		delete(cfg, "my-experiment")
+
+		_, err = app.Parse([]string{"cmd"})
+		require.Error(t, err)
+		assert.Contains(t, logBuffer.String(), "Command is experimental: my-cli cmd")
+		assert.Contains(t, logBuffer.String(), "spice.experiment.my-experiment")
+	})
+
+	t.Run("Enabled", func(t *testing.T) {
+		cfg["my-experiment"] = struct{}{}
+
+		_, err = app.Parse([]string{"cmd"})
+		require.NoError(t, err)
+	})
+
+	t.Run("NotAnExperiment", func(t *testing.T) {
+		_, err = app.Parse([]string{"other-cmd"})
+		require.NoError(t, err)
+	})
+}
+
+type mustNotRunCmd struct{}
+
+func (*mustNotRunCmd) Run() error {
+	panic("must not run")
+}
+
+type mapEnabler map[string]struct{}
+
+var _ experiment.Enabler = mapEnabler{}
+
+func (e mapEnabler) ExperimentEnabled(name string) bool {
+	_, ok := e[name]
+	return ok
+}

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/mattn/go-isatty"
 	"go.abhg.dev/gs/internal/browser"
+	"go.abhg.dev/gs/internal/cli/experiment"
 	"go.abhg.dev/gs/internal/cli/shorthand"
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/forge/github"
@@ -131,6 +132,7 @@ func main() {
 		kong.Resolvers(spiceConfig),
 		kong.Bind(logger, &forges),
 		kong.BindTo(ctx, (*context.Context)(nil)),
+		kong.BindTo(spiceConfig, (*experiment.Enabler)(nil)),
 		kong.BindTo(secretStash, (*secret.Stash)(nil)),
 		kong.Vars{
 			// Default to prompting only when the terminal is interactive.
@@ -264,6 +266,7 @@ func main() {
 
 type mainCmd struct {
 	kong.Plugins
+	experiment.Check
 
 	Profile ProfileFlags `embed:""`
 


### PR DESCRIPTION
Add support for experimental commands in git-spice.
Experimental commands are marked with an "experiment" tag
and can be enabled or disabled via git configuration.

Includes updates to the doc website to list all available experiments
and links between reference and the experiments documentation.