### PR TITLE
fix(repo sync): Don't delete branch if open PR is found

### DIFF
--- a/.changes/unreleased/Fixed-20251028-143010.yaml
+++ b/.changes/unreleased/Fixed-20251028-143010.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: >-
+  Prevent `gs repo sync` from prompting to delete a branch
+  when both a merged and an open PR are present for it.
+time: 2025-10-28T14:30:10-07:00

--- a/internal/handler/sync/handler.go
+++ b/internal/handler/sync/handler.go
@@ -501,7 +501,7 @@ func (h *Handler) findForgeFinishedBranches(
 			wg.Go(func() {
 				for b := range trackedch {
 					changes, err := h.RemoteRepository.FindChangesByBranch(ctx, b.Name, forge.FindChangesOptions{
-						Limit: 3,
+						Limit: 10,
 					})
 					if err != nil {
 						h.Log.Error("Failed to list changes", "branch", b.Name, "error", err)

--- a/testdata/script/repo_sync_detect_externally_created_prs.txt
+++ b/testdata/script/repo_sync_detect_externally_created_prs.txt
@@ -1,6 +1,5 @@
 # 'repo sync' detects and deletes branches for PRs
 # that were created externally and then merged.
-# Does not delete branches with an open PR.
 
 as 'Test <test@example.com>'
 at '2024-06-05T05:29:28Z'
@@ -35,46 +34,19 @@ mv $WORK/extra/modified-feature2.txt feature2.txt
 git add feature2.txt
 gs cc -m 'Modify feature2'
 
-# Create a third branch, submit and merge it.
-gs trunk
-git add feature3-v1.txt
-gs bc -m 'Add feature3 v1' feature3
-gs branch submit --fill
-stderr 'Created #'
-shamhub merge alice/example 3
-
-# Sync to delete feature3
-gs repo sync
-stderr 'feature3: #3 was merged'
-! git rev-parse --verify feature3
-
-# Delete the remote branch so we can reuse the same branch name for the next PR
-git push origin --delete feature3
-
-# Create a new branch with the same name feature3 and submit it.
-gs trunk
-git add feature3-v2.txt
-gs bc -m 'Add feature3 v2' feature3
-gs branch submit --fill
-stderr 'Created #'
-
 # Forget all state.
 gs repo init --reset --trunk=main --remote=origin
 # At this point, gs has no knowledge of the PRs.
-
-# Merge feature1 and feature2 server-side. Do not merge feature3 so PR #4 is still open.
+# Merge them server-side.
 shamhub merge alice/example 1
 shamhub merge alice/example 2
 
 # Track the branches and sync.
 gs branch track --base=main feature1
 gs branch track --base=main feature2
-gs branch track --base=main feature3
 gs repo sync
 stderr 'feature1: #1 was merged'
 stderr 'feature2: #2 was merged but local SHA \(6b83ef3\) does not match remote SHA \(33f1653\). Skipping'
-# feature3 should not be reported as merged because PR #4 is still open
-! stderr 'feature3.*was merged'
 
 git graph --branches
 cmp stdout $WORK/golden/merged-log.txt
@@ -88,31 +60,19 @@ Contents of feature
 -- repo/feature2.txt --
 Contents of feature2
 
--- repo/feature3-v1.txt --
-Contents of feature3 v1
-
--- repo/feature3-v2.txt --
-Contents of feature3 v2
-
 -- extra/modified-feature2.txt --
 New contents of feature2
 
 -- golden/merged-log.txt --
-* 6b83ef3 (feature2) Modify feature2
-| * 24a756d (HEAD -> feature3, origin/feature3) Add feature3 v2
-| | *   478956e (origin/main, main) Merge change #2
-| | |\  
-| |_|/  
-|/| |   
-* | | 33f1653 (origin/feature2) Add feature2
-| | * e6e05a1 Merge change #1
-| |/| 
-| | * 7bf98f4 Add feature1
+* 6b83ef3 (HEAD -> feature2) Modify feature2
+| *   e9220e5 (origin/main, main) Merge change #2
+| |\  
 | |/  
 |/|   
-| * 5bf1af3 Merge change #3
+* | 33f1653 (origin/feature2) Add feature2
+| * b58492c Merge change #1
 |/| 
-| * 5eadeb7 Add feature3 v1
+| * 7bf98f4 Add feature1
 |/  
 * 13538da Initial commit
 -- golden/pull.json --
@@ -138,7 +98,7 @@ New contents of feature2
         "name": "example"
       },
       "ref": "main",
-      "sha": "478956e24c966031e82588f5962f112d2076ef10"
+      "sha": "e9220e54445ee9da6c56bbfddf2feabc9fc3d279"
     }
   },
   {
@@ -148,7 +108,7 @@ New contents of feature2
         "name": "example"
       },
       "ref": "main",
-      "sha": "478956e24c966031e82588f5962f112d2076ef10"
+      "sha": "e9220e54445ee9da6c56bbfddf2feabc9fc3d279"
     },
     "body": "",
     "head": {
@@ -164,52 +124,5 @@ New contents of feature2
     "number": 2,
     "state": "closed",
     "title": "Add feature2"
-  },
-  {
-    "number": 3,
-    "state": "closed",
-    "title": "Add feature3 v1",
-    "body": "",
-    "merged": true,
-    "html_url": "$SHAMHUB_URL/alice/example/change/3",
-    "head": {
-      "repository": {
-        "owner": "alice",
-        "name": "example"
-      },
-      "ref": "feature3",
-      "sha": "24a756d6cd38b02016397e63a4d55715e90c7101"
-    },
-    "base": {
-      "repository": {
-        "owner": "alice",
-        "name": "example"
-      },
-      "ref": "main",
-      "sha": "478956e24c966031e82588f5962f112d2076ef10"
-    }
-  },
-  {
-    "number": 4,
-    "state": "open",
-    "title": "Add feature3 v2",
-    "body": "",
-    "html_url": "$SHAMHUB_URL/alice/example/change/4",
-    "head": {
-      "repository": {
-        "owner": "alice",
-        "name": "example"
-      },
-      "ref": "feature3",
-      "sha": "24a756d6cd38b02016397e63a4d55715e90c7101"
-    },
-    "base": {
-      "repository": {
-        "owner": "alice",
-        "name": "example"
-      },
-      "ref": "main",
-      "sha": "478956e24c966031e82588f5962f112d2076ef10"
-    }
   }
 ]

