### PR TITLE
Core bitbucket implementation (forge skeleton and auth)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,19 @@ unless explicitly stated otherwise:
         mise run build
         ```
 
-    4. Changelog
+    4. Generate
+
+        If the change adds or modifies CLI commands, flags, or
+        configuration options (e.g., adding a new forge),
+        regenerate documentation and other generated files:
+
+        ```bash
+        mise run generate
+        ```
+
+        This updates `doc/includes/cli-reference.md` and other generated files.
+
+    5. Changelog
 
         If the change is user-facing, that is,
         it adds or modifies functionality visible to end users,
@@ -88,7 +100,7 @@ unless explicitly stated otherwise:
         changie new --kind $kind --body $body
         ```
 
-    5. Commit
+    6. Commit
 
         Create a commit with a descriptive message.
         Follow user-specified guidelines for commit messages if provided.

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -12,7 +12,7 @@ gs (git-spice) is a command line tool for stacking Git branches.
 * `-C`, `--dir=DIR`: Change to DIR before doing anything
 * `--[no-]prompt`: Whether to prompt for missing information
 
-**Configuration**: [spice.forge.github.apiUrl](/cli/config.md#spiceforgegithubapiurl), [spice.forge.github.url](/cli/config.md#spiceforgegithuburl), [spice.forge.gitlab.apiURL](/cli/config.md#spiceforgegitlabapiurl), [spice.forge.gitlab.oauth.clientID](/cli/config.md#spiceforgegitlaboauthclientid), [spice.forge.gitlab.removeSourceBranch](/cli/config.md#spiceforgegitlabremovesourcebranch), [spice.forge.gitlab.url](/cli/config.md#spiceforgegitlaburl)
+**Configuration**: [spice.forge.bitbucket.apiURL](/cli/config.md#spiceforgebitbucketapiurl), [spice.forge.bitbucket.url](/cli/config.md#spiceforgebitbucketurl), [spice.forge.github.apiUrl](/cli/config.md#spiceforgegithubapiurl), [spice.forge.github.url](/cli/config.md#spiceforgegithuburl), [spice.forge.gitlab.apiURL](/cli/config.md#spiceforgegitlabapiurl), [spice.forge.gitlab.oauth.clientID](/cli/config.md#spiceforgegitlaboauthclientid), [spice.forge.gitlab.removeSourceBranch](/cli/config.md#spiceforgegitlabremovesourcebranch), [spice.forge.gitlab.url](/cli/config.md#spiceforgegitlaburl)
 
 ## Shell
 

--- a/internal/forge/bitbucket/auth.go
+++ b/internal/forge/bitbucket/auth.go
@@ -1,0 +1,143 @@
+package bitbucket
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/secret"
+	"go.abhg.dev/gs/internal/ui"
+)
+
+// AuthType identifies the authentication method used.
+type AuthType int
+
+const (
+	// AuthTypeAPIToken indicates authentication via API token.
+	AuthTypeAPIToken AuthType = iota
+
+	// AuthTypeEnvironmentVariable indicates authentication via environment variable.
+	// This is set to 100 to distinguish from user-selected auth types.
+	AuthTypeEnvironmentVariable AuthType = 100
+)
+
+// AuthenticationToken defines the token returned by the Bitbucket forge.
+type AuthenticationToken struct {
+	forge.AuthenticationToken
+
+	// AuthType specifies the authentication method used.
+	AuthType AuthType `json:"auth_type"`
+
+	// AccessToken is the Bitbucket API token.
+	AccessToken string `json:"access_token,omitempty"`
+}
+
+var _ forge.AuthenticationToken = (*AuthenticationToken)(nil)
+
+// AuthenticationFlow prompts the user to authenticate with Bitbucket.
+// This rejects the request if the user is already authenticated
+// with a BITBUCKET_TOKEN environment variable.
+func (f *Forge) AuthenticationFlow(
+	ctx context.Context,
+	view ui.View,
+) (forge.AuthenticationToken, error) {
+	log := f.logger()
+
+	if f.Options.Token != "" {
+		log.Error("Already authenticated with BITBUCKET_TOKEN.")
+		log.Error("Unset BITBUCKET_TOKEN to login with a different method.")
+		return nil, errors.New("already authenticated")
+	}
+
+	// For now, only API token auth is supported.
+	// GCM integration can be added in a future PR.
+	return f.apiTokenAuth(ctx, view)
+}
+
+func (f *Forge) apiTokenAuth(_ context.Context, view ui.View) (*AuthenticationToken, error) {
+	f.logger().Info("Bitbucket Cloud uses API tokens for authentication.")
+	f.logger().Info("Create one at: https://bitbucket.org/account/settings/api-tokens/")
+	f.logger().Info("Required scopes: pullrequest:write, account")
+	f.logger().Info("  pullrequest:write - create and edit pull requests")
+	f.logger().Info("  account - read workspace members for reviewer lookup")
+
+	token, err := promptRequired(view, "Enter API token", "API token is required")
+	if err != nil {
+		return nil, fmt.Errorf("prompt for API token: %w", err)
+	}
+
+	return &AuthenticationToken{
+		AuthType:    AuthTypeAPIToken,
+		AccessToken: token,
+	}, nil
+}
+
+func promptRequired(view ui.View, title, errMsg string) (string, error) {
+	var value string
+	err := ui.Run(view, ui.NewInput().
+		WithTitle(title).
+		WithValidate(requiredValidator(errMsg)).
+		WithValue(&value),
+	)
+	return value, err
+}
+
+func requiredValidator(errMsg string) func(string) error {
+	return func(input string) error {
+		if strings.TrimSpace(input) == "" {
+			return errors.New(errMsg)
+		}
+		return nil
+	}
+}
+
+// SaveAuthenticationToken saves the given authentication token to the stash.
+func (f *Forge) SaveAuthenticationToken(
+	stash secret.Stash,
+	t forge.AuthenticationToken,
+) error {
+	bbt := t.(*AuthenticationToken)
+
+	// If the user has set BITBUCKET_TOKEN, we should not save it to the stash.
+	if f.Options.Token != "" && f.Options.Token == bbt.AccessToken {
+		return nil
+	}
+
+	data, err := json.Marshal(bbt)
+	if err != nil {
+		return fmt.Errorf("marshal token: %w", err)
+	}
+
+	return stash.SaveSecret(f.URL(), "token", string(data))
+}
+
+// LoadAuthenticationToken loads the authentication token from the stash.
+func (f *Forge) LoadAuthenticationToken(stash secret.Stash) (forge.AuthenticationToken, error) {
+	// Environment variable takes precedence.
+	if f.Options.Token != "" {
+		return &AuthenticationToken{
+			AuthType:    AuthTypeEnvironmentVariable,
+			AccessToken: f.Options.Token,
+		}, nil
+	}
+
+	data, err := stash.LoadSecret(f.URL(), "token")
+	if err != nil {
+		return nil, fmt.Errorf("load token: %w", err)
+	}
+
+	var token AuthenticationToken
+	if err := json.Unmarshal([]byte(data), &token); err != nil {
+		return nil, fmt.Errorf("unmarshal token: %w", err)
+	}
+
+	return &token, nil
+}
+
+// ClearAuthenticationToken removes the authentication token from the stash.
+func (f *Forge) ClearAuthenticationToken(stash secret.Stash) error {
+	return stash.DeleteSecret(f.URL(), "token")
+}

--- a/internal/forge/bitbucket/client.go
+++ b/internal/forge/bitbucket/client.go
@@ -1,0 +1,24 @@
+package bitbucket
+
+import (
+	"net/http"
+
+	"go.abhg.dev/gs/internal/silog"
+)
+
+// client is an HTTP client for the Bitbucket API.
+type client struct {
+	baseURL string
+	token   *AuthenticationToken
+	http    *http.Client
+	log     *silog.Logger
+}
+
+func newClient(baseURL string, token *AuthenticationToken, log *silog.Logger) *client {
+	return &client{
+		baseURL: baseURL,
+		token:   token,
+		http:    http.DefaultClient,
+		log:     log,
+	}
+}

--- a/internal/forge/bitbucket/forge.go
+++ b/internal/forge/bitbucket/forge.go
@@ -1,0 +1,126 @@
+package bitbucket
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"net/url"
+
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/forge/forgeurl"
+	"go.abhg.dev/gs/internal/silog"
+)
+
+// Forge builds a Bitbucket Forge.
+type Forge struct {
+	Options Options
+
+	// Log specifies the logger to use.
+	Log *silog.Logger
+}
+
+var (
+	_ forge.Forge           = (*Forge)(nil)
+	_ forge.WithDisplayName = (*Forge)(nil)
+)
+
+func (f *Forge) logger() *silog.Logger {
+	if f.Log == nil {
+		return silog.Nop()
+	}
+	return f.Log.WithPrefix("bitbucket")
+}
+
+// URL returns the base URL configured for the Bitbucket Forge
+// or the default URL if none is set.
+func (f *Forge) URL() string {
+	return cmp.Or(f.Options.URL, DefaultURL)
+}
+
+// APIURL returns the base API URL configured for the Bitbucket Forge
+// or the default URL if none is set.
+func (f *Forge) APIURL() string {
+	return cmp.Or(f.Options.APIURL, DefaultAPIURL)
+}
+
+// ID reports a unique key for this forge.
+func (*Forge) ID() string { return "bitbucket" }
+
+// DisplayName returns a human-friendly name for the forge.
+func (*Forge) DisplayName() string { return "Bitbucket (Atlassian)" }
+
+// CLIPlugin returns the CLI plugin for the Bitbucket Forge.
+func (f *Forge) CLIPlugin() any { return &f.Options }
+
+// ChangeTemplatePaths reports the paths at which change templates
+// can be found in a Bitbucket repository.
+func (*Forge) ChangeTemplatePaths() []string {
+	// Bitbucket does not have native PR template support like GitHub/GitLab.
+	// Some repositories use community conventions.
+	return []string{
+		"PULL_REQUEST_TEMPLATE.md",
+		"pull_request_template.md",
+		".bitbucket/PULL_REQUEST_TEMPLATE.md",
+		".bitbucket/pull_request_template.md",
+	}
+}
+
+// ParseRemoteURL parses the given remote URL and returns a [RepositoryID]
+// for the Bitbucket repository it points to.
+//
+// It returns [ErrUnsupportedURL] if the remote URL is not a valid Bitbucket URL.
+func (f *Forge) ParseRemoteURL(remoteURL string) (forge.RepositoryID, error) {
+	workspace, repo, err := extractRepoInfo(f.URL(), remoteURL)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", forge.ErrUnsupportedURL, err)
+	}
+
+	return &RepositoryID{
+		url:       f.URL(),
+		workspace: workspace,
+		name:      repo,
+	}, nil
+}
+
+// OpenRepository opens the Bitbucket repository that the given ID points to.
+func (f *Forge) OpenRepository(
+	_ context.Context,
+	token forge.AuthenticationToken,
+	id forge.RepositoryID,
+) (forge.Repository, error) {
+	rid := mustRepositoryID(id)
+	tok := token.(*AuthenticationToken)
+
+	client := newClient(f.APIURL(), tok, f.logger())
+	return newRepository(f, rid.workspace, rid.name, f.logger(), client), nil
+}
+
+func extractRepoInfo(bitbucketURL, remoteURL string) (workspace, repo string, err error) {
+	baseURL, err := url.Parse(bitbucketURL)
+	if err != nil {
+		return "", "", fmt.Errorf("bad base URL: %w", err)
+	}
+
+	u, err := forgeurl.Parse(remoteURL)
+	if err != nil {
+		return "", "", err
+	}
+
+	forgeurl.StripDefaultPort(baseURL, u)
+
+	if !forgeurl.MatchesHost(baseURL, u) {
+		return "", "", fmt.Errorf(
+			"%v is not a Bitbucket URL: expected host %q, got %q",
+			u, baseURL.Host, u.Host,
+		)
+	}
+
+	workspace, repo, ok := forgeurl.ExtractPath(u.Path)
+	if !ok {
+		return "", "", fmt.Errorf(
+			"path %q does not contain a Bitbucket repository", u.Path,
+		)
+	}
+
+	return workspace, repo, nil
+}

