### PR TITLE
Add prompt for stack/upstack restack from trunk

### DIFF
--- a/.changes/unreleased/Added-20251018-115634.yaml
+++ b/.changes/unreleased/Added-20251018-115634.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: >-
+  {stack, upstack} restack: prompt for confirmation when invoked from trunk
+  to prevent accidental full-repository restacking.
+  To do this without a prompt, prefer using the `gs repo restack` command instead.
+time: 2025-10-18T11:56:34.32969-07:00

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -376,13 +376,11 @@ Restack a branch and its upstack
 The current branch and all branches above it
 are rebased on top of their respective bases,
 ensuring a linear history.
+
 Use --branch to start at a different branch.
+
 Use --skip-start to skip the starting branch,
 but still rebase all branches above it.
-
-The target branch defaults to the current branch.
-If run from the trunk branch,
-all managed branches will be restacked.
 
 **Flags**
 

--- a/stack_restack.go
+++ b/stack_restack.go
@@ -2,10 +2,14 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/silog"
+	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 type stackRestackCmd struct {
@@ -21,6 +25,45 @@ func (*stackRestackCmd) Help() string {
 	`)
 }
 
+// verifyRestackFromTrunk checks if we're restacking from trunk
+// and prompts for confirmation if so.
+//
+// Returns nil if the operation should proceed, or an error.
+func verifyRestackFromTrunk(
+	log *silog.Logger,
+	view ui.View,
+	store *state.Store,
+	currentBranch string,
+	commandName string,
+) error {
+	if currentBranch != store.Trunk() {
+		return nil
+	}
+
+	desc := fmt.Sprintf("Running 'gs %s restack' from trunk restacks all tracked branches.\n"+
+		"Use 'gs repo restack' to suppress this prompt.", commandName)
+
+	// Non-interactive mode: print warning and proceed
+	if !ui.Interactive(view) {
+		log.Warn(desc)
+		return nil
+	}
+
+	proceed := true // default true so user can "enter" to accept
+	confirm := ui.NewConfirm().
+		WithTitle("Restack all branches?").
+		WithDescription(desc).
+		WithValue(&proceed)
+	if err := ui.Run(view, confirm); err != nil {
+		return fmt.Errorf("run prompt: %w", err)
+	}
+
+	if !proceed {
+		return errors.New("operation aborted")
+	}
+	return nil
+}
+
 func (cmd *stackRestackCmd) AfterApply(ctx context.Context, wt *git.Worktree) error {
 	if cmd.Branch == "" {
 		currentBranch, err := wt.CurrentBranch(ctx)
@@ -32,6 +75,16 @@ func (cmd *stackRestackCmd) AfterApply(ctx context.Context, wt *git.Worktree) er
 	return nil
 }
 
-func (cmd *stackRestackCmd) Run(ctx context.Context, handler RestackHandler) error {
+func (cmd *stackRestackCmd) Run(
+	ctx context.Context,
+	log *silog.Logger,
+	view ui.View,
+	store *state.Store,
+	handler RestackHandler,
+) error {
+	if err := verifyRestackFromTrunk(log, view, store, cmd.Branch, "stack"); err != nil {
+		return err
+	}
+
 	return handler.RestackStack(ctx, cmd.Branch)
 }

--- a/testdata/script/restack_from_trunk_prompt.txt
+++ b/testdata/script/restack_from_trunk_prompt.txt
@@ -1,0 +1,133 @@
+# 'stack restack' and 'upstack restack' from trunk
+# prompt for confirmation before proceeding.
+
+as 'Test <test@example.com>'
+at '2025-10-18T21:28:29Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# set up feature1 -> feature2 -> feature3
+git add feature1.txt
+gs bc feature1 -m 'Add feature1'
+git add feature2.txt
+gs bc feature2 -m 'Add feature2'
+git add feature3.txt
+gs bc feature3 -m 'Add feature3'
+
+# make changes to require a restack
+gs trunk
+cp $WORK/extra/feature0.txt .
+git add feature0.txt
+git commit -m 'Add feature0'
+
+git graph --branches
+cmp stdout $WORK/golden/graph-before.txt
+
+# Test 1: gs stack restack: User aborts the operation.
+env ROBOT_INPUT=$WORK/robot-stack-no.golden ROBOT_OUTPUT=$WORK/robot-stack-no.actual
+! gs stack restack
+cmp $WORK/robot-stack-no.actual $WORK/robot-stack-no.golden
+env ROBOT_INPUT=
+
+# no changes
+git graph --branches
+cmp stdout $WORK/golden/graph-before.txt
+
+# Test 2: gs upstack restack: User aborts the operation.
+env ROBOT_INPUT=$WORK/robot-upstack-no.golden ROBOT_OUTPUT=$WORK/robot-upstack-no.actual
+! gs upstack restack
+cmp $WORK/robot-upstack-no.actual $WORK/robot-upstack-no.golden
+env ROBOT_INPUT=
+
+# no changes
+git graph --branches
+cmp stdout $WORK/golden/graph-before.txt
+
+# Test 3: stack restack: user agrees to restack
+env ROBOT_INPUT=$WORK/robot-stack-yes.golden ROBOT_OUTPUT=$WORK/robot-stack-yes.actual
+gs stack restack
+stderr 'feature1: restacked on main'
+stderr 'feature2: restacked on feature1'
+stderr 'feature3: restacked on feature2'
+cmp $WORK/robot-stack-yes.actual $WORK/robot-stack-yes.golden
+env ROBOT_INPUT=
+
+git graph --branches
+cmp stdout $WORK/golden/graph-after-stack-restack.txt
+
+# Make another change on trunk for upstack restack.
+gs trunk
+cp $WORK/extra/feature0b.txt feature0.txt
+git add feature0.txt
+git commit -m 'Update feature0'
+
+# Test 4: upstack restack: user agrees to restack
+env ROBOT_INPUT=$WORK/robot-upstack-yes.golden ROBOT_OUTPUT=$WORK/robot-upstack-yes.actual
+gs stack restack
+stderr 'feature1: restacked on main'
+stderr 'feature2: restacked on feature1'
+stderr 'feature3: restacked on feature2'
+cmp $WORK/robot-upstack-yes.actual $WORK/robot-upstack-yes.golden
+env ROBOT_INPUT=
+
+git graph --branches
+cmp stdout $WORK/golden/graph-after-upstack-restack.txt
+
+-- repo/feature1.txt --
+foo
+-- repo/feature2.txt --
+bar
+-- repo/feature3.txt --
+baz
+-- extra/feature0.txt --
+quux
+-- extra/feature0b.txt --
+quux updated
+-- robot-stack-yes.golden --
+===
+> Restack all branches?: [Y/n]
+> Running 'gs stack restack' from trunk restacks all tracked branches.
+> Use 'gs repo restack' to suppress this prompt.
+true
+-- robot-stack-no.golden --
+===
+> Restack all branches?: [Y/n]
+> Running 'gs stack restack' from trunk restacks all tracked branches.
+> Use 'gs repo restack' to suppress this prompt.
+false
+-- robot-upstack-yes.golden --
+===
+> Restack all branches?: [Y/n]
+> Running 'gs stack restack' from trunk restacks all tracked branches.
+> Use 'gs repo restack' to suppress this prompt.
+true
+-- robot-upstack-no.golden --
+===
+> Restack all branches?: [Y/n]
+> Running 'gs upstack restack' from trunk restacks all tracked branches.
+> Use 'gs repo restack' to suppress this prompt.
+false
+-- golden/graph-before.txt --
+* 0a8abdd (feature3) Add feature3
+* 3666a4f (feature2) Add feature2
+* b845ef3 (feature1) Add feature1
+| * 6d2eee0 (HEAD -> main) Add feature0
+|/  
+* c269208 Initial commit
+-- golden/graph-after-stack-restack.txt --
+* e361be0 (feature3) Add feature3
+* 38ddc8b (feature2) Add feature2
+* 9a2f14e (feature1) Add feature1
+* 6d2eee0 (HEAD -> main) Add feature0
+* c269208 Initial commit
+-- golden/graph-after-upstack-restack.txt --
+* 38bf181 (feature3) Add feature3
+* b0cc571 (feature2) Add feature2
+* f64b0d2 (feature1) Add feature1
+* 9051342 (HEAD -> main) Update feature0
+* 6d2eee0 Add feature0
+* c269208 Initial commit

--- a/testdata/script/upstack_restack_linear.txt
+++ b/testdata/script/upstack_restack_linear.txt
@@ -29,11 +29,13 @@ cp $WORK/extra/feature0.txt .
 git add feature0.txt
 git commit -m 'Add feature0'
 
-gs upstack restack
-stderr 'feature1: restacked on main'
-stderr 'feature2: restacked on feature1'
-stderr 'feature3: restacked on feature2'
-stderr 'feature4: restacked on feature3'
+gs upstack restack --no-prompt
+stderr 'WRN Running ''gs upstack restack'' from trunk restacks all tracked branches.'
+stderr 'WRN Use ''gs repo restack'' to suppress this prompt.'
+stderr 'INF feature1: restacked on main'
+stderr 'INF feature2: restacked on feature1'
+stderr 'INF feature3: restacked on feature2'
+stderr 'INF feature4: restacked on feature3'
 
 # should still be on main
 git branch


### PR DESCRIPTION
When running 'stack restack' or 'upstack restack' from the trunk branch,
prompt users to confirm the operation in interactive mode,
and log a warning in non-interactive mode.

This helps prevent accidental restacking of all managed branches.

Users who actually meant to do this and don't want to see the prompt
can use the 'gs repo restack' command instead,

Resolves #898