### PR TITLE
refac(commit): share commit options

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -1,5 +1,21 @@
 package main
 
+import "go.abhg.dev/gs/internal/git"
+
+type commitOptions struct {
+	Message  string `short:"m" placeholder:"MSG" help:"Use the given message as the commit message."`
+	NoVerify bool   `help:"Bypass pre-commit and commit-msg hooks."`
+}
+
+func (opts *commitOptions) commitRequest(req *git.CommitRequest) git.CommitRequest {
+	if req == nil {
+		req = &git.CommitRequest{}
+	}
+	req.Message = opts.Message
+	req.NoVerify = opts.NoVerify
+	return *req
+}
+
 type commitCmd struct {
 	Create commitCreateCmd `cmd:"" aliases:"c" help:"Create a new commit"`
 	Amend  commitAmendCmd  `cmd:"" aliases:"a" help:"Amend the current commit"`

--- a/commit_amend.go
+++ b/commit_amend.go
@@ -16,13 +16,12 @@ import (
 
 type commitAmendCmd struct {
 	branchCreateConfig // TODO: find a way to avoid this
+	commitOptions
 
-	All        bool   `short:"a" help:"Stage all changes before committing."`
-	AllowEmpty bool   `help:"Create a commit even if it contains no changes."`
-	Message    string `short:"m" placeholder:"MSG" help:"Use the given message as the commit message."`
+	All        bool `short:"a" help:"Stage all changes before committing."`
+	AllowEmpty bool `help:"Create a commit even if it contains no changes."`
 
-	NoEdit   bool `help:"Don't edit the commit message"`
-	NoVerify bool `help:"Bypass pre-commit and commit-msg hooks."`
+	NoEdit bool `help:"Don't edit the commit message"`
 }
 
 func (*commitAmendCmd) Help() string {
@@ -176,14 +175,12 @@ func (cmd *commitAmendCmd) Run(
 		}
 	}
 
-	if err := wt.Commit(ctx, git.CommitRequest{
-		Message:    cmd.Message,
+	if err := wt.Commit(ctx, cmd.commitRequest(&git.CommitRequest{
 		AllowEmpty: cmd.AllowEmpty,
 		Amend:      true,
 		NoEdit:     cmd.NoEdit,
-		NoVerify:   cmd.NoVerify,
 		All:        cmd.All,
-	}); err != nil {
+	})); err != nil {
 		return fmt.Errorf("commit: %w", err)
 	}
 

--- a/commit_create.go
+++ b/commit_create.go
@@ -12,11 +12,11 @@ import (
 )
 
 type commitCreateCmd struct {
+	commitOptions
+
 	All        bool   `short:"a" help:"Stage all changes before committing."`
 	AllowEmpty bool   `help:"Create a new commit even if it contains no changes."`
 	Fixup      string `help:"Create a fixup commit. See also 'gs commit fixup'." placeholder:"COMMIT"`
-	Message    string `short:"m" placeholder:"MSG" help:"Use the given message as the commit message."`
-	NoVerify   bool   `help:"Bypass pre-commit and commit-msg hooks."`
 }
 
 func (*commitCreateCmd) Help() string {
@@ -46,13 +46,11 @@ func (cmd *commitCreateCmd) Run(
 	wt *git.Worktree,
 	restackHandler RestackHandler,
 ) error {
-	if err := wt.Commit(ctx, git.CommitRequest{
-		Message:    cmd.Message,
+	if err := wt.Commit(ctx, cmd.commitRequest(&git.CommitRequest{
 		All:        cmd.All,
 		AllowEmpty: cmd.AllowEmpty,
 		Fixup:      cmd.Fixup,
-		NoVerify:   cmd.NoVerify,
-	}); err != nil {
+	})); err != nil {
 		return fmt.Errorf("commit: %w", err)
 	}
 

--- a/commit_split.go
+++ b/commit_split.go
@@ -12,8 +12,7 @@ import (
 )
 
 type commitSplitCmd struct {
-	Message  string `short:"m" placeholder:"MSG" help:"Use the given message as the commit message."`
-	NoVerify bool   `help:"Bypass pre-commit and commit-msg hooks."`
+	commitOptions
 }
 
 func (*commitSplitCmd) Help() string {
@@ -69,10 +68,7 @@ func (cmd *commitSplitCmd) Run(
 		return fmt.Errorf("select hunks: %w", err)
 	}
 
-	if err := wt.Commit(ctx, git.CommitRequest{
-		Message:  cmd.Message,
-		NoVerify: cmd.NoVerify,
-	}); err != nil {
+	if err := wt.Commit(ctx, cmd.commitRequest(nil)); err != nil {
 		return fmt.Errorf("commit: %w", err)
 	}
 

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -974,11 +974,11 @@ when you want to apply changes to an older commit.
 
 **Flags**
 
+* `-m`, `--message=MSG`: Use the given message as the commit message.
+* `--no-verify`: Bypass pre-commit and commit-msg hooks.
 * `-a`, `--all`: Stage all changes before committing.
 * `--allow-empty`: Create a new commit even if it contains no changes.
 * `--fixup=COMMIT`: Create a fixup commit. See also 'gs commit fixup'.
-* `-m`, `--message=MSG`: Use the given message as the commit message.
-* `--no-verify`: Bypass pre-commit and commit-msg hooks.
 
 ### gs commit amend
 
@@ -1007,11 +1007,11 @@ The --no-prompt flag can be used to skip this prompt in scripts.
 
 **Flags**
 
+* `-m`, `--message=MSG`: Use the given message as the commit message.
+* `--no-verify`: Bypass pre-commit and commit-msg hooks.
 * `-a`, `--all`: Stage all changes before committing.
 * `--allow-empty`: Create a commit even if it contains no changes.
-* `-m`, `--message=MSG`: Use the given message as the commit message.
 * `--no-edit`: Don't edit the commit message
-* `--no-verify`: Bypass pre-commit and commit-msg hooks.
 
 **Configuration**: [spice.branchCreate.prefix](/cli/config.md#spicebranchcreateprefix)
 


### PR DESCRIPTION
Share common flags between commit create, amend, and split commands.
This will make it easier to add new shared flags in the future.

[skip changelog]: no user facing changes