### PR TITLE
refac(log): Extract presentation logic into logPresenter

### DIFF
--- a/log_long.go
+++ b/log_long.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 
+	"github.com/alecthomas/kong"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/text"
 )
@@ -21,10 +22,11 @@ func (*logLongCmd) Help() string {
 
 func (cmd *logLongCmd) Run(
 	ctx context.Context,
+	kctx *kong.Context,
 	wt *git.Worktree,
 	listHandler ListHandler,
 ) (err error) {
-	return cmd.run(ctx, &branchLogOptions{
+	return cmd.run(ctx, kctx, &branchLogOptions{
 		Commits: true,
 	}, wt, listHandler)
 }

--- a/log_short.go
+++ b/log_short.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 
+	"github.com/alecthomas/kong"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/text"
 )
@@ -21,8 +22,9 @@ func (*logShortCmd) Help() string {
 
 func (cmd *logShortCmd) Run(
 	ctx context.Context,
+	kctx *kong.Context,
 	wt *git.Worktree,
 	listHandler ListHandler,
 ) (err error) {
-	return cmd.run(ctx, nil, wt, listHandler)
+	return cmd.run(ctx, kctx, nil, wt, listHandler)
 }


### PR DESCRIPTION
Extracts the logic to render a log of branches
into a separate interface so that we can implement
the upcoming JSON output format using the same underlying data.

[skip changelog]: no user facing changes.