### PR TITLE
fix(submit): Validate fetch refspecs and fix upstream tracking

### DIFF
--- a/.changes/unreleased/Fixed-20251204-211214.yaml
+++ b/.changes/unreleased/Fixed-20251204-211214.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'branch submit: Check if git configuration prevents pushed branches from being tracked, which could leave branches in a state where follow-up submits are not possible'
+time: 2025-12-04T21:12:14.799178-08:00

--- a/.changes/unreleased/Fixed-20251204-211302.yaml
+++ b/.changes/unreleased/Fixed-20251204-211302.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'branch submit: Fix panic when updating CRs that have no upstream branch configured'
+time: 2025-12-04T21:13:02.794912-08:00

--- a/internal/git/ref.go
+++ b/internal/git/ref.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"strings"
 
 	"go.abhg.dev/gs/internal/silog"
 )
@@ -12,6 +13,45 @@ type Refspec string
 
 func (r Refspec) String() string {
 	return string(r)
+}
+
+// Matches checks if a branch name matches a fetch refspec pattern.
+//
+// The refspec should be in the format used by git fetch, e.g.:
+//   - "refs/heads/foo/*" (pattern)
+//   - "+refs/heads/foo/*:refs/remotes/origin/foo/*" (full refspec with destination)
+//   - "refs/heads/master" (exact match)
+//
+// For fetch refspecs with a destination (containing ':'),
+// only the source side (left of ':') is used for matching.
+//
+// This implements the same algorithm as Git:
+// https://github.com/git/git/blob/f0ef5b6d9bcc258e4cbef93839d1b7465d5212b9/refspec.c#L298-L333
+func (r Refspec) Matches(ref string) bool {
+	pattern := strings.TrimPrefix(string(r), "+") // "+" prefix is optional
+
+	// For refspecs with destination, extract source side (left of ':').
+	// E.g.
+	// "+refs/heads/foo/*:refs/remotes/origin/foo/*" -> "refs/heads/foo/*"
+	pattern, _, _ = strings.Cut(pattern, ":")
+
+	prefix, suffix, ok := strings.Cut(pattern, "*")
+	if !ok {
+		// If this is not a pattern refspec (no '*'), do exact match
+		return pattern == ref
+	}
+
+	prefixLen := len(prefix)
+	suffixLen := len(suffix)
+	refLen := len(ref)
+
+	// Match if:
+	// 1. branchName starts with prefix
+	// 2. branchName is long enough for prefix + suffix
+	// 3. branchName ends with suffix
+	return refLen >= prefixLen+suffixLen &&
+		strings.HasPrefix(ref, prefix) &&
+		strings.HasSuffix(ref, suffix)
 }
 
 // SetRefRequest is a request to set a ref to a new hash.

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -60,6 +60,32 @@ func (r *Repository) RemoteDefaultBranch(ctx context.Context, remote string) (st
 	return ref, nil
 }
 
