### PR TITLE
branch split: Allow using original name for mid commits

### DIFF
--- a/.changes/unreleased/Added-20250914-095715.yaml
+++ b/.changes/unreleased/Added-20250914-095715.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'branch split: Allow reusing original branch name for intermediate commits during split'
+time: 2025-09-14T09:57:15.397904-07:00

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -737,6 +737,11 @@ For example:
 	# split at the previous commit
 	gs branch split --at HEAD^:newbranch
 
+When prompted for branch names, you can reuse the original branch
+name for one of the intermediate commits. When you do this, the
+original branch will be reassigned to that commit, and you'll be
+prompted to provide a name for the remaining HEAD commits.
+
 **Flags**
 
 * `--at=COMMIT:NAME,...`: Commits to split the branch at.

--- a/doc/src/guide/branch.md
+++ b/doc/src/guide/branch.md
@@ -463,6 +463,14 @@ to one of the branches.
 --8<-- "captures/branch-split-reassociate.txt"
 ```
 
+<!-- gs:version unreleased -->
+When prompted for branch names during a split,
+you can reuse the original branch name for one of the intermediate commits.
+When you do this, the original branch will be reassigned to that commit,
+preserving its metadata (such as change requests),
+and you'll be prompted to provide a new name for the remaining HEAD commits.
+This gives you more control over which commits retain the original branch's identity.
+
 ### Splitting non-interactively
 
 ```freeze language="terminal" float="right"

--- a/internal/git/ref.go
+++ b/internal/git/ref.go
@@ -19,16 +19,19 @@ type SetRefRequest struct {
 	// Ref is the name of the ref to set.
 	// If the ref is a branch or tag, it should be fully qualified
 	// (e.g., "refs/heads/main" or "refs/tags/v1.0").
-	Ref string
+	Ref string // required
 
 	// Hash is the hash to set the ref to.
-	Hash Hash
+	Hash Hash // required
 
 	// OldHash, if set, specifies the current value of the ref.
 	// The ref will only be updated if it currently points to OldHash.
 	// Set this to ZeroHash to ensure that a ref being created
 	// does not already exist.
 	OldHash Hash
+
+	// Reason, if set, is a human-readable reason for the ref update.
+	Reason string
 }
 
 // SetRef changes the value of a ref to a new hash.
