### PR TITLE
Fix gocritic appendAssign lint error in git/cmd.go

### DIFF
--- a/internal/git/cmd.go
+++ b/internal/git/cmd.go
@@ -47,8 +47,8 @@ func (ec *extraConfig) WithArgs(cmd *xec.Cmd) *xec.Cmd {
 		return cmd
 	}
 
-	args := append(newArgs, cmd.Args()...)
-	return cmd.WithArgs(args...)
+	newArgs = append(newArgs, cmd.Args()...)
+	return cmd.WithArgs(newArgs...)
 }
 
 // newGitCmd builds a new Git command with the given arguments.


### PR DESCRIPTION
The linter requires that append results be assigned back to the same slice being appended to. Changed from creating a new 'args' variable to reassigning 'newArgs' directly.