### PR TITLE
release: Remove 'gs' binary from published packages

### DIFF
--- a/.changes/unreleased/Removed-20260222-155525.yaml
+++ b/.changes/unreleased/Removed-20260222-155525.yaml
@@ -1,0 +1,5 @@
+kind: Removed
+body: >-
+  Remove 'gs' binary from published packages:
+  GitHub Releasees, Homebrew Cask, and ArchLinux AUR package.
+time: 2026-02-22T15:55:25.164173-08:00

--- a/.changes/unreleased/Removed-20260222-155555.yaml
+++ b/.changes/unreleased/Removed-20260222-155555.yaml
@@ -1,0 +1,3 @@
+kind: Removed
+body: A warning is no longer printed if the program is invoked as 'gs'.
+time: 2026-02-22T15:55:55.252664-08:00

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,8 +2,7 @@ version: 2
 project_name: git-spice
 
 builds:
-  - &default_build
-    id: git-spice
+  - id: git-spice
     env:
       - CGO_ENABLED=0
     main: .
@@ -19,11 +18,6 @@ builds:
         goarch: arm
     flags:
       - -trimpath
-
-  # Second build with the 'gs' name.
-  - <<: *default_build
-    id: gs
-    binary: gs
 
 archives:
   - formats: tar.gz
@@ -52,13 +46,10 @@ aurs:
     private_key: '{{ .Env.AUR_KEY }}'
     provides:
       - git-spice
-      - gs
     conflicts:
       - git-spice    # no non-bin package exists yet, but just in case
-      - ghostscript  # ghostscript also provides a 'gs' binary
     package: |-
       install -Dm755 "./git-spice" "${pkgdir}/usr/bin/git-spice"
-      install -Dm755 "./gs" "${pkgdir}/usr/bin/gs"
       install -Dm644 "./LICENSE" "${pkgdir}/usr/share/licenses/git-spice/LICENSE"
       install -Dm644 "./README.md" "${pkgdir}/usr/share/doc/git-spice/README.md"
       install -Dm644 "./CHANGELOG.md" "${pkgdir}/usr/share/doc/git-spice/CHANGELOG.md"
@@ -79,13 +70,12 @@ homebrew_casks:
     description: "A tool for stacking Git branches."
     license: "GPL-3.0-or-later"
     skip_upload: auto
-    binaries: ["git-spice", "gs"]
+    binaries: ["git-spice"]
     hooks:
       post:
         install: |
           if OS.mac?
             system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/git-spice"]
-            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/gs"]
           end
 
 checksum:

--- a/main.go
+++ b/main.go
@@ -303,15 +303,6 @@ func (cmd *mainCmd) AfterApply(ctx context.Context, kctx *kong.Context, logger *
 	// so that commands that don't need worktree aren't forced to use it
 	// just to get the current branch name.
 
-	// Deprecation warning for using the "gs" name.
-	// A future release will only be invokable as "git-spice".
-	if filepath.Base(os.Args[0]) == "gs" && os.Getenv("GIT_SPICE_NO_GS_WARNING") != "1" {
-		logger.Warn("Invoking git-spice as 'gs' is deprecated and will stop working in the future.")
-		logger.Warn("Please use 'git-spice', or add the following to your shell configuration:")
-		logger.Warn("  alias gs=git-spice")
-		logger.Warn("To suppress this warning, set GIT_SPICE_NO_GS_WARNING=1")
-	}
-
 	return errors.Join(
 		kctx.BindSingletonProvider(func() (*git.Worktree, error) {
 			return git.OpenWorktree(ctx, ".", git.OpenOptions{

--- a/script_test.go
+++ b/script_test.go
@@ -48,10 +48,6 @@ func TestMain(m *testing.M) {
 
 	testscript.Main(m, map[string]func(){
 		"gs": func() {
-			// Don't pollute tests with warnings about
-			// the binary being named 'gs'.
-			_ = os.Setenv("GIT_SPICE_NO_GS_WARNING", "1")
-
 			logger := silog.New(os.Stderr, &silog.Options{
 				Level: silog.LevelDebug,
 			})


### PR DESCRIPTION
Per #469, remove the 'gs' binary from published artifacts
and stop printing a warning when invoked as 'gs'.

Testing:

```
❯ goreleaser release --snapshot --clean

❯ tar tf dist/git-spice.Darwin-arm64.tar.gz
CHANGELOG.md
LICENSE
README.md
git-spice

❯ grep binary dist/homebrew/Casks/git-spice.rb
  binary "git-spice"

❯ grep usr/bin dist/aur/git-spice-bin.pkgbuild
  install -Dm755 "./git-spice" "${pkgdir}/usr/bin/git-spice"
```