### PR TITLE
gitlab: Support new token output format from glab CLI v1.66.0

### DIFF
--- a/.changes/unreleased/Fixed-20260201-101102.yaml
+++ b/.changes/unreleased/Fixed-20260201-101102.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: >-
+  gitlab: Token extraction for CLI-based authentication
+  now supports the format used by glab CLI v1.66.0 and later.
+time: 2026-02-01T10:11:02.655003-08:00

--- a/internal/forge/gitlab/auth.go
+++ b/internal/forge/gitlab/auth.go
@@ -489,7 +489,7 @@ func (gc *glabCLI) Status(ctx context.Context, host string) (ok bool, err error)
 	return true, nil
 }
 
-var _tokenRe = regexp.MustCompile(`(?m)^\W+Token:\s+([\w\-]+)\s*$`)
+var _tokenRe = regexp.MustCompile(`(?m)^\W+Token(?:\s+found)?:\s+([\w\-]+)\s*$`)
 
 // Token returns the authentication token from the GitLab CLI.
 func (gc *glabCLI) Token(ctx context.Context, host string) (string, error) {

--- a/internal/forge/gitlab/auth_test.go
+++ b/internal/forge/gitlab/auth_test.go
@@ -560,8 +560,18 @@ func TestCLITokenParsing(t *testing.T) {
 			want: "1234567890abcdef",
 		},
 		{
+			name: "TokenFound",
+			give: "  ✓ Token found: abcdef\n",
+			want: "abcdef",
+		},
+		{
 			name: "glabPrefix",
 			give: "  ✓ Token: glab-AAAAA\n",
+			want: "glab-AAAAA",
+		},
+		{
+			name: "glabPrefixTokenFound",
+			give: "  ✓ Token found: glab-AAAAA\n",
 			want: "glab-AAAAA",
 		},
 		{
@@ -572,6 +582,10 @@ func TestCLITokenParsing(t *testing.T) {
 		{
 			name: "NoToken",
 			give: "  ✓ Token: \n",
+		},
+		{
+			name: "NoTokenFound",
+			give: "  ✓ Token found: \n",
 		},
 		{
 			name: "Unrelated",


### PR DESCRIPTION
## Summary

- Update token extraction regex to recognize both old (`Token: <value>`)
  and new (`Token found: <value>`) output formats from `glab auth status`
- Add test cases for the new format while preserving existing tests

The glab CLI v1.66.0 changed the auth status output format.
This maintains backward compatibility with older glab versions.

Resolves #1001

## Test plan

- [x] Existing tests for old format still pass
- [x] New tests for "Token found:" format pass
- [x] Linter passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)