### PR TITLE
fix: Fix panic in LoadBranches on lookup error

### DIFF
--- a/.changes/unreleased/Fixed-20251103-162308.yaml
+++ b/.changes/unreleased/Fixed-20251103-162308.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fix crash when information for a branch could not be loaded from Git
+time: 2025-11-03T16:23:08.7112-08:00

--- a/internal/spice/branch.go
+++ b/internal/spice/branch.go
@@ -443,6 +443,7 @@ func (s *Service) LoadBranches(ctx context.Context) ([]LoadBranchItem, error) {
 					mu.Lock()
 					errs = append(errs, fmt.Errorf("get branch %v: %w", name, err))
 					mu.Unlock()
+					continue
 				}
 
 				mu.Lock()


### PR DESCRIPTION
LoadBranches would panic with a nil pointer dereference
when LookupBranch returned an error that wasn't a
DeletedBranchError.
The code appended the error to the errors list
but continued to access fields on the nil response pointer.

Added a continue statement to skip processing
when a non-DeletedBranchError occurs,
preventing the nil pointer dereference.

Added regression test TestService_LoadBranches_lookupError_issue926
to verify the fix.

Fixes #926

