### PR TITLE
commit split: Support multi-way split and non-HEAD commits

### DIFF
--- a/.changes/unreleased/Added-20260124-021619.yaml
+++ b/.changes/unreleased/Added-20260124-021619.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'commit split: Support multi-way split and non-HEAD commit splitting'
+time: 2026-01-24T02:16:19.528555502-08:00

--- a/commit_split.go
+++ b/commit_split.go
@@ -8,25 +8,72 @@ import (
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/silog"
+	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
 )
 
 type commitSplitCmd struct {
-	Message  string `short:"m" placeholder:"MSG" help:"Use the given message as the commit message."`
+	Message  string `short:"m" placeholder:"MSG" help:"Commit message for first split."`
 	NoVerify bool   `help:"Bypass pre-commit and commit-msg hooks."`
+	Commit   string `arg:"" optional:"" help:"Commit to split (default: HEAD)."`
 }
 
 func (*commitSplitCmd) Help() string {
 	return text.Dedent(`
-		Interactively select hunks from the current commit
-		to split into new commits below it.
+		Interactively select hunks from a commit
+		to split into multiple new commits below it.
 		Branches upstack are restacked as needed.
+
+		The commit defaults to HEAD.
+		If a different commit is specified,
+		an interactive rebase will be used to split it.
+
+		The split process loops until all changes are committed.
+		Press 'q' during hunk selection to stop splitting
+		and commit any remaining changes together.
 	`)
 }
 
 func (cmd *commitSplitCmd) Run(
 	ctx context.Context,
 	log *silog.Logger,
+	view ui.View,
+	repo *git.Repository,
+	wt *git.Worktree,
+	svc *spice.Service,
+	restackHandler RestackHandler,
+) (err error) {
+	// Determine which commit to split.
+	targetCommit := cmd.Commit
+	if targetCommit == "" {
+		targetCommit = "HEAD"
+	}
+
+	target, err := repo.PeelToCommit(ctx, targetCommit)
+	if err != nil {
+		return fmt.Errorf("resolve commit %q: %w", targetCommit, err)
+	}
+
+	head, err := wt.Head(ctx)
+	if err != nil {
+		return fmt.Errorf("get HEAD: %w", err)
+	}
+
+	// Check if splitting HEAD or a different commit.
+	if target == head {
+		return cmd.splitHead(ctx, log, view, repo, wt, restackHandler)
+	}
+
+	// For non-HEAD commits, we need to use rebase.
+	return cmd.splitNonHead(ctx, log, view, repo, wt, svc, restackHandler, target)
+}
+
+// splitHead handles splitting the HEAD commit.
+func (cmd *commitSplitCmd) splitHead(
+	ctx context.Context,
+	log *silog.Logger,
+	view ui.View,
 	repo *git.Repository,
 	wt *git.Worktree,
 	restackHandler RestackHandler,
@@ -36,25 +83,28 @@ func (cmd *commitSplitCmd) Run(
 		return fmt.Errorf("get HEAD: %w", err)
 	}
 
+	// Read original commit message for the final commit.
+	commitObj, err := repo.ReadCommit(ctx, head.String())
+	if err != nil {
+		return fmt.Errorf("read commit: %w", err)
+	}
+	originalMessage := commitObj.Message()
+
 	parent, err := repo.PeelToCommit(ctx, head.String()+"^")
 	if err != nil {
 		return fmt.Errorf("get HEAD^: %w", err)
 	}
 
+	// Reset to parent, keeping working tree.
 	if err := wt.Reset(ctx, parent.String(), git.ResetOptions{
-		Mode: git.ResetMixed, // don't touch the working tree
+		Mode: git.ResetMixed,
 	}); err != nil {
 		return fmt.Errorf("reset to HEAD^: %w", err)
 	}
 
 	defer func() {
 		if err != nil {
-			// The operation may have failed
-			// because the user pressed Ctrl-C.
-			// That would invalidate the current context.
-			// Create an uncanceled context to perform the rollback.
 			ctx := context.WithoutCancel(ctx)
-
 			log.Warn("Rolling back to previous commit", "commit", head)
 			err = errors.Join(err, wt.Reset(ctx, head.String(), git.ResetOptions{
 				Mode: git.ResetMixed,
@@ -62,45 +112,19 @@ func (cmd *commitSplitCmd) Run(
 		}
 	}()
 
-	log.Info("Select hunks to extract into a new commit")
-	// Can't use 'git add' here because reset will have unstaged
-	// new files, which 'git add' will ignore.
-	if err := wt.Reset(ctx, head.String(), git.ResetOptions{Patch: true}); err != nil {
-		return fmt.Errorf("select hunks: %w", err)
+	// Run the multi-way split loop.
+	if err := cmd.splitLoop(ctx, log, view, wt, head, parent, originalMessage); err != nil {
+		return err
 	}
 
-	if err := wt.Commit(ctx, git.CommitRequest{
-		Message:  cmd.Message,
-		NoVerify: cmd.NoVerify,
-	}); err != nil {
-		return fmt.Errorf("commit: %w", err)
-	}
-
-	if err := wt.Reset(ctx, head.String(), git.ResetOptions{
-		Paths: []string{"."}, // reset index to remaining changes
-	}); err != nil {
-		return fmt.Errorf("select hunks: %w", err)
-	}
-
-	// Commit will move HEAD to the new commit,
-	// updating branch ref if necessary.
-	if err := wt.Commit(ctx, git.CommitRequest{
-		ReuseMessage: head.String(),
-		NoVerify:     cmd.NoVerify,
-	}); err != nil {
-		return fmt.Errorf("commit: %w", err)
-	}
-
+	// Check if we're in the middle of a rebase.
 	if _, err := wt.RebaseState(ctx); err == nil {
-		// In the middle of a rebase.
-		// Don't restack upstack branches.
 		log.Debug("A rebase is in progress, skipping restack")
 		return nil
 	}
 
 	currentBranch, err := wt.CurrentBranch(ctx)
 	if err != nil {
-		// No restack needed if we're in a detached head state.
 		if errors.Is(err, git.ErrDetachedHead) {
 			log.Debug("HEAD is detached, skipping restack")
 			return nil
@@ -111,4 +135,217 @@ func (cmd *commitSplitCmd) Run(
 	return restackHandler.RestackUpstack(ctx, currentBranch, &restack.UpstackOptions{
 		SkipStart: true,
 	})
+}
+
+// splitNonHead handles splitting a commit that is not HEAD using rebase.
+func (cmd *commitSplitCmd) splitNonHead(
+	ctx context.Context,
+	log *silog.Logger,
+	view ui.View,
+	repo *git.Repository,
+	wt *git.Worktree,
+	svc *spice.Service,
+	restackHandler RestackHandler,
+	target git.Hash,
+) error {
+	head, err := wt.Head(ctx)
+	if err != nil {
+		return fmt.Errorf("get HEAD: %w", err)
+	}
+
+	// Validate target is an ancestor of HEAD.
+	if !repo.IsAncestor(ctx, target, head) {
+		return fmt.Errorf("commit %v is not in the current branch history", target.Short())
+	}
+
+	currentBranch, err := wt.CurrentBranch(ctx)
+	if err != nil {
+		if !errors.Is(err, git.ErrDetachedHead) {
+			return fmt.Errorf("get current branch: %w", err)
+		}
+		currentBranch = ""
+	}
+
+	// Start interactive rebase with "edit" at target commit.
+	if err := wt.RebaseEdit(ctx, target); err != nil {
+		rebaseErr := new(git.RebaseInterruptError)
+		if !errors.As(err, &rebaseErr) {
+			return fmt.Errorf("start rebase: %w", err)
+		}
+
+		// Rebase was interrupted as expected (deliberate edit).
+		if rebaseErr.Kind != git.RebaseInterruptDeliberate {
+			return svc.RebaseRescue(ctx, spice.RebaseRescueRequest{
+				Err:     err,
+				Command: []string{"commit", "split", target.String()},
+				Branch:  currentBranch,
+				Message: "interrupted: split commit " + target.Short(),
+			})
+		}
+	}
+
+	// Now HEAD is at target commit. Split it.
+	if err := cmd.splitHead(ctx, log, view, repo, wt, restackHandler); err != nil {
+		// If split failed, abort the rebase.
+		ctx := context.WithoutCancel(ctx)
+		if abortErr := wt.RebaseAbort(ctx); abortErr != nil {
+			log.Warn("Failed to abort rebase", "error", abortErr)
+		}
+		return err
+	}
+
+	// Continue the rebase to complete.
+	if err := wt.RebaseContinue(ctx, nil); err != nil {
+		rebaseErr := new(git.RebaseInterruptError)
+		if errors.As(err, &rebaseErr) {
+			return svc.RebaseRescue(ctx, spice.RebaseRescueRequest{
+				Err:     err,
+				Command: []string{"upstack", "restack"},
+				Branch:  currentBranch,
+				Message: "interrupted: split commit continuation",
+			})
+		}
+		return fmt.Errorf("continue rebase: %w", err)
+	}
+
+	// Restack upstack branches.
+	if currentBranch == "" {
+		log.Debug("HEAD is detached, skipping restack")
+		return nil
+	}
+
+	return restackHandler.RestackUpstack(ctx, currentBranch, &restack.UpstackOptions{
+		SkipStart: true,
+	})
+}
+
+// splitLoop performs the multi-way split.
+// It loops, allowing the user to select hunks for each split commit,
+// until no more changes remain.
+func (cmd *commitSplitCmd) splitLoop(
+	ctx context.Context,
+	log *silog.Logger,
+	view ui.View,
+	wt *git.Worktree,
+	original git.Hash,
+	parent git.Hash,
+	originalMessage string,
+) error {
+	commitNum := 1
+	nextMessage := cmd.Message
+
+	for {
+		log.Infof("Select hunks for commit %d", commitNum)
+
+		// Use git reset --patch to select hunks.
+		// Can't use 'git add' here because reset will have unstaged
+		// new files, which 'git add' will ignore.
+		if err := wt.Reset(ctx, original.String(), git.ResetOptions{Patch: true}); err != nil {
+			return fmt.Errorf("select hunks: %w", err)
+		}
+
+		// Check if anything was staged.
+		staged, err := wt.DiffIndex(ctx, parent.String())
+		if err != nil {
+			return fmt.Errorf("check staged: %w", err)
+		}
+		if len(staged) == 0 {
+			// User quit without selecting anything.
+			log.Info("No hunks selected, stopping split")
+			break
+		}
+
+		// Prompt for commit message if not provided.
+		message := nextMessage
+		if message == "" {
+			if err := cmd.promptMessage(view, &message, originalMessage, commitNum); err != nil {
+				return fmt.Errorf("prompt message: %w", err)
+			}
+		}
+		nextMessage = "" // Only use -m for first commit.
+
+		// Create the split commit.
+		if err := wt.Commit(ctx, git.CommitRequest{
+			Message:  message,
+			NoVerify: cmd.NoVerify,
+		}); err != nil {
+			return fmt.Errorf("commit: %w", err)
+		}
+
+		// Update parent to the new commit for the next iteration.
+		newHead, err := wt.Head(ctx)
+		if err != nil {
+			return fmt.Errorf("get new HEAD: %w", err)
+		}
+		parent = newHead
+
+		// Reset index to remaining changes from original.
+		if err := wt.Reset(ctx, original.String(), git.ResetOptions{
+			Paths: []string{"."},
+		}); err != nil {
+			return fmt.Errorf("reset index: %w", err)
+		}
+
+		// Check if there are remaining changes.
+		var hasRemaining bool
+		for _, err := range wt.DiffWork(ctx) {
+			if err != nil {
+				return fmt.Errorf("check remaining: %w", err)
+			}
+			hasRemaining = true
+			break
+		}
+		if !hasRemaining {
+			// No more changes to split.
+			log.Info("All changes committed")
+			return nil
+		}
+
+		commitNum++
+	}
+
+	// Commit any remaining changes with original message.
+	if err := wt.Reset(ctx, original.String(), git.ResetOptions{
+		Paths: []string{"."},
+	}); err != nil {
+		return fmt.Errorf("reset index: %w", err)
+	}
+
+	staged, err := wt.DiffIndex(ctx, parent.String())
+	if err != nil {
+		return fmt.Errorf("check staged: %w", err)
+	}
+	if len(staged) > 0 {
+		if err := wt.Commit(ctx, git.CommitRequest{
+			ReuseMessage: original.String(),
+			NoVerify:     cmd.NoVerify,
+		}); err != nil {
+			return fmt.Errorf("commit remainder: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// promptMessage prompts the user for a commit message.
+func (cmd *commitSplitCmd) promptMessage(
+	view ui.View,
+	message *string,
+	originalMessage string,
+	commitNum int,
+) error {
+	if !ui.Interactive(view) {
+		// Non-interactive mode: use a default message.
+		*message = fmt.Sprintf("Split commit %d", commitNum)
+		return nil
+	}
+
+	*message = originalMessage
+	field := ui.NewInput().
+		WithTitle(fmt.Sprintf("Commit %d message", commitNum)).
+		WithDescription("Enter message for this split commit").
+		WithValue(message).
+		WithOptions([]string{originalMessage})
+
+	return ui.Run(view, field)
 }

--- a/testdata/script/commit_split_multiway.txt
+++ b/testdata/script/commit_split_multiway.txt
@@ -1,0 +1,97 @@
+# Test 'commit split' with multiple files, allowing multi-way split.
+
+[!unix] skip # pending github.com/creack/pty/pull/155
+[!git:2.52] skip # git add -p output is fixed to Git version
+
+as 'Test <test@example.com>'
+at '2024-07-08T05:04:32Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# Create a commit with 3 files
+git add file1.txt file2.txt file3.txt
+gs bc -m 'Add all features' features
+
+# Create an upstack branch to verify restacking
+git add extra.txt
+gs bc -m 'Add extra' extra
+gs down
+
+# Split: select file1 first, then quit to get remainder
+with-term -final exit $WORK/input.txt -- gs commit split -m 'Add file1'
+cmp stdout $WORK/golden/output.txt
+
+# Verify log shows 2 commits
+git log --oneline features
+cmp stdout $WORK/golden/log.txt
+
+# Verify branch stack
+gs ll
+cmp stderr $WORK/golden/ll.txt
+
+-- repo/file1.txt --
+file 1 content
+
+-- repo/file2.txt --
+file 2 content
+
+-- repo/file3.txt --
+file 3 content
+
+-- repo/extra.txt --
+extra content
+
+-- input.txt --
+await file1
+feed y\r
+clear
+await file2
+feed q\r
+await
+
+-- golden/output.txt --
+### exit ###
+INF Select hunks for commit 1
+diff --git b/file1.txt a/file1.txt
+new file mode 100644
+index 0000000..a024894
+--- /dev/null
++++ a/file1.txt
+@@ -0,0 +1,2 @@
++file 1 content
++
+(1/3) Apply addition to index [y,n,q,a,d,e,p,P,?]? y
+
+diff --git b/file2.txt a/file2.txt
+new file mode 100644
+index 0000000..6bb0100
+--- /dev/null
++++ a/file2.txt
+@@ -0,0 +1,2 @@
++file 2 content
++
+(1/2) Apply addition to index [y,n,q,a,d,e,p,P,?]? q
+
+[features f94af9e] Add file1
+ 1 file changed, 2 insertions(+)
+ create mode 100644 file1.txt
+[features 40e0b8e] Add all features
+ Date: Mon Jul 8 05:04:32 2024 +0000
+ 2 files changed, 4 insertions(+)
+ create mode 100644 file2.txt
+ create mode 100644 file3.txt
+INF extra: restacked on features
+-- golden/log.txt --
+40e0b8e Add all features
+f94af9e Add file1
+-- golden/ll.txt --
+  ┏━□ extra
+  ┃   cc6a2fb Add extra (now)
+┏━┻■ features ◀
+┃    40e0b8e Add all features (now)
+┃    f94af9e Add file1 (now)
+main

--- a/testdata/script/commit_split_nonhead.txt
+++ b/testdata/script/commit_split_nonhead.txt
@@ -1,0 +1,91 @@
+# Test 'commit split' for a non-HEAD commit using rebase.
+
+[!unix] skip # pending github.com/creack/pty/pull/155
+[!git:2.52] skip # git add -p output is fixed to Git version
+
+as 'Test <test@example.com>'
+at '2024-07-08T05:04:32Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# Create a branch with 3 commits
+git add file1.txt
+gs bc -m 'Commit 1' feature
+
+git add file2a.txt file2b.txt
+gs cc -m 'Commit 2 (to be split)'
+
+git add file3.txt
+gs cc -m 'Commit 3'
+
+# Show log before split
+git log --oneline -3
+
+# Split commit 2 (not HEAD) - using HEAD~1 to reference it
+with-term -final exit $WORK/input.txt -- gs commit split -m 'Commit 2a' HEAD~1
+cmp stdout $WORK/golden/output.txt
+
+# Verify log shows 4 commits total
+git log --oneline feature
+cmp stdout $WORK/golden/log.txt
+
+-- repo/file1.txt --
+file 1 content
+
+-- repo/file2a.txt --
+file 2a content
+
+-- repo/file2b.txt --
+file 2b content
+
+-- repo/file3.txt --
+file 3 content
+
+-- input.txt --
+await file2a
+feed y\r
+clear
+await file2b
+feed q\r
+await
+
+-- golden/output.txt --
+### exit ###
+INF Select hunks for commit 1
+diff --git b/file2a.txt a/file2a.txt
+new file mode 100644
+index 0000000..ca7daff
+--- /dev/null
++++ a/file2a.txt
+@@ -0,0 +1,2 @@
++file 2a content
++
+(1/2) Apply addition to index [y,n,q,a,d,e,p,P,?]? y
+
+diff --git b/file2b.txt a/file2b.txt
+new file mode 100644
+index 0000000..b44c68d
+--- /dev/null
++++ a/file2b.txt
+@@ -0,0 +1,2 @@
++file 2b content
++
+(1/1) Apply addition to index [y,n,q,a,d,e,p,P,?]? q
+
+[detached HEAD 88c1b2f] Commit 2a
+ 1 file changed, 2 insertions(+)
+ create mode 100644 file2a.txt
+[detached HEAD 4a3f8d2] Commit 2 (to be split)
+ Date: Mon Jul 8 05:04:32 2024 +0000
+ 1 file changed, 2 insertions(+)
+ create mode 100644 file2b.txt
+Successfully rebased and updated refs/heads/feature.
+-- golden/log.txt --
+7b2c3d1 Commit 3
+4a3f8d2 Commit 2 (to be split)
+88c1b2f Commit 2a
+a1b2c3d Commit 1


### PR DESCRIPTION
## Summary

Enhance `gs commit split` with two new capabilities:

- **Multi-way split**: Instead of splitting into exactly 2 commits, the command now loops to allow splitting into N commits. Users can select hunks for each split commit until they press 'q' to quit, at which point remaining changes are committed together with the original message.

- **Non-HEAD split**: Users can now specify a commit argument to split any commit in the current branch history, not just HEAD. This works by starting an interactive rebase that pauses at the target commit with an "edit" instruction.

## Implementation

- Add optional `Commit` argument to `commitSplitCmd`
- Refactor into `splitHead()` and `splitNonHead()` methods
- Add `splitLoop()` for multi-way split with message prompting
- Add `RebaseEdit()` helper in `internal/git/rebase_wt.go`
- Add test scripts for multi-way and non-HEAD splitting

## Test plan

- [ ] Run existing `commit_split` test to verify no regression
- [ ] Run new `commit_split_multiway` test
- [ ] Run new `commit_split_nonhead` test
- [ ] Manual test: Create a commit with multiple files, run `gs commit split`, verify loop behavior
- [ ] Manual test: Run `gs commit split <older-commit>`, verify rebase flow

Note: Test scripts include placeholder golden files that need to be updated with `--update` flag on first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)