### PR TITLE
internal: add stack-based signal handler

### DIFF
--- a/internal/sigstack/stack.go
+++ b/internal/sigstack/stack.go
@@ -1,0 +1,124 @@
+// Package sigstack provides a stack-based signal handler
+// that allows multiple components to register handlers
+// for the same signal without clobbering each other.
+package sigstack
+
+import (
+	"os"
+	"os/signal"
+	"slices"
+	"sync"
+)
+
+// Signal is an alias for [os.Signal].
+type Signal = os.Signal
+
+// Stack manages a stack of signal handlers per signal.
+// When a signal fires, only the topmost channel receives it.
+//
+// The zero value is ready to use.
+type Stack struct {
+	mu         sync.Mutex
+	states     map[Signal]*sigState
+	sigsByRecv map[chan<- Signal][]Signal
+}
+
+// sigState holds per-signal state:
+// the OS channel, the dispatch goroutine's done signal,
+// and the stack of registered channels.
+type sigState struct {
+	ossig chan os.Signal  // receives from os/signal
+	done  chan struct{}   // stops dispatch goroutine
+	recvs []chan<- Signal // stack of registered channels
+}
+
+// Notify registers ch to receive the given signals,
+// adding it to the top of the handler stack for each signal.
+//
+// Like [signal.Notify], signals are sent non-blocking,
+// so the caller should use a buffered channel.
+func (s *Stack) Notify(ch chan<- Signal, sigs ...Signal) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.states == nil {
+		s.states = make(map[Signal]*sigState)
+	}
+	if s.sigsByRecv == nil {
+		s.sigsByRecv = make(map[chan<- Signal][]Signal)
+	}
+
+	for _, sig := range sigs {
+		state, ok := s.states[sig]
+		if !ok {
+			state = &sigState{
+				ossig: make(chan os.Signal, 1),
+				done:  make(chan struct{}),
+			}
+			s.states[sig] = state
+			signal.Notify(state.ossig, sig)
+			go s.dispatch(sig, state)
+		}
+		state.recvs = append(state.recvs, ch)
+	}
+
+	s.sigsByRecv[ch] = append(s.sigsByRecv[ch], sigs...)
+}
+
+// Stop unregisters ch from all signals
+// and removes it from the handler stacks.
+//
+// It is safe to call Stop multiple times.
+func (s *Stack) Stop(ch chan<- Signal) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	sigs, ok := s.sigsByRecv[ch]
+	if !ok {
+		return
+	}
+
+	for _, sig := range sigs {
+		state := s.states[sig]
+		state.recvs = slices.DeleteFunc(state.recvs, func(c chan<- Signal) bool {
+			return c == ch
+		})
+
+		// If the stack is empty,
+		// tear down the OS handler and dispatch goroutine.
+		if len(state.recvs) == 0 {
+			signal.Stop(state.ossig)
+			close(state.done)
+			delete(s.states, sig)
+		}
+	}
+
+	delete(s.sigsByRecv, ch)
+}
+
+// dispatch reads from the OS signal channel
+// and sends to the topmost registered channel.
+func (s *Stack) dispatch(sig Signal, state *sigState) {
+	for {
+		select {
+		case <-state.ossig:
+			s.mu.Lock()
+			var top chan<- Signal
+			if n := len(state.recvs); n > 0 {
+				top = state.recvs[n-1]
+			}
+			s.mu.Unlock()
+
+			if top != nil {
+				// Non-blocking send, like os/signal.
+				select {
+				case top <- sig:
+				default:
+				}
+			}
+
+		case <-state.done:
+			return
+		}
+	}
+}

