### PR TITLE
forge: extract shared URL parsing utilities

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,6 +329,9 @@ Where:
     or command domains (e.g., "submit", "github").
   - See CHANGELOG.md for existing patterns.
 
+To skip the changelog check for internal changes, refactors,
+or test-only changes, include `[skip changelog]: <cause description>` in the PR description as a trailer.
+
 # Code Quality
 
 - Never introduce new third-party dependencies.
@@ -342,6 +345,23 @@ Where:
   Aim to keep lines within this limit for readability.
 
   Never exceed 120 characters per line.
+
+- **Package naming**
+
+  Do not pluralize package names.
+  Use singular nouns or compound names instead.
+
+  ```
+  // BAD: pluralized package names
+  urls
+  utils
+  helpers
+
+  // GOOD: singular or compound names
+  forgeurl
+  stringutil
+  testhelper
+  ```
 
 - **Logical grouping with comments**
 

--- a/internal/forge/forgeurl/urls.go
+++ b/internal/forge/forgeurl/urls.go
@@ -1,0 +1,91 @@
+// Package forgeurl provides shared URL parsing utilities for forge implementations.
+package forgeurl
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// _gitProtocols is a list of known git protocols including the :// suffix.
+var _gitProtocols []string
+
+func init() {
+	protocols := []string{
+		"ssh",
+		"git",
+		"git+ssh",
+		"git+https",
+		"git+http",
+		"https",
+		"http",
+	}
+	_gitProtocols = make([]string, len(protocols))
+	for i, proto := range protocols {
+		_gitProtocols[i] = proto + "://"
+	}
+}
+
+// HasGitProtocol reports whether the URL starts with a known git protocol.
+func HasGitProtocol(rawURL string) bool {
+	for _, proto := range _gitProtocols {
+		if strings.HasPrefix(rawURL, proto) {
+			return true
+		}
+	}
+	return false
+}
+
+// Parse parses a git remote URL, normalizing SSH shorthand syntax.
+//
+// It converts SCP-style URLs (git@host:path) to standard SSH URLs
+// (ssh://git@host/path) before parsing.
+func Parse(rawURL string) (*url.URL, error) {
+	if !HasGitProtocol(rawURL) && strings.Contains(rawURL, ":") {
+		rawURL = "ssh://" + strings.Replace(rawURL, ":", "/", 1)
+	}
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse remote URL: %w", err)
+	}
+	return u, nil
+}
+
+// StripDefaultPort removes default HTTP/HTTPS ports (80, 443) from the
+// remote URL's host when the base URL doesn't explicitly specify a port.
+func StripDefaultPort(baseURL, remoteURL *url.URL) {
+	if baseURL.Port() != "" {
+		return
+	}
+	host, port, err := net.SplitHostPort(remoteURL.Host)
+	if err != nil {
+		return
+	}
+	if port == "443" || port == "80" {
+		remoteURL.Host = host
+	}
+}
+
+// MatchesHost reports whether the remote URL's host matches the base URL's
+// host, either exactly or as a subdomain.
+func MatchesHost(baseURL, remoteURL *url.URL) bool {
+	if remoteURL.Host == baseURL.Host {
+		return true
+	}
+	return strings.HasSuffix(remoteURL.Host, "."+baseURL.Host)
+}
+
+// ExtractPath extracts owner and repository name from a URL path.
+//
+// It strips leading/trailing slashes and the .git suffix, then splits
+// on the first slash to get owner/repo components.
+func ExtractPath(path string) (owner, repo string, ok bool) {
+	s := strings.TrimPrefix(path, "/")
+	s = strings.TrimSuffix(s, "/")
+	s = strings.TrimSuffix(s, ".git")
+
+	owner, repo, ok = strings.Cut(s, "/")
+	return owner, repo, ok
+}