+// RemoteFetchRefspecs returns the fetch refspecs for a remote.
+// That is, the refspecs used when fetching from the remote.
+// Example:
+//
+//	+refs/heads/*:refs/remotes/origin/*
+func (r *Repository) RemoteFetchRefspecs(ctx context.Context, remote string) ([]Refspec, error) {
+	output, err := r.gitCmd(
+		ctx, "config", "--get-all", "remote."+remote+".fetch").
+		OutputString(r.exec)
+	if err != nil {
+		return nil, fmt.Errorf("config get-all remote.%s.fetch: %w", remote, err)
+	}
+
+	var refspecs []Refspec
+	for line := range strings.SplitSeq(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		refspecs = append(refspecs, Refspec(line))
+	}
+
+	return refspecs, nil
+}
+
 // RemoteRef is a reference in a remote Git repository.
 type RemoteRef struct {
 	// Name is the full name of the reference.

--- a/testdata/script/issue962_branch_submit_minimal_fetch_refspec.txt
+++ b/testdata/script/issue962_branch_submit_minimal_fetch_refspec.txt
@@ -1,0 +1,111 @@
+# https://github.com/abhinav/git-spice/issues/962
+#
+# When git is configured with a minimal fetch refspec
+# that doesn't include the pushed branch,
+# the upstream tracking fails to be set after push.
+# On the second submit, git-spice panics
+# because it expects upstream to be set if a CR exists.
+
+as 'Test <test@example.com>'
+at '2024-05-18T13:57:12Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub register alice
+shamhub new origin alice/example.git
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# Configure git with a minimal fetch refspec that only fetches main.
+# This simulates the condition where pushed branches don't get fetched back.
+git config --unset-all remote.origin.fetch
+git config --add remote.origin.fetch '+refs/heads/main:refs/remotes/origin/main'
+
+# create a new branch and submit it
+git add feature1.txt
+gs bc -m 'Add feature1' feature1
+
+# Submit fails because feature1 is not covered by the fetch refspec.
+! gs branch submit --fill
+cmp stderr $WORK/golden/refspec_does_not_match.txt
+
+# Test 1: Fix with --force
+gs branch submit --fill --force
+
+# Follow-up submit fails again because upstream is still not set.
+cp $WORK/extra/feature1-update.txt feature1.txt
+git add feature1.txt
+git commit -m 'update feature1'
+! gs branch submit
+cmp stderr $WORK/golden/no_upstream_set.txt
+
+# Test 2: Fix by adding a fetch refspec
+gs trunk
+git add feature2.txt
+gs bc -m 'Add feature2' feature2
+
+# Submit fails with a similar error.
+! gs branch submit --fill
+stderr 'None of these will fetch branch'
+stderr 'To fix this, you can do one of the following:'
+stderr 'git config --add'
+
+# Fix by adding a fetch refspec for feature* branches.
+git config --add remote.origin.fetch '+refs/heads/feature*:refs/remotes/origin/feature*'
+
+# Submit succeeds now.
+gs branch submit --fill
+
+# Follow-up submit also works.
+cp $WORK/extra/feature2-update.txt feature2.txt
+git add feature2.txt
+git commit -m 'update feature2'
+gs branch submit
+
+# With the new refspec, we can also submit feature1 updates now.
+git checkout feature1
+git fetch
+git branch --set-upstream-to=origin/feature1
+gs branch submit
+
+-- repo/feature1.txt --
+Contents of feature1
+
+-- extra/feature1-update.txt --
+New contents of feature1
+
+-- repo/feature2.txt --
+Contents of feature2
+
+-- extra/feature2-update.txt --
+Updated contents of feature2
+
+-- golden/refspec_does_not_match.txt --
+ERR Remote 'origin' has refspecs:
+ERR   - +refs/heads/main:refs/remotes/origin/main
+ERR None of these will fetch branch 'feature1' after pushing.
+ERR This will make follow up changes on them impossible.
+ERR To fix this, you can do one of the following:
+ERR 1. Manually add a fetch refspec for just this branch:
+ERR        git config --add remote.origin.fetch +refs/heads/feature1:refs/remotes/origin/feature1
+ERR 2. Prefix all your branches with your username (e.g. 'yourname/feature1'),
+ERR    and add a fetch refspec to fetch all branches under that prefix:
+ERR        git config --add remote.origin.fetch '+refs/heads/yourname/*:refs/remotes/origin/yourname/*'
+ERR    You can configure git-spice to automatically add this prefix for future branches with:
+ERR        git config --global spice.branchCreate.prefix yourname/
+ERR 3. Use the --force flag to push anyway (not recommended).
+FTL gs: submit branch feature1: remote cannot fetch pushed branch
+-- golden/no_upstream_set.txt --
+ERR No upstream branch was found for branch %v with existing CR %v  feature1=#1
+ERR We cannot update the CR without an upstream branch name.
+ERR To fix this, identify the correct upstream branch name and set it with, e.g.:
+ERR   git branch --set-upstream-to=<remote>/<branch> %v  !BADKEY=feature1
+ERR Then, try again.
+FTL gs: submit branch feature1: upstream branch not set


### PR DESCRIPTION
Fixes a panic when updating CRs without upstream tracking
and prevents branches from being left in an untrackable state.

When git is configured with minimal fetch refspecs
(e.g., only fetching main),
pushing a new branch would succeed,
but the branch could not be fetched back locally.
This left the branch without upstream tracking,
causing a panic on subsequent submit attempts.

This change adds validation before pushing
to ensure the remote's fetch refspecs will actually fetch
the pushed branch.
If not, it provides clear error messages
with options to fix the configuration.

Additionally, replaces the panic when updating CRs
without upstream tracking
with a helpful error message
guiding users to set the upstream manually.

LLM assistance:
An LLM was used to reproduce the original panic,
to identify in Git source code where refspec matching is implemented,
to transform that logic into Go code, and to draft the original commit message.

Fixes #962