--- a/internal/forge/bitbucket/forge_test.go
+++ b/internal/forge/bitbucket/forge_test.go
@@ -1,0 +1,206 @@
+package bitbucket
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/forge"
+)
+
+func TestForge_ID(t *testing.T) {
+	f := &Forge{}
+	assert.Equal(t, "bitbucket", f.ID())
+}
+
+func TestForge_URL(t *testing.T) {
+	tests := []struct {
+		name    string
+		options Options
+		want    string
+	}{
+		{
+			name:    "Default",
+			options: Options{},
+			want:    "https://bitbucket.org",
+		},
+		{
+			name: "CustomURL",
+			options: Options{
+				URL: "https://bitbucket.example.com",
+			},
+			want: "https://bitbucket.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &Forge{Options: tt.options}
+			assert.Equal(t, tt.want, f.URL())
+		})
+	}
+}
+
+func TestForge_APIURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		options Options
+		want    string
+	}{
+		{
+			name:    "Default",
+			options: Options{},
+			want:    "https://api.bitbucket.org/2.0",
+		},
+		{
+			name: "CustomAPIURL",
+			options: Options{
+				APIURL: "https://api.bitbucket.example.com/2.0",
+			},
+			want: "https://api.bitbucket.example.com/2.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &Forge{Options: tt.options}
+			assert.Equal(t, tt.want, f.APIURL())
+		})
+	}
+}
+
+func TestForge_ParseRemoteURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		remoteURL string
+		want      string
+		wantErr   error
+	}{
+		{
+			name:      "HTTPS",
+			remoteURL: "https://bitbucket.org/workspace/repo.git",
+			want:      "workspace/repo",
+		},
+		{
+			name:      "HTTPSNoGit",
+			remoteURL: "https://bitbucket.org/workspace/repo",
+			want:      "workspace/repo",
+		},
+		{
+			name:      "SSH",
+			remoteURL: "git@bitbucket.org:workspace/repo.git",
+			want:      "workspace/repo",
+		},
+		{
+			name:      "SSHNoGit",
+			remoteURL: "git@bitbucket.org:workspace/repo",
+			want:      "workspace/repo",
+		},
+		{
+			name:      "HTTPSWithPort443",
+			remoteURL: "https://bitbucket.org:443/workspace/repo.git",
+			want:      "workspace/repo",
+		},
+		{
+			name:      "GitProtocol",
+			remoteURL: "git://bitbucket.org/workspace/repo.git",
+			want:      "workspace/repo",
+		},
+		{
+			name:      "GitSSHProtocol",
+			remoteURL: "git+ssh://git@bitbucket.org/workspace/repo.git",
+			want:      "workspace/repo",
+		},
+		{
+			name:      "WrongHost",
+			remoteURL: "https://github.com/owner/repo.git",
+			wantErr:   forge.ErrUnsupportedURL,
+		},
+		{
+			name:      "NoRepo",
+			remoteURL: "https://bitbucket.org/workspace",
+			wantErr:   forge.ErrUnsupportedURL,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &Forge{}
+			rid, err := f.ParseRemoteURL(tt.remoteURL)
+
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, rid.String())
+		})
+	}
+}
+
+func TestForge_ParseRemoteURL_CustomURL(t *testing.T) {
+	f := &Forge{
+		Options: Options{
+			URL: "https://bitbucket.example.com",
+		},
+	}
+
+	tests := []struct {
+		name      string
+		remoteURL string
+		want      string
+		wantErr   error
+	}{
+		{
+			name:      "HTTPS",
+			remoteURL: "https://bitbucket.example.com/workspace/repo.git",
+			want:      "workspace/repo",
+		},
+		{
+			name:      "SSH",
+			remoteURL: "git@bitbucket.example.com:workspace/repo.git",
+			want:      "workspace/repo",
+		},
+		{
+			name:      "WrongHost",
+			remoteURL: "https://bitbucket.org/workspace/repo.git",
+			wantErr:   forge.ErrUnsupportedURL,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rid, err := f.ParseRemoteURL(tt.remoteURL)
+
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, rid.String())
+		})
+	}
+}
+
+func TestRepositoryID_ChangeURL(t *testing.T) {
+	rid := &RepositoryID{
+		url:       "https://bitbucket.org",
+		workspace: "myworkspace",
+		name:      "myrepo",
+	}
+
+	pr := &PR{Number: 42}
+	got := rid.ChangeURL(pr)
+
+	assert.Equal(t, "https://bitbucket.org/myworkspace/myrepo/pull-requests/42", got)
+}
+
+func TestForge_ChangeTemplatePaths(t *testing.T) {
+	f := &Forge{}
+	paths := f.ChangeTemplatePaths()
+
+	assert.NotEmpty(t, paths)
+	assert.Contains(t, paths, "PULL_REQUEST_TEMPLATE.md")
+}