--- a/testdata/script/repo_sync_detect_externally_created_prs.txt
+++ b/testdata/script/repo_sync_detect_externally_created_prs.txt
@@ -1,5 +1,6 @@
 # 'repo sync' detects and deletes branches for PRs
 # that were created externally and then merged.
+# Does not delete branches with an open PR.
 
 as 'Test <test@example.com>'
 at '2024-06-05T05:29:28Z'
@@ -34,19 +35,46 @@ mv $WORK/extra/modified-feature2.txt feature2.txt
 git add feature2.txt
 gs cc -m 'Modify feature2'
 
+# Create a third branch, submit and merge it.
+gs trunk
+git add feature3-v1.txt
+gs bc -m 'Add feature3 v1' feature3
+gs branch submit --fill
+stderr 'Created #'
+shamhub merge alice/example 3
+
+# Sync to delete feature3
+gs repo sync
+stderr 'feature3: #3 was merged'
+! git rev-parse --verify feature3
+
+# Delete the remote branch so we can reuse the same branch name for the next PR
+git push origin --delete feature3
+
+# Create a new branch with the same name feature3 and submit it.
+gs trunk
+git add feature3-v2.txt
+gs bc -m 'Add feature3 v2' feature3
+gs branch submit --fill
+stderr 'Created #'
+
 # Forget all state.
 gs repo init --reset --trunk=main --remote=origin
 # At this point, gs has no knowledge of the PRs.
-# Merge them server-side.
+
+# Merge feature1 and feature2 server-side. Do not merge feature3 so PR #4 is still open.
 shamhub merge alice/example 1
 shamhub merge alice/example 2
 
 # Track the branches and sync.
 gs branch track --base=main feature1
 gs branch track --base=main feature2
