### PR TITLE
fix(repo restack): autostash dirty changes before restack

### DIFF
--- a/.changes/unreleased/Fixed-20250915-194553.yaml
+++ b/.changes/unreleased/Fixed-20250915-194553.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: >-
+  repo restack: Autostash dirty changes in the working tree before the operation.
+  Previously, the changes wouldn't be stashed until checking out the first branch,
+  an operation which might fail because of other conflicts.
+time: 2025-09-15T19:45:53.329986-07:00

--- a/internal.go
+++ b/internal.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"errors"
+
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/silog"
+)
+
+type internalCmd struct {
+	AutostashPop internalAutostashPop `cmd:""`
+}
+
+type internalAutostashPop struct {
+	Hash string `name:"hash" arg:"" required:""`
+}
+
+func (cmd *internalAutostashPop) Run(
+	ctx context.Context,
+	log *silog.Logger,
+	wt *git.Worktree,
+) error {
+	err := wt.StashApply(ctx, cmd.Hash)
+	if err == nil {
+		log.Info("Applied autostash")
+		return nil
+	}
+
+	// If autostash apply fails,
+	// log the error, and save the stash for restoration.
+	log.Error("Failed to apply autostashed changes", "error", err)
+	if err := wt.StashStore(ctx, git.Hash(cmd.Hash), "git-spice: autostash failed to apply"); err != nil {
+		// If even stash store fails, there's nothing we can do.
+		// Tell the user to manually recover the stash.
+		log.Error("Failed to save autostashed changes", "error", err)
+		log.Errorf("You can try recovering them with 'git stash apply %s'", cmd.Hash)
+		return errors.New("stashed changes could not be applied or saved")
+	}
+
+	log.Error("Your changes are safe in the stash. You can:")
+	log.Error("- apply them with 'git stash pop';")
+	log.Error("- or drop them with 'git stash drop'")
+	return errors.New("autostashed changes could not be applied")
+}

--- a/internal/git/stash.go
+++ b/internal/git/stash.go
@@ -1,0 +1,62 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// ErrNoChanges is returned when there are no changes to stash.
+var ErrNoChanges = errors.New("no changes to stash")
+
+// StashCreate creates a stash entry and returns its object name.
+// It does not store the stash in the stash reflog.
+// Returns ErrNoChanges if there are no changes to stash.
+func (w *Worktree) StashCreate(ctx context.Context, message string) (Hash, error) {
+	args := []string{"stash", "create"}
+	if message != "" {
+		args = append(args, message)
+	}
+
+	out, err := w.gitCmd(ctx, args...).OutputString(w.exec)
+	if err != nil {
+		return ZeroHash, fmt.Errorf("stash create: %w", err)
+	}
+
+	if out == "" {
+		return ZeroHash, ErrNoChanges
+	}
+
+	return Hash(out), nil
+}
+
+// StashStore stores a stash created by StashCreate in the stash reflog.
+func (w *Worktree) StashStore(ctx context.Context, stashHash Hash, message string) error {
+	args := []string{"stash", "store"}
+	if message != "" {
+		args = append(args, "-m", message)
+	}
+	args = append(args, stashHash.String())
+
+	if err := w.gitCmd(ctx, args...).Run(w.exec); err != nil {
+		return fmt.Errorf("stash store: %w", err)
+	}
+
+	return nil
+}
+
+// StashApply applies a stash to the working directory.
+// If stash is not supplied, the most recent stash is applied.
+// Unlike 'stash pop', this accepts a hash string to identify the stash.
+func (w *Worktree) StashApply(ctx context.Context, stash string) error {
+	args := []string{"stash", "apply"}
+	if stash != "" {
+		args = append(args, stash)
+	}
+
+	if err := w.gitCmd(ctx, args...).CaptureStdout().Run(w.exec); err != nil {
+		return fmt.Errorf("stash apply: %w", err)
+	}
+
+	return nil
+}

