### PR TITLE
docs: Provide llms.txt and llms-full.txt for LLM-friendly documentation

### DIFF
--- a/doc/hooks/freeze.py
+++ b/doc/hooks/freeze.py
@@ -76,10 +76,15 @@ def _formatter(
     # Convenience:
     # If language is terminal, we actually want "ansi",
     # but we want to transform escapes in the source.
+
+    plain_text_source = source
     if options["language"] == "terminal":
         options["language"] = "ansi"
         for pattern, replacement in _terminalReplacements:
             source = source.replace(pattern, replacement)
+            # For each replacement, make a second copy that does a no-op
+            # for a plain text version for use in the <code> block.
+            plain_text_source = plain_text_source.replace(pattern, '')
 
     with tempfile.TemporaryDirectory() as tmpdir:
         outfile = f"{tmpdir}/output.svg"
@@ -121,6 +126,9 @@ def _formatter(
 
     # insert viewBox="0 0 width height" into the svg,
     # and drop the width and height attributes.
+    #
+    # Also mark the svg as presentation, and hide it from screen readers.
+    # A plain text version of the source is provided in a <code> block below.
     svg = svg.replace(
         '<svg', f'<svg viewBox="0 0 {width} {height}" role="presentation" aria-hidden="true"', 1,
     )
@@ -140,6 +148,7 @@ def _formatter(
     if options["center"]:
         style += 'margin:0 auto;'
 
-    code_block = f'<pre class="visually-hidden"><code>{source}</code></pre>'
-
+    # This code block is not visually shown,
+    # but is available to screen readers.
+    code_block = f'<pre class="visually-hidden"><code>{plain_text_source}</code></pre>'
     return f'<div style="{style}">{svg}{code_block}</div>'

--- a/doc/hooks/freeze.py
+++ b/doc/hooks/freeze.py
@@ -63,6 +63,7 @@ _terminalReplacements = [
     ('{reset}', '\x1b[0;0m'),
 ]
 
+_ansiRegex = re.compile(r'\x1b\[[0-9;]*m')
 
 # run freeze --window --language=$language in a subprocess,
 # writing to a temporary file.
@@ -85,6 +86,9 @@ def _formatter(
             # For each replacement, make a second copy that does a no-op
             # for a plain text version for use in the <code> block.
             plain_text_source = plain_text_source.replace(pattern, '')
+    elif options["language"] == "ansi":
+        # Text that is already ANSI should be stripped as well.
+        plain_text_source = _ansiRegex.sub('', plain_text_source)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         outfile = f"{tmpdir}/output.svg"

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -73,6 +73,38 @@ plugins:
   - search
   - social:
       enabled: !ENV [CI, false]
+  - llmstxt:
+      full_output: llms-full.txt
+      sections:
+        Overview: 
+          - index.md
+        Get started:
+          - start/index.md
+          - start/install.md
+          - start/stack.md
+          - start/submit.md
+        User Guide:
+          - guide/index.md
+          - guide/concepts.md
+          - guide/branch.md
+          - guide/cr.md
+          - guide/limits.md
+          - guide/troubleshooting.md
+          - guide/internals.md
+        Setting up:
+          - setup/index.md
+          - setup/auth.md
+          - setup/shell.md
+        CLI:
+          - cli/index.md
+          - cli/reference.md
+          - cli/config.md
+          - cli/experiments.md
+          - cli/shorthand.md
+        Recipes:
+          - recipes.md
+        FAQ: 
+          - faq.md
 
 hooks:
   - hooks/replace.py

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -60,6 +60,35 @@ extra_css:
 exclude_docs: |
   img/README.md
 
+nav:
+  - Home: index.md
+  - Get started: &get-started
+    - start/index.md
+    - start/install.md
+    - start/stack.md
+    - start/submit.md
+  - User Guide: &user-guide
+    - guide/index.md
+    - guide/concepts.md
+    - guide/branch.md
+    - guide/cr.md
+    - guide/limits.md
+    - guide/troubleshooting.md
+    - guide/internals.md
+  - Setting up: &setup
+    - setup/index.md
+    - setup/auth.md
+    - setup/shell.md
+  - CLI: &cli
+    - cli/index.md
+    - cli/reference.md
+    - cli/config.md
+    - cli/experiments.md
+    - cli/shorthand.md
+  - Recipes: recipes.md
+  - FAQ: faq.md
+  - Changelog: changelog.md
+
 plugins:
   - markdown-exec
   - privacy:
@@ -76,34 +105,15 @@ plugins:
   - llmstxt:
       full_output: llms-full.txt
       sections:
-        Overview: 
+        Home:
           - index.md
-        Get started:
-          - start/index.md
-          - start/install.md
-          - start/stack.md
-          - start/submit.md
-        User Guide:
-          - guide/index.md
-          - guide/concepts.md
-          - guide/branch.md
-          - guide/cr.md
-          - guide/limits.md
-          - guide/troubleshooting.md
-          - guide/internals.md
-        Setting up:
-          - setup/index.md
-          - setup/auth.md
-          - setup/shell.md
-        CLI:
-          - cli/index.md
-          - cli/reference.md
-          - cli/config.md
-          - cli/experiments.md
-          - cli/shorthand.md
+        Get started: *get-started
+        User Guide: *user-guide
+        Setting up: *setup
+        CLI: *cli
         Recipes:
           - recipes.md
-        FAQ: 
+        FAQ:
           - faq.md
 
 hooks:
@@ -136,35 +146,6 @@ markdown_extensions:
   - pymdownx.tasklist:
       custom_checkbox: true
   - toc: {permalink: true}
-
-nav:
-  - Home: index.md
-  - Get started:
-    - start/index.md
-    - start/install.md
-    - start/stack.md
-    - start/submit.md
-  - User Guide:
-    - guide/index.md
-    - guide/concepts.md
-    - guide/branch.md
-    - guide/cr.md
-    - guide/limits.md
-    - guide/troubleshooting.md
-    - guide/internals.md
-  - Setting up:
-    - setup/index.md
-    - setup/auth.md
-    - setup/shell.md
-  - CLI:
-    - cli/index.md
-    - cli/reference.md
-    - cli/config.md
-    - cli/experiments.md
-    - cli/shorthand.md
-  - Recipes: recipes.md
-  - FAQ: faq.md
-  - Changelog: changelog.md
 
 watch:
   - includes

--- a/doc/pyproject.toml
+++ b/doc/pyproject.toml
@@ -9,6 +9,7 @@ dev-dependencies = [
     "mkdocs-material[imaging]>=9.5.33",
     "markdown-exec[ansi]>=1.9.3",
     "mkdocs-redirects>=1.2.1",
+    "mkdocs-llmstxt>=0.3.1",
     "mkdocs>=1.6.0",
     "cairosvg>=2.7.1",
     "pillow>=10.4.0",

--- a/doc/src/css/custom.css
+++ b/doc/src/css/custom.css
@@ -19,3 +19,16 @@
     border-end-end-radius: 2px;
     box-shadow: 0 0 0 1px inset var(--md-accent-fg-color--transparent);
 }
+
+.visually-hidden:not(:focus):not(:active) {
+    border: 0;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+}

--- a/doc/uv.lock
+++ b/doc/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -23,6 +23,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bf/fa31834dc27a7f05e5290eae47c82690edc3a7b37d58f7fb35a1bdbf355b/backrefs-5.9-py313-none-any.whl", hash = "sha256:cc37b19fa219e93ff825ed1fed8879e47b4d89aa7a1884860e2db64ccd7c676b", size = 399843, upload-time = "2025-06-22T19:34:09.68Z" },
     { url = "https://files.pythonhosted.org/packages/fc/24/b29af34b2c9c41645a9f4ff117bae860291780d73880f449e0b5d948c070/backrefs-5.9-py314-none-any.whl", hash = "sha256:df5e169836cc8acb5e440ebae9aad4bf9d15e226d3bad049cf3f6a5c20cc8dc9", size = 411762, upload-time = "2025-06-22T19:34:11.037Z" },
     { url = "https://files.pythonhosted.org/packages/41/ff/392bff89415399a979be4a65357a41d92729ae8580a66073d8ec8d810f98/backrefs-5.9-py39-none-any.whl", hash = "sha256:f48ee18f6252b8f5777a22a00a09a85de0ca931658f1dd96d4406a34f3748c60", size = 380265, upload-time = "2025-06-22T19:34:12.405Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.13.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/2e/3e5079847e653b1f6dc647aa24549d68c6addb4c595cc0d902d1b19308ad/beautifulsoup4-4.13.5.tar.gz", hash = "sha256:5e70131382930e7c3de33450a2f54a63d5e4b19386eab43a5b34d594268f3695", size = 622954, upload-time = "2025-08-24T14:06:13.168Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/eb/f4151e0c7377a6e08a38108609ba5cede57986802757848688aeedd1b9e8/beautifulsoup4-4.13.5-py3-none-any.whl", hash = "sha256:642085eaa22233aceadff9c69651bc51e8bf3f874fb6d7104ece2beb24b47c4a", size = 105113, upload-time = "2025-08-24T14:06:14.884Z" },
 ]
 
 [[package]]
@@ -202,6 +215,7 @@ dev = [
     { name = "cairosvg" },
     { name = "markdown-exec", extra = ["ansi"] },
     { name = "mkdocs" },
+    { name = "mkdocs-llmstxt" },
     { name = "mkdocs-material", extra = ["imaging"] },
     { name = "mkdocs-redirects" },
     { name = "pillow" },
@@ -214,6 +228,7 @@ dev = [
     { name = "cairosvg", specifier = ">=2.7.1" },
     { name = "markdown-exec", extras = ["ansi"], specifier = ">=1.9.3" },
     { name = "mkdocs", specifier = ">=1.6.0" },
+    { name = "mkdocs-llmstxt", specifier = ">=0.3.1" },
     { name = "mkdocs-material", extras = ["imaging"], specifier = ">=9.5.33" },
     { name = "mkdocs-redirects", specifier = ">=1.2.1" },
     { name = "pillow", specifier = ">=10.4.0" },
@@ -267,6 +282,31 @@ ansi = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
+]
+
+[[package]]
+name = "markdownify"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/1b/6f2697b51eaca81f08852fd2734745af15718fea10222a1d40f8a239c4ea/markdownify-1.2.0.tar.gz", hash = "sha256:f6c367c54eb24ee953921804dfe6d6575c5e5b42c643955e7242034435de634c", size = 18771, upload-time = "2025-08-09T17:44:15.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/e2/7af643acb4cae0741dffffaa7f3f7c9e7ab4046724543ba1777c401d821c/markdownify-1.2.0-py3-none-any.whl", hash = "sha256:48e150a1c4993d4d50f282f725c0111bd9eb25645d41fa2f543708fd44161351", size = 15561, upload-time = "2025-08-09T17:44:14.074Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -302,6 +342,40 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098, upload-time = "2024-10-18T15:21:40.813Z" },
     { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208, upload-time = "2024-10-18T15:21:41.814Z" },
     { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739, upload-time = "2024-10-18T15:21:42.784Z" },
+]
+
+[[package]]
+name = "mdformat"
+version = "0.7.22"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/eb/b5cbf2484411af039a3d4aeb53a5160fae25dd8c84af6a4243bc2f3fedb3/mdformat-0.7.22.tar.gz", hash = "sha256:eef84fa8f233d3162734683c2a8a6222227a229b9206872e6139658d99acb1ea", size = 34610, upload-time = "2025-01-30T18:00:51.418Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/6f/94a7344f6d634fe3563bea8b33bccedee37f2726f7807e9a58440dc91627/mdformat-0.7.22-py3-none-any.whl", hash = "sha256:61122637c9e1d9be1329054f3fa216559f0d1f722b7919b060a8c2a4ae1850e5", size = 34447, upload-time = "2025-01-30T18:00:48.708Z" },
+]
+
+[[package]]
+name = "mdformat-tables"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdformat" },
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/fc/995ba209096bdebdeb8893d507c7b32b7e07d9a9f2cdc2ec07529947794b/mdformat_tables-1.0.0.tar.gz", hash = "sha256:a57db1ac17c4a125da794ef45539904bb8a9592e80557d525e1f169c96daa2c8", size = 6106, upload-time = "2024-08-23T23:41:33.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/37/d78e37d14323da3f607cd1af7daf262cb87fe614a245c15ad03bb03a2706/mdformat_tables-1.0.0-py3-none-any.whl", hash = "sha256:94cd86126141b2adc3b04c08d1441eb1272b36c39146bab078249a41c7240a9a", size = 5104, upload-time = "2024-08-23T23:41:31.863Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -349,6 +423,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/98/f5/ed29cd50067784976f25ed0ed6fcd3c2ce9eb90650aa3b2796ddf7b6870b/mkdocs_get_deps-0.2.0.tar.gz", hash = "sha256:162b3d129c7fad9b19abfdcb9c1458a651628e4b1dea628ac68790fb3061c60c", size = 10239, upload-time = "2023-11-20T17:51:09.981Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/d4/029f984e8d3f3b6b726bd33cafc473b75e9e44c0f7e80a5b29abc466bdea/mkdocs_get_deps-0.2.0-py3-none-any.whl", hash = "sha256:2bf11d0b133e77a0dd036abeeb06dec8775e46efa526dc70667d8863eefc6134", size = 9521, upload-time = "2023-11-20T17:51:08.587Z" },
+]
+
+[[package]]
+name = "mkdocs-llmstxt"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "markdownify" },
+    { name = "mdformat" },
+    { name = "mdformat-tables" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/c2/a394c26eeb3e967877662748844f032c289688bac71d3b11e1f5e5d99dbb/mkdocs_llmstxt-0.3.1.tar.gz", hash = "sha256:123119d9b984c1d1224ed5af250bfbc49879ad83decdaff59d8b0ebb459ddc54", size = 31329, upload-time = "2025-08-05T13:42:41.412Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/77/52514b44c8e73e0a81883270ab6d3e64be7a6f62f54783719437e847a50e/mkdocs_llmstxt-0.3.1-py3-none-any.whl", hash = "sha256:31f5b6aaae6123c09a2b1c32912c3eb21ccb356b5db7abb867f105e8cc392653", size = 11175, upload-time = "2025-08-05T13:42:40.436Z" },
 ]
 
 [[package]]
