### PR TITLE
branchtree: extract branch tree rendering from widgets

### DIFF
--- a/internal/ui/branchtree/doc.go
+++ b/internal/ui/branchtree/doc.go
@@ -1,0 +1,2 @@
+// Package branchtree specializes fliptree to branches.
+package branchtree

--- a/internal/ui/branchtree/tree.go
+++ b/internal/ui/branchtree/tree.go
@@ -1,0 +1,486 @@
+package branchtree
+
+import (
+	"cmp"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/ui"
+	"go.abhg.dev/gs/internal/ui/commit"
+	"go.abhg.dev/gs/internal/ui/fliptree"
+)
+
+// Graph holds the tree structure for rendering.
+// Pass this into [Write] to render a branch tree.
+type Graph struct {
+	// Items is the list of all branch items.
+	Items []*Item
+
+	// Roots lists indexes of root branches (those with no base)
+	// in the Items list.
+	Roots []int
+}
+
+// Item represents a single branch in a rendered tree.
+type Item struct {
+	// Branch is the name of the branch.
+	Branch string
+
+	// Aboves lists indexes of branches stacked directly above this one.
+	// These indexes refer to positions in Graph.Items.
+	Aboves []int
+
+	// BranchHighlights contains rune indexes in [Branch] to highlight.
+	// Characters at these indexes use Style.TextHighlight.
+	BranchHighlights []int
+
+	// TODO: Combine (string, []int) pairs into a HighlightedString type?
+
+	// ChangeID is the optional change ID or URL to display.
+	//
+	// If non-empty, rendered as "($id)" or "($id $state)"
+	// depending on ChangeState.
+	ChangeID string
+
+	// ChangeIDHighlights contains rune indexes in [ChangeID] to highlight.
+	// Characters at these indexes use Style.TextHighlight.
+	ChangeIDHighlights []int
+
+	// ChangeState reports whether the change is open, closed, or merged.
+	// Only rendered if ChangeID is also set.
+	// nil indicates state is not available.
+	ChangeState *forge.ChangeState
+
+	// Worktree is the absolute path where this branch is checked out.
+	// If non-empty and differs from GraphOptions.CurrentWorktree,
+	// rendered as "[wt: path]".
+	Worktree string
+
+	// WorktreeHighlights contains rune indexes in [Worktree] to highlight.
+	// Characters at these indexes use Style.TextHighlight.
+	WorktreeHighlights []int
+
+	// Commits is an optional list of commits to render below the branch.
+	// Each commit renders on its own line.
+	//
+	// Style depends on Highlighted: normal if true, faint otherwise.
+	Commits []commit.Summary
+
+	// NeedsRestack indicates whether the branch needs restacking.
+	// If true, renders the needs-restack indicator.
+	NeedsRestack bool
+
+	// PushStatus contains push-related information.
+	// Rendered according to GraphOptions.PushStatusFormat.
+	PushStatus PushStatus
+
+	// Highlighted indicates this is the current/selected branch.
+	//
+	// When true:
+	//   - Node marker uses filled square (Style.NodeMarkerHighlighted)
+	//   - Trailing marker is shown (Style.Marker)
+	//   - Commits use normal style instead of faint
+	//
+	// It is invalid for both Disabled and Highlighted to be true.
+	Highlighted bool
+
+	// Disabled renders this branch faintly
+	// to indicate that this entry is disabled.
+	//
+	// When true:
+	//   - Node marker uses faint style (Style.NodeMarkerDisabled)
+	//   - Branch name uses faint style
+	//
+	// It is invalid for both Disabled and Highlighted to be true.
+	Disabled bool
+
+	// TODO: enum for highlighted/disabled state?
+}
+
+// PushStatus contains push-related information
+// if the branch has been pushed to a remote.
+type PushStatus struct {
+	// Ahead is the number of commits ahead of the remote.
+	Ahead int
+
+	// Behind is the number of commits behind the remote.
+	Behind int
+
+	// NeedsPush indicates whether the branch has unpushed commits.
+	//
+	// This is true if either Ahead or Behind is non-zero.
+	NeedsPush bool
+}
+
+// Style defines visual styling for branch items.
+type Style struct {
+	// Branch styles the branch name for normal items.
+	Branch lipgloss.Style
+
+	// BranchHighlighted styles the branch name for highlighted items.
+	BranchHighlighted lipgloss.Style
+
+	// BranchDisabled styles the branch name for disabled items.
+	BranchDisabled lipgloss.Style
+
+	// ChangeID styles the change ID/URL text.
+	ChangeID lipgloss.Style
+
+	// ChangeState styles for different change states.
+	// Each style must include the text via SetString.
+	ChangeState ChangeStateStyle
+
+	// Worktree styles the worktree indicator.
+	Worktree lipgloss.Style
+
+	// PushStatus styles the push status text.
+	PushStatus lipgloss.Style
+
+	// NeedsRestack styles the needs-restack indicator.
+	// Must include the text " (needs restack)" via SetString.
+	NeedsRestack lipgloss.Style
+
+	// NodeMarker is the default node marker style.
+	// Must include the marker character via SetString.
+	NodeMarker lipgloss.Style
+
+	// NodeMarkerHighlighted styles the node marker for highlighted items.
+	// Must include the marker character via SetString.
+	NodeMarkerHighlighted lipgloss.Style
+
+	// NodeMarkerDisabled styles the node marker for disabled items.
+	// Must include the marker character via SetString.
+	NodeMarkerDisabled lipgloss.Style
+
+	// TextHighlight styles characters matching fuzzy search.
+	TextHighlight lipgloss.Style
+
+	// Marker is the trailing selection marker shown for highlighted items.
+	// Must include the marker character via SetString.
+	Marker lipgloss.Style
+}
+
+// ChangeStateStyle styles different change states.
+type ChangeStateStyle struct {
+	// Open styles the "open" state text.
+	// Must include text via SetString.
+	Open lipgloss.Style
+
+	// Closed styles the "closed" state text.
+	// Must include text via SetString.
+	Closed lipgloss.Style
+
+	// Merged styles the "merged" state text.
+	// Must include text via SetString.
+	Merged lipgloss.Style
+}
+
+// DefaultStyle is the default style for rendering branch trees.
+// Copy and modify this to create custom styles.
+var DefaultStyle = Style{
+	Branch:            ui.NewStyle().Bold(true),
+	BranchHighlighted: ui.NewStyle().Bold(true).Foreground(ui.Cyan),
+	BranchDisabled:    ui.NewStyle().Foreground(ui.Gray),
+	ChangeID:          ui.NewStyle(),
+	ChangeState: ChangeStateStyle{
+		Open:   ui.NewStyle().Foreground(ui.Green).SetString("open"),
+		Closed: ui.NewStyle().Foreground(ui.Gray).SetString("closed"),
+		Merged: ui.NewStyle().Foreground(ui.Magenta).SetString("merged"),
+	},
+	Worktree:              ui.NewStyle().Faint(true),
+	PushStatus:            ui.NewStyle().Foreground(ui.Yellow).Faint(true),
+	NeedsRestack:          ui.NewStyle().Foreground(ui.Gray).SetString(" (needs restack)"), // TODO: drop leading space
+	NodeMarker:            fliptree.DefaultNodeMarker,
+	NodeMarkerHighlighted: fliptree.DefaultNodeMarker.SetString("■"),
+	NodeMarkerDisabled:    fliptree.DefaultNodeMarker.Faint(true),
+	TextHighlight:         ui.NewStyle().Foreground(ui.Cyan),
+	Marker:                ui.NewStyle().Foreground(ui.Yellow).Bold(true).SetString("◀"),
+}
+
+// GraphOptions configures branch tree rendering.
+type GraphOptions struct {
+	// Style defines visual styling for all items.
+	// If nil, DefaultStyle is used.
+	Style *Style
+
+	// CommitStyle defines styling for commit summaries.
+	// If nil, commit.DefaultSummaryStyle is used.
+	CommitStyle *commit.SummaryStyle
+
+	// PushStatusFormat controls how push status is rendered.
+	// Default is PushStatusDisabled (nothing rendered).
+	PushStatusFormat PushStatusFormat
+
+	// CurrentWorktree is the path to the current worktree.
+	// Branches checked out in this worktree won't show "[wt: ...]".
+	CurrentWorktree string
+
+	// HomeDir is used for "~" substitution in worktree paths.
+	// If empty, no substitution is performed.
+	HomeDir string
+}
+
+// PushStatusFormat controls how push status is rendered.
+type PushStatusFormat int
+
+const (
+	// PushStatusDisabled renders nothing for push status.
+	PushStatusDisabled PushStatusFormat = iota
+
+	// PushStatusSimple renders "(needs push)" if NeedsPush is true,
+	// otherwise renders nothing.
+	PushStatusSimple
+
+	// PushStatusAheadBehind renders "(⇡N⇣M)" showing ahead/behind counts.
+	// Only rendered if either Ahead or Behind is non-zero.
+	PushStatusAheadBehind
+)
+
+// Write renders the branch tree to w.
+func Write(w io.Writer, g Graph, opts *GraphOptions) error {
+	if opts == nil {
+		opts = &GraphOptions{}
+	}
+
+	style := *cmp.Or(opts.Style, &DefaultStyle)
+	renderer := branchTreeRenderer{
+		Style:            style,
+		CommitStyle:      *cmp.Or(opts.CommitStyle, &commit.DefaultSummaryStyle),
+		PushStatusFormat: opts.PushStatusFormat,
+		CurrentWorktree:  opts.CurrentWorktree,
+		HomeDir:          opts.HomeDir,
+	}
+
+	treeStyle := &fliptree.Style[*Item]{
+		Joint: ui.NewStyle().Faint(true),
+		NodeMarker: func(item *Item) lipgloss.Style {
+			switch {
+			case item.Disabled:
+				return style.NodeMarkerDisabled
+			case item.Highlighted:
+				return style.NodeMarkerHighlighted
+			default:
+				return style.NodeMarker
+			}
+		},
+	}
+
+	return fliptree.Write(w, fliptree.Graph[*Item]{
+		Values: g.Items,
+		Roots:  g.Roots,
+		Edges:  func(item *Item) []int { return item.Aboves },
+		View:   renderer.RenderItem,
+	}, fliptree.Options[*Item]{Style: treeStyle})
+}
+
+type branchTreeRenderer struct {
+	Style            Style
+	CommitStyle      commit.SummaryStyle
+	PushStatusFormat PushStatusFormat
+	CurrentWorktree  string
+	HomeDir          string
+}
+
+func (r *branchTreeRenderer) RenderItem(item *Item) string {
+	var sb strings.Builder
+	r.item(&sb, item)
+	return sb.String()
+}
+
+func (r *branchTreeRenderer) item(sb *strings.Builder, item *Item) {
+	r.branchName(sb, item)
+
+	if item.ChangeID != "" {
+		r.changeID(sb, item.ChangeID, item.ChangeIDHighlights, item.ChangeState)
+	}
+
+	if wt := item.Worktree; wt != "" && wt != r.CurrentWorktree {
+		r.worktree(sb, item.Worktree, item.WorktreeHighlights)
+	}
+
+	if item.NeedsRestack {
+		sb.WriteString(r.Style.NeedsRestack.String())
+	}
+
+	r.pushStatus(sb, item.PushStatus)
+
+	if item.Highlighted {
+		sb.WriteString(" ")
+		sb.WriteString(r.Style.Marker.String())
+	}
+
+	if len(item.Commits) > 0 {
+		r.commits(sb, item.Highlighted, item.Commits)
+	}
+}
+
+// branchName renders the branch name with fuzzy highlighting.
+func (r *branchTreeRenderer) branchName(sb *strings.Builder, item *Item) {
+	baseStyle := r.Style.Branch
+	switch {
+	case item.Highlighted:
+		baseStyle = r.Style.BranchHighlighted
+	case item.Disabled:
+		baseStyle = r.Style.BranchDisabled
+	}
+
+	renderTextWithHighlights(sb, item.Branch, item.BranchHighlights, baseStyle, r.Style.TextHighlight)
+}
+
+func (r *branchTreeRenderer) changeID(
+	sb *strings.Builder,
+	changeID string,
+	changeIDHighlights []int,
+	changeState *forge.ChangeState,
+) {
+	sb.WriteString(" (")
+	defer sb.WriteString(")")
+
+	renderTextWithHighlights(sb, changeID, changeIDHighlights, r.Style.ChangeID, r.Style.TextHighlight)
+
+	if changeState != nil {
+		sb.WriteString(" ")
+		switch *changeState {
+		case forge.ChangeOpen:
+			sb.WriteString(r.Style.ChangeState.Open.String())
+		case forge.ChangeClosed:
+			sb.WriteString(r.Style.ChangeState.Closed.String())
+		case forge.ChangeMerged:
+			sb.WriteString(r.Style.ChangeState.Merged.String())
+		}
+	}
+}
+
+func (r *branchTreeRenderer) worktree(
+	sb *strings.Builder,
+	wt string,
+	highlights []int,
+) {
+	sb.WriteString(r.Style.Worktree.Render(" [wt: "))
+	defer sb.WriteString(r.Style.Worktree.Render("]"))
+
+	if r.HomeDir != "" {
+		rel, err := filepath.Rel(r.HomeDir, wt)
+		if err == nil && filepath.IsLocal(rel) {
+			newWT := filepath.Join("~", rel)
+			// Replacing "$HOME" prefix in wt with "~"
+			// requires shifting the highlights.
+			//
+			// Any highlights inside range [0:len($HOME))
+			// will become '0' to refer to the '~' character.
+			//
+			// Highlights following that will be shifted left
+			// to match the new string by:
+			//
+			//     len(wt) - len(newWT)
+			//
+			// Example:
+			//
+			//              1
+			//    01234567890123     01234
+			//    /home/user/foo  => ~/foo
+			//
+			// Indexes are offset by:
+			//
+			//    len("/home/user/foo") - len("~/foo")
+			//    = 14 - 5
+			//    = 9
+			//
+			homeIdx := len(wt) - len(rel)
+			offset := len(wt) - len(newWT)
+
+			var adjustedHighlights []int
+			for _, idx := range highlights {
+				if idx < homeIdx {
+					// Highlight the "~" character.
+					// If adjustedHighlights is non-empty
+					// then we've already added it.
+					if len(adjustedHighlights) == 0 {
+						adjustedHighlights = append(adjustedHighlights, 0)
+					}
+					continue
+				}
+
+				adjusted := idx - offset
+				adjustedHighlights = append(adjustedHighlights, adjusted)
+			}
+			highlights = adjustedHighlights
+			wt = newWT
+		}
+	}
+
+	renderTextWithHighlights(sb, wt, highlights, r.Style.Worktree, r.Style.TextHighlight)
+}
+
+func (r *branchTreeRenderer) pushStatus(
+	sb *strings.Builder,
+	status PushStatus,
+) {
+	switch r.PushStatusFormat {
+	case PushStatusDisabled:
+		// Nothing to render.
+
+	case PushStatusSimple:
+		if status.NeedsPush {
+			sb.WriteString(r.Style.PushStatus.Render(" (needs push)"))
+		}
+
+	case PushStatusAheadBehind:
+		if status.Ahead > 0 || status.Behind > 0 {
+			var parts []string
+			if status.Ahead > 0 {
+				parts = append(parts, fmt.Sprintf("⇡%d", status.Ahead))
+			}
+			if status.Behind > 0 {
+				parts = append(parts, fmt.Sprintf("⇣%d", status.Behind))
+			}
+			sb.WriteString(r.Style.PushStatus.Render(" (" + strings.Join(parts, "") + ")"))
+		}
+	}
+}
+
+func (r *branchTreeRenderer) commits(
+	sb *strings.Builder,
+	highlighted bool,
+	commits []commit.Summary,
+) {
+	commitStyle := r.CommitStyle
+	if !highlighted {
+		commitStyle = commitStyle.Faint(true)
+	}
+
+	for _, commit := range commits {
+		sb.WriteString("\n")
+		commit.Render(sb, commitStyle, nil /* options */)
+	}
+}
+
+// renderTextWithHighlights renders text with fuzzy search highlighting.
+// Characters at indexes specified in highlights are rendered with highlightStyle.
+// All other characters are rendered with baseStyle.
+var renderTextWithHighlights = _renderTextWithHighlights
+
+func _renderTextWithHighlights(
+	sb *strings.Builder,
+	text string,
+	highlights []int,
+	baseStyle, highlightStyle lipgloss.Style,
+) {
+	if len(highlights) == 0 {
+		sb.WriteString(baseStyle.Render(text))
+		return
+	}
+
+	var lastRuneIdx int
+	runes := []rune(text)
+	for _, runeIdx := range highlights {
+		sb.WriteString(baseStyle.Render(string(runes[lastRuneIdx:runeIdx])))
+		sb.WriteString(highlightStyle.Render(string(runes[runeIdx])))
+		lastRuneIdx = runeIdx + 1
+	}
+	sb.WriteString(baseStyle.Render(string(runes[lastRuneIdx:])))
+}

