### PR TITLE
fix(mise): don't pass verbose flag to 'go test'

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -64,7 +64,6 @@ run = """
 gotestsum
   {%- if flag(name='verbose') == 'true' %} --format=standard-verbose
   {%- endif %} -- {# -#}
-  -v={{option(name='verbose')}} {# verbose output -#}
   -tags=script {# enable script tests -#}
   -run TestScript/{{option(name='run')}} {# run only script tests -#}
   -race={{flag(name='race')}} {# race detection -#}


### PR DESCRIPTION
go test output should not be suppressed even in non-verbose mode,
because in that case, gotestsum doesn't see anything
(and won't report any tests as run even if they did).

`go test` should always be verbose,
and the `--format` flag to gotestsum
controls how much output is shown.

[skip changelog]: no user facing changes