@@ -584,6 +673,15 @@ wheels = [
 ]
 
 [[package]]
+name = "soupsieve"
+version = "2.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/e6/21ccce3262dd4889aa3332e5a119a3491a95e8f60939870a3a035aabac0d/soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f", size = 103472, upload-time = "2025-08-27T15:39:51.78Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c", size = 36679, upload-time = "2025-08-27T15:39:50.179Z" },
+]
+
+[[package]]
 name = "tinycss2"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -593,6 +691,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7a/fd/7a5ee21fd08ff70d3d33a5781c255cbe779659bd03278feb98b19ee550f4/tinycss2-1.4.0.tar.gz", hash = "sha256:10c0972f6fc0fbee87c3edb76549357415e94548c1ae10ebccdea16fb404a9b7", size = 87085, upload-time = "2024-10-24T14:58:29.895Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl", hash = "sha256:3a49cf47b7675da0b15d0c6e1df8df4ebd96e9394bb905a5775adb0d884c5289", size = 26610, upload-time = "2024-10-24T14:58:28.029Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]
@@ -626,6 +733,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.2.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301, upload-time = "2024-01-06T02:10:57.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166, upload-time = "2024-01-06T02:10:55.763Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Uses the `mkdocs-llmstxt` plugin to generate structured documentation files (`llms.txt` and `llms-full.txt`) that LLMs can easily parse and reference.

Currently, these files expose most of the same content as the main documentation site, except for the changelog. Due to plugin limitations, the pages included in `llms.txt` must be explicitly configured. Future plugin versions may allow reusing the nav configuration by default.

To ensure code snippets wrapped in SVGs (created by freeze) are included in the output, we also wrap them in a hidden `<code>` tag. This improves accessibility for both screen readers and allows the plugin generating the `llms.txt` file to include it in its output.

This only a first minimal implementation. Further iterations may be required to ensure cleaner markdown of the documentation pages.

Closes #827