### PR TITLE
commit: Add --signoff flag to add Signed-off-by trailer

### DIFF
--- a/.changes/unreleased/Added-20251019-135718.yaml
+++ b/.changes/unreleased/Added-20251019-135718.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'commit: Add ''--signoff'' flag to add Signed-off-by trailer to commit messages'
+time: 2025-10-19T13:57:18.317702-07:00

--- a/branch_create.go
+++ b/branch_create.go
@@ -30,6 +30,7 @@ type branchCreateCmd struct {
 	Message string `short:"m" placeholder:"MSG" help:"Commit message"`
 
 	NoVerify bool `help:"Bypass pre-commit and commit-msg hooks."`
+	Signoff  bool `config:"commit.signoff" help:"Add Signed-off-by trailer to the commit message"`
 
 	Commit bool `negatable:"" default:"true" config:"branchCreate.commit" help:"Commit staged changes to the new branch, or create an empty commit"`
 }
@@ -349,6 +350,7 @@ func (cmd *branchCreateCmd) commit(
 		Message:    cmd.Message,
 		NoVerify:   cmd.NoVerify,
 		All:        cmd.All,
+		Signoff:    cmd.Signoff,
 	}); err != nil {
 		if err := wt.CheckoutBranch(ctx, baseName); err != nil {
 			log.Warn("Could not restore original branch. You may need to reset manually.", "error", err)

--- a/commit_amend.go
+++ b/commit_amend.go
@@ -23,6 +23,7 @@ type commitAmendCmd struct {
 
 	NoEdit   bool `help:"Don't edit the commit message"`
 	NoVerify bool `help:"Bypass pre-commit and commit-msg hooks."`
+	Signoff  bool `config:"commit.signoff" help:"Add Signed-off-by trailer to the commit message"`
 }
 
 func (*commitAmendCmd) Help() string {
@@ -118,6 +119,7 @@ func (cmd *commitAmendCmd) Run(
 					All:                cmd.All,
 					NoVerify:           cmd.NoVerify,
 					Message:            cmd.Message,
+					Signoff:            cmd.Signoff,
 					Commit:             true,
 				}).Run(ctx, log, repo, wt, store, svc, restackHandler)
 			}
@@ -183,6 +185,7 @@ func (cmd *commitAmendCmd) Run(
 		NoEdit:     cmd.NoEdit,
 		NoVerify:   cmd.NoVerify,
 		All:        cmd.All,
+		Signoff:    cmd.Signoff,
 	}); err != nil {
 		return fmt.Errorf("commit: %w", err)
 	}

--- a/commit_create.go
+++ b/commit_create.go
@@ -17,6 +17,7 @@ type commitCreateCmd struct {
 	Fixup      string `help:"Create a fixup commit. See also 'gs commit fixup'." placeholder:"COMMIT"`
 	Message    string `short:"m" placeholder:"MSG" help:"Use the given message as the commit message."`
 	NoVerify   bool   `help:"Bypass pre-commit and commit-msg hooks."`
+	Signoff    bool   `config:"commit.signoff" help:"Add Signed-off-by trailer to the commit message"`
 }
 
 func (*commitCreateCmd) Help() string {
@@ -52,6 +53,7 @@ func (cmd *commitCreateCmd) Run(
 		AllowEmpty: cmd.AllowEmpty,
 		Fixup:      cmd.Fixup,
 		NoVerify:   cmd.NoVerify,
+		Signoff:    cmd.Signoff,
 	}); err != nil {
 		return fmt.Errorf("commit: %w", err)
 	}

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -684,9 +684,10 @@ target (A) to the specified branch:
 * `-a`, `--all`: Automatically stage modified and deleted files
 * `-m`, `--message=MSG`: Commit message
 * `--no-verify`: Bypass pre-commit and commit-msg hooks.
