### PR TITLE
branch create: make -m/--message imply --commit

### DIFF
--- a/.changes/unreleased/Changed-20251005-195348.yaml
+++ b/.changes/unreleased/Changed-20251005-195348.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'branch create: -m/--message now implies --commit'
+time: 2025-10-05T19:53:48.191031-07:00

--- a/branch_create.go
+++ b/branch_create.go
@@ -41,6 +41,7 @@ func (*branchCreateCmd) Help() string {
 		Use -a/--all to automatically stage modified and deleted files,
 		just like 'git commit -a'.
 		Use --no-commit to create the branch without committing.
+		-m/--message always implies --commit.
 
 		If a branch name is not provided,
 		it will be generated from the commit message.
@@ -100,6 +101,11 @@ func (cmd *branchCreateCmd) Run(
 ) (err error) {
 	if cmd.Name == "" && !cmd.Commit {
 		return errors.New("a branch name is required with --no-commit")
+	}
+
+	// If a message is specified, automatically enable commits
+	if cmd.Message != "" {
+		cmd.Commit = true
 	}
 
 	trunk := store.Trunk()

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -627,6 +627,7 @@ If there are no staged changes, an empty commit will be created.
 Use -a/--all to automatically stage modified and deleted files,
 just like 'git commit -a'.
 Use --no-commit to create the branch without committing.
+-m/--message always implies --commit.
 
 If a branch name is not provided,
 it will be generated from the commit message.

--- a/doc/src/recipes.md
+++ b/doc/src/recipes.md
@@ -36,10 +36,11 @@ and then work on them, you can use the following to adjust the workflow:
     ```
 
 - If, for some branches, you do want to commit staged changes upon creation,
-  use the `--commit` flag.
+  use the `--commit` flag or `-m`/`--message` (which always implies `--commit`).
 
     ```bash
     gs branch create my-branch --commit
+    gs branch create my-branch -m "Commit message"
     ```
 
 ### Working with unsupported remotes

--- a/testdata/script/branch_create_message_implies_commit.txt
+++ b/testdata/script/branch_create_message_implies_commit.txt
@@ -1,0 +1,39 @@
+# branch create with -m should automatically enable commits
+# even when commits are disabled by default via config.
+
+as 'Test <test@example.com>'
+at '2025-10-05T12:00:00Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# disable commits by default
+git config spice.branchCreate.commit false
+
+# using -m should automatically enable commits
+# even though commits are disabled
+git add foo.txt
+gs bc feat1 -m 'Add foo'
+
+# verify commit was created
+git status --porcelain
+! stdout .
+
+gs ll
+cmp stderr $WORK/golden/ll-feat1.txt
+
+git graph --branches
+cmp stdout $WORK/golden/graph.txt
+
+-- repo/foo.txt --
+foo
+
+-- golden/ll-feat1.txt --
+┏━■ feat1 ◀
+┃   aadd769 Add foo (now)
+main
+-- golden/graph.txt --
+* aadd769 (HEAD -> feat1) Add foo
+* b4e1d23 (main) Initial commit


### PR DESCRIPTION
When users specify -m/--message with branch create,
they clearly intend to create a commit.
Automatically enable commits in this case,
even if commits are disabled by default via config.

Resolves #882