--- a/internal/forge/bitbucket/options.go
+++ b/internal/forge/bitbucket/options.go
@@ -1,0 +1,26 @@
+// Package bitbucket provides a wrapper around Bitbucket's APIs
+// in a manner compliant with the [forge.Forge] interface.
+package bitbucket
+
+// DefaultURL is the default URL for Bitbucket Cloud.
+const DefaultURL = "https://bitbucket.org"
+
+// DefaultAPIURL is the default URL for Bitbucket Cloud API.
+const DefaultAPIURL = "https://api.bitbucket.org/2.0"
+
+// Options defines command line options for the Bitbucket Forge.
+// These are all hidden in the CLI,
+// and are expected to be set only via environment variables.
+type Options struct {
+	// URL is the URL for Bitbucket.
+	// Override this for testing or self-hosted Bitbucket instances.
+	URL string `name:"bitbucket-url" hidden:"" config:"forge.bitbucket.url" env:"BITBUCKET_URL" help:"Base URL for Bitbucket web requests"`
+
+	// APIURL is the URL for Bitbucket's API.
+	// Override this for testing or self-hosted Bitbucket instances.
+	APIURL string `name:"bitbucket-api-url" hidden:"" config:"forge.bitbucket.apiURL" env:"BITBUCKET_API_URL" help:"Base URL for Bitbucket API requests"`
+
+	// Token is a fixed token used to authenticate with Bitbucket.
+	// This may be used to skip the login flow.
+	Token string `name:"bitbucket-token" hidden:"" env:"BITBUCKET_TOKEN" help:"Bitbucket API token"`
+}

