### PR TITLE
doc: brew install --cask for tap

### DIFF
--- a/doc/src/start/install.md
+++ b/doc/src/start/install.md
@@ -41,7 +41,7 @@ brew install git-spice
 You can also use my Homebrew Tap to install the latest release:
 
 ```bash
-brew install abhinav/tap/git-spice
+brew install --cask abhinav/tap/git-spice
 ```
 
 ### Binary installation tools


### PR DESCRIPTION
Installation instructions for using the git-spice cask should add the --cask flag so homebrew prefers that over the (now) deprecated formula.