--- a/internal/ui/branchtree/tree_test.go
+++ b/internal/ui/branchtree/tree_test.go
@@ -1,0 +1,587 @@
+package branchtree
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/ui"
+	"go.abhg.dev/gs/internal/ui/commit"
+	"go.abhg.dev/testing/stub"
+)
+
+func TestWrite(t *testing.T) {
+	p := filepath.FromSlash
+
+	// Fixed time for consistent commit rendering.
+	now := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		give Graph
+		opts *GraphOptions
+		want string
+	}{
+		{
+			name: "SingleBranch",
+			give: Graph{
+				Items: []*Item{{Branch: "main"}},
+				Roots: []int{0},
+			},
+			want: "main\n",
+		},
+		{
+			name: "LinearChain",
+			give: Graph{
+				Items: []*Item{
+					{Branch: "main", Aboves: []int{1}},
+					{Branch: "feat1", Aboves: []int{2}},
+					{Branch: "feat2"},
+				},
+				Roots: []int{0},
+			},
+			want: joinLines(
+				"  ┏━□ feat2",
+				"┏━┻□ feat1",
+				"main",
+			),
+		},
+		{
+			name: "MultipleChildren",
+			give: Graph{
+				Items: []*Item{
+					{Branch: "main", Aboves: []int{1, 2}},
+					{Branch: "feat1"},
+					{Branch: "feat2"},
+				},
+				Roots: []int{0},
+			},
+			want: joinLines(
+				"┏━□ feat1",
+				"┣━□ feat2",
+				"main",
+			),
+		},
+		{
+			name: "DeepTree",
+			give: Graph{
+				Items: []*Item{
+					{Branch: "main", Aboves: []int{1, 3}},
+					{Branch: "feat1", Aboves: []int{2}},
+					{Branch: "feat1.1"},
+					{Branch: "feat2", Aboves: []int{4}},
+					{Branch: "feat2.1"},
+				},
+				Roots: []int{0},
+			},
+			want: joinLines(
+				"  ┏━□ feat1.1",
+				"┏━┻□ feat1",
+				"┃ ┏━□ feat2.1",
+				"┣━┻□ feat2",
+				"main",
+			),
+		},
+		{
+			name: "MultipleTrees",
+			give: Graph{
+				Items: []*Item{
+					{Branch: "main", Aboves: []int{1}},
+					{Branch: "feat1"},
+					{Branch: "develop", Aboves: []int{3}},
+					{Branch: "hotfix"},
+				},
+				Roots: []int{0, 2},
+			},
+			want: joinLines(
+				"┏━□ feat1",
+				"main",
+				"┏━□ hotfix",
+				"develop",
+			),
+		},
+		{
+			name: "WithChangeID",
+			give: Graph{
+				Items: []*Item{{Branch: "feat1", ChangeID: "#123"}},
+				Roots: []int{0},
+			},
+			want: "feat1 (#123)\n",
+		},
+		{
+			name: "WithChangeStateOpen",
+			give: Graph{
+				Items: []*Item{{
+					Branch:      "feat1",
+					ChangeID:    "#123",
+					ChangeState: ptr(forge.ChangeOpen),
+				}},
+				Roots: []int{0},
+			},
+			want: "feat1 (#123 open)\n",
+		},
+		{
+			name: "WithChangeStateClosed",
+			give: Graph{
+				Items: []*Item{{
+					Branch:      "feat1",
+					ChangeID:    "#456",
+					ChangeState: ptr(forge.ChangeClosed),
+				}},
+				Roots: []int{0},
+			},
+			want: "feat1 (#456 closed)\n",
+		},
+		{
+			name: "WithChangeStateMerged",
+			give: Graph{
+				Items: []*Item{{
+					Branch:      "feat1",
+					ChangeID:    "#789",
+					ChangeState: ptr(forge.ChangeMerged),
+				}},
+				Roots: []int{0},
+			},
+			want: "feat1 (#789 merged)\n",
+		},
+		{
+			name: "WithWorktree",
+			give: Graph{
+				Items: []*Item{{Branch: "feat1", Worktree: p("/path/to/worktree")}},
+				Roots: []int{0},
+			},
+			want: "feat1 [wt: " + p("/path/to/worktree") + "]\n",
+		},
+		{
+			name: "NeedsRestack",
+			give: Graph{
+				Items: []*Item{{Branch: "feat1", NeedsRestack: true}},
+				Roots: []int{0},
+			},
+			want: "feat1 (needs restack)\n",
+		},
+		{
+			name: "Highlighted",
+			give: Graph{
+				Items: []*Item{{Branch: "feat1", Highlighted: true}},
+				Roots: []int{0},
+			},
+			want: "feat1 ◀\n",
+		},
+		{
+			name: "Disabled",
+			give: Graph{
+				Items: []*Item{{Branch: "feat1", Disabled: true}},
+				Roots: []int{0},
+			},
+			want: "feat1\n",
+		},
+		{
+			name: "WithCommits",
+			give: Graph{
+				Items: []*Item{{
+					Branch: "feat1",
+					Commits: []commit.Summary{
+						{ShortHash: "abc1234", Subject: "Add feature", AuthorDate: now.Add(-2 * time.Hour)},
+						{ShortHash: "def5678", Subject: "Fix bug", AuthorDate: now.Add(-1 * time.Hour)},
+					},
+				}},
+				Roots: []int{0},
+			},
+			opts: &GraphOptions{
+				CommitStyle: plainCommitStyle(),
+			},
+			want: joinLines(
+				"feat1",
+				"abc1234 Add feature (2 years ago)",
+				"def5678 Fix bug (2 years ago)",
+			),
+		},
+		{
+			name: "PushStatusSimple",
+			give: Graph{
+				Items: []*Item{{
+					Branch:     "feat1",
+					PushStatus: PushStatus{NeedsPush: true},
+				}},
+				Roots: []int{0},
+			},
+			opts: &GraphOptions{
+				PushStatusFormat: PushStatusSimple,
+			},
+			want: "feat1 (needs push)\n",
+		},
+		{
+			name: "PushStatusAheadOnly",
+			give: Graph{
+				Items: []*Item{{
+					Branch:     "feat1",
+					PushStatus: PushStatus{Ahead: 3},
+				}},
+				Roots: []int{0},
+			},
+			opts: &GraphOptions{
+				PushStatusFormat: PushStatusAheadBehind,
+			},
+			want: "feat1 (⇡3)\n",
+		},
+		{
+			name: "PushStatusBehindOnly",
+			give: Graph{
+				Items: []*Item{{
+					Branch:     "feat1",
+					PushStatus: PushStatus{Behind: 2},
+				}},
+				Roots: []int{0},
+			},
+			opts: &GraphOptions{
+				PushStatusFormat: PushStatusAheadBehind,
+			},
+			want: "feat1 (⇣2)\n",
+		},
+		{
+			name: "PushStatusAheadBehind",
+			give: Graph{
+				Items: []*Item{{
+					Branch:     "feat1",
+					PushStatus: PushStatus{Ahead: 3, Behind: 2},
+				}},
+				Roots: []int{0},
+			},
+			opts: &GraphOptions{
+				PushStatusFormat: PushStatusAheadBehind,
+			},
+			want: "feat1 (⇡3⇣2)\n",
+		},
+		{
+			name: "CurrentWorktreeHidden",
+			give: Graph{
+				Items: []*Item{{Branch: "feat1", Worktree: p("/current/worktree")}},
+				Roots: []int{0},
+			},
+			opts: &GraphOptions{
+				CurrentWorktree: p("/current/worktree"),
+			},
+			want: "feat1\n",
+		},
+		{
+			name: "WorktreeWithHomeSubstitution",
+			give: Graph{
+				Items: []*Item{{Branch: "feat1", Worktree: p("/home/user/projects/repo")}},
+				Roots: []int{0},
+			},
+			opts: &GraphOptions{
+				HomeDir: p("/home/user"),
+			},
+			want: "feat1 [wt: " + p("~/projects/repo") + "]\n",
+		},
+		{
+			name: "AllFeatures",
+			give: Graph{
+				Items: []*Item{{
+					Branch:       "feat1",
+					ChangeID:     "#42",
+					ChangeState:  ptr(forge.ChangeOpen),
+					Worktree:     p("/home/user/feat1"),
+					NeedsRestack: true,
+					PushStatus:   PushStatus{Ahead: 1},
+					Highlighted:  true,
+					Commits: []commit.Summary{
+						{ShortHash: "abc1234", Subject: "WIP", AuthorDate: now.Add(-30 * time.Minute)},
+					},
+				}},
+				Roots: []int{0},
+			},
+			opts: &GraphOptions{
+				HomeDir:          p("/home/user"),
+				PushStatusFormat: PushStatusAheadBehind,
+				CommitStyle:      plainCommitStyle(),
+			},
+			want: joinLines(
+				"feat1 (#42 open) [wt: "+p("~/feat1")+"] (needs restack) (⇡1) ◀",
+				"abc1234 WIP (2 years ago)",
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := tt.opts
+			if opts == nil {
+				opts = &GraphOptions{}
+			}
+			opts.Style = plainStyle()
+			if opts.CommitStyle == nil {
+				opts.CommitStyle = plainCommitStyle()
+			}
+
+			var sb strings.Builder
+			require.NoError(t, Write(&sb, tt.give, opts))
+			assert.Equal(t, tt.want, sb.String())
+		})
+	}
+}
+
+func TestBranchTreeRenderer_worktree(t *testing.T) {
+	p := filepath.FromSlash
+
+	tests := []struct {
+		name    string
+		wt      string
+		homeDir string
+		want    string
+	}{
+		{
+			name: "NoHomeDir",
+			wt:   p("/path/to/worktree"),
+			want: " [wt: " + p("/path/to/worktree") + "]",
+		},
+		{
+			name:    "WithHomeSubstitution",
+			wt:      p("/home/user/projects/repo"),
+			homeDir: p("/home/user"),
+			want:    " [wt: " + p("~/projects/repo") + "]",
+		},
+		{
+			name:    "PathOutsideHome",
+			wt:      p("/opt/repos/myproject"),
+			homeDir: p("/home/user"),
+			want:    " [wt: " + p("/opt/repos/myproject") + "]",
+		},
+		{
+			name:    "ExactlyHomeDir",
+			wt:      p("/home/user"),
+			homeDir: p("/home/user"),
+			want:    " [wt: ~]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &branchTreeRenderer{
+				Style:   *plainStyle(),
+				HomeDir: tt.homeDir,
+			}
+
+			var sb strings.Builder
+			r.worktree(&sb, tt.wt, nil)
+
+			assert.Equal(t, tt.want, sb.String())
+		})
+	}
+}
+
+func TestBranchTreeRenderer_worktreeHighlights(t *testing.T) {
+	p := filepath.FromSlash
+
+	tests := []struct {
+		name    string
+		wt      highlightedString
+		homeDir string
+		want    highlightedString
+	}{
+		{
+			name: "NoTransformation",
+			wt:   highlightedString(p("/t{m}p/repo")),
+			want: highlightedString(p("/t{m}p/repo")),
+		},
+		{
+			name:    "NoHighlights",
+			wt:      highlightedString(p("/home/user/projects")),
+			homeDir: p("/home/user"),
+			want:    highlightedString(p("~/projects")),
+		},
+		{
+			name:    "HighlightsInHomePart",
+			wt:      highlightedString(p("/h{o}m{e}/user/projects")),
+			homeDir: p("/home/user"),
+			want:    highlightedString(p("{~}/projects")),
+		},
+		{
+			name:    "HighlightsInRelativePart",
+			wt:      highlightedString(p("/home/user/{p}ro{j}ects")),
+			homeDir: p("/home/user"),
+			want:    highlightedString(p("~/{p}ro{j}ects")),
+		},
+		{
+			name:    "MixedHighlights",
+			wt:      highlightedString(p("/ho{m}e/user/{p}rojects")),
+			homeDir: p("/home/user"),
+			want:    highlightedString(p("{~}/{p}rojects")),
+		},
+		{
+			name:    "MultipleHighlightsInHome",
+			wt:      highlightedString(p("/{h}{o}{m}{e}/user/repo")),
+			homeDir: p("/home/user"),
+			want:    highlightedString(p("{~}/repo")),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wt, highlights := tt.wt.Split()
+
+			var capturedText string
+			var capturedHighlights []int
+			defer stub.Value(&renderTextWithHighlights,
+				func(
+					_ *strings.Builder,
+					text string,
+					hl []int,
+					_, _ lipgloss.Style,
+				) {
+					capturedText = text
+					capturedHighlights = hl
+				},
+			)()
+
+			r := &branchTreeRenderer{
+				Style:   *plainStyle(),
+				HomeDir: tt.homeDir,
+			}
+
+			var sb strings.Builder
+			r.worktree(&sb, wt, highlights)
+
+			wantText, wantHighlights := tt.want.Split()
+			assert.Equal(t, wantText, capturedText, "text mismatch")
+			assert.Equal(t, wantHighlights, capturedHighlights, "highlights mismatch")
+		})
+	}
+}
+
+// highlightedString represents text with highlighted characters.
+// Characters wrapped in {braces} are highlighted.
+// Example: "fo{o}bar" represents "foobar" with index 2 highlighted.
+type highlightedString string
+
+// Split parses the highlighted string into plain text and highlight indexes.
+func (s highlightedString) Split() (text string, highlights []int) {
+	var sb strings.Builder
+	var runeCount int
+	runes := []rune(s)
+	for i := 0; i < len(runes); i++ {
+		if runes[i] == '{' {
+			// Find closing brace.
+			j := i + 1
+			for j < len(runes) && runes[j] != '}' {
+				j++
+			}
+			// Add each character between braces as highlighted.
+			for k := i + 1; k < j; k++ {
+				highlights = append(highlights, runeCount)
+				sb.WriteRune(runes[k])
+				runeCount++
+			}
+			i = j // skip past '}'
+			continue
+		}
+		sb.WriteRune(runes[i])
+		runeCount++
+	}
+	return sb.String(), highlights
+}
+
+func TestHighlightedString_Split(t *testing.T) {
+	tests := []struct {
+		name           string
+		give           highlightedString
+		wantText       string
+		wantHighlights []int
+	}{
+		{
+			name:           "NoHighlights",
+			give:           "foobar",
+			wantText:       "foobar",
+			wantHighlights: nil,
+		},
+		{
+			name:           "FirstChar",
+			give:           "{f}oobar",
+			wantText:       "foobar",
+			wantHighlights: []int{0},
+		},
+		{
+			name:           "LastChar",
+			give:           "fooba{r}",
+			wantText:       "foobar",
+			wantHighlights: []int{5},
+		},
+		{
+			name:           "MiddleChar",
+			give:           "fo{o}bar",
+			wantText:       "foobar",
+			wantHighlights: []int{2},
+		},
+		{
+			name:           "MultipleChars",
+			give:           "{f}o{o}ba{r}",
+			wantText:       "foobar",
+			wantHighlights: []int{0, 2, 5},
+		},
+		{
+			name:           "ContiguousChars",
+			give:           "fo{ob}ar",
+			wantText:       "foobar",
+			wantHighlights: []int{2, 3},
+		},
+		{
+			name:           "Unicode",
+			give:           "héllo {w}ör{l}d",
+			wantText:       "héllo wörld",
+			wantHighlights: []int{6, 9},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			text, highlights := tt.give.Split()
+			assert.Equal(t, tt.wantText, text)
+			assert.Equal(t, tt.wantHighlights, highlights)
+		})
+	}
+}
+
+// plainStyle returns a style with no ANSI escapes for readable test output.
+func plainStyle() *Style {
+	return &Style{
+		Branch:            ui.NewStyle(),
+		BranchHighlighted: ui.NewStyle(),
+		ChangeID:          ui.NewStyle(),
+		ChangeState: ChangeStateStyle{
+			Open:   ui.NewStyle().SetString("open"),
+			Closed: ui.NewStyle().SetString("closed"),
+			Merged: ui.NewStyle().SetString("merged"),
+		},
+		Worktree:              ui.NewStyle(),
+		PushStatus:            ui.NewStyle(),
+		NeedsRestack:          ui.NewStyle().SetString(" (needs restack)"),
+		NodeMarker:            ui.NewStyle().SetString("□"),
+		NodeMarkerHighlighted: ui.NewStyle().SetString("■"),
+		NodeMarkerDisabled:    ui.NewStyle().SetString("□"),
+		TextHighlight:         ui.NewStyle(),
+		Marker:                ui.NewStyle().SetString("◀"),
+	}
+}
+
+func plainCommitStyle() *commit.SummaryStyle {
+	return &commit.SummaryStyle{
+		Hash:    ui.NewStyle(),
+		Subject: ui.NewStyle(),
+		Time:    ui.NewStyle(),
+	}
+}
+
+// joinLines joins lines with newlines and adds a trailing newline.
+func joinLines(lines ...string) string {
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/internal/ui/widget/testdata/script/branch_tree_select/worktree_filter_current.txt
+++ b/internal/ui/widget/testdata/script/branch_tree_select/worktree_filter_current.txt
@@ -1,0 +1,37 @@
+init
+
+await Select a branch
+snapshot
+cmp stdout prompt
+
+# Filter by "main" which is part of the current worktree path.
+# feat4 is checked out in /home/user/main (the current worktree),
+# so it should NOT match via its worktree path (which isn't displayed).
+# Only "main" branch should match (via branch name).
+feed main
+await
+snapshot
+cmp stdout filter
+
+feed <Enter>
+
+-- home --
+/home/user
+-- worktree --
+/home/user/main
+-- branches --
+[
+  {"branch": "main"},
+  {"branch": "feat1", "base": "main", "worktree": "/home/user/wt1"},
+  {"branch": "feat4", "base": "main", "worktree": "/home/user/main"}
+]
+-- prompt --
+Select a branch:
+┏━■ feat1 [wt: /home/user/wt1] ◀
+┣━□ feat4
+main
+-- filter --
+Select a branch:
+main ◀
+-- want --
+main

--- a/internal/ui/widget/testdata/script/branch_tree_select/worktree_filter_other.txt
+++ b/internal/ui/widget/testdata/script/branch_tree_select/worktree_filter_other.txt
@@ -1,0 +1,34 @@
+init
+
+await Select a branch
+snapshot
+cmp stdout prompt
+
+# Filter by a string that only matches feat1's worktree path.
+feed other-wt
+await
+snapshot
+cmp stdout filter
+
+feed <Enter>
+
+-- home --
+/home/user
+-- worktree --
+/home/user/main
+-- branches --
+[
+  {"branch": "main"},
+  {"branch": "feat1", "base": "main", "worktree": "/home/user/other-wt"},
+  {"branch": "feat2", "base": "main"}
+]
+-- prompt --
+Select a branch:
+┏━■ feat1 [wt: /home/user/other-wt] ◀
+┣━□ feat2
+main
+-- filter --
+Select a branch:
+feat1 [wt: /home/user/other-wt] ◀
+-- want --
+feat1

--- a/log.go
+++ b/log.go
@@ -10,22 +10,18 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/alecthomas/kong"
-	"github.com/charmbracelet/lipgloss"
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/handler/list"
-	"go.abhg.dev/gs/internal/must"
 	"go.abhg.dev/gs/internal/secret"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
-	"go.abhg.dev/gs/internal/ui"
+	"go.abhg.dev/gs/internal/ui/branchtree"
 	"go.abhg.dev/gs/internal/ui/commit"
-	"go.abhg.dev/gs/internal/ui/fliptree"
 )
 
 type logCmd struct {
@@ -54,39 +50,6 @@ func (*logCmd) AfterApply(kctx *kong.Context) error {
 		}, nil
 	})
 }
