### PR TITLE
forges(bitbucket+github): add support for GCM-managed credentials

### DIFF
--- a/.changes/unreleased/Added-20260211-095116.yaml
+++ b/.changes/unreleased/Added-20260211-095116.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'auth: Add Git Credential Manager (GCM) authentication support for GitHub and Bitbucket'
+time: 2026-02-11T09:51:16.808027-05:00

--- a/doc/hooks/replace.py
+++ b/doc/hooks/replace.py
@@ -10,8 +10,10 @@ from mkdocs.structure.pages import Page
 REPLACEMENTS = {
     '<!-- gs:github -->': ':simple-github: GitHub',
     '<!-- gs:gitlab -->': ':simple-gitlab: GitLab',
+    '<!-- gs:bitbucket -->': ':simple-bitbucket: BitBucket',
     '<!-- gs:badge:github ': '<!-- gs:badge simple-github GitHub ',
     '<!-- gs:badge:gitlab ': '<!-- gs:badge simple-gitlab GitLab ',
+    '<!-- gs:badge:bitbucket ': '<!-- gs:badge simple-bitbucket BitBucket ',
 }
 
 

--- a/doc/src/guide/limits.md
+++ b/doc/src/guide/limits.md
@@ -3,11 +3,12 @@ icon: octicons/stop-16
 title: Limitations
 description: >-
   Usage constraints and limitations when using git-spice
-  to interact with GitHub or GitLab.
+  to interact with GitHub, GitLab, or Bitbucket Cloud.
 ---
 
-Usage of git-spice with GitHub and GitLab runs into limitations
-of what is possible on those platforms, and how they handle Git commits.
+Usage of git-spice with GitHub, GitLab, and Bitbucket Cloud
+runs into limitations of what is possible on those platforms,
+and how they handle Git commits.
 Some limitations imposed on git-spice are listed below.
 
 ## Write access required
@@ -87,6 +88,22 @@ branches upstack from it need to be restacked, and all their CRs updated.
 
 <!-- TODO: can be alleviated somewhat if we implement
      https://github.com/abhinav/git-spice/issues/65 -->
+
+## Bitbucket Cloud limitations
+
+<!-- gs:version unreleased -->
+
+Bitbucket Cloud support has some limitations
+compared to GitHub and GitLab:
+
+- **No PR labels**: Bitbucket does not support pull request labels.
+  The `--label` flag is ignored.
+- **No PR assignees**: Bitbucket does not support pull request assignees.
+  The `--assign` flag is ignored.
+- **No template enumeration**: Bitbucket does not provide an API
+  to list pull request templates.
+
+These are platform limitations, not git-spice limitations.
 
 ## Base branch change may dismiss approvals
 

--- a/doc/src/setup/auth.md
+++ b/doc/src/setup/auth.md
@@ -1,7 +1,7 @@
 ---
 icon: material/lock
 description: >-
-  Authenticate with GitHub/GitLab to push and pull changes.
+  Authenticate with GitHub/GitLab/Bitbucket to push and pull changes.
 ---
 
 # Authentication
@@ -11,8 +11,10 @@ It does not require authentication for local stacking operations.
 However, once you want to push or pull changes to/from a remote repository,
 you will need to authenticate with the respective service.
 
-This page covers methods to authenticate git-spice with GitHub and GitLab.
+This page covers methods to authenticate git-spice
+with GitHub, GitLab, and Bitbucket Cloud.
 Note that GitLab support requires at least version <!-- gs:version v0.9.0 -->.
+Bitbucket Cloud support requires at least version <!-- gs:version unreleased -->.
 
 ## Logging in
 
