### PR TITLE
fix(submit): Prompt for draft status on all branches in stack

### DIFF
--- a/.changes/unreleased/Fixed-20251114-191245.yaml
+++ b/.changes/unreleased/Fixed-20251114-191245.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'submit: Fix draft prompt being skipped for branches after the first one when submitting a stack interactively'
+time: 2025-11-14T19:12:45.004898-08:00

--- a/internal/handler/submit/handler.go
+++ b/internal/handler/submit/handler.go
@@ -292,10 +292,13 @@ func (h *Handler) SubmitBatch(ctx context.Context, req *BatchRequest) error {
 
 	var branchesToComment []string
 	for _, branch := range req.Branches {
+		// Shallow copy the options because submitBranch may modify them.
+		opts := *opts
+
 		status, err := h.submitBranch(
 			ctx,
 			branch,
-			&submitOptions{Options: opts},
+			&submitOptions{Options: &opts},
 		)
 		if err != nil {
 			return fmt.Errorf("submit branch %s: %w", branch, err)

--- a/testdata/script/issue936_stack_submit_interactive_draft_prompt.txt
+++ b/testdata/script/issue936_stack_submit_interactive_draft_prompt.txt
@@ -1,0 +1,86 @@
+# Regression test for https://github.com/abhinav/git-spice/issues/936
+# Interactive prompt wasn't asking about draft status for CRs after the first one.
+
+as 'Test <test@example.com>'
+at '2025-01-14T10:00:00Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# create a stack: main -> feat1 -> feat2 -> feat3
+git add feat1.txt
+gs branch create feat1 -m 'Add feature 1'
+git add feat2.txt
+gs branch create feat2 -m 'Add feature 2'
+git add feat3.txt
+gs branch create feat3 -m 'Add feature 3'
+
+# submit the stack interactively
+env ROBOT_INPUT=$WORK/robot.golden ROBOT_OUTPUT=$WORK/robot.actual
+gs stack submit
+cmp $WORK/robot.actual $WORK/robot.golden
+
+gs ls -a
+cmp stderr $WORK/golden/ls.txt
+
+-- repo/feat1.txt --
+This is feature 1
+-- repo/feat2.txt --
+This is feature 2
+-- repo/feat3.txt --
+This is feature 3
+
+-- robot.golden --
+===
+> Title: Add feature 1 
+> Short summary of the change
+"Add feature 1"
+===
+> Body: Press [e] to open mockedit or [enter/tab] to skip
+> Open your editor to write a detailed description of the change
+""
+===
+> Draft: [y/N]
+> Mark the change as a draft?
+false
+===
+> Title: Add feature 2 
+> Short summary of the change
+"Add feature 2"
+===
+> Body: Press [e] to open mockedit or [enter/tab] to skip
+> Open your editor to write a detailed description of the change
+""
+===
+> Draft: [y/N]
+> Mark the change as a draft?
+false
+===
+> Title: Add feature 3 
+> Short summary of the change
+"Add feature 3"
+===
+> Body: Press [e] to open mockedit or [enter/tab] to skip
+> Open your editor to write a detailed description of the change
+""
+===
+> Draft: [y/N]
+> Mark the change as a draft?
+false
+
+-- golden/ls.txt --
+    ┏━■ feat3 (#3) ◀
+  ┏━┻□ feat2 (#2)
+┏━┻□ feat1 (#1)
+main


### PR DESCRIPTION
When submitting multiple branches in a stack interactively,
the draft status prompt was only shown for the first branch.
Subsequent branches would skip the prompt entirely.

The issue occurred because `SubmitBatch` reused the same
`Options` struct across all branches in the loop.
When processing the first branch,
`submitBranch` would set `opts.Draft` from `nil` to a pointer.
For subsequent branches,
the `opts.Draft != nil` check would fail,
preventing the draft prompt from appearing.

Fix this by creating a shallow copy of the `Options` struct
for each branch before passing it to `submitBranch`.
This ensures that modifications to the options
only affect the current branch being processed.

Resolves #936