### PR TITLE
fix(branch delete): Exit gracefully when user declines prompt

### DIFF
--- a/.changes/unreleased/Fixed-20251025-142941.yaml
+++ b/.changes/unreleased/Fixed-20251025-142941.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'branch delete: Exit gracefully when user declines to delete an unmerged branch'
+time: 2025-10-25T14:29:41.038227-07:00

--- a/internal/handler/delete/handler.go
+++ b/internal/handler/delete/handler.go
@@ -325,6 +325,12 @@ func (h *Handler) DeleteBranches(ctx context.Context, req *Request) error {
 			if err := ui.Run(h.View, prompt); err != nil {
 				return fmt.Errorf("run prompt: %w", err)
 			}
+
+			// If the user declined the prompt, skip this branch.
+			if !force {
+				log.Infof("%v: skipped deletion", branch)
+				continue
+			}
 		}
 
 		if exists {

--- a/testdata/script/issue912_branch_delete_unmerged_declined.txt
+++ b/testdata/script/issue912_branch_delete_unmerged_declined.txt
@@ -1,0 +1,36 @@
+# When declining the prompt to delete an unmerged branch,
+# the branch should not be deleted.
+#
+# https://github.com/abhinav/git-spice/issues/912
+
+as 'Test <test@example.com>'
+at '2025-10-25T10:00:00Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'initial commit'
+gs repo init
+
+git add foo.txt
+gs bc foo -m 'add foo.txt'
+
+git checkout main
+
+# Decline the prompt to delete the unmerged branch
+env ROBOT_INPUT=$WORK/robot.golden ROBOT_OUTPUT=$WORK/robot.actual
+gs branch delete foo
+cmp $WORK/robot.actual $WORK/robot.golden
+stderr 'foo: skipped deletion'
+
+# Branch should still exist
+git rev-parse --verify foo
+stdout '1b2aafed11ebc65ef2643881bf22015cf352790f'
+
+-- repo/foo.txt --
+whatever
+-- robot.golden --
+===
+> Delete foo anyway?: [y/N]
+> foo has not been merged into HEAD. This may result in data loss.
+false


### PR DESCRIPTION
Previously, when attempting to delete an unmerged branch,
`gs branch delete` would prompt the user to confirm the deletion.
If the user declined the prompt,
the command would proceed to attempt the deletion anyway,
causing git to refuse the operation and the command to exit with an error.

This change checks whether the user declined the prompt,
and if so, skips the deletion for that branch
and logs an informational message instead of attempting the deletion.

Fixes #912

🤖 Generated with [Claude Code](https://claude.com/claude-code)
