### PR TITLE
test: Fix flaky stack_submit_with_labels test on Windows

### DIFF
--- a/testdata/script/stack_submit_with_labels.txt
+++ b/testdata/script/stack_submit_with_labels.txt
@@ -31,7 +31,9 @@ git config spice.submit.label spice
 # submit the entire stack from the middle.
 git checkout feature1
 gs stack submit --fill --label label1 --label label2,label3
-cmpenv stderr $WORK/golden/submit-log.txt
+stderr 'Created #1'
+stderr 'Created #2'
+stderr 'Created #3'
 
 shamhub dump changes
 cmpenvJSON stdout $WORK/golden/start.json
@@ -56,10 +58,6 @@ This is feature 2
 -- repo/feature3.txt --
 This is feature 3
 
--- golden/submit-log.txt --
-INF Created #1: $SHAMHUB_URL/alice/example/change/1
-INF Created #2: $SHAMHUB_URL/alice/example/change/2
-INF Created #3: $SHAMHUB_URL/alice/example/change/3
 -- golden/start.json --
 [
   {


### PR DESCRIPTION
Replace exact stderr comparison with pattern matching
in the `stack_submit_with_labels.txt` test script.
The test was intermittently failing on Windows
due to warning messages about template caching
that appear non-deterministically,
similar to #956 and #957.

Instead of comparing the entire stderr output
against a golden file,
the test now checks for the presence
of the three "Created #X" messages,
which is sufficient to verify the command succeeded.

Co-Authored-By: Claude <noreply@anthropic.com>