@@ -36,17 +39,21 @@ type SetRefRequest struct {
 // It optionally allows verifying the current value of the ref
 // before updating it.
 func (r *Repository) SetRef(ctx context.Context, req SetRefRequest) error {
+	// TODO: Add bulk update API with --stdin
 	r.log.Debug("Updating Git ref",
 		"name", req.Ref,
 		"hash", req.Hash,
 		silog.NonZero("oldHash", req.OldHash),
 	)
 
-	// git update-ref <rev> <newvalue> [<oldvalue>]
-	args := []string{"update-ref", req.Ref, string(req.Hash)}
+	// git update-ref [-m <reason>] <rev> <newvalue> [<oldvalue>]
+	args := []string{"update-ref"}
+	if req.Reason != "" {
+		args = append(args, "-m", req.Reason)
+	}
+	args = append(args, req.Ref, string(req.Hash))
 	if req.OldHash != "" {
 		args = append(args, string(req.OldHash))
 	}
-
 	return r.gitCmd(ctx, args...).Run(r.exec)
 }

--- a/internal/git/ref_test.go
+++ b/internal/git/ref_test.go
@@ -1,0 +1,106 @@
+package git_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/git/gittest"
+	"go.abhg.dev/gs/internal/silog/silogtest"
+	"go.abhg.dev/gs/internal/sliceutil"
+	"go.abhg.dev/gs/internal/text"
+)
+
+func TestSetRef(t *testing.T) {
+	fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+		as 'Test <test@example.com>'
+		at '2024-09-14T15:55:40Z'
+
+		git init
+		git commit --allow-empty -m 'Initial commit'
+
+		git add feat1.txt
+		git commit -m 'Add feat1'
+
+		git add feat2.txt
+		git commit -m 'Add feat2'
+
+		git add feat3.txt
+		git commit -m 'Add feat3'
+
+		-- feat1.txt --
+		Feature 1
+		-- feat2.txt --
+		Feature 2
+		-- feat3.txt --
+		Feature 3
+	`)))
+	require.NoError(t, err)
+	t.Cleanup(fixture.Cleanup)
+
+	repo, err := git.Open(t.Context(), fixture.Dir(), git.OpenOptions{
+		Log: silogtest.New(t),
+	})
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	branches, err := sliceutil.CollectErr(repo.LocalBranches(ctx, nil))
+	require.NoError(t, err)
+	if assert.Len(t, branches, 1) {
+		assert.Equal(t, "main", branches[0].Name)
+	}
+
+	feat3Hash, err := repo.PeelToCommit(ctx, "HEAD")
+	require.NoError(t, err)
+
+	require.NoError(t, repo.SetRef(ctx, git.SetRefRequest{
+		Ref:     "refs/heads/my-feature",
+		Hash:    feat3Hash,
+		OldHash: git.ZeroHash,
+	}))
+
+	branches, err = sliceutil.CollectErr(repo.LocalBranches(ctx, nil))
+	require.NoError(t, err)
+	if assert.Len(t, branches, 2) {
+		names := []string{branches[0].Name, branches[1].Name}
+		assert.ElementsMatch(t, []string{"main", "my-feature"}, names)
+	}
+
+	branchHead, err := repo.PeelToCommit(ctx, "my-feature")
+	require.NoError(t, err)
+	assert.Equal(t, feat3Hash, branchHead)
+
+	t.Run("UpdateBranch", func(t *testing.T) {
+		feat2Hash, err := repo.PeelToCommit(ctx, "HEAD^")
+		require.NoError(t, err)
+
+		err = repo.SetRef(ctx, git.SetRefRequest{
+			Ref:     "refs/heads/my-feature",
+			Hash:    feat2Hash,
+			OldHash: feat3Hash,
+			Reason:  "Moving my-feature back to feat2",
+		})
+		require.NoError(t, err)
+
+		branchHead, err := repo.PeelToCommit(ctx, "my-feature")
+		require.NoError(t, err)
+		assert.Equal(t, feat2Hash, branchHead)
+	})
+
+	t.Run("AlreadyExists", func(t *testing.T) {
+		feat1Hash, err := repo.PeelToCommit(ctx, "HEAD^^")
+		require.NoError(t, err)
+
+		err = repo.SetRef(ctx, git.SetRefRequest{
+			Ref:     "refs/heads/my-feature",
+			Hash:    feat1Hash,
+			OldHash: git.ZeroHash,
+		})
+		require.Error(t, err)
+
+		branchHead, err := repo.PeelToCommit(ctx, "my-feature")
+		require.NoError(t, err)
+		assert.NotEqual(t, feat1Hash, branchHead)
+	})
+}

--- a/testdata/script/branch_split_reuse_name.txt
+++ b/testdata/script/branch_split_reuse_name.txt
@@ -1,0 +1,87 @@
+# Test that branch split allows reusing the original branch name
+# for one of the intermediate commits/branches.
+#
+# This tests the functionality requested in issue #411:
+# allowing users to specify which set of commits retains
+# the original branch name during a split.
+#
+# https://github.com/abhinav/git-spice/issues/411
+
+as 'Test <test@example.com>'
+at '2024-06-23T10:00:12Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git add feature1.txt
+gs bc -m 'Add feature1' features
+git add feature2.txt
+gs cc -m 'Add feature2'
+git add feature3.txt
+gs cc -m 'Add feature3'
+
+gs ll -a
+cmp stderr $WORK/golden/before.txt
+
+env ROBOT_INPUT=$WORK/robot.golden ROBOT_OUTPUT=$WORK/robot.actual
+gs branch split
+cmp $WORK/robot.actual $WORK/robot.golden
+
+gs ll -a
+cmp stderr $WORK/golden/after.txt
+
+# Should be on feature3 branch with clean working tree
+git branch --show-current
+cmp stdout $WORK/golden/current_branch.txt
+
+git status --porcelain
+! stdout .
+
+-- repo/feature1.txt --
+feature1
+-- repo/feature2.txt --
+feature2
+-- repo/feature3.txt --
+feature3
+-- golden/before.txt --
+┏━■ features ◀
+┃   1b17c72 Add feature3 (now)
+┃   0c7ed55 Add feature2 (now)
+┃   a3a4c59 Add feature1 (now)
+main
+-- golden/after.txt --
+    ┏━■ feature3 ◀
+    ┃   1b17c72 Add feature3 (now)
+  ┏━┻□ feature2
+  ┃    0c7ed55 Add feature2 (now)
+┏━┻□ features
+┃    a3a4c59 Add feature1 (now)
+main
+-- golden/current_branch.txt --
+feature3
+-- robot.golden --
+===
+> Select commits: 
+> ▶   a3a4c59 Add feature1 (now)
+>     0c7ed55 Add feature2 (now)
+>   ■ 1b17c72 Add feature3 (now) [features]
+>   Done
+> Select commits to split the branch at
+[
+  "a3a4c59",
+  "0c7ed55"
+]
+===
+> Branch name:  
+>   □ a3a4c59 Add feature1 (now)
+"features"
+===
+> Branch name:  
+>   □ 0c7ed55 Add feature2 (now)
+"feature2"
+===
+> Branch name:  
+>   ■ 1b17c72 Add feature3 (now) [features]
+"feature3"

--- a/testdata/script/branch_split_reuse_name_non_interactive.txt
+++ b/testdata/script/branch_split_reuse_name_non_interactive.txt
@@ -1,0 +1,60 @@
+# Test that branch split allows reusing the original branch name
+# for intermediate commits in non-interactive mode using --at flags.
+#
+# This tests the non-interactive version of the functionality
+# requested in issue #411.
+
+as 'Test <test@example.com>'
+at '2024-06-23T10:00:12Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git add feature1.txt
+gs bc -m 'Add feature1' features
+git add feature2.txt
+gs cc -m 'Add feature2'
+git add feature3.txt
+gs cc -m 'Add feature3'
+
+gs ll -a
+cmp stderr $WORK/golden/before.txt
+
+# Split using --at flags, reusing original branch name for first commit
+# and providing names for second and third commits
+gs branch split --at a3a4c59:features --at 0c7ed55:feature2 --at 1b17c72:feature3
+
+gs ll -a
+cmp stderr $WORK/golden/after.txt
+
+# Should be on feature3 branch with clean working tree
+git branch --show-current
+cmp stdout $WORK/golden/current_branch.txt
+
+git status --porcelain
+! stdout .
+
+-- repo/feature1.txt --
+feature1
+-- repo/feature2.txt --
+feature2
+-- repo/feature3.txt --
+feature3
+-- golden/before.txt --
+┏━■ features ◀
+┃   1b17c72 Add feature3 (now)
+┃   0c7ed55 Add feature2 (now)
+┃   a3a4c59 Add feature1 (now)
+main
+-- golden/after.txt --
+    ┏━■ feature3 ◀
+    ┃   1b17c72 Add feature3 (now)
+  ┏━┻□ feature2
+  ┃    0c7ed55 Add feature2 (now)
+┏━┻□ features
+┃    a3a4c59 Add feature1 (now)
+main
+-- golden/current_branch.txt --
+feature3

--- a/testdata/script/branch_split_reuse_name_with_cr.txt
+++ b/testdata/script/branch_split_reuse_name_with_cr.txt
@@ -1,0 +1,96 @@
+# 'branch split' to move branch HEAD down to a lower commit
+# also moves the associated CR.
+
+as 'Test <test@example.com>'
+at '2025-09-14T16:09:12Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+shamhub init
+shamhub register alice
+shamhub new origin alice/example.git
+git push origin main
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+git add feature1.txt
+gs bc -m 'Add feature1' features
+git add feature2.txt
+gs cc -m 'Add feature2'
+git add feature3.txt
+gs cc -m 'Add feature3'
+
+gs bs --fill
+
+# Verify prior state
+gs ll -a
+cmp stderr $WORK/golden/before_split.txt
+
+# Split the branch, move "features" down to "feature1".
+env ROBOT_INPUT=$WORK/robot.golden ROBOT_OUTPUT=$WORK/robot.actual
+gs branch split
+cmp $WORK/robot.actual $WORK/robot.golden
+
+# Verify new state
+gs ll -a
+cmp stderr $WORK/golden/after_split.txt
+
+-- repo/feature1.txt --
+feature1
+-- repo/feature2.txt --
+feature2
+-- repo/feature3.txt --
+feature3
+-- golden/before_split.txt --
+┏━■ features (#1) ◀
+┃   242e421 Add feature3 (now)
+┃   3c19fb9 Add feature2 (now)
+┃   569c763 Add feature1 (now)
+main
+-- golden/after_split.txt --
+    ┏━■ feature3 ◀
+    ┃   242e421 Add feature3 (now)
+  ┏━┻□ feature2
+  ┃    3c19fb9 Add feature2 (now)
+┏━┻□ features (#1) (needs push)
+┃    569c763 Add feature1 (now)
+main
+-- golden/current_branch.txt --
+feature3
+-- robot.golden --
+===
+> Select commits: 
+> ▶   569c763 Add feature1 (now)
+>     3c19fb9 Add feature2 (now)
+>   ■ 242e421 Add feature3 (now) [features]
+>   Done
+> Select commits to split the branch at
+[
+  "569c763",
+  "3c19fb9"
+]
+===
+> Branch name:  
+>   □ 569c763 Add feature1 (now)
+"features"
+===
+> Branch name:  
+>   □ 3c19fb9 Add feature2 (now)
+"feature2"
+===
+> Branch name:  
+>   ■ 242e421 Add feature3 (now) [features]
+"feature3"
+===
+> Assign CR #1 to branch: 
+>
+> ▶ features
+>   feature2
+>   feature3
+>
+> Branch being split has an open CR assigned to it.
+> Select which branch should take over the CR.
+"features"


### PR DESCRIPTION
Today, 'gs branch split' requires branch names for intermediate commits
to be unique and different from the original branch name.
This is good for when the split commit is intended to precede
the original branch:

    o (main)                       o (main)
     \                              \
      A --> B (feature)    =>        A (feature-pre)
                                      \
                                       B (feature)

However, this does not work for cases where the split
should take over the original branch, such as:

    o (main)                       o (main)
     \                              \
      A --> B (feature)    =>        A (feature)
                                      \
                                       B (feature-post)

This commit adds support for reusing the original branch name
for an intermediate commit during a branch split.

This works for interactive and non-interactive modes.

- For interactive mode, if any of the intermediate commits
  request the original branch name,
  a new field is presented to name the original HEAD commit.
- For non-interactive mode, if any of the split points
  reuse the original branch name,
  it is required that a split point for the HEAD commit
  is also provided with a different name.

Resolves #411