### PR TITLE
fix(xec): EditCommand should forward stdout/stderr/stdin

### DIFF
--- a/internal/xec/edit.go
+++ b/internal/xec/edit.go
@@ -20,5 +20,8 @@ func EditCommand(editCmd string, args ...string) *exec.Cmd {
 		cmd = exec.Command("sh", args...)
 	}
 	cmd.Env = append(os.Environ(), _gitSpiceEnv)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
 	return cmd
 }


### PR DESCRIPTION
EditCommand should not leave stdout/stdin/stderr unset
as these will make the editor not work.

[skip changelog]: bug wasn't released yet