--- a/internal/forge/bitbucket/repoid.go
+++ b/internal/forge/bitbucket/repoid.go
@@ -1,0 +1,38 @@
+package bitbucket
+
+import (
+	"fmt"
+
+	"go.abhg.dev/gs/internal/forge"
+)
+
+// RepositoryID is a unique identifier for a Bitbucket repository.
+type RepositoryID struct {
+	url       string // required
+	workspace string // required
+	name      string // required
+}
+
+var _ forge.RepositoryID = (*RepositoryID)(nil)
+
+func mustRepositoryID(id forge.RepositoryID) *RepositoryID {
+	rid, ok := id.(*RepositoryID)
+	if ok {
+		return rid
+	}
+	panic(fmt.Sprintf("expected *RepositoryID, got %T", id))
+}
+
+// String returns a human-readable name for the repository ID.
+func (rid *RepositoryID) String() string {
+	return fmt.Sprintf("%s/%s", rid.workspace, rid.name)
+}
+
+// ChangeURL returns the URL for a Pull Request hosted on Bitbucket.
+func (rid *RepositoryID) ChangeURL(id forge.ChangeID) string {
+	prNum := mustPR(id).Number
+	return fmt.Sprintf(
+		"%s/%s/%s/pull-requests/%v",
+		rid.url, rid.workspace, rid.name, prNum,
+	)
+}