+gs branch track --base=main feature3
 gs repo sync
 stderr 'feature1: #1 was merged'
 stderr 'feature2: #2 was merged but local SHA \(6b83ef3\) does not match remote SHA \(33f1653\). Skipping'
+# feature3 should not be reported as merged because PR #4 is still open
+! stderr 'feature3.*was merged'
 
 git graph --branches
 cmp stdout $WORK/golden/merged-log.txt
@@ -60,19 +88,31 @@ Contents of feature
 -- repo/feature2.txt --
 Contents of feature2
 
+-- repo/feature3-v1.txt --
+Contents of feature3 v1
+
+-- repo/feature3-v2.txt --
+Contents of feature3 v2
+
 -- extra/modified-feature2.txt --
 New contents of feature2
 
 -- golden/merged-log.txt --
-* 6b83ef3 (HEAD -> feature2) Modify feature2
-| *   e9220e5 (origin/main, main) Merge change #2
-| |\  
+* 6b83ef3 (feature2) Modify feature2
+| * 24a756d (HEAD -> feature3, origin/feature3) Add feature3 v2
+| | *   478956e (origin/main, main) Merge change #2
+| | |\  
+| |_|/  
+|/| |   
+* | | 33f1653 (origin/feature2) Add feature2
+| | * e6e05a1 Merge change #1
+| |/| 
+| | * 7bf98f4 Add feature1
 | |/  
 |/|   
-* | 33f1653 (origin/feature2) Add feature2
-| * b58492c Merge change #1
+| * 5bf1af3 Merge change #3
 |/| 
-| * 7bf98f4 Add feature1
+| * 5eadeb7 Add feature3 v1
 |/  
 * 13538da Initial commit
 -- golden/pull.json --
@@ -98,7 +138,7 @@ New contents of feature2
         "name": "example"
       },
       "ref": "main",
-      "sha": "e9220e54445ee9da6c56bbfddf2feabc9fc3d279"
+      "sha": "478956e24c966031e82588f5962f112d2076ef10"
     }
   },
   {
@@ -108,7 +148,7 @@ New contents of feature2
         "name": "example"
       },
       "ref": "main",
-      "sha": "e9220e54445ee9da6c56bbfddf2feabc9fc3d279"
+      "sha": "478956e24c966031e82588f5962f112d2076ef10"
     },
     "body": "",
     "head": {
@@ -124,5 +164,52 @@ New contents of feature2
     "number": 2,
     "state": "closed",
     "title": "Add feature2"
+  },
+  {
+    "number": 3,
+    "state": "closed",
+    "title": "Add feature3 v1",
+    "body": "",
+    "merged": true,
+    "html_url": "$SHAMHUB_URL/alice/example/change/3",
+    "head": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "feature3",
+      "sha": "24a756d6cd38b02016397e63a4d55715e90c7101"
+    },
+    "base": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "main",
+      "sha": "478956e24c966031e82588f5962f112d2076ef10"
+    }
+  },
+  {
+    "number": 4,
+    "state": "open",
+    "title": "Add feature3 v2",
+    "body": "",
+    "html_url": "$SHAMHUB_URL/alice/example/change/4",
+    "head": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "feature3",
+      "sha": "24a756d6cd38b02016397e63a4d55715e90c7101"
+    },
+    "base": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "main",
+      "sha": "478956e24c966031e82588f5962f112d2076ef10"
+    }
   }
 ]

