### PR TITLE
fix(commit fixup): handle autostashing dirty changes

### DIFF
--- a/internal/git/restore_wt.go
+++ b/internal/git/restore_wt.go
@@ -1,0 +1,25 @@
+package git
+
+import (
+	"context"
+	"fmt"
+)
+
+// RestoreRequest specifies options for the git restore command.
+type RestoreRequest struct {
+	// PathSpecs specifies the files or directories to restore.
+	// These may include patterns (e.g. "*.go").
+	PathSpecs []string // required
+}
+
+// Restore restores files in the working tree and/or index from a tree-ish.
+func (w *Worktree) Restore(ctx context.Context, req *RestoreRequest) error {
+	args := []string{"restore"}
+	args = append(args, "--")
+	args = append(args, req.PathSpecs...)
+	if err := w.gitCmd(ctx, args...).Run(w.exec); err != nil {
+		return fmt.Errorf("git restore: %w", err)
+	}
+
+	return nil
+}

--- a/internal/git/restore_wt_test.go
+++ b/internal/git/restore_wt_test.go
@@ -1,0 +1,191 @@
+package git_test
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/git/gittest"
+	"go.abhg.dev/gs/internal/silog/silogtest"
+	"go.abhg.dev/gs/internal/text"
+	"go.uber.org/mock/gomock"
+)
+
+func TestWorktree_Restore(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Success", func(t *testing.T) {
+		mockExecer := git.NewMockExecer(gomock.NewController(t))
+		_, wt := git.NewFakeRepository(t, "", mockExecer)
+		ctx := t.Context()
+
+		mockExecer.EXPECT().
+			Run(gomock.Any()).
+			DoAndReturn(func(cmd *exec.Cmd) error {
+				assert.Equal(t, []string{"git", "restore", "--", "file1.txt", "file2.txt"}, cmd.Args)
+				return nil
+			})
+
+		err := wt.Restore(ctx, &git.RestoreRequest{
+			PathSpecs: []string{"file1.txt", "file2.txt"},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("SingleFile", func(t *testing.T) {
+		mockExecer := git.NewMockExecer(gomock.NewController(t))
+		_, wt := git.NewFakeRepository(t, "", mockExecer)
+		ctx := t.Context()
+
+		mockExecer.EXPECT().
+			Run(gomock.Any()).
+			DoAndReturn(func(cmd *exec.Cmd) error {
+				assert.Equal(t, []string{"git", "restore", "--", "."}, cmd.Args)
+				return nil
+			})
+
+		err := wt.Restore(ctx, &git.RestoreRequest{
+			PathSpecs: []string{"."},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("CommandFailure", func(t *testing.T) {
+		mockExecer := git.NewMockExecer(gomock.NewController(t))
+		_, wt := git.NewFakeRepository(t, "", mockExecer)
+		ctx := t.Context()
+
+		mockExecer.EXPECT().
+			Run(gomock.Any()).
+			Return(errors.New("git command failed"))
+
+		err := wt.Restore(ctx, &git.RestoreRequest{
+			PathSpecs: []string{"file.txt"},
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "git restore")
+	})
+}
+
+func TestWorktree_RestoreIntegration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("RestoreOneFile", func(t *testing.T) {
+		fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+			as 'Test User <test@example.com>'
+			at '2025-09-20T21:28:29Z'
+
+			git init
+			git add file1.txt file2.txt
+			git commit -m 'Initial commit'
+
+			# Modify files in working tree
+			mv file1.modified.txt file1.txt
+			mv file2.modified.txt file2.txt
+
+			-- file1.txt --
+			original content 1
+			-- file2.txt --
+			original content 2
+			-- file1.modified.txt --
+			modified content 1
+			-- file2.modified.txt --
+			modified content 2
+		`)))
+		require.NoError(t, err)
+		t.Cleanup(fixture.Cleanup)
+
+		ctx := t.Context()
+		wt, err := git.OpenWorktree(ctx, fixture.Dir(), git.OpenOptions{
+			Log: silogtest.New(t),
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, wt.Restore(ctx, &git.RestoreRequest{
+			PathSpecs: []string{"file1.txt"},
+		}))
+
+		file1, err := os.ReadFile(filepath.Join(fixture.Dir(), "file1.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, "original content 1", strings.TrimSpace(string(file1)))
+
+		file2, err := os.ReadFile(filepath.Join(fixture.Dir(), "file2.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, "modified content 2", strings.TrimSpace(string(file2)))
+	})
+
+	t.Run("RestoreAllFiles", func(t *testing.T) {
+		fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+			as 'Test User <test@example.com>'
+			at '2025-09-20T21:28:29Z'
+
+			git init
+			git add original.txt
+			git commit -m 'Initial commit'
+
+			# Stage new file and modify existing file
+			git add new.txt
+			mv original.modified.txt original.txt
+
+			-- original.txt --
+			original content
+			-- new.txt --
+			new file content
+			-- original.modified.txt --
+			modified original
+		`)))
+		require.NoError(t, err)
+		t.Cleanup(fixture.Cleanup)
+
+		ctx := t.Context()
+		wt, err := git.OpenWorktree(ctx, fixture.Dir(), git.OpenOptions{
+			Log: silogtest.New(t),
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, wt.Restore(ctx, &git.RestoreRequest{
+			PathSpecs: []string{"."},
+		}))
+
+		body, err := os.ReadFile(filepath.Join(fixture.Dir(), "original.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, "original content", strings.TrimSpace(string(body)))
+		assert.FileExists(t, filepath.Join(fixture.Dir(), "new.txt"))
+	})
+
+	t.Run("AbsentFile", func(t *testing.T) {
+		fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+			as 'Test User <test@example.com>'
+			at '2025-09-20T21:28:29Z'
+
+			git init
+			git add existing.txt
+			git commit -m 'Initial commit'
+
+			-- existing.txt --
+			existing content
+		`)))
+		require.NoError(t, err)
+		t.Cleanup(fixture.Cleanup)
+
+		ctx := t.Context()
+		wt, err := git.OpenWorktree(ctx, fixture.Dir(), git.OpenOptions{
+			Log: silogtest.New(t),
+		})
+		require.NoError(t, err)
+
+		err = wt.Restore(ctx, &git.RestoreRequest{
+			PathSpecs: []string{"nonexistent.txt"},
+		})
+
+		// Git restore fails for nonexistent files.
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "git restore")
+	})
+}

--- a/internal/handler/fixup/mocks_test.go
+++ b/internal/handler/fixup/mocks_test.go
@@ -222,6 +222,44 @@ func (c *MockGitWorktreeRebaseCall) DoAndReturn(f func(context.Context, git.Reba
 	return c
 }
 
+// Reset mocks base method.
+func (m *MockGitWorktree) Reset(ctx context.Context, commit string, opts git.ResetOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Reset", ctx, commit, opts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Reset indicates an expected call of Reset.
+func (mr *MockGitWorktreeMockRecorder) Reset(ctx, commit, opts any) *MockGitWorktreeResetCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockGitWorktree)(nil).Reset), ctx, commit, opts)
+	return &MockGitWorktreeResetCall{Call: call}
+}
+
+// MockGitWorktreeResetCall wrap *gomock.Call
+type MockGitWorktreeResetCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockGitWorktreeResetCall) Return(arg0 error) *MockGitWorktreeResetCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockGitWorktreeResetCall) Do(f func(context.Context, string, git.ResetOptions) error) *MockGitWorktreeResetCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockGitWorktreeResetCall) DoAndReturn(f func(context.Context, string, git.ResetOptions) error) *MockGitWorktreeResetCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // WriteIndexTree mocks base method.
 func (m *MockGitWorktree) WriteIndexTree(ctx context.Context) (git.Hash, error) {
 	m.ctrl.T.Helper()

--- a/testdata/script/commit_fixup_autostash_clean_apply.txt
+++ b/testdata/script/commit_fixup_autostash_clean_apply.txt
@@ -1,0 +1,80 @@
+# Test commit fixup with autostash when dirty changes apply cleanly after returning to original branch.
+# See: https://github.com/abhinav/git-spice/discussions/867#discussioncomment-14465048
+
+[!git:2.45.0] skip # feature requires git 2.45
+
+as 'Test <test@example.com>'
+at '2025-09-20T21:28:29Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+git config spice.experiment.commitFixup true
+
+# Create stack: main -> feat1 -> feat2
+# feat1 adds feat1.txt
+git add feat1.txt
+gs bc -m 'Add feat1.txt' feat1
+
+# feat2 adds feat2.txt
+git add feat2.txt
+gs bc -m 'Add feat2.txt' feat2
+
+# Verify initial stack
+git graph --branches
+cmp stdout $WORK/golden/initial_stack.txt
+
+# On feat2: modify both files
+# Stage changes to feat1.txt (for fixup)
+# Leave changes to feat2.txt unstaged (will cause conflict on feat1)
+cp $WORK/extra/feat1_fixup.txt feat1.txt
+git add feat1.txt
+cp $WORK/extra/feat2_dirty.txt feat2.txt
+
+# Verify dirty state before fixup
+git status --porcelain
+cmp stdout $WORK/golden/dirty_before_fixup.txt
+
+# Attempt fixup of feat1 commit
+# Should autostash, perform fixup, then restore changes cleanly on feat2
+gs commit fixup HEAD~1
+
+# Should be back on feat2
+git branch --show-current
+stdout 'feat2'
+
+# Verify fixup was applied to feat1 without switching branches
+git cat-file -p feat1:feat1.txt
+cmp stdout $WORK/extra/feat1_fixup.txt
+
+# Verify unstaged changes were restored and working state
+git status --porcelain
+cmp stdout $WORK/golden/dirty_after_fixup.txt
+cmp feat2.txt $WORK/extra/feat2_dirty.txt
+
+# Verify final stack structure
+git graph --branches
+cmp stdout $WORK/golden/final_stack.txt
+
+-- repo/feat1.txt --
+Original feat1 content
+-- repo/feat2.txt --
+Original feat2 content
+-- extra/feat1_fixup.txt --
+Fixed feat1 content
+-- extra/feat2_dirty.txt --
+Dirty changes to feat2
+-- golden/initial_stack.txt --
+* 242a7e5 (HEAD -> feat2) Add feat2.txt
+* 7846e3d (feat1) Add feat1.txt
+* 08bbcd9 (main) Initial commit
+-- golden/dirty_before_fixup.txt --
+M  feat1.txt
+ M feat2.txt
+-- golden/dirty_after_fixup.txt --
+ M feat2.txt
+-- golden/final_stack.txt --
+* 22a9ae4 (HEAD -> feat2) Add feat2.txt
+* 3d57c30 (feat1) Add feat1.txt
+* 08bbcd9 (main) Initial commit

--- a/testdata/script/commit_fixup_autostash_with_upstack_conflict.txt
+++ b/testdata/script/commit_fixup_autostash_with_upstack_conflict.txt
@@ -1,0 +1,123 @@
+# Test commit fixup with autostash and upstack conflict requiring manual resolution.
+
+[!git:2.45.0] skip # feature requires git 2.45
+
+as 'Test <test@example.com>'
+at '2025-09-20T21:28:29Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+git config spice.experiment.commitFixup true
+
+# Create stack: main -> feat1 -> feat2 -> feat3
+# feat1 adds shared.txt and feat1.txt
+git add shared.txt feat1.txt
+gs bc -m 'Add shared and feat1 files' feat1
+
+# feat2 adds feat2.txt
+git add feat2.txt
+gs bc -m 'Add feat2.txt' feat2
+
+# feat3 modifies shared.txt and adds feat3.txt (creates future conflict)
+cp $WORK/extra/shared_modified.txt shared.txt
+git add shared.txt feat3.txt
+gs bc -m 'Modify shared.txt and add feat3.txt' feat3
+
+# Verify initial stack
+git graph --branches
+cmp stdout $WORK/golden/initial_stack.txt
+
+# Go back to feat2 and create conflicting changes
+gs bco feat2
+# Stage changes to shared.txt (for fixup into feat1)
+# Leave changes to feat2.txt unstaged (will cause conflict on feat3)
+cp $WORK/extra/shared_fixup.txt shared.txt
+git add shared.txt
+cp $WORK/extra/feat2_dirty.txt feat2.txt
+
+# Verify dirty state before fixup
+git status --porcelain
+cmp stdout $WORK/golden/dirty_before_fixup.txt
+
+# Attempt fixup of feat1 commit
+# Should autostash, perform fixup, but fail during upstack restack
+! gs commit fixup HEAD~1
+stderr 'There was a conflict while rebasing'
+stderr 'gs rebase continue'
+stderr 'gs rebase abort'
+stderr 'Modify shared.txt and add feat3.txt'
+
+# Check conflict status
+git status --porcelain
+cmp stdout $WORK/golden/upstack_conflict_status.txt
+
+# Resolve the conflict
+cp $WORK/extra/shared_conflict_resolved.txt shared.txt
+git add shared.txt
+gs rebase continue --no-edit
+
+# Should be back on feat2
+git branch --show-current
+stdout 'feat2'
+
+# Verify fixup was applied to feat1
+git cat-file -p feat1:shared.txt
+cmp stdout $WORK/extra/shared_fixup.txt
+
+# Verify feat3 has the resolved conflict
+git cat-file -p feat3:shared.txt
+cmp stdout $WORK/extra/shared_conflict_resolved.txt
+
+# Verify unstaged changes were restored
+git status --porcelain
+cmp stdout $WORK/golden/dirty_after_fixup.txt
+cmp feat2.txt $WORK/extra/feat2_dirty.txt
+
+# Verify final stack structure
+git graph --branches
+cmp stdout $WORK/golden/final_stack.txt
+
+-- repo/shared.txt --
+Original shared content
+line 1
+line 2
+-- repo/feat1.txt --
+feat1 content
+-- repo/feat2.txt --
+Original feat2 content
+-- repo/feat3.txt --
+feat3 content
+-- extra/shared_modified.txt --
+Modified shared content
+line 1
+different line 2
+-- extra/shared_fixup.txt --
+Fixed shared content
+line 1
+line 2
+-- extra/shared_conflict_resolved.txt --
+Fixed shared content
+line 1
+different line 2
+-- extra/feat2_dirty.txt --
+Dirty changes to feat2
+-- golden/initial_stack.txt --
+* de39174 (HEAD -> feat3) Modify shared.txt and add feat3.txt
+* 91cf256 (feat2) Add feat2.txt
+* cefe544 (feat1) Add shared and feat1 files
+* 08bbcd9 (main) Initial commit
+-- golden/dirty_before_fixup.txt --
+ M feat2.txt
+M  shared.txt
+-- golden/upstack_conflict_status.txt --
+A  feat3.txt
+UU shared.txt
+-- golden/dirty_after_fixup.txt --
+ M feat2.txt
+-- golden/final_stack.txt --
+* 7659d59 (feat3) Modify shared.txt and add feat3.txt
+* ad90258 (HEAD -> feat2) Add feat2.txt
+* 61a8c4e (feat1) Add shared and feat1 files
+* 08bbcd9 (main) Initial commit


### PR DESCRIPTION
If there are unstaged changes in the worktree when using commit fixup
to fix up a downstack branch, we should not pop the autostashed changes
until after the upstack restack is complete,
and we've switched back to the original branch (not the fixed branch).

Ref: https://github.com/abhinav/git-spice/discussions/867#discussioncomment-14465048

[skip changelog]: New entry not required as fixup hasn't been released yet.