+* `--signoff` ([:material-wrench:{ .middle title="spice.commit.signoff" }](/cli/config.md#spicecommitsignoff)): Add Signed-off-by trailer to the commit message
 * `--[no-]commit` ([:material-wrench:{ .middle title="spice.branchCreate.commit" }](/cli/config.md#spicebranchcreatecommit)): Commit staged changes to the new branch, or create an empty commit
 
-**Configuration**: [spice.branchCreate.commit](/cli/config.md#spicebranchcreatecommit), [spice.branchCreate.prefix](/cli/config.md#spicebranchcreateprefix)
+**Configuration**: [spice.branchCreate.commit](/cli/config.md#spicebranchcreatecommit), [spice.branchCreate.prefix](/cli/config.md#spicebranchcreateprefix), [spice.commit.signoff](/cli/config.md#spicecommitsignoff)
 
 ### gs branch delete
 
@@ -977,6 +978,9 @@ when you want to apply changes to an older commit.
 * `--fixup=COMMIT`: Create a fixup commit. See also 'gs commit fixup'.
 * `-m`, `--message=MSG`: Use the given message as the commit message.
 * `--no-verify`: Bypass pre-commit and commit-msg hooks.
+* `--signoff` ([:material-wrench:{ .middle title="spice.commit.signoff" }](/cli/config.md#spicecommitsignoff)): Add Signed-off-by trailer to the commit message
+
+**Configuration**: [spice.commit.signoff](/cli/config.md#spicecommitsignoff)
 
 ### gs commit amend
 
@@ -1010,8 +1014,9 @@ The --no-prompt flag can be used to skip this prompt in scripts.
 * `-m`, `--message=MSG`: Use the given message as the commit message.
 * `--no-edit`: Don't edit the commit message
 * `--no-verify`: Bypass pre-commit and commit-msg hooks.
+* `--signoff` ([:material-wrench:{ .middle title="spice.commit.signoff" }](/cli/config.md#spicecommitsignoff)): Add Signed-off-by trailer to the commit message
 
-**Configuration**: [spice.branchCreate.prefix](/cli/config.md#spicebranchcreateprefix)
+**Configuration**: [spice.branchCreate.prefix](/cli/config.md#spicebranchcreateprefix), [spice.commit.signoff](/cli/config.md#spicecommitsignoff)
 
 ### gs commit split
 

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -104,13 +104,25 @@ and use the `--commit` flag to commit changes when needed.
 
 <!-- gs:version v0.14.0 -->
 
-If set, the prefix will be prepended to the name of every branch created 
+If set, the prefix will be prepended to the name of every branch created
 with $$gs branch create$$.
 
 Commonly used values are:
 
 - `<name>/`: the committer's name
 - `<username>/`: the committer's username
+
+### spice.commit.signoff
+
+<!-- gs:version unreleased -->
+
+Whether commit commands should add a `Signed-off-by` trailer
+to commit messages by default.
+
+**Accepted values:**
+
+- `true`
+- `false` (default)
 
 ### spice.checkout.verbose
 

--- a/internal/git/commit_wt.go
+++ b/internal/git/commit_wt.go
@@ -46,6 +46,9 @@ type CommitRequest struct {
 
 	// NoVerify allows a commit with pre-commit and commit-msg hooks bypassed.
 	NoVerify bool
+
+	// Signoff adds a Signed-off-by trailer to the commit message.
+	Signoff bool
 }
 
 // Commit runs the 'git commit' command,
@@ -92,6 +95,9 @@ func (w *Worktree) Commit(ctx context.Context, req CommitRequest) error {
 	}
 	if req.Fixup != "" {
 		args = append(args, "--fixup", req.Fixup)
+	}
+	if req.Signoff {
+		args = append(args, "--signoff")
 	}
 
 	err := w.gitCmd(ctx, args...).

--- a/internal/git/commit_wt_test.go
+++ b/internal/git/commit_wt_test.go
@@ -1,0 +1,89 @@
+package git_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hexops/autogold/v2"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/git/gittest"
+	"go.abhg.dev/gs/internal/silog/silogtest"
+	"go.abhg.dev/gs/internal/text"
+)
+
+func TestWorktree_Commit_signoff(t *testing.T) {
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	t.Setenv("USER", "testuser")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("GIT_COMMITTER_NAME", "Test Committer")
+	t.Setenv("GIT_COMMITTER_EMAIL", "committer@example.com")
+	t.Setenv("GIT_AUTHOR_NAME", "Test Author")
+	t.Setenv("GIT_AUTHOR_EMAIL", "author@example.com")
+
+	fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+		at '2025-08-30T21:28:29Z'
+		as 'Test Owner <test@example.com>'
+
+		git init
+		git commit --allow-empty -m 'Initial commit'
+
+		git add file.txt  # used to commit below
+
+		-- file.txt --
+		test content
+	`)))
+	require.NoError(t, err)
+	t.Cleanup(fixture.Cleanup)
+
+	ctx := t.Context()
+	worktree, err := git.OpenWorktree(ctx, fixture.Dir(), git.OpenOptions{
+		Log: silogtest.New(t),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, worktree.Commit(ctx, git.CommitRequest{
+		Message: "Add test file\n\nBody of the commit message.",
+		Signoff: true,
+	}))
+
+	repo := worktree.Repository()
+
+	assertCommitBodyEquals := func(t *testing.T, value autogold.Value) {
+		commit, err := repo.ReadCommit(ctx, "HEAD")
+		require.NoError(t, err)
+		value.Equal(t, strings.TrimSpace(commit.Body))
+	}
+
+	assertCommitBodyEquals(t, autogold.Expect(`Body of the commit message.
+
+Signed-off-by: Test Committer <committer@example.com>`))
+
+	t.Run("AmendAlreadySignedOff", func(t *testing.T) {
+		require.NoError(t, worktree.Commit(ctx, git.CommitRequest{
+			Amend:   true,
+			Signoff: true,
+			NoEdit:  true,
+		}))
+
+		assertCommitBodyEquals(t, autogold.Expect(`Body of the commit message.
+
+Signed-off-by: Test Committer <committer@example.com>`))
+	})
+
+	t.Run("AmendAlreadySignedOffNewAuthor", func(t *testing.T) {
+		t.Setenv("GIT_AUTHOR_NAME", "Test Signer")
+		t.Setenv("GIT_COMMITTER_EMAIL", "signer@example.com")
+		require.NoError(t, worktree.Commit(ctx, git.CommitRequest{
+			Amend:   true,
+			Signoff: true,
+			NoEdit:  true,
+		}))
+
+		assertCommitBodyEquals(t, autogold.Expect(`Body of the commit message.
+
+Signed-off-by: Test Committer <committer@example.com>
+Signed-off-by: Test Committer <signer@example.com>`))
+	})
+}

--- a/testdata/script/branch_create_signoff.txt
+++ b/testdata/script/branch_create_signoff.txt
@@ -1,0 +1,25 @@
+# Test that gs branch create --signoff adds Signed-off-by trailer
+
+as 'Test User <test@example.com>'
+at '2025-10-19T21:28:29Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# Create a branch with signoff
+cp $WORK/extra/feature.txt feature.txt
+git add feature.txt
+gs branch create feature --signoff -m 'Add feature'
+
+# Verify the commit has Signed-off-by trailer
+git log -n1 --pretty=%b
+cmp stdout $WORK/golden/commit-body.txt
+
+-- extra/feature.txt --
+feature content
+-- golden/commit-body.txt --
+Signed-off-by: Test User <test@example.com>
+

--- a/testdata/script/commit_amend_signoff.txt
+++ b/testdata/script/commit_amend_signoff.txt
@@ -1,0 +1,28 @@
+# Test that gs commit amend --signoff adds Signed-off-by trailer
+
+as 'Test User <test@example.com>'
+at '2025-10-19T21:28:29Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# Create initial commit without signoff
+gs branch create feature -m 'Add feature'
+
+# Make a change and amend with signoff
+cp $WORK/extra/feature.txt feature.txt
+git add feature.txt
+gs commit amend --signoff --no-edit
+
+# Verify the commit has Signed-off-by trailer
+git log -n1 --pretty=%b
+cmp stdout $WORK/golden/commit-body.txt
+
+-- extra/feature.txt --
+feature content
+-- golden/commit-body.txt --
+Signed-off-by: Test User <test@example.com>
+

--- a/testdata/script/commit_create_signoff.txt
+++ b/testdata/script/commit_create_signoff.txt
@@ -1,0 +1,34 @@
+# Test that gs commit create --signoff adds Signed-off-by trailer
+
+as 'Test User <test@example.com>'
+at '2025-10-19T21:28:29Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# Create a file and commit with signoff
+cp $WORK/extra/feature.txt feature.txt
+git add feature.txt
+gs commit create --signoff -m 'Add feature'
+
+# Verify the commit has Signed-off-by trailer
+git log -n1 --pretty=%B
+cmp stdout $WORK/golden/commit-message.txt
+
+# Verify the signoff is in the body
+git log -n1 --pretty=%b
+cmp stdout $WORK/golden/commit-body.txt
+
+-- extra/feature.txt --
+feature content
+-- golden/commit-message.txt --
+Add feature
+
+Signed-off-by: Test User <test@example.com>
+
+-- golden/commit-body.txt --
+Signed-off-by: Test User <test@example.com>
+

--- a/testdata/script/commit_signoff_config.txt
+++ b/testdata/script/commit_signoff_config.txt
@@ -1,0 +1,47 @@
+# Test that commit.signoff config enables signoff by default
+
+as 'Test User <test@example.com>'
+at '2025-10-19T21:28:29Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# Set the commit.signoff config option
+git config spice.commit.signoff true
+
+# Test with gs commit create
+cp $WORK/extra/file1.txt file1.txt
+git add file1.txt
+gs commit create -m 'Add file1'
+
+git log -n1 --pretty=%b
+cmp stdout $WORK/golden/signoff.txt
+
+# Test with gs branch create
+cp $WORK/extra/file2.txt file2.txt
+git add file2.txt
+gs branch create feature --commit -m 'Add file2'
+
+git log -n1 --pretty=%b
+cmp stdout $WORK/golden/signoff.txt
+
+# Test with gs commit amend
+cp $WORK/extra/file3.txt file3.txt
+git add file3.txt
+gs commit amend --no-edit
+
+git log -n1 --pretty=%b
+cmp stdout $WORK/golden/signoff.txt
+
+-- extra/file1.txt --
+file1 content
+-- extra/file2.txt --
+file2 content
+-- extra/file3.txt --
+file3 content
+-- golden/signoff.txt --
+Signed-off-by: Test User <test@example.com>
+


### PR DESCRIPTION
Add support for the --signoff flag to commit commands.
When used, this adds a Signed-off-by trailer to commit messages.

The flag is available on:

- gs commit create
- gs commit amend
- gs branch create

A new configuration option `spice.commit.signoff`
enables signoff by default when set to true.

Resolves #863