### PR TITLE
forge: add comment modularity interfaces

### DIFF
--- a/internal/handler/submit/nav_comment_test.go
+++ b/internal/handler/submit/nav_comment_test.go
@@ -784,7 +784,7 @@ func TestGenerateStackNavigationComment(t *testing.T) {
 				tt.want + "\n" +
 				_commentFooter + "\n" +
 				_commentMarker + "\n"
-			got := generateStackNavigationComment(tt.graph, tt.current, "")
+			got := generateStackNavigationComment(tt.graph, tt.current, "", nil)
 			assert.Equal(t, want, got)
 
 			// Sanity check: All generated comments must match
@@ -804,7 +804,7 @@ func TestGenerateStackNavigationComment(t *testing.T) {
 		}
 		graph[0].Aboves = []int{1}
 
-		got := generateStackNavigationComment(graph, 1, "<-- you are here")
+		got := generateStackNavigationComment(graph, 1, "<-- you are here", nil)
 		want := _commentHeader + "\n\n" +
 			joinLines(
 				"- #123",


### PR DESCRIPTION
Adds support for creating direct CR links instead of relying on forge's auto-linking when they encounter a `#nnn` magic string. Prerequisite for implementing bitbucket forge (which does not auto link magic strings).

[skip changelog]: Internal-only refactor to allow forges that don't auto-link CR's when they see a `#nnn` magic string