--- a/testdata/script/repo_sync_keeps_branches_with_open_prs.txt
+++ b/testdata/script/repo_sync_keeps_branches_with_open_prs.txt
@@ -1,0 +1,123 @@
+# 'repo sync' does not delete branches with open PRs
+# even if a PR for a branch with the same name has already merged.
+
+as 'Test <test@example.com>'
+at '2024-06-05T05:29:28Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# Create a new branch, submit it, and merge it
+git add feature1-v1.txt
+gs bc -m 'Add feature1 v1' feature1
+gs branch submit --fill
+stderr 'Created #'
+# Merge the change and delete the remote branch
+shamhub merge alice/example 1
+git push origin --delete feature1
+
+# Sync to delete feature1
+gs repo sync
+stderr 'feature1: #1 was merged'
+! git rev-parse --verify feature1
+
+# Create a new branch with the same name feature1 and submit it.
+gs trunk
+git add feature1-v2.txt
+gs bc -m 'Add feature1 v2' feature1
+gs branch submit --fill
+stderr 'Created #'
+
+# Forget all state.
+gs repo init --reset --trunk=main --remote=origin
+# At this point, gs has no knowledge of the PRs.
+
+# Track the branch and sync.
+gs branch track --base=main feature1
+gs repo sync
+# feature1 should not be reported as merged because PR #2 is still open
+! stderr 'feature1: #1 was merged'
+
+git graph --branches
+cmp stdout $WORK/golden/merged-log.txt
+
+shamhub dump changes
+cmpenvJSON stdout $WORK/golden/pull.json
+
+-- repo/feature1-v1.txt --
+Contents of feature1 v1
+
+-- repo/feature1-v2.txt --
+Contents of feature1 v2
+
+-- extra/modified-feature2.txt --
+New contents of feature2
+
+-- golden/merged-log.txt --
+* d7fb222 (HEAD -> feature1, origin/feature1) Add feature1 v2
+*   7d4de38 (origin/main, main) Merge change #1
+|\  
+| * 59fca0b Add feature1 v1
+|/  
+* 13538da Initial commit
+-- golden/pull.json --
+[
+  {
+    "base": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "main",
+      "sha": "7d4de38b4aca2b76457c8bfb0d741dd042d5fdf5"
+    },
+    "body": "",
+    "head": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "feature1",
+      "sha": "d7fb2224bd84f58022bd8d8be21a360d0d14f083"
+    },
+    "html_url": "$SHAMHUB_URL/alice/example/change/1",
+    "merged": true,
+    "number": 1,
+    "state": "closed",
+    "title": "Add feature1 v1"
+  },
+  {
+    "base": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "main",
+      "sha": "7d4de38b4aca2b76457c8bfb0d741dd042d5fdf5"
+    },
+    "body": "",
+    "head": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "feature1",
+      "sha": "d7fb2224bd84f58022bd8d8be21a360d0d14f083"
+    },
+    "html_url": "$SHAMHUB_URL/alice/example/change/2",
+    "number": 2,
+    "state": "open",
+    "title": "Add feature1 v2"
+  }
+]


### PR DESCRIPTION
## Proposed change

If you're re-using a branch name, this PR reduces the likelihood that `git-spice` prompts you to delete it.

This helps reduce friction for new users in old/large codebases, where they're probably using some combination of `git-spice` and regular `git`+web UI, by making it less likely that they'll accidentally delete one of their branches.

It does this by changing how `gs repo sync` handles _externally_ created changes such that if it finds an open change, it will not prompt the user to delete the local branch. So if you're re-using a branch name for a change that was merged in the past _and_ you already have a change open for the new branch, then `git-spice` won't mark the branch as merged or prompt you to delete it. However, this PR does not help if you haven't externally opened a change request or you haven't run `gs branch submit`.


This functionality is achieved by making the following changes:

- When checking for externally created changes:
  - Instead of loading only `merged` changes, load all types of changes
  - If any of the 3 loaded changes are open, set the open one as the change for the branch
  - If no open changes are found and a merged change is found, set that one as the change for the branch

### Test

I've made a change to the existing test file for how `repo sync` handles external branches to test this behavior. I am happy to instead make a new test file if desired!

### Caveat

I'm not proficient in Go, so the initial version of the code and the test was written with Claude Sonnet 4.5. I reviewed and refactored the code to the best of my ability, but I am willing to iterate on this or change direction.

### Questions

The original code loaded 3 changes, and I'm assuming they're loaded in reverse chronological order (newest first). Is this true?

I think only loading 3 is fine, although ideally we could filter to PRs that are either open or merged, but not closed. I'm thinking that it's unlikely that a user has 3 closed PRs for the same branch that are newer than the open one they care about.