--- a/internal/forge/forgeurl/urls_test.go
+++ b/internal/forge/forgeurl/urls_test.go
@@ -1,0 +1,249 @@
+package forgeurl
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasGitProtocol(t *testing.T) {
+	tests := []struct {
+		name string
+		give string
+		want bool
+	}{
+		{"HTTPS", "https://github.com/owner/repo", true},
+		{"HTTP", "http://github.com/owner/repo", true},
+		{"SSH protocol", "ssh://git@github.com/owner/repo", true},
+		{"Git protocol", "git://github.com/owner/repo.git", true},
+		{"Git+SSH", "git+ssh://git@github.com/owner/repo", true},
+		{"Git+HTTPS", "git+https://github.com/owner/repo", true},
+		{"Git+HTTP", "git+http://github.com/owner/repo", true},
+		{"SCP-style SSH", "git@github.com:owner/repo", false},
+		{"Plain path", "/path/to/repo", false},
+		{"Empty", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HasGitProtocol(tt.give)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name     string
+		give     string
+		wantHost string
+		wantPath string
+	}{
+		{
+			name:     "HTTPS",
+			give:     "https://github.com/owner/repo",
+			wantHost: "github.com",
+			wantPath: "/owner/repo",
+		},
+		{
+			name:     "SSH protocol",
+			give:     "ssh://git@github.com/owner/repo",
+			wantHost: "github.com",
+			wantPath: "/owner/repo",
+		},
+		{
+			name:     "SCP-style SSH normalized",
+			give:     "git@github.com:owner/repo",
+			wantHost: "github.com",
+			wantPath: "/owner/repo",
+		},
+		{
+			name:     "SSH with port",
+			give:     "ssh://git@ssh.github.com:443/owner/repo",
+			wantHost: "ssh.github.com:443",
+			wantPath: "/owner/repo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse(tt.give)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantHost, got.Host)
+			assert.Equal(t, tt.wantPath, got.Path)
+		})
+	}
+}
+
+func TestParse_error(t *testing.T) {
+	_, err := Parse("NOT\tA\nVALID URL")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse remote URL")
+}
+
+func TestStripDefaultPort(t *testing.T) {
+	tests := []struct {
+		name       string
+		baseURL    string
+		remoteHost string
+		wantHost   string
+	}{
+		{
+			name:       "strip 443",
+			baseURL:    "https://github.com",
+			remoteHost: "github.com:443",
+			wantHost:   "github.com",
+		},
+		{
+			name:       "strip 80",
+			baseURL:    "http://github.com",
+			remoteHost: "github.com:80",
+			wantHost:   "github.com",
+		},
+		{
+			name:       "keep custom port",
+			baseURL:    "https://github.com",
+			remoteHost: "github.com:8443",
+			wantHost:   "github.com:8443",
+		},
+		{
+			name:       "base has port",
+			baseURL:    "https://github.com:443",
+			remoteHost: "github.com:443",
+			wantHost:   "github.com:443",
+		},
+		{
+			name:       "no port to strip",
+			baseURL:    "https://github.com",
+			remoteHost: "github.com",
+			wantHost:   "github.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseURL, err := url.Parse(tt.baseURL)
+			require.NoError(t, err)
+
+			remoteURL := &url.URL{Host: tt.remoteHost}
+			StripDefaultPort(baseURL, remoteURL)
+
+			assert.Equal(t, tt.wantHost, remoteURL.Host)
+		})
+	}
+}
+
+func TestMatchesHost(t *testing.T) {
+	tests := []struct {
+		name       string
+		baseHost   string
+		remoteHost string
+		want       bool
+	}{
+		{
+			name:       "exact match",
+			baseHost:   "github.com",
+			remoteHost: "github.com",
+			want:       true,
+		},
+		{
+			name:       "subdomain match",
+			baseHost:   "github.com",
+			remoteHost: "ssh.github.com",
+			want:       true,
+		},
+		{
+			name:       "no match",
+			baseHost:   "github.com",
+			remoteHost: "gitlab.com",
+			want:       false,
+		},
+		{
+			name:       "partial suffix not a match",
+			baseHost:   "github.com",
+			remoteHost: "notgithub.com",
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseURL := &url.URL{Host: tt.baseHost}
+			remoteURL := &url.URL{Host: tt.remoteHost}
+
+			got := MatchesHost(baseURL, remoteURL)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestExtractPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		give      string
+		wantOwner string
+		wantRepo  string
+		wantOK    bool
+	}{
+		{
+			name:      "simple",
+			give:      "/owner/repo",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantOK:    true,
+		},
+		{
+			name:      "with .git suffix",
+			give:      "/owner/repo.git",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantOK:    true,
+		},
+		{
+			name:      "trailing slash",
+			give:      "/owner/repo/",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantOK:    true,
+		},
+		{
+			name:      "both suffix and slash",
+			give:      "/owner/repo.git/",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantOK:    true,
+		},
+		{
+			name:      "no leading slash",
+			give:      "owner/repo",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantOK:    true,
+		},
+		{
+			name:   "no repo component",
+			give:   "/owner",
+			wantOK: false,
+		},
+		{
+			name:   "empty",
+			give:   "",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner, repo, ok := ExtractPath(tt.give)
+
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.wantOwner, owner)
+				assert.Equal(t, tt.wantRepo, repo)
+			}
+		})
+	}
+}