--- a/internal/sigstack/stack_unix_test.go
+++ b/internal/sigstack/stack_unix_test.go
@@ -1,0 +1,216 @@
+//go:build unix
+
+package sigstack
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var _testBinary string
+
+func TestMain(m *testing.M) {
+	exe, err := os.Executable()
+	if err != nil {
+		fmt.Fprintln(os.Stderr,
+			"Failed to get executable path:", err)
+		os.Exit(1)
+	}
+	_testBinary = exe
+
+	os.Exit(m.Run())
+}
+
+func TestStack_Notify(t *testing.T) {
+	var s Stack
+
+	ch := make(chan Signal, 1)
+	s.Notify(ch, syscall.SIGUSR1)
+	defer s.Stop(ch)
+
+	sendSignal(t, syscall.SIGUSR1)
+	assertRecv(t, ch, time.Second)
+
+	t.Run("StopCleansUp", func(t *testing.T) {
+		s.Stop(ch)
+
+		// After Stop, the signal state should be cleaned up.
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		assert.NotContains(t, s.states, syscall.SIGUSR1,
+			"signal state should be removed after Stop")
+	})
+}
+
+func TestStack_Notify_stackOrdering(t *testing.T) {
+	var s Stack
+
+	chA := make(chan Signal, 1)
+	s.Notify(chA, syscall.SIGUSR1)
+	defer s.Stop(chA)
+
+	chB := make(chan Signal, 1)
+	s.Notify(chB, syscall.SIGUSR1)
+	defer s.Stop(chB)
+
+	// With both registered, only B (topmost) should receive.
+	sendSignal(t, syscall.SIGUSR1)
+	assertRecv(t, chB, time.Second)
+	assert.Empty(t, chA)
+
+	// Stop B, send again — A should now receive.
+	t.Run("StopTopmost", func(t *testing.T) {
+		s.Stop(chB)
+
+		sendSignal(t, syscall.SIGUSR1)
+		assertRecv(t, chA, time.Second)
+		assert.Empty(t, chB)
+	})
+}
+
+func TestStack_Notify_multipleSignals(t *testing.T) {
+	var s Stack
+
+	ch := make(chan Signal, 2)
+	s.Notify(ch, syscall.SIGUSR1, syscall.SIGUSR2)
+	defer s.Stop(ch)
+
+	sendSignal(t, syscall.SIGUSR1)
+	assertRecv(t, ch, time.Second)
+
+	sendSignal(t, syscall.SIGUSR2)
+	assertRecv(t, ch, time.Second)
+}
+
+func TestStack_Stop_idempotent(t *testing.T) {
+	var s Stack
+
+	ch := make(chan Signal, 1)
+	s.Notify(ch, syscall.SIGUSR1)
+	s.Stop(ch)
+
+	// Second Stop should not panic.
+	assert.NotPanics(t, func() { s.Stop(ch) })
+}
+
+func TestStack_Stop_outOfOrder(t *testing.T) {
+	var s Stack
+
+	chA := make(chan Signal, 1)
+	s.Notify(chA, syscall.SIGUSR1)
+	defer s.Stop(chA)
+
+	chB := make(chan Signal, 1)
+	s.Notify(chB, syscall.SIGUSR1)
+	defer s.Stop(chB)
+
+	// Stop A (non-topmost); B should still receive.
+	s.Stop(chA)
+
+	sendSignal(t, syscall.SIGUSR1)
+	assertRecv(t, chB, time.Second)
+	assert.Empty(t, chA)
+}
+
+func TestStack_Notify_noopAbsorbs(t *testing.T) {
+	var s Stack
+
+	// A registered channel absorbs the signal
+	// without terminating the process.
+	ch := make(chan Signal, 1)
+	s.Notify(ch, syscall.SIGUSR1)
+	defer s.Stop(ch)
+
+	sendSignal(t, syscall.SIGUSR1)
+
+	// If we reach here, the signal was absorbed.
+}
+
+func TestStack_Stop_unregistersHandler(t *testing.T) {
+	if os.Getenv("INSIDE_TEST") == "1" {
+		// Subprocess mode:
+		// register a handler, wait for a signal,
+		// then unregister and block forever.
+		var s Stack
+		go func() {
+			ch := make(chan Signal, 1)
+			s.Notify(ch, syscall.SIGINT)
+
+			fmt.Println("ready")
+			<-ch
+
+			s.Stop(ch)
+			fmt.Println("stopped")
+		}()
+
+		select {} // block forever (will be killed by SIGINT)
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, _testBinary, "-test.run=^"+t.Name()+"$")
+	cmd.Env = append(os.Environ(), "INSIDE_TEST=1")
+
+	stdout, err := cmd.StdoutPipe()
+	require.NoError(t, err)
+	require.NoError(t, cmd.Start())
+
+	scanner := bufio.NewScanner(stdout)
+
+	// Wait for the subprocess to register its handler.
+	require.True(t, scanner.Scan(), "expected 'ready' line")
+	assert.Equal(t, "ready", scanner.Text())
+
+	// First SIGINT: handled by the Stack.
+	require.NoError(t, cmd.Process.Signal(syscall.SIGINT))
+
+	// Wait for the subprocess to call Stop.
+	require.True(t, scanner.Scan(), "expected 'stopped' line")
+	assert.Equal(t, "stopped", scanner.Text())
+
+	// Second SIGINT: handler is unregistered,
+	// so the default action (terminate) should apply.
+	require.NoError(t, cmd.Process.Signal(syscall.SIGINT))
+
+	err = cmd.Wait()
+	require.Error(t, err, "subprocess should have been killed")
+
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+
+	status, ok := exitErr.Sys().(syscall.WaitStatus)
+	require.True(t, ok, "expected syscall.WaitStatus")
+	assert.Equal(t, syscall.SIGINT,
+		status.Signal(),
+		"subprocess should have been killed by SIGINT",
+	)
+}
+
+func assertRecv(t testing.TB, ch <-chan Signal, timeout time.Duration) {
+	t.Helper()
+
+	select {
+	case <-ch:
+		// ok
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for signal")
+	}
+}
+
+func sendSignal(t *testing.T, sig syscall.Signal) {
+	t.Helper()
+
+	require.NoError(t,
+		syscall.Kill(syscall.Getpid(), sig),
+	)
+}


### PR DESCRIPTION
Add a Stack type that manages per-signal handler stacks.
Handlers are invoked in LIFO order,
and signal registration is managed lazily:
Notify on first push, Stop+Reset when the stack empties.

This allows multiple components to register handlers
for the same signal without clobbering each other.

[skip changelog]: no user facing changes