--- a/internal/forge/bitbucket/repository.go
+++ b/internal/forge/bitbucket/repository.go
@@ -1,0 +1,156 @@
+package bitbucket
+
+import (
+	"context"
+	"errors"
+	"iter"
+
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/silog"
+)
+
+// ErrNotImplemented indicates that a feature is not yet implemented.
+var ErrNotImplemented = errors.New("not implemented")
+
+// Repository is a Bitbucket repository.
+type Repository struct {
+	client *client
+
+	workspace, repo string
+	log             *silog.Logger
+	forge           *Forge
+}
+
+var _ forge.Repository = (*Repository)(nil)
+
+func newRepository(
+	forge *Forge,
+	workspace, repo string,
+	log *silog.Logger,
+	client *client,
+) *Repository {
+	return &Repository{
+		client:    client,
+		workspace: workspace,
+		repo:      repo,
+		forge:     forge,
+		log:       log,
+	}
+}
+
+// Forge returns the forge this repository belongs to.
+func (r *Repository) Forge() forge.Forge { return r.forge }
+
+// SubmitChange creates a new pull request in the repository.
+//
+// This is a stub that will be implemented in a future PR.
+func (r *Repository) SubmitChange(
+	_ context.Context,
+	_ forge.SubmitChangeRequest,
+) (forge.SubmitChangeResult, error) {
+	return forge.SubmitChangeResult{}, ErrNotImplemented
+}
+
+// EditChange edits an existing pull request.
+//
+// This is a stub that will be implemented in a future PR.
+func (r *Repository) EditChange(
+	_ context.Context,
+	_ forge.ChangeID,
+	_ forge.EditChangeOptions,
+) error {
+	return ErrNotImplemented
+}
+
+// FindChangesByBranch finds pull requests by branch name.
+//
+// This is a stub that will be implemented in a future PR.
+func (r *Repository) FindChangesByBranch(
+	_ context.Context,
+	_ string,
+	_ forge.FindChangesOptions,
+) ([]*forge.FindChangeItem, error) {
+	return nil, ErrNotImplemented
+}
+
+// FindChangeByID finds a pull request by its ID.
+//
+// This is a stub that will be implemented in a future PR.
+func (r *Repository) FindChangeByID(
+	_ context.Context,
+	_ forge.ChangeID,
+) (*forge.FindChangeItem, error) {
+	return nil, ErrNotImplemented
+}
+
+// ChangesStates retrieves the states of multiple pull requests.
+//
+// This is a stub that will be implemented in a future PR.
+func (r *Repository) ChangesStates(
+	_ context.Context,
+	_ []forge.ChangeID,
+) ([]forge.ChangeState, error) {
+	return nil, ErrNotImplemented
+}
+
+// PostChangeComment posts a comment on a pull request.
+//
+// This is a stub that will be implemented in a future PR.
+func (r *Repository) PostChangeComment(
+	_ context.Context,
+	_ forge.ChangeID,
+	_ string,
+) (forge.ChangeCommentID, error) {
+	return nil, ErrNotImplemented
+}
+
+// UpdateChangeComment updates an existing comment.
+//
+// This is a stub that will be implemented in a future PR.
+func (r *Repository) UpdateChangeComment(
+	_ context.Context,
+	_ forge.ChangeCommentID,
+	_ string,
+) error {
+	return ErrNotImplemented
+}
+
+// DeleteChangeComment deletes an existing comment.
+//
+// This is a stub that will be implemented in a future PR.
+func (r *Repository) DeleteChangeComment(
+	_ context.Context,
+	_ forge.ChangeCommentID,
+) error {
+	return ErrNotImplemented
+}
+
+// ListChangeComments lists comments on a pull request.
+//
+// This is a stub that will be implemented in a future PR.
+func (r *Repository) ListChangeComments(
+	_ context.Context,
+	_ forge.ChangeID,
+	_ *forge.ListChangeCommentsOptions,
+) iter.Seq2[*forge.ListChangeCommentItem, error] {
+	return func(yield func(*forge.ListChangeCommentItem, error) bool) {
+		yield(nil, ErrNotImplemented)
+	}
+}
+
+// NewChangeMetadata returns the metadata for a pull request.
+func (r *Repository) NewChangeMetadata(
+	_ context.Context,
+	id forge.ChangeID,
+) (forge.ChangeMetadata, error) {
+	pr := mustPR(id)
+	return &PRMetadata{PR: pr}, nil
+}
+
+// ListChangeTemplates lists pull request templates in the repository.
+// Bitbucket has limited template support, so this returns an empty list.
+func (r *Repository) ListChangeTemplates(
+	_ context.Context,
+) ([]*forge.ChangeTemplate, error) {
+	return nil, nil
+}

--- a/internal/forge/bitbucket/types.go
+++ b/internal/forge/bitbucket/types.go
@@ -1,0 +1,120 @@
+package bitbucket
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"go.abhg.dev/gs/internal/forge"
+)
+
+// PR uniquely identifies a Pull Request in Bitbucket.
+// It's a valid forge.ChangeID.
+type PR struct {
+	// Number is the pull request ID.
+	Number int64 `json:"number"`
+}
+
+var _ forge.ChangeID = (*PR)(nil)
+
+func mustPR(id forge.ChangeID) *PR {
+	pr, ok := id.(*PR)
+	if !ok {
+		panic(fmt.Sprintf("bitbucket: expected *PR, got %T", id))
+	}
+	return pr
+}
+
+func (id *PR) String() string {
+	return fmt.Sprintf("#%d", id.Number)
+}
+
+// PRComment uniquely identifies a comment on a pull request.
+type PRComment struct {
+	// ID is the comment ID.
+	ID int64 `json:"id"`
+}
+
+var _ forge.ChangeCommentID = (*PRComment)(nil)
+
+func mustPRComment(id forge.ChangeCommentID) *PRComment {
+	if id == nil {
+		return nil
+	}
+	c, ok := id.(*PRComment)
+	if !ok {
+		panic(fmt.Sprintf("bitbucket: expected *PRComment, got %T", id))
+	}
+	return c
+}
+
+func (c *PRComment) String() string {
+	return fmt.Sprintf("comment:%d", c.ID)
+}
+
+// PRMetadata is the metadata for a pull request
+// persisted in git-spice's data store.
+type PRMetadata struct {
+	// PR is the pull request this metadata is for.
+	PR *PR `json:"pr,omitempty"`
+
+	// NavigationComment is the comment on the pull request
+	// where we visualize the stack of PRs.
+	NavigationComment *PRComment `json:"comment,omitempty"`
+}
+
+var _ forge.ChangeMetadata = (*PRMetadata)(nil)
+
+// ForgeID reports the forge ID that owns this metadata.
+func (*PRMetadata) ForgeID() string {
+	return "bitbucket"
+}
+
+// ChangeID reports the change ID of the pull request.
+func (m *PRMetadata) ChangeID() forge.ChangeID {
+	return m.PR
+}
+
+// NavigationCommentID reports the comment ID of the navigation comment
+// left on the pull request.
+func (m *PRMetadata) NavigationCommentID() forge.ChangeCommentID {
+	if m.NavigationComment == nil {
+		return nil
+	}
+	return m.NavigationComment
+}
+
+// SetNavigationCommentID sets the comment ID of the navigation comment
+// left on the pull request.
+//
+// id may be nil.
+func (m *PRMetadata) SetNavigationCommentID(id forge.ChangeCommentID) {
+	m.NavigationComment = mustPRComment(id)
+}
+
+// MarshalChangeMetadata serializes a PRMetadata into JSON.
+func (*Forge) MarshalChangeMetadata(md forge.ChangeMetadata) (json.RawMessage, error) {
+	return json.Marshal(md)
+}
+
+// UnmarshalChangeMetadata deserializes a PRMetadata from JSON.
+func (*Forge) UnmarshalChangeMetadata(data json.RawMessage) (forge.ChangeMetadata, error) {
+	var md PRMetadata
+	if err := json.Unmarshal(data, &md); err != nil {
+		return nil, fmt.Errorf("unmarshal PR metadata: %w", err)
+	}
+	return &md, nil
+}
+
+// MarshalChangeID serializes a PR into JSON.
+func (*Forge) MarshalChangeID(id forge.ChangeID) (json.RawMessage, error) {
+	return json.Marshal(mustPR(id))
+}
+
+// UnmarshalChangeID deserializes a PR from JSON.
+func (*Forge) UnmarshalChangeID(data json.RawMessage) (forge.ChangeID, error) {
+	var id PR
+	if err := json.Unmarshal(data, &id); err != nil {
+		return nil, fmt.Errorf("unmarshal PR ID: %w", err)
+	}
+	return &id, nil
+}

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -173,6 +173,27 @@ type Forge interface {
 	ClearAuthenticationToken(secret.Stash) error
 }
 
+// WithDisplayName is an optional interface that forges can implement
+// to provide a human-friendly display name for the UI.
+// If not implemented, the forge's ID is used as the display name.
+type WithDisplayName interface {
+	Forge
+
+	// DisplayName returns a human-friendly name for the forge,
+	// e.g. "Bitbucket (Atlassian)" instead of just "bitbucket".
+	DisplayName() string
+}
+
+// GetDisplayName returns the display name for a forge.
+// If the forge implements WithDisplayName, it returns DisplayName().
+// Otherwise, it returns the forge's ID.
+func GetDisplayName(f Forge) string {
+	if fd, ok := f.(WithDisplayName); ok {
+		return fd.DisplayName()
+	}
+	return f.ID()
+}
+
 // AuthenticationToken is a secret that results from a successful login.
 // It will be persisted in a safe place,
 // and re-used for future authentication with the forge.

--- a/internal/forge/forge_test.go
+++ b/internal/forge/forge_test.go
@@ -65,6 +65,18 @@ func TestRegister(t *testing.T) {
 	})
 }
 
+func TestGetDisplayName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	t.Run("WithoutDisplayName", func(t *testing.T) {
+		mockForge := forgetest.NewMockForge(ctrl)
+		mockForge.EXPECT().ID().Return("test-forge")
+
+		name := forge.GetDisplayName(mockForge)
+		assert.Equal(t, "test-forge", name)
+	})
+}
+
 func TestChangeState(t *testing.T) {
 	tests := []struct {
 		state forge.ChangeState

--- a/internal/forge/forgetest/testconfig.yaml
+++ b/internal/forge/forgetest/testconfig.yaml
@@ -1,0 +1,42 @@
+# Test configuration for forge integration tests.
+#
+# Copy this file to testconfig.yaml and fill in your values.
+# This file is required only when recording fixtures (using the -update flag).
+#
+# Authentication tokens are NOT stored here - they use the existing mechanisms:
+#   - Environment variables (GITHUB_TOKEN, GITLAB_TOKEN, BITBUCKET_TOKEN)
+#   - git-credential-manager
+#   - gs auth login credentials
+#
+# The values in this file will be sanitized in recorded fixtures,
+# replaced with canonical placeholders for portability.
+
+github:
+  # Repository owner (your GitHub username or organization)
+  owner: "ed-irl"
+  # Test repository name (should be a repo you have write access to)
+  repo: "git-spice-test"
+  # A GitHub user who can be added as a reviewer (can be a bot account)
+  reviewer: "ekohlwey"
+  # A GitHub user who can be assigned to PRs (can be the same as reviewer)
+  assignee: "ekohlwey"
+
+gitlab:
+  # Project namespace (your GitLab username or group)
+  owner: "ed-irlllc"
+  # Test project name
+  repo: "git-spice-test"
+  # A GitLab user who can be added as a reviewer
+  reviewer: "ekohlwey1"
+  # A GitLab user who can be assigned to MRs
+  assignee: "ekohlwey1"
+
+bitbucket:
+  # Bitbucket workspace
+  owner: "shambucket"
+  # Test repository name
+  repo: "shambucket"
+  # A Bitbucket user who can be added as a reviewer (use nickname from API)
+  reviewer: "Ed IRL Kohlwey"
+  # Bitbucket does not support assignees, leave empty
+  assignee: ""

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"go.abhg.dev/gs/internal/cli/experiment"
 	"go.abhg.dev/gs/internal/cli/shorthand"
 	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/forge/bitbucket"
 	"go.abhg.dev/gs/internal/forge/github"
 	"go.abhg.dev/gs/internal/forge/gitlab"
 	"go.abhg.dev/gs/internal/git"
@@ -67,6 +68,7 @@ func main() {
 
 	// Register supported forges.
 	var forges forge.Registry
+	forges.Register(&bitbucket.Forge{Log: logger})
 	forges.Register(&github.Forge{Log: logger})
 	forges.Register(&gitlab.Forge{Log: logger})
 	for _, f := range _extraForges {

--- a/testdata/script/auth_prompt_forge.txt
+++ b/testdata/script/auth_prompt_forge.txt
@@ -15,7 +15,8 @@ cmp $WORK/robot.actual $WORK/robot.golden
 ===
 > Select a Forge: 
 >
-> ▶ github
+> ▶ bitbucket
+>   github
 >   gitlab
 >   shamhub
 "shamhub"


### PR DESCRIPTION
Add the foundational types and basic authentication for Bitbucket Cloud support. Repository operations are stubbed and will be implemented in follow-up PRs.

[skip changelog]: Stub bitbucket implementation only; will include changie in next PR with the PR operation implementations.