--- a/internal/forge/github/forge.go
+++ b/internal/forge/github/forge.go
@@ -6,12 +6,11 @@ import (
 	"cmp"
 	"context"
 	"fmt"
-	"net"
 	"net/url"
-	"strings"
 
 	"github.com/shurcooL/githubv4"
 	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/forge/forgeurl"
 	"go.abhg.dev/gs/internal/silog"
 	"golang.org/x/oauth2"
 )
@@ -159,78 +158,26 @@ func extractRepoInfo(githubURL, remoteURL string) (owner, repo string, err error
 		return "", "", fmt.Errorf("bad base URL: %w", err)
 	}
 
-	// We recognize the following GitHub remote URL formats:
-	//
-	//	http(s)://github.com/OWNER/REPO.git
-	//	git@github.com:OWNER/REPO.git
-	//
-	// We can parse these all with url.Parse
-	// if we normalize the latter to:
-	//
-	//	ssh://git@github.com/OWNER/REPO.git
-	if !hasGitProtocol(remoteURL) && strings.Contains(remoteURL, ":") {
-		// $user@$host:$path => ssh://$user@$host/$path
-		remoteURL = "ssh://" + strings.Replace(remoteURL, ":", "/", 1)
-	}
-
-	u, err := url.Parse(remoteURL)
+	u, err := forgeurl.Parse(remoteURL)
 	if err != nil {
-		return "", "", fmt.Errorf("parse remote URL: %w", err)
+		return "", "", err
 	}
 
-	// If base URL doesn't explicitly specify a port,
-	// and the remote URL does, *and* it's a default port,
-	// strip it from the remote URL.
-	if baseURL.Port() == "" {
-		if host, port, err := net.SplitHostPort(u.Host); err == nil {
-			switch port {
-			case "443", "80":
-				u.Host = host
-			}
-		}
+	forgeurl.StripDefaultPort(baseURL, u)
+
+	if !forgeurl.MatchesHost(baseURL, u) {
+		return "", "", fmt.Errorf(
+			"%v is not a GitHub URL: expected host %q, got %q",
+			u, baseURL.Host, u.Host,
+		)
 	}
 
-	// May be a subdomain of base URL.
-	if u.Host != baseURL.Host && !strings.HasSuffix(u.Host, "."+baseURL.Host) {
-		return "", "", fmt.Errorf("%v is not a GitHub URL: expected host %q, got %q", u, baseURL.Host, u.Host)
-	}
-
-	s := u.Path                       // /OWNER/REPO.git/
-	s = strings.TrimPrefix(s, "/")    // OWNER/REPO.git/
-	s = strings.TrimSuffix(s, "/")    // OWNER/REPO/
-	s = strings.TrimSuffix(s, ".git") // OWNER/REPO
-
-	owner, repo, ok := strings.Cut(s, "/")
+	owner, repo, ok := forgeurl.ExtractPath(u.Path)
 	if !ok {
-		return "", "", fmt.Errorf("path %q does not contain a GitHub repository", s)
+		return "", "", fmt.Errorf(
+			"path %q does not contain a GitHub repository", u.Path,
+		)
 	}
 
 	return owner, repo, nil
-}
-
-// _gitProtocols is a list of known git protocols
-// including the :// suffix.
-var _gitProtocols = []string{
-	"ssh",
-	"git",
-	"git+ssh",
-	"git+https",
-	"git+http",
-	"https",
-	"http",
-}
-
-func init() {
-	for i, proto := range _gitProtocols {
-		_gitProtocols[i] = proto + "://"
-	}
-}
-
-func hasGitProtocol(url string) bool {
-	for _, proto := range _gitProtocols {
-		if strings.HasPrefix(url, proto) {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
Extract duplicate URL parsing code from github and gitlab forges into a new internal/forge/urls package.

The new package provides:
- HasGitProtocol: check if URL has a known git protocol
- Parse: parse git remote URLs, normalizing SCP-style SSH syntax
- StripDefaultPort: remove default ports when base URL doesn't specify one
- MatchesHost: check if hosts match including subdomains
- ExtractPath: extract owner/repo from URL path

This reduces code duplication and will allow the bitbucket forge to reuse the same URL parsing logic.