--- a/internal/git/stash_test.go
+++ b/internal/git/stash_test.go
@@ -1,0 +1,299 @@
+package git_test
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/git/gittest"
+	"go.abhg.dev/gs/internal/silog/silogtest"
+	"go.abhg.dev/gs/internal/text"
+	"go.uber.org/mock/gomock"
+)
+
+func TestRepository_StashCreate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Success", func(t *testing.T) {
+		mockExecer := git.NewMockExecer(gomock.NewController(t))
+		_, wt := git.NewFakeRepository(t, "", mockExecer)
+		ctx := t.Context()
+
+		mockExecer.EXPECT().
+			Output(gomock.Any()).
+			DoAndReturn(func(cmd *exec.Cmd) ([]byte, error) {
+				assert.Equal(t, []string{"git", "stash", "create", "test message"}, cmd.Args)
+				return []byte("abc123def456\n"), nil
+			})
+
+		hash, err := wt.StashCreate(ctx, "test message")
+		require.NoError(t, err)
+		assert.Equal(t, git.Hash("abc123def456"), hash)
+	})
+
+	t.Run("NoMessage", func(t *testing.T) {
+		mockExecer := git.NewMockExecer(gomock.NewController(t))
+		_, wt := git.NewFakeRepository(t, "", mockExecer)
+		ctx := t.Context()
+
+		mockExecer.EXPECT().
+			Output(gomock.Any()).
+			DoAndReturn(func(cmd *exec.Cmd) ([]byte, error) {
+				assert.Equal(t, []string{"git", "stash", "create"}, cmd.Args)
+				return []byte("abc123def456\n"), nil
+			})
+
+		hash, err := wt.StashCreate(ctx, "")
+		require.NoError(t, err)
+		assert.Equal(t, git.Hash("abc123def456"), hash)
+	})
+
+	t.Run("NoChanges", func(t *testing.T) {
+		mockExecer := git.NewMockExecer(gomock.NewController(t))
+		_, wt := git.NewFakeRepository(t, "", mockExecer)
+		ctx := t.Context()
+
+		mockExecer.EXPECT().
+			Output(gomock.Any()).
+			Return([]byte(""), nil)
+
+		hash, err := wt.StashCreate(ctx, "test message")
+		assert.ErrorIs(t, err, git.ErrNoChanges)
+		assert.Equal(t, git.ZeroHash, hash)
+	})
+
+	t.Run("CommandFailure", func(t *testing.T) {
+		mockExecer := git.NewMockExecer(gomock.NewController(t))
+		_, wt := git.NewFakeRepository(t, "", mockExecer)
+		ctx := t.Context()
+
+		mockExecer.EXPECT().
+			Output(gomock.Any()).
+			Return(nil, errors.New("git command failed"))
+
+		hash, err := wt.StashCreate(ctx, "test message")
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "stash create")
+		assert.Equal(t, git.ZeroHash, hash)
+	})
+}
+
+func TestRepository_StashStore(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Success", func(t *testing.T) {
+		mockExecer := git.NewMockExecer(gomock.NewController(t))
+		_, wt := git.NewFakeRepository(t, "", mockExecer)
+		ctx := t.Context()
+
+		mockExecer.EXPECT().
+			Run(gomock.Any()).
+			DoAndReturn(func(cmd *exec.Cmd) error {
+				assert.Equal(t, []string{"git", "stash", "store", "-m", "test message", "abc123def456"}, cmd.Args)
+				return nil
+			})
+
+		err := wt.StashStore(ctx, git.Hash("abc123def456"), "test message")
+		require.NoError(t, err)
+	})
+
+	t.Run("NoMessage", func(t *testing.T) {
+		mockExecer := git.NewMockExecer(gomock.NewController(t))
+		_, wt := git.NewFakeRepository(t, "", mockExecer)
+		ctx := t.Context()
+
+		mockExecer.EXPECT().
+			Run(gomock.Any()).
+			DoAndReturn(func(cmd *exec.Cmd) error {
+				assert.Equal(t, []string{"git", "stash", "store", "abc123def456"}, cmd.Args)
+				return nil
+			})
+
+		err := wt.StashStore(ctx, git.Hash("abc123def456"), "")
+		require.NoError(t, err)
+	})
+
+	t.Run("CommandFailure", func(t *testing.T) {
+		mockExecer := git.NewMockExecer(gomock.NewController(t))
+		_, wt := git.NewFakeRepository(t, "", mockExecer)
+		ctx := t.Context()
+
+		mockExecer.EXPECT().
+			Run(gomock.Any()).
+			Return(errors.New("git command failed"))
+
+		err := wt.StashStore(ctx, git.Hash("abc123def456"), "test message")
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "stash store")
+	})
+}
+
+func TestRepository_StashApply(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Success", func(t *testing.T) {
+		mockExecer := git.NewMockExecer(gomock.NewController(t))
+		_, wt := git.NewFakeRepository(t, "", mockExecer)
+		ctx := t.Context()
+
+		mockExecer.EXPECT().
+			Run(gomock.Any()).
+			DoAndReturn(func(cmd *exec.Cmd) error {
+				assert.Equal(t, []string{"git", "stash", "apply", "stash@{1}"}, cmd.Args)
+				return nil
+			})
+
+		err := wt.StashApply(ctx, "stash@{1}")
+		require.NoError(t, err)
+	})
+
+	t.Run("NoIndex", func(t *testing.T) {
+		mockExecer := git.NewMockExecer(gomock.NewController(t))
+		_, wt := git.NewFakeRepository(t, "", mockExecer)
+		ctx := t.Context()
+
+		mockExecer.EXPECT().
+			Run(gomock.Any()).
+			DoAndReturn(func(cmd *exec.Cmd) error {
+				assert.Equal(t, []string{"git", "stash", "apply"}, cmd.Args)
+				return nil
+			})
+
+		err := wt.StashApply(ctx, "")
+		require.NoError(t, err)
+	})
+
+	t.Run("CommandFailure", func(t *testing.T) {
+		mockExecer := git.NewMockExecer(gomock.NewController(t))
+		_, wt := git.NewFakeRepository(t, "", mockExecer)
+		ctx := t.Context()
+
+		mockExecer.EXPECT().
+			Run(gomock.Any()).
+			Return(errors.New("git command failed"))
+
+		err := wt.StashApply(ctx, "stash@{0}")
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "stash apply")
+	})
+}
+
+func TestRepository_StashIntegration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("StashCreateAndStore", func(t *testing.T) {
+		fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+			as 'Test User <test@example.com>'
+			at '2025-08-23T06:07:08Z'
+
+			git init
+			git add file1.txt
+			git commit -m 'Initial commit'
+
+			# Make some changes to stash
+			git add file2.txt
+			mv file1.new.txt file1.txt
+
+			-- file1.txt --
+			original content
+			-- file2.txt --
+			new content
+			-- file1.new.txt --
+			modified
+		`)))
+		require.NoError(t, err)
+		t.Cleanup(fixture.Cleanup)
+
+		ctx := t.Context()
+		wt, err := git.OpenWorktree(ctx, fixture.Dir(), git.OpenOptions{
+			Log: silogtest.New(t),
+		})
+		require.NoError(t, err)
+
+		hash, err := wt.StashCreate(ctx, "test stash message")
+		require.NoError(t, err)
+		assert.NotEqual(t, git.ZeroHash, hash)
+		assert.Len(t, hash.String(), 40)
+
+		err = wt.StashStore(ctx, hash, "stored test stash")
+		require.NoError(t, err)
+	})
+
+	t.Run("Create", func(t *testing.T) {
+		fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+			as 'Test User <test@example.com>'
+			at '2025-08-30T06:07:08Z'
+
+			git init
+			git add original.txt
+			git commit -m 'Initial commit'
+
+			# Make changes to stash
+			git add new.txt
+			mv modified.txt original.txt
+
+			-- original.txt --
+			original content
+			-- new.txt --
+			new file content
+			-- modified.txt --
+			modified content
+		`)))
+		require.NoError(t, err)
+		t.Cleanup(fixture.Cleanup)
+
+		ctx := t.Context()
+		wt, err := git.OpenWorktree(ctx, fixture.Dir(), git.OpenOptions{
+			Log: silogtest.New(t),
+		})
+		require.NoError(t, err)
+
+		hash, err := wt.StashCreate(ctx, "test stash for pop")
+		require.NoError(t, err)
+		assert.NotEqual(t, git.ZeroHash, hash)
+
+		t.Run("ApplyFromHash", func(t *testing.T) {
+			require.NoError(t, wt.Reset(ctx, "HEAD", git.ResetOptions{Mode: git.ResetHard}))
+
+			require.NoError(t, wt.StashApply(ctx, hash.String()))
+			assert.FileExists(t, fixture.Dir()+"/new.txt", "stashed file should exist after pop")
+		})
+
+		t.Run("StoreAndApply", func(t *testing.T) {
+			require.NoError(t, wt.Reset(ctx, "HEAD", git.ResetOptions{Mode: git.ResetHard}))
+
+			require.NoError(t, wt.StashStore(ctx, hash, "stored stash for pop test"))
+			require.NoError(t, wt.StashApply(ctx, "stash@{0}"))
+			assert.FileExists(t, fixture.Dir()+"/new.txt", "stashed file should exist after pop")
+		})
+	})
+
+	t.Run("NoChangesToStash", func(t *testing.T) {
+		fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+			as 'Test User <test@example.com>'
+			at '2025-06-20T21:28:29Z'
+
+			git init
+			git add clean.txt
+			git commit -m 'Clean state'
+
+			-- clean.txt --
+			clean content
+		`)))
+		require.NoError(t, err)
+		t.Cleanup(fixture.Cleanup)
+
+		ctx := t.Context()
+		wt, err := git.OpenWorktree(ctx, fixture.Dir(), git.OpenOptions{
+			Log: silogtest.New(t),
+		})
+		require.NoError(t, err)
+
+		hash, err := wt.StashCreate(ctx, "should fail")
+		assert.ErrorIs(t, err, git.ErrNoChanges)
+		assert.Equal(t, git.ZeroHash, hash)
+	})
+}

--- a/internal/handler/restack/handler.go
+++ b/internal/handler/restack/handler.go
@@ -162,6 +162,10 @@ func (h *Handler) Restack(ctx context.Context, req *Request) (int, error) {
 	branchesToActuallyRestack := branchesToRestack[:0]
 	var requestBranchWT string // worktree of request.Branch
 	for _, branch := range branchesToRestack {
+		if branch == h.Store.Trunk() {
+			continue // skip restacking trunk branch
+		}
+
 		if info, ok := branchGraph.Lookup(branch); ok {
 			if _, baseSkipped := skipped[info.Base]; baseSkipped {
 				// Base branch not being restacked,
@@ -190,10 +194,6 @@ func (h *Handler) Restack(ctx context.Context, req *Request) (int, error) {
 	var restackCount int
 loop:
 	for _, branch := range branchesToRestack {
-		if branch == h.Store.Trunk() {
-			continue loop // skip restacking trunk branch
-		}
-
 		res, err := h.Service.Restack(ctx, branch)
 		if err != nil {
 			var rebaseErr *git.RebaseInterruptError

--- a/main.go
+++ b/main.go
@@ -303,6 +303,8 @@ type mainCmd struct {
 
 	Version versionCmd `cmd:"" help:"Print version information and quit"`
 
+	Internal internalCmd `cmd:"" hidden:"" help:"For internal use only."`
+
 	// Hidden commands:
 	DumpMD dumpMarkdownCmd `name:"dumpmd" hidden:"" cmd:"" help:"Dump a Markdown reference to stdout and quit"`
 }

--- a/repo_restack.go
+++ b/repo_restack.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/silog"
+	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
 )
@@ -25,11 +27,50 @@ func (*repoRestackCmd) Run(
 	log *silog.Logger,
 	wt *git.Worktree,
 	store *state.Store,
+	service *spice.Service,
 	handler RestackHandler,
-) error {
+) (retErr error) {
 	currentBranch, err := wt.CurrentBranch(ctx)
 	if err != nil {
 		return fmt.Errorf("get current branch: %w", err)
+	}
+
+	stashMsg := "git-spice: autostash before restacking"
+	if stashHash, err := wt.StashCreate(ctx, stashMsg); err != nil {
+		if !errors.Is(err, git.ErrNoChanges) {
+			return fmt.Errorf("stash changes: %w", err)
+		}
+		// No changes to stash, that's fine.
+	} else {
+		// We created a stash.
+		// We will reset the working tree to HEAD
+		// (losing any uncommitted changes),
+		// then one of the following:
+		//
+		//  - if the command exits with success,
+		//    we will pop the stash to restore the changes.
+		//  - if the command exits with an error,
+		//    schedule an "internal autostash-pop" command
+		//    to be run when the rebase operation is finished.
+		if err := wt.Reset(ctx, "HEAD", git.ResetOptions{Mode: git.ResetHard}); err != nil {
+			return fmt.Errorf("reset before restack: %w", err)
+		}
+
+		defer func() {
+			if retErr == nil {
+				retErr = (&internalAutostashPop{
+					Hash: stashHash.String(),
+				}).Run(ctx, log, wt)
+				return
+			}
+
+			retErr = service.RebaseRescue(ctx, spice.RebaseRescueRequest{
+				Err:     retErr,
+				Command: []string{"internal", "autostash-pop", stashHash.String()},
+				Branch:  currentBranch,
+				Message: fmt.Sprintf("interrupted: restore stashed changes %q", stashHash),
+			})
+		}()
 	}
 
 	count, err := handler.Restack(ctx, &restack.Request{

--- a/testdata/script/issue804_repo_restack_dirty_tree.txt
+++ b/testdata/script/issue804_repo_restack_dirty_tree.txt
@@ -1,0 +1,53 @@
+# Test 'repo restack' with dirty worktree changes.
+# https://github.com/abhinav/git-spice/issues/804
+
+as 'Test User <test@example.com>'
+at 2025-06-20T21:28:29Z
+
+cd repo
+git init
+git commit -m 'Initial commit' --allow-empty
+
+gs repo init
+git add feat1.txt
+gs branch create feat1 -m 'feat1 commit'
+git add feat2.txt  
+gs branch create feat2 -m 'feat2 commit'
+
+# Create a new commit on trunk to make branches need restacking
+gs branch checkout main
+git commit --allow-empty -m 'New trunk commit'
+
+# Switch to feat2 and make dirty changes
+gs branch checkout feat2
+cp $WORK/extra/dirty.txt feat2.txt
+
+# Verify worktree is dirty
+git status --porcelain
+cmp stdout $WORK/golden/dirty-status.txt
+
+# Now try to restack - dirty changes should be preserved
+gs repo restack
+
+# Verify dirty changes are still present after restack
+cmp feat2.txt $WORK/extra/dirty.txt
+git status --porcelain
+cmp stdout $WORK/golden/dirty-status.txt
+
+# Verify branches are properly restacked
+git graph --branches
+cmp stdout $WORK/golden/graph.txt
+
+-- repo/feat1.txt --
+feature 1
+-- repo/feat2.txt --
+feature 2
+-- extra/dirty.txt --
+dirty changes to feature 2
+-- golden/dirty-status.txt --
+ M feat2.txt
+-- golden/graph.txt --
+* f5121c8 (HEAD -> feat2) feat2 commit
+* c1f17f5 (feat1) feat1 commit
+* 8e9b73c (main) New trunk commit
+* 91af7b5 Initial commit

--- a/testdata/script/repo_restack_autostash_apply_conflict.txt
+++ b/testdata/script/repo_restack_autostash_apply_conflict.txt
@@ -1,0 +1,64 @@
+# 'repo restack' with dirty changes that are autostashed
+# but fail to apply after the restack.
+
+as 'Test User <test@example.com>'
+at 2025-06-20T21:28:29Z
+
+cd repo
+git init
+git commit -m 'Initial commit' --allow-empty
+gs repo init
+
+# create a feature branch
+git add feature.txt
+gs branch create feat1 -m 'feat1 commit'
+
+# make main diverge with a new commit
+gs trunk
+git add main.txt
+git commit -m 'Add main content'
+
+# Dirty changes in feat1 before restacking
+gs branch checkout feat1
+cp $WORK/extra/feature-main.txt main.txt
+git add main.txt
+git status --porcelain
+cmp stdout $WORK/golden/dirty-status.txt
+
+# Now restack - this should stash, restack successfully,
+# but fail on stash apply
+! gs repo restack
+stderr 'Failed to apply autostashed changes'
+stderr 'Your changes are safe in the stash'
+stderr 'apply them with.*git stash pop'
+stderr 'drop them with.*git stash drop'
+
+# working tree should have conflict markers.
+git status --porcelain
+cmp stdout $WORK/golden/conflict-status.txt
+
+# restack operation itself succeeded
+git graph --branches
+cmp stdout $WORK/golden/graph-restacked.txt
+
+# There's an entry in the stash.
+git stash list
+stdout 'stash@\{0\}'
+
+# User can manually apply the stash with conflict resolution
+git stash drop
+
+-- repo/main.txt --
+main change
+-- repo/feature.txt --
+original feature
+-- extra/feature-main.txt --
+dirty changes on feature branch
+-- golden/dirty-status.txt --
+A  main.txt
+-- golden/graph-restacked.txt --
+* edda5cf (HEAD -> feat1) feat1 commit
+* be103e1 (main) Add main content
+* 91af7b5 Initial commit
+-- golden/conflict-status.txt --
+AA main.txt

--- a/testdata/script/repo_restack_autostash_restack_conflict.txt
+++ b/testdata/script/repo_restack_autostash_restack_conflict.txt
@@ -1,0 +1,75 @@
+# 'repo restack' when restack operation has conflicts
+# still restores autostashed changes.
+
+as 'Test User <test@example.com>'
+at 2025-06-20T21:28:29Z
+
+cd repo
+git init
+git commit -m 'Initial commit' --allow-empty
+git add file.txt other.txt
+git commit -m 'Add file.txt'
+gs repo init
+
+# Modify file.txt on feat1
+cp $WORK/other/feat1-file.txt file.txt
+git add file.txt
+gs branch create feat1 -m 'Modify file.txt in feat1'
+
+# Modify trunk so a restack is required
+gs trunk
+cp $WORK/other/trunk-change.txt file.txt
+git add file.txt
+git commit -m 'Modify file.txt in trunk'
+
+# Switch back to feat1 and add dirty changes
+gs bco feat1
+cp $WORK/extra/dirty-changes.txt other.txt
+git status --porcelain
+cmp stdout $WORK/golden/dirty-before.txt
+
+# Restack should fail due to conflict
+! gs repo restack
+stderr 'rebase of feat1 interrupted by a conflict'
+
+# Verify that working tree is clean (dirty changes were stashed)
+git status --porcelain
+cmp stdout $WORK/golden/conflict-status.txt
+
+# Resolve the conflict
+cp ../other/resolved.txt file.txt
+git add file.txt
+gs rebase continue --no-edit
+
+# After restack completes, verify original dirty changes are restored
+git status --porcelain
+cmp stdout $WORK/golden/dirty-after.txt
+cmp other.txt $WORK/extra/dirty-changes.txt
+
+# Verify branches are properly restacked
+git graph --branches
+cmp stdout $WORK/golden/graph-resolved.txt
+
+-- repo/file.txt --
+original content
+-- repo/other.txt --
+other file
+-- other/feat1-file.txt --
+feat1 content
+-- other/trunk-change.txt --
+trunk content
+-- other/resolved.txt --
+resolved content
+-- extra/dirty-changes.txt --
+dirty working tree changes
+-- golden/dirty-before.txt --
+ M other.txt
+-- golden/conflict-status.txt --
+UU file.txt
+-- golden/dirty-after.txt --
+ M other.txt
+-- golden/graph-resolved.txt --
+* d7faae9 (HEAD -> feat1) Modify file.txt in feat1
+* dc721d9 (main) Modify file.txt in trunk
+* 0e0af0a Add file.txt
+* 91af7b5 Initial commit


### PR DESCRIPTION
Introduces an 'internal' hidden namespace for commands
to be used by operations like popping the stash
after the main operation is complete.

Right now, we're only using this for 'repo restack'.
We may expand this to fully git-spice managed stashing
for restack operations in the future.

Resolves #804
