### PR TITLE
feat: add ctrl+u key binding for clearing branch select filter

### DIFF
--- a/.changes/unreleased/Added-20251118-224817.yaml
+++ b/.changes/unreleased/Added-20251118-224817.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'branch select: Add ctrl+u key binding to clear filter'
+time: 2025-11-18T22:48:17.04645-08:00

--- a/internal/ui/widget/branch_select.go
+++ b/internal/ui/widget/branch_select.go
@@ -21,8 +21,9 @@ type BranchSelectKeyMap struct {
 	Up   key.Binding // move up the list
 	Down key.Binding // move down the list
 
-	Accept key.Binding // accept the focused option
-	Delete key.Binding // delete the last character in the filter
+	Accept  key.Binding // accept the focused option
+	Delete  key.Binding // delete the last character in the filter
+	Discard key.Binding // discard the current selection
 }
 
 // DefaultBranchSelectKeyMap is the default key map for a [Select].
@@ -42,6 +43,10 @@ var DefaultBranchSelectKeyMap = BranchSelectKeyMap{
 	Delete: key.NewBinding(
 		key.WithKeys("backspace", "ctrl+h"),
 		key.WithHelp("backspace", "delete filter character"),
+	),
+	Discard: key.NewBinding(
+		key.WithKeys("ctrl+u"),
+		key.WithHelp("ctrl+u", "delete filter line"),
 	),
 }
 
@@ -305,6 +310,12 @@ func (b *BranchTreeSelect) Update(msg tea.Msg) tea.Cmd {
 	case key.Matches(keyMsg, b.KeyMap.Delete):
 		if len(b.filter) > 0 {
 			b.filter = b.filter[:len(b.filter)-1]
+			filterChanged = true
+		}
+
+	case key.Matches(keyMsg, b.KeyMap.Discard):
+		if len(b.filter) > 0 {
+			b.filter = b.filter[:0]
 			filterChanged = true
 		}
 


### PR DESCRIPTION
similar to #666 this adds a common key binding convention for line editors: `ctrl+u` to discard the current line of input.

my muscle memory has attempted this on a few occasions and figure others might too :)