@@ -44,9 +46,11 @@ Each supported service supports different authentication methods.
 
 - [OAuth](#oauth): <!-- gs:badge:github --> <!-- gs:badge:gitlab -->
 - [GitHub App](#github-app): <!-- gs:badge:github -->
+- [Git Credential Manager](#git-credential-manager): <!-- gs:badge:github --> <!-- gs:badge:bitbucket -->
 - [Personal Access Token](#personal-access-token): <!-- gs:badge:github --> <!-- gs:badge:gitlab -->
+- [API Token](#api-token): <!-- gs:badge:bitbucket -->
 - [Service CLI](#service-cli): <!-- gs:badge:github --> <!-- gs:badge:gitlab -->
-- [Environment variable](#environment-variable): <!-- gs:badge:github --> <!-- gs:badge:gitlab -->
+- [Environment variable](#environment-variable): <!-- gs:badge:github --> <!-- gs:badge:gitlab --> <!-- gs:badge:bitbucket -->
 
 Read on for more details on each method,
 or skip on to [Pick an authentication method](#picking-an-authentication-method).
@@ -128,6 +132,76 @@ You **must** install the GitHub App to access repositories with git-spice.
     to allow installation of the git-spice GitHub App.
     If that is not an option,
     use a [Personal Access Token](#personal-access-token).
+
+### Git Credential Manager
+
+**Supported by** <!-- gs:badge:github --> <!-- gs:badge:bitbucket -->
+
+[Git Credential Manager](https://github.com/git-credential-manager/git-credential-manager)
+(GCM) is a secure credential storage system for Git.
+If you already have GCM configured for GitHub or Bitbucket,
+git-spice can reuse those credentials automatically.
+
+```freeze language="terminal"
+{green}${reset} gs auth login
+Select an authentication method: {red}Git Credential Manager{reset}
+{green}INF{reset} successfully logged in
+```
+
+To set up GCM:
+
+1. Install Git Credential Manager:
+
+    === "macOS"
+
+        ```sh
+        brew install git-credential-manager
+        ```
+
+    === "Linux"
+
+        Follow the instructions at
+        <https://github.com/git-credential-manager/git-credential-manager>
+
+2. Configure Git to use GCM:
+
+    ```sh
+    git config --global credential.helper manager
+    ```
+
+3. Push or pull from a GitHub or Bitbucket repository once.
+   This triggers the OAuth flow in your browser.
+
+After that, git-spice will use the stored OAuth token automatically.
+
+Additionally, if you have GCM configured,
+git-spice will automatically fall back to GCM credentials
+when no other authentication token is available—even
+without running `gs auth login`.
+
+### API Token
+
+**Supported by** <!-- gs:badge:bitbucket -->
+
+Bitbucket API tokens provide a way to authenticate
+without using your main account password.
+To use an API token with git-spice:
+
+1. Go to <https://bitbucket.org/account/settings/api-tokens/>.
+2. Click "Create token".
+3. Enter a descriptive label.
+4. Select the following scopes:
+    - **pullrequest:write** - create and edit pull requests
+    - **account** - read workspace members for reviewer lookup
+5. Click "Create" and copy the generated token.
+
+```freeze language="terminal"
+{green}${reset} gs auth login
+Select an authentication method: {red}API Token{reset}
+{green}Enter Atlassian account email{reset}: user@example.com
+{green}Enter API token{reset}:
+{green}INF{reset} bitbucket: successfully logged in
+```
 
 ### Personal Access Token
 
@@ -235,7 +309,7 @@ git-spice will request a token from the CLI as needed.
 
 ### Environment variable
 
-**Supported by** <!-- gs:badge:github --> <!-- gs:badge:gitlab -->
+**Supported by** <!-- gs:badge:github --> <!-- gs:badge:gitlab --> <!-- gs:badge:bitbucket -->
 
 You can provide the authentication token as an environment variable.
 This is not recommended as a primary authentication method,
@@ -249,6 +323,11 @@ but it can be useful in CI/CD environments.
 
     Set the `GITLAB_TOKEN` environment variable to your token.
 
+=== "<!-- gs:bitbucket -->"
+
+    Set the `BITBUCKET_TOKEN` environment variable to your OAuth token.
+    This should be a Bearer token (OAuth access token).
+
 If you have the environment variable set,
 this takes precedence over all other authentication methods.
 
@@ -256,24 +335,54 @@ The $$gs auth login$$ operation will always fail if you use this method.
 
 ## Picking an authentication method
 
-[OAuth](#oauth) is best if you have the permissions needed
-to install it on all repositories that you want to use git-spice with.
-Additionally, on GitHub, [GitHub App](#github-app) is similar,
-but it may be preferable if you don't want to give git-spice
-access to all your repositories.
+=== "<!-- gs:github -->"
 
-[Service CLI](#service-cli) is the most convenient method if you already have
-the CLI for the service installed and authenticated,
-and your organization already allows its use.
-It loses security benefits of the other methods,
-as it re-uses the token assigned to the CLI.
-For example, it you lose the ability to revoke the git-spice token
-without revoking the CLI token.
+    [OAuth](#oauth) is best if you have the permissions needed
+    to install it on all repositories that you want to use git-spice with.
+    [GitHub App](#github-app) is similar,
+    but it may be preferable if you don't want to give git-spice
+    access to all your repositories.
 
-[Personal Access Token](#personal-access-token) is flexible and secure.
-It may be used even with repositories where you don't have permission to
-install OAuth or GitHub Apps.
-However, it requires manual token management, making it less convenient.
+    [Git Credential Manager](#git-credential-manager)
+    is convenient if you already have GCM installed for git operations.
+    git-spice can reuse your existing GCM credentials automatically,
+    and will fall back to them even without explicit login.
+
+    [Service CLI](#service-cli) is the most convenient method
+    if you already have the GitHub CLI installed and authenticated.
+    It loses security benefits of the other methods,
+    as it re-uses the token assigned to the CLI.
+
+    [Personal Access Token](#personal-access-token)
+    is flexible and secure.
+    It may be used even with repositories where you don't have
+    permission to install OAuth or GitHub Apps.
+    However, it requires manual token management,
+    making it less convenient.
+
+=== "<!-- gs:gitlab -->"
+
+    [OAuth](#oauth) is best if you have the permissions needed
+    to install it on all repositories that you want to use git-spice with.
+
+    [Service CLI](#service-cli) is the most convenient method if you already have
+    the GitLab CLI installed and authenticated.
+    It loses security benefits of the other methods,
+    as it re-uses the token assigned to the CLI.
+
+    [Personal Access Token](#personal-access-token) is flexible and secure.
+    It may be used even with repositories where you don't have permission to
+    install OAuth Apps.
+    However, it requires manual token management, making it less convenient.
+
+=== "<!-- gs:bitbucket -->"
+
+    [Git Credential Manager](#git-credential-manager) integrates with
+    Bitbucket's OAuth flow and handles token refresh automatically.
+    This is convenient if you already have GCM installed for git operations.
+
+    [API Token](#api-token) is flexible and secure.
+    It requires manual token management but works without additional tools.
 
 [Environment variable](#environment-variable) is the least convenient
 and the least secure method. End users should typically never pick this.
@@ -396,3 +505,4 @@ reporting the full path to the secrets file.
 ```
 
 </details>
+

--- a/internal/forge/bitbucket/auth.go
+++ b/internal/forge/bitbucket/auth.go
@@ -9,6 +9,7 @@ import (
 
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/secret"
+	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/ui"
 )
 
@@ -18,6 +19,10 @@ type AuthType int
 const (
 	// AuthTypeAPIToken indicates authentication via API token.
 	AuthTypeAPIToken AuthType = iota
+
+	// AuthTypeGCM indicates authentication via git-credential-manager.
+	// GCM stores OAuth tokens obtained through browser-based authentication.
+	AuthTypeGCM
 
 	// AuthTypeEnvironmentVariable indicates authentication via environment variable.
 	// This is set to 100 to distinguish from user-selected auth types.
@@ -37,6 +42,14 @@ type AuthenticationToken struct {
 
 var _ forge.AuthenticationToken = (*AuthenticationToken)(nil)
 
+// authMethod identifies a user-selectable authentication method.
+type authMethod int
+
+const (
+	authMethodGCM authMethod = iota
+	authMethodAPIToken
+)
+
 // AuthenticationFlow prompts the user to authenticate with Bitbucket.
 // This rejects the request if the user is already authenticated
 // with a BITBUCKET_TOKEN environment variable.
@@ -52,9 +65,65 @@ func (f *Forge) AuthenticationFlow(
 		return nil, errors.New("already authenticated")
 	}
 
-	// For now, only API token auth is supported.
-	// GCM integration can be added in a future PR.
-	return f.apiTokenAuth(ctx, view)
+	method, err := f.selectAuthMethod(view)
+	if err != nil {
+		return nil, fmt.Errorf("select auth method: %w", err)
+	}
+
+	switch method {
+	case authMethodGCM:
+		return f.gcmAuth(ctx, log)
+	case authMethodAPIToken:
+		return f.apiTokenAuth(ctx, view)
+	default:
+		return nil, fmt.Errorf("unknown auth method: %d", method)
+	}
+}
+
+func (f *Forge) selectAuthMethod(view ui.View) (authMethod, error) {
+	methods := []ui.ListItem[authMethod]{
+		{
+			Title:       "Git Credential Manager",
+			Description: gcmAuthDescription,
+			Value:       authMethodGCM,
+		},
+		{
+			Title:       "API Token",
+			Description: apiTokenAuthDescription,
+			Value:       authMethodAPIToken,
+		},
+	}
+
+	var method authMethod
+	err := ui.Run(view,
+		ui.NewList[authMethod]().
+			WithTitle("Select an authentication method").
+			WithItems(methods...).
+			WithValue(&method),
+	)
+	return method, err
+}
+
+func gcmAuthDescription(bool) string {
+	return "Use OAuth credentials from git-credential-manager.\n" +
+		"You must have GCM installed and already authenticated."
+}
+
+func apiTokenAuthDescription(bool) string {
+	return "Enter an API token manually.\n" +
+		"Create one at https://bitbucket.org/account/settings/api-tokens/"
+}
+
+func (f *Forge) gcmAuth(ctx context.Context, log *silog.Logger) (*AuthenticationToken, error) {
+	token, err := f.loadGCMCredentials(ctx)
+	if err != nil {
+		log.Error("Could not load credentials from git-credential-manager.")
+		log.Error("Ensure GCM is installed and you have authenticated to Bitbucket.")
+		return nil, fmt.Errorf("load GCM credentials: %w", err)
+	}
+
+	log.Info("Successfully loaded credentials from git-credential-manager.")
+	return token, nil
 }
 
 func (f *Forge) apiTokenAuth(_ context.Context, view ui.View) (*AuthenticationToken, error) {
@@ -115,8 +184,12 @@ func (f *Forge) SaveAuthenticationToken(
 }
 
 // LoadAuthenticationToken loads the authentication token from the stash.
+// Priority order:
+//  1. Environment variable (BITBUCKET_TOKEN)
+//  2. Stored token in secret stash
+//  3. git-credential-manager (GCM)
 func (f *Forge) LoadAuthenticationToken(stash secret.Stash) (forge.AuthenticationToken, error) {
-	// Environment variable takes precedence.
+	// Environment variable takes highest precedence.
 	if f.Options.Token != "" {
 		return &AuthenticationToken{
 			AuthType:    AuthTypeEnvironmentVariable,
@@ -124,20 +197,57 @@ func (f *Forge) LoadAuthenticationToken(stash secret.Stash) (forge.Authenticatio
 		}, nil
 	}
 
+	var errs []error
+
+	// Try stored token next.
+	if token, err := f.loadStoredToken(stash); err != nil {
+		errs = append(errs, fmt.Errorf("load stored token: %w", err))
+	} else {
+		return token, nil
+	}
+
+	// Fall back to git-credential-manager.
+	// No caller-provided context here; use Background.
+	if token, err := f.loadGCMCredentials(context.Background()); err != nil {
+		errs = append(errs, fmt.Errorf("load GCM credentials: %w", err))
+	} else {
+		f.logger().Debug("Using credentials from git-credential-manager")
+		return token, nil
+	}
+
+	return nil, fmt.Errorf("no authentication token available:\n%w",
+		errors.Join(errs...))
+}
+
+func (f *Forge) loadStoredToken(stash secret.Stash) (*AuthenticationToken, error) {
 	data, err := stash.LoadSecret(f.URL(), "token")
 	if err != nil {
-		return nil, fmt.Errorf("load token: %w", err)
+		return nil, err
 	}
 
 	var token AuthenticationToken
 	if err := json.Unmarshal([]byte(data), &token); err != nil {
-		return nil, fmt.Errorf("unmarshal token: %w", err)
+		return nil, err
 	}
-
 	return &token, nil
 }
 
 // ClearAuthenticationToken removes the authentication token from the stash.
 func (f *Forge) ClearAuthenticationToken(stash secret.Stash) error {
 	return stash.DeleteSecret(f.URL(), "token")
+}
+
+// loadGCMCredentials attempts to load OAuth credentials
+// from git-credential-manager.
+// Returns an error if GCM credentials are not available.
+func (f *Forge) loadGCMCredentials(ctx context.Context) (*AuthenticationToken, error) {
+	cred, err := forge.LoadGCMCredential(ctx, f.URL())
+	if err != nil {
+		return nil, err
+	}
+
+	return &AuthenticationToken{
+		AuthType:    AuthTypeGCM,
+		AccessToken: cred.Password,
+	}, nil
 }

--- a/internal/forge/gcm.go
+++ b/internal/forge/gcm.go
@@ -1,0 +1,79 @@
+package forge
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"go.abhg.dev/gs/internal/xec"
+)
+
+// GCMCredential holds credentials retrieved from git-credential-manager.
+type GCMCredential struct {
+	// Username is the account identifier (may be empty).
+	Username string
+
+	// Password is the access token or password.
+	Password string
+}
+
+// LoadGCMCredential loads credentials from git-credential-manager
+// for the given URL. Returns an error if GCM is not available
+// or has no credentials for the host.
+func LoadGCMCredential(ctx context.Context, forgeURL string) (*GCMCredential, error) {
+	host := extractHost(forgeURL)
+	input := fmt.Sprintf("protocol=https\nhost=%s\n\n", host)
+
+	output, err := xec.Command(ctx, nil, "git", "credential", "fill").
+		WithStdinString(input).
+		Output()
+	if err != nil {
+		return nil, fmt.Errorf("git credential fill: %w", err)
+	}
+
+	return parseCredentialOutput(output)
+}
+
+// parseCredentialOutput parses the output of `git credential fill`.
+// The format is key=value pairs, one per line.
+func parseCredentialOutput(output []byte) (*GCMCredential, error) {
+	var cred GCMCredential
+
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	for scanner.Scan() {
+		key, value, ok := strings.Cut(scanner.Text(), "=")
+		if !ok {
+			continue
+		}
+
+		switch key {
+		case "username":
+			cred.Username = value
+		case "password":
+			cred.Password = value
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("parse credential output: %w", err)
+	}
+
+	if cred.Password == "" {
+		return nil, errors.New("no password in credential output")
+	}
+
+	return &cred, nil
+}
+
+// extractHost extracts the host from a URL.
+func extractHost(rawURL string) string {
+	u, err := url.ParseRequestURI(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	return u.Host
+}

--- a/internal/forge/gcm_test.go
+++ b/internal/forge/gcm_test.go
@@ -1,0 +1,130 @@
+package forge
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCredentialOutput(t *testing.T) {
+	tests := []struct {
+		name         string
+		output       string
+		wantUsername string
+		wantPassword string
+		wantErr      bool
+	}{
+		{
+			name: "ValidCredentials",
+			output: `protocol=https
+host=bitbucket.org
+username=user@example.com
+password=oauth-token-here
+`,
+			wantUsername: "user@example.com",
+			wantPassword: "oauth-token-here",
+		},
+		{
+			name: "PasswordOnly",
+			output: `protocol=https
+host=bitbucket.org
+password=token-only
+`,
+			wantUsername: "",
+			wantPassword: "token-only",
+		},
+		{
+			name: "ExtraFields",
+			output: `protocol=https
+host=bitbucket.org
+username=user
+password=secret
+path=/repo
+`,
+			wantUsername: "user",
+			wantPassword: "secret",
+		},
+		{
+			name:    "EmptyOutput",
+			output:  "",
+			wantErr: true,
+		},
+		{
+			name: "NoPassword",
+			output: `protocol=https
+host=bitbucket.org
+username=user
+`,
+			wantErr: true,
+		},
+		{
+			name: "MalformedLines",
+			output: `protocol=https
+invalid-line-without-equals
+password=secret
+`,
+			wantPassword: "secret",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cred, err := parseCredentialOutput([]byte(tt.output))
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantUsername, cred.Username)
+			assert.Equal(t, tt.wantPassword, cred.Password)
+		})
+	}
+}
+
+func TestExtractHost(t *testing.T) {
+	tests := []struct {
+		name    string
+		rawURL  string
+		wantOut string
+	}{
+		{
+			name:    "HTTPS",
+			rawURL:  "https://bitbucket.org",
+			wantOut: "bitbucket.org",
+		},
+		{
+			name:    "HTTPSWithPath",
+			rawURL:  "https://bitbucket.org/workspace/repo",
+			wantOut: "bitbucket.org",
+		},
+		{
+			name:    "HTTPSWithPort",
+			rawURL:  "https://bitbucket.example.com:443",
+			wantOut: "bitbucket.example.com:443",
+		},
+		{
+			name:    "HTTP",
+			rawURL:  "http://bitbucket.local",
+			wantOut: "bitbucket.local",
+		},
+		{
+			name:    "NoProtocol",
+			rawURL:  "bitbucket.org",
+			wantOut: "bitbucket.org",
+		},
+		{
+			name:    "NoProtocolWithPath",
+			rawURL:  "bitbucket.org/workspace",
+			wantOut: "bitbucket.org/workspace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantOut, extractHost(tt.rawURL))
+		})
+	}
+}

--- a/internal/forge/github/auth.go
+++ b/internal/forge/github/auth.go
@@ -81,6 +81,7 @@ func (f *Forge) AuthenticationFlow(ctx context.Context, view ui.View) (forge.Aut
 
 	auth, err := selectAuthenticator(view, authenticatorOptions{
 		Endpoint: oauthEndpoint,
+		ForgeURL: f.URL(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("select authenticator: %w", err)
@@ -108,17 +109,40 @@ func (f *Forge) SaveAuthenticationToken(stash secret.Stash, t forge.Authenticati
 }
 
 // LoadAuthenticationToken loads the authentication token from the stash.
-// If the user has set GITHUB_TOKEN, it will be used instead.
+// Priority order:
+//  1. Environment variable (GITHUB_TOKEN)
+//  2. Stored token in secret stash
+//  3. git-credential-manager (GCM)
 func (f *Forge) LoadAuthenticationToken(stash secret.Stash) (forge.AuthenticationToken, error) {
 	if f.Options.Token != "" {
-		// If the user has set GITHUB_TOKEN, we should use that
-		// regardless of what's in the stash.
 		return &AuthenticationToken{AccessToken: f.Options.Token}, nil
 	}
 
+	var errs []error
+
+	// Try stored token.
+	if tok, err := f.loadStoredToken(stash); err != nil {
+		errs = append(errs, fmt.Errorf("load stored token: %w", err))
+	} else {
+		return tok, nil
+	}
+
+	// Fall back to git-credential-manager.
+	if tok, err := f.loadGCMToken(); err != nil {
+		errs = append(errs, fmt.Errorf("load GCM token: %w", err))
+	} else {
+		f.logger().Debug("Using credentials from git-credential-manager")
+		return tok, nil
+	}
+
+	return nil, fmt.Errorf("no authentication token available:\n%w",
+		errors.Join(errs...))
+}
+
+func (f *Forge) loadStoredToken(stash secret.Stash) (*AuthenticationToken, error) {
 	tokstr, err := stash.LoadSecret(f.URL(), "token")
 	if err != nil {
-		return nil, fmt.Errorf("load token: %w", err)
+		return nil, err
 	}
 
 	var tok AuthenticationToken
@@ -126,8 +150,16 @@ func (f *Forge) LoadAuthenticationToken(stash secret.Stash) (forge.Authenticatio
 		// Old token format, just use it as the access token.
 		return &AuthenticationToken{AccessToken: tokstr}, nil
 	}
-
 	return &tok, nil
+}
+
+func (f *Forge) loadGCMToken() (*AuthenticationToken, error) {
+	// No caller-provided context here; use Background.
+	cred, err := forge.LoadGCMCredential(context.Background(), f.URL())
+	if err != nil {
+		return nil, err
+	}
+	return &AuthenticationToken{AccessToken: cred.Password}, nil
 }
 
 // ClearAuthenticationToken removes the authentication token from the stash.
@@ -199,12 +231,24 @@ var _authenticationMethods = []struct {
 			return &CLIAuthenticator{GH: ghExe}
 		},
 	},
+	{
+		Title:       "Git Credential Manager",
+		Description: gcmDesc,
+		Build: func(a authenticatorOptions) authenticator {
+			// Offer this option only if git is available.
+			if _, err := xec.LookPath("git"); err != nil {
+				return nil
+			}
+			return &GCMAuthenticator{URL: a.ForgeURL}
+		},
+	},
 }
 
 // authenticatorOptions presents the user with multiple authentication methods,
 // prompts them to choose one, and executes the chosen method.
 type authenticatorOptions struct {
 	Endpoint oauth2.Endpoint // required
+	ForgeURL string          // required
 }
 
 func selectAuthenticator(view ui.View, a authenticatorOptions) (authenticator, error) {
@@ -277,6 +321,13 @@ func ghDesc(focused bool) string {
 	You must be logged into gh with 'gh auth login' for this to work.
 	You can use this if you're just experimenting and don't want to set up a token yet.
 	`, urlStyle(focused).Render("https://cli.github.com"))
+}
+
+func gcmDesc(bool) string {
+	return text.Dedent(`
+	Use OAuth credentials from git-credential-manager.
+	You must have GCM installed and already authenticated to GitHub.
+	`)
 }
 
 func urlStyle(focused bool) lipgloss.Style {
@@ -379,4 +430,23 @@ func (a *CLIAuthenticator) Authenticate(ctx context.Context, _ ui.View) (*Authen
 	}
 
 	return &AuthenticationToken{GitHubCLI: true}, nil
+}
+
+// GCMAuthenticator loads OAuth credentials
+// from git-credential-manager.
+type GCMAuthenticator struct {
+	URL string // required
+}
+
+// Authenticate loads credentials from git-credential-manager.
+func (a *GCMAuthenticator) Authenticate(
+	ctx context.Context, _ ui.View,
+) (*AuthenticationToken, error) {
+	cred, err := forge.LoadGCMCredential(ctx, a.URL)
+	if err != nil {
+		return nil, fmt.Errorf("load GCM credentials: %w", err)
+	}
+	return &AuthenticationToken{
+		AccessToken: cred.Password,
+	}, nil
 }

--- a/internal/forge/github/auth_test.go
+++ b/internal/forge/github/auth_test.go
@@ -192,6 +192,7 @@ func TestSelectAuthenticator(t *testing.T) {
 	drv := uitest.Drive(t, func(view ui.InteractiveView) {
 		auth, err := selectAuthenticator(view, authenticatorOptions{
 			Endpoint: oauth2.Endpoint{},
+			ForgeURL: "https://github.com",
 		})
 		require.NoError(t, err)
 		assert.True(t, reflect.TypeFor[*DeviceFlowAuthenticator]() == reflect.TypeOf(auth),
@@ -233,10 +234,14 @@ func TestSelectAuthenticator(t *testing.T) {
   You must be logged into gh with 'gh auth login' for this to work.
   You can use this if you're just experimenting and don't want to set up a
   token yet.
+
+  Git Credential Manager
+  Use OAuth credentials from git-credential-manager.
+  You must have GCM installed and already authenticated to GitHub.
 `).Equal(t, drv.Snapshot())
 
 	// Wrap around to "OAuth".
-	drv.PressN(tea.KeyDown, 2)
+	drv.PressN(tea.KeyDown, 3)
 	autogold.Expect(`Select an authentication method:
 ▶ OAuth
   Authorize git-spice to act on your behalf from this device only.
@@ -271,6 +276,10 @@ func TestSelectAuthenticator(t *testing.T) {
   You must be logged into gh with 'gh auth login' for this to work.
   You can use this if you're just experimenting and don't want to set up a
   token yet.
+
+  Git Credential Manager
+  Use OAuth credentials from git-credential-manager.
+  You must have GCM installed and already authenticated to GitHub.
 `).Equal(t, drv.Snapshot())
 
 	drv.Press(tea.KeyEnter) // select "OAuth"
@@ -320,6 +329,10 @@ func TestAuthenticationFlow_PAT(t *testing.T) {
   You must be logged into gh with 'gh auth login' for this to work.
   You can use this if you're just experimenting and don't want to set up a
   token yet.
+
+  Git Credential Manager
+  Use OAuth credentials from git-credential-manager.
+  You must have GCM installed and already authenticated to GitHub.
 `).Equal(t, drv.Snapshot())
 	drv.Press(tea.KeyEnter) // Select it.
 


### PR DESCRIPTION
Adds support for GCM-managed OAuth credentials for BitBucket and Github (GitLab's GCM managed credentials lack the scopes needed to be used for Git Spice)