-
-var (
-	_branchStyle        = ui.NewStyle().Bold(true)
-	_currentBranchStyle = ui.NewStyle().
-				Foreground(ui.Cyan).
-				Bold(true)
-
-	_logCommitStyle = commit.SummaryStyle{
-		Hash:    ui.NewStyle().Foreground(ui.Yellow),
-		Subject: ui.NewStyle().Foreground(ui.Plain),
-		Time:    ui.NewStyle().Foreground(ui.Gray),
-	}
-	_logCommitFaintStyle = _logCommitStyle.Faint(true)
-
-	_needsRestackStyle = ui.NewStyle().
-				Foreground(ui.Gray).
-				SetString(" (needs restack)")
-
-	_pushStatusStyle = ui.NewStyle().
-				Foreground(ui.Yellow).
-				Faint(true)
-
-	_worktreeStyle = ui.NewStyle().Faint(true)
-
-	_markerStyle = ui.NewStyle().
-			Foreground(ui.Yellow).
-			Bold(true).
-			SetString("◀")
-
-	_stateOpenStyle   = ui.NewStyle().Foreground(ui.Green).SetString("open")
-	_stateClosedStyle = ui.NewStyle().Foreground(ui.Gray).SetString("closed")
-	_stateMergedStyle = ui.NewStyle().Foreground(ui.Magenta).SetString("merged")
-)
 
 type ListHandler interface {
 	ListBranches(context.Context, *list.BranchesRequest) (*list.BranchesResponse, error)
@@ -199,110 +162,83 @@ type graphLogPresenter struct {
 }
 
 func (p *graphLogPresenter) Present(res *list.BranchesResponse, currentBranch string) error {
-	treeStyle := fliptree.DefaultStyle[*list.BranchItem]()
-	treeStyle.NodeMarker = func(b *list.BranchItem) lipgloss.Style {
-		if b.Name == currentBranch {
-			return fliptree.DefaultNodeMarker.SetString("■")
-		}
-		return fliptree.DefaultNodeMarker
-	}
-
 	home, err := os.UserHomeDir()
 	if err != nil {
 		home = "" // if no home directory, we won't substitute paths
 	}
 
-	var s strings.Builder
-	err = fliptree.Write(&s, fliptree.Graph[*list.BranchItem]{
-		Roots:  []int{res.TrunkIdx},
-		Values: res.Branches,
-		View: func(b *list.BranchItem) string {
-			var o strings.Builder
-			if b.Name == currentBranch {
-				o.WriteString(_currentBranchStyle.Render(b.Name))
-			} else {
-				o.WriteString(_branchStyle.Render(b.Name))
+	// Convert list.BranchItem to widget.BranchItem.
+	items := make([]*branchtree.Item, len(res.Branches))
+	for i, b := range res.Branches {
+		item := &branchtree.Item{
+			Branch:       b.Name,
+			Worktree:     b.Worktree,
+			NeedsRestack: b.NeedsRestack,
+			Aboves:       b.Aboves,
+			Highlighted:  b.Name == currentBranch,
+		}
+
+		// Format change ID based on requested format.
+		if b.ChangeID != nil {
+			switch p.ChangeFormat {
+			case changeFormatID:
+				item.ChangeID = b.ChangeID.String()
+			case changeFormatURL:
+				item.ChangeID = b.ChangeURL
 			}
 
-			if cid := b.ChangeID; cid != nil {
-				var crText strings.Builder
-				crText.WriteString(" (")
-				switch p.ChangeFormat {
-				case changeFormatID:
-					crText.WriteString(cid.String())
-				case changeFormatURL:
-					crText.WriteString(b.ChangeURL)
-				default:
-					must.Failf("unknown change format: %v", p.ChangeFormat)
-				}
-
-				var crStatus string
-				if p.ShowCRStatus {
-					switch b.ChangeState {
-					case forge.ChangeOpen:
-						crStatus = _stateOpenStyle.String()
-					case forge.ChangeClosed:
-						crStatus = _stateClosedStyle.String()
-					case forge.ChangeMerged:
-						crStatus = _stateMergedStyle.String()
-					}
-				}
-
-				if crStatus != "" {
-					crText.WriteString(" ")
-					crText.WriteString(crStatus)
-				}
-				crText.WriteString(")")
-				o.WriteString(crText.String())
+			// Include change state if requested.
+			if p.ShowCRStatus && b.ChangeState != 0 {
+				item.ChangeState = &b.ChangeState
 			}
+		}
 
-			// TODO: share this logic with branch_select.
-			if wt := b.Worktree; wt != "" && wt != p.CurrentWorktree {
-				// If the path is relative to the user's home directory
-				// use "~/$rel" instead.
-				rel, err := filepath.Rel(home, wt)
-				if err == nil && filepath.IsLocal(rel) {
-					wt = filepath.Join("~", rel)
-				}
-
-				o.WriteString(_worktreeStyle.Render(" [wt: "))
-				o.WriteString(_worktreeStyle.Render(wt))
-				o.WriteString(_worktreeStyle.Render("]"))
+		if s := b.PushStatus; s != nil {
+			item.PushStatus = branchtree.PushStatus{
+				Ahead:     s.Ahead,
+				Behind:    s.Behind,
+				NeedsPush: s.NeedsPush,
 			}
+		}
 
-			if b.NeedsRestack {
-				o.WriteString(_needsRestackStyle.String())
-			}
-
-			if s := b.PushStatus; s != nil {
-				p.PushStatusFormat.FormatTo(&o, s.Ahead, s.Behind, s.NeedsPush)
-			}
-
-			if b.Name == currentBranch {
-				o.WriteString(" " + _markerStyle.String())
-			}
-
-			commitStyle := _logCommitStyle
-			if b.Name != currentBranch {
-				commitStyle = _logCommitFaintStyle
-			}
-
-			for _, c := range b.Commits {
-				o.WriteString("\n")
-				(&commit.Summary{
+		if len(b.Commits) > 0 {
+			item.Commits = make([]commit.Summary, len(b.Commits))
+			for j, c := range b.Commits {
+				item.Commits[j] = commit.Summary{
 					ShortHash:  c.ShortHash,
 					Subject:    c.Subject,
 					AuthorDate: c.AuthorDate,
-				}).Render(&o, commitStyle, nil)
+				}
 			}
+		}
 
-			return o.String()
-		},
-		Edges: func(bi *list.BranchItem) []int {
-			return bi.Aboves
-		},
-	}, fliptree.Options[*list.BranchItem]{Style: treeStyle})
-	if err != nil {
+		items[i] = item
+	}
+
+	// Convert push status format.
+	var pushFmt branchtree.PushStatusFormat
+	switch p.PushStatusFormat {
+	case pushStatusEnabled:
+		pushFmt = branchtree.PushStatusSimple
+	case pushStatusAheadBehind:
+		pushFmt = branchtree.PushStatusAheadBehind
+	default:
+		pushFmt = branchtree.PushStatusDisabled
+	}
+
+	g := branchtree.Graph{
+		Items: items,
+		Roots: []int{res.TrunkIdx},
+	}
+
+	opts := &branchtree.GraphOptions{
+		PushStatusFormat: pushFmt,
+		CurrentWorktree:  p.CurrentWorktree,
+		HomeDir:          home,
+	}
+
+	var s strings.Builder
+	if err := branchtree.Write(&s, g, opts); err != nil {
 		return fmt.Errorf("write tree: %w", err)
 	}
 
@@ -526,36 +462,6 @@ func (f pushStatusFormat) String() string {
 
 func (f pushStatusFormat) Enabled() bool {
 	return f == pushStatusEnabled || f == pushStatusAheadBehind
-}
-
-func (f pushStatusFormat) FormatTo(sb *strings.Builder, ahead, behind int, needsPush bool) {
-	switch f {
-	case pushStatusEnabled:
-		if needsPush {
-			sb.WriteString(_pushStatusStyle.Render(" (needs push)"))
-		}
-
-	case pushStatusAheadBehind:
-		if ahead == 0 && behind == 0 {
-			break
-		}
-
-		// TODO: Should we support changing these symbols?
-		var ab strings.Builder
-		ab.WriteString(" (")
-		if ahead > 0 {
-			_, _ = fmt.Fprintf(&ab, "⇡%d", ahead)
-		}
-		if behind > 0 {
-			_, _ = fmt.Fprintf(&ab, "⇣%d", behind)
-		}
-		ab.WriteString(")")
-
-		sb.WriteString(_pushStatusStyle.Render(ab.String()))
-
-	case pushStatusDisabled:
-		// do nothing
-	}
 }
 
 // changeFormat enumerates the possible values for the changeFormat config.


### PR DESCRIPTION
Add a new branchtree package that specializes fliptree for rendering
branch trees with rich metadata (change IDs, worktrees, push status).

This extracts and generalizes the rendering logic previously embedded
in branch_select.go and log.go, providing a reusable Graph/Item model
with configurable styling.