### PR TITLE
fix(graphqlutil): Fix buffer use-after-free in RoundTrip

### DIFF
--- a/.changes/unreleased/Fixed-20251030-073655.yaml
+++ b/.changes/unreleased/Fixed-20251030-073655.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: >-
+  Fix data race in reading GraphQL responses from GitHub
+  where buffers could be reused while response bodies were still being read.
+time: 2025-10-30T07:36:55.001974-07:00


### PR DESCRIPTION
The graphQLTransport.RoundTrip method had a use-after-free bug
where buffers from the sync.Pool were returned to the pool
immediately when the function exited via defer putBuffer(buff).
However, the response body contained a bytes.NewReader
that referenced the buffer's underlying byte slice.

When concurrent requests occurred,
a buffer could be returned to the pool and reused
by another goroutine while the first goroutine
was still reading from the response body,
causing a data race.

This fix introduces pooledReadCloser,
which wraps both the bytes.Reader and the buffer.
The buffer is only returned to the pool
when the response body is closed by the caller.
For error cases where no response is returned,
the buffer is returned immediately via the defer function.

The fix preserves the performance benefits of buffer pooling
while ensuring buffers remain valid
for the lifetime of the response body.