### PR TITLE
all: rename 'gs' references to 'git-spice' or os.Args[0]

### DIFF
--- a/.changes/unreleased/Changed-20260222-172859.yaml
+++ b/.changes/unreleased/Changed-20260222-172859.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Guidance printed by git-spice commands will use the name of the active binary instead of always using 'gs' or 'git-spice'.
+time: 2026-02-22T17:28:59.653573-08:00

--- a/auth.go
+++ b/auth.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/alecthomas/kong"
+	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/silog"
@@ -106,7 +107,7 @@ func guessCurrentForge(ctx context.Context, forges *forge.Registry, log *silog.L
 		return nil, nil, errors.New("not in a Git repository")
 	}
 
-	// If the repository is already initialized with gs,
+	// If the repository is already initialized with git-spice,
 	// and a remote is configured, use the forge for that remote.
 	var remote string
 	if store, err := state.OpenStore(ctx, newRepoStorage(repo, log), log); err == nil {
@@ -130,10 +131,10 @@ func guessCurrentForge(ctx context.Context, forges *forge.Registry, log *silog.L
 			remote = remotes[0]
 
 		default:
-			// Repository not initialized with gs
+			// Repository not initialized with git-spice
 			// and has multiple remotes.
 			// We can't guess the forge in this case.
-			return nil, nil, errors.New("multiple remotes found: initialize with gs first")
+			return nil, nil, fmt.Errorf("multiple remotes found: initialize with %s first", cli.Name())
 		}
 	}
 

--- a/auth_login.go
+++ b/auth_login.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/secret"
 	"go.abhg.dev/gs/internal/silog"
@@ -16,7 +17,8 @@ type authLoginCmd struct {
 }
 
 func (*authLoginCmd) Help() string {
-	return text.Dedent(`
+	name := cli.Name()
+	return text.Dedent(fmt.Sprintf(`
 		A prompt will allow selecting between available authentication methods.
 		Available methods include:
 
@@ -29,12 +31,12 @@ func (*authLoginCmd) Help() string {
 
 		The authentication token is stored in a system-provided
 		secure storage if available.
-		Use 'gs auth logout' to log out and delete the token from storage.
+		Use '%[1]s auth logout' to log out and delete the token from storage.
 
 		Fails if already logged in.
 		Use --refresh to force a refresh of the authentication token
 		or change the authentication method.
-	`)
+	`, name))
 }
 
 func (cmd *authLoginCmd) Run(

--- a/auth_logout.go
+++ b/auth_logout.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+
+	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/secret"
 	"go.abhg.dev/gs/internal/silog"
@@ -10,12 +13,13 @@ import (
 type authLogoutCmd struct{}
 
 func (*authLogoutCmd) Help() string {
-	return text.Dedent(`
+	name := cli.Name()
+	return text.Dedent(fmt.Sprintf(`
 		The stored authentication information is deleted.
-		Use 'gs auth login' to log in again.
+		Use '%[1]s auth login' to log in again.
 
 		Does not do anything if not logged in.
-	`)
+	`, name))
 }
 
 func (cmd *authLogoutCmd) Run(

--- a/branch_checkout.go
+++ b/branch_checkout.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/handler/checkout"
 	"go.abhg.dev/gs/internal/silog"
@@ -170,12 +171,12 @@ func (cmd *branchCheckoutCmd) Run(
 				return true, nil
 
 			case trackUntrackedNever:
-				log.Warnf("%v: branch not tracked: run 'gs branch track'", branch)
+				log.Warnf("%v: branch not tracked: run '%s branch track'", branch, cli.Name())
 				return false, nil
 
 			default: // trackUntrackedPrompt
 				if !ui.Interactive(view) {
-					log.Warnf("%v: branch not tracked: run 'gs branch track'", branch)
+					log.Warnf("%v: branch not tracked: run '%s branch track'", branch, cli.Name())
 					return false, nil
 				}
 

--- a/branch_create.go
+++ b/branch_create.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/spice"
@@ -37,7 +38,8 @@ type branchCreateCmd struct {
 }
 
 func (*branchCreateCmd) Help() string {
-	return text.Dedent(`
+	name := cli.Name()
+	return text.Dedent(fmt.Sprintf(`
 		Staged changes will be committed to the new branch.
 		If there are no staged changes, an empty commit will be created.
 		Use -a/--all to automatically stage modified and deleted files,
@@ -66,10 +68,10 @@ func (*branchCreateCmd) Help() string {
 			┌─┴ A ◀
 			trunk
 
-		'gs branch create X' will have the following effects
+		'%[1]s branch create X' will have the following effects
 		with different flags:
 
-			         gs branch create X
+			         %[1]s branch create X
 
 			 default  │   --insert   │  --below
 			──────────┼──────────────┼──────────
@@ -82,7 +84,7 @@ func (*branchCreateCmd) Help() string {
 		In all cases above, use of -t/--target flag will change the
 		target (A) to the specified branch:
 
-			     gs branch create X --target B
+			     %[1]s branch create X --target B
 
 			 default  │   --insert   │  --below
 			──────────┼──────────────┼────────────
@@ -91,7 +93,7 @@ func (*branchCreateCmd) Help() string {
 			  ┌─┴ B   │    ┌─┴ B     │   ┌─┴ X
 			┌─┴ A     │  ┌─┴ A       │ ┌─┴ A
 			trunk     │  trunk       │ trunk
-	`)
+	`, name))
 }
 
 func (cmd *branchCreateCmd) Run(

--- a/branch_onto.go
+++ b/branch_onto.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/spice"
@@ -21,7 +22,8 @@ type branchOntoCmd struct {
 }
 
 func (*branchOntoCmd) Help() string {
-	return text.Dedent(`
+	name := cli.Name()
+	return text.Dedent(fmt.Sprintf(`
 		Commits of the current branch
 		are transplanted onto another branch
 		while leaving the rest of the stack intact.
@@ -34,18 +36,18 @@ func (*branchOntoCmd) Help() string {
 		Use the --branch flag to target a different branch for the move.
 
 		For example, given the following stack with B checked out,
-		running 'gs branch onto main' will move B onto main
+		running '%[1]s branch onto main' will move B onto main
 		and leave C on top of A.
 
-			       gs branch onto main
+			       %[1]s branch onto main
 
 			    ┌── C               ┌── B ◀
 			  ┌─┴ B ◀               │ ┌── C
 			┌─┴ A                   ├─┴ A
 			trunk                   trunk
 
-		Use 'gs upstack onto' to also move the upstack branches.
-	`)
+		Use '%[1]s upstack onto' to also move the upstack branches.
+	`, name))
 }
 
 func (cmd *branchOntoCmd) AfterApply(

--- a/branch_rename.go
+++ b/branch_rename.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/must"
 	"go.abhg.dev/gs/internal/spice"
@@ -19,25 +20,26 @@ type branchRenameCmd struct {
 }
 
 func (*branchRenameCmd) Help() string {
-	return text.Dedent(`
+	name := cli.Name()
+	return text.Dedent(fmt.Sprintf(`
 		The following usage modes are supported:
 
 			# Rename <old> to <new>
-			gs branch rename <old> <new>
+			%[1]s branch rename <old> <new>
 
 			# Rename current branch to <new>
-			gs branch rename <new>
+			%[1]s branch rename <new>
 
 			# Rename current branch interactively
-			gs branch rename
+			%[1]s branch rename
 
-		If a branch was renamed outside of 'gs',
+		If a branch was renamed outside of '%[1]s',
 		for example with 'git branch -m',
 		the branch tracking information will be out of date.
 		To fix this,
-		untrack the old branch name with 'gs branch untrack <old>',
-		and track the new branch name with 'gs branch track <new>'.
-	`)
+		untrack the old branch name with '%[1]s branch untrack <old>',
+		and track the new branch name with '%[1]s branch track <new>'.
+	`, name))
 }
 
 func (cmd *branchRenameCmd) Run(
@@ -47,7 +49,7 @@ func (cmd *branchRenameCmd) Run(
 	svc *spice.Service,
 ) (err error) {
 	oldName, newName := cmd.OldName, cmd.NewName
-	// For "gs branch rename <new>",
+	// For "git-spice branch rename <new>",
 	// we'll actually get oldName = <new> and newName = "".
 	if oldName != "" && newName == "" {
 		oldName, newName = "", oldName

--- a/branch_split.go
+++ b/branch_split.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 
+	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/handler/split"
 	"go.abhg.dev/gs/internal/text"
@@ -22,7 +23,8 @@ type branchSplitCmd struct {
 }
 
 func (*branchSplitCmd) Help() string {
-	return text.Dedent(`
+	name := cli.Name()
+	return text.Dedent(fmt.Sprintf(`
 		Splits the current branch into two or more branches
 		at specific commits,
 		inserting the new branches into the stack
@@ -40,10 +42,10 @@ func (*branchSplitCmd) Help() string {
 		For example:
 
 			# split at a specific commit
-			gs branch split --at 1234567:newbranch
+			%[1]s branch split --at 1234567:newbranch
 
 			# split at the previous commit
-			gs branch split --at HEAD^:newbranch
+			%[1]s branch split --at HEAD^:newbranch
 
 		If the original branch is assigned to one of the splits,
 		it is required to provide a new name for the commit at HEAD.
@@ -57,7 +59,7 @@ func (*branchSplitCmd) Help() string {
 
 		A split at commit 2 using the branch name "A"
 		would require a new name to be provided for commit 3.
-	`)
+	`, name))
 }
 
 // SplitHandler is a subset of split.Handler.

--- a/branch_track.go
+++ b/branch_track.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/handler/track"
 	"go.abhg.dev/gs/internal/text"
@@ -15,16 +16,17 @@ type branchTrackCmd struct {
 }
 
 func (*branchTrackCmd) Help() string {
-	return text.Dedent(`
-		A branch must be tracked to be able to run gs operations on it.
-		Use 'gs branch create' to automatically track new branches.
+	name := cli.Name()
+	return text.Dedent(fmt.Sprintf(`
+		A branch must be tracked to be able to run %[1]s operations on it.
+		Use '%[1]s branch create' to automatically track new branches.
 
 		The base is guessed by comparing against other tracked branches.
 		Use --base to specify a base explicitly.
 
-		Use 'gs downstack track' from the topmost branch
+		Use '%[1]s downstack track' from the topmost branch
 		to track a manully created stack of branches at once.
-	`)
+	`, name))
 }
 
 // TrackHandler allows tracking branches.

--- a/commit_create.go
+++ b/commit_create.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/silog"
@@ -14,18 +15,19 @@ import (
 type commitCreateCmd struct {
 	All        bool   `short:"a" help:"Stage all changes before committing."`
 	AllowEmpty bool   `help:"Create a new commit even if it contains no changes."`
-	Fixup      string `help:"Create a fixup commit. See also 'gs commit fixup'." placeholder:"COMMIT"`
+	Fixup      string `help:"Create a fixup commit. See also 'git-spice commit fixup'." placeholder:"COMMIT"`
 	Message    string `short:"m" placeholder:"MSG" help:"Use the given message as the commit message."`
 	NoVerify   bool   `help:"Bypass pre-commit and commit-msg hooks."`
 	Signoff    bool   `config:"commit.signoff" help:"Add Signed-off-by trailer to the commit message"`
 }
 
 func (*commitCreateCmd) Help() string {
-	return text.Dedent(`
+	name := cli.Name()
+	return text.Dedent(fmt.Sprintf(`
 		Staged changes are committed to the current branch.
 		Branches upstack are restacked if necessary.
 		Use this as a shortcut for 'git commit'
-		followed by 'gs upstack restack'.
+		followed by '%[1]s upstack restack'.
 
 		An editor is opened to edit the commit message.
 		Use the -m/--message option to specify the message
@@ -36,9 +38,9 @@ func (*commitCreateCmd) Help() string {
 
 		Use the --fixup flag to create a new commit that will be merged
 		into another commit when run with 'git rebase --autosquash'.
-		See also, the 'gs commit fixup' command, which is preferable
+		See also, the '%[1]s commit fixup' command, which is preferable
 		when you want to apply changes to an older commit.
-	`)
+	`, name))
 }
 
 func (cmd *commitCreateCmd) Run(

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -1037,7 +1037,7 @@ when you want to apply changes to an older commit.
 
 * `-a`, `--all`: Stage all changes before committing.
 * `--allow-empty`: Create a new commit even if it contains no changes.
-* `--fixup=COMMIT`: Create a fixup commit. See also 'gs commit fixup'.
+* `--fixup=COMMIT`: Create a fixup commit. See also 'git-spice commit fixup'.
 * `-m`, `--message=MSG`: Use the given message as the commit message.
 * `--no-verify`: Bypass pre-commit and commit-msg hooks.
 * `--signoff` ([:material-wrench:{ .middle title="spice.commit.signoff" }](/cli/config.md#spicecommitsignoff)): Add Signed-off-by trailer to the commit message

--- a/help_test.go
+++ b/help_test.go
@@ -10,16 +10,21 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/cli"
 )
 
 //go:generate go test -run ^TestHelp$ -update
 
 func TestHelp(t *testing.T) {
+	oldName := cli.Name()
+	cli.SetName("gs")
+	defer cli.SetName(oldName)
+
 	// Build Kong parser with the same configuration as main
 	var cmd mainCmd
 	parser, err := kong.New(&cmd,
 		kong.Name("gs"),
-		kong.Description("gs (git-spice) is a command line tool for stacking Git branches."),
+		kong.Description("git-spice is a command line tool for stacking Git branches."),
 		kong.Help(helpPrinter),
 		kong.Exit(func(int) {}), // Don't actually exit in tests
 		kong.Vars{
@@ -67,7 +72,7 @@ func TestHelp(t *testing.T) {
 			var helpBuf bytes.Buffer
 			testParser, err := kong.New(&cmd,
 				kong.Name("gs"),
-				kong.Description("gs (git-spice) is a command line tool for stacking Git branches."),
+				kong.Description("git-spice is a command line tool for stacking Git branches."),
 				kong.ConfigureHelp(kong.HelpOptions{Compact: true}),
 				kong.Help(helpPrinter),
 				kong.Exit(func(int) {}),

--- a/internal/cli/name.go
+++ b/internal/cli/name.go
@@ -1,0 +1,21 @@
+// Package cli provides core CLI tools for git-spice.
+package cli
+
+import (
+	"os"
+	"path/filepath"
+)
+
+var _name = filepath.Base(os.Args[0])
+
+// Name returns the name of the current binary.
+func Name() string {
+	return _name
+}
+
+// SetName sets the name of the current binary.
+//
+// This is used at startup to override the default name.
+func SetName(name string) {
+	_name = name
+}

--- a/internal/handler/checkout/handler.go
+++ b/internal/handler/checkout/handler.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 
+	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/handler/track"
 	"go.abhg.dev/gs/internal/must"
@@ -104,7 +105,7 @@ func (h *Handler) CheckoutBranch(ctx context.Context, req *Request) error {
 			var restackErr *spice.BranchNeedsRestackError
 			switch {
 			case errors.As(err, &restackErr): // needs to be restacked
-				log.Warnf("%v: needs to be restacked: run 'gs branch restack --branch=%v'", branch, branch)
+				log.Warnf("%v: needs to be restacked: run '%s branch restack --branch=%v'", branch, cli.Name(), branch)
 
 			case errors.Is(err, git.ErrNotExist): // does not exist
 				// Branch name might be a reference to a remote branch.

--- a/internal/handler/checkout/handler_test.go
+++ b/internal/handler/checkout/handler_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/handler/track"
 	"go.abhg.dev/gs/internal/silog"
@@ -232,7 +233,7 @@ func TestHandler_CheckoutBranch_NonTrunk(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.Contains(t, logBuffer.String(), "needs to be restacked")
-		assert.Contains(t, logBuffer.String(), "gs branch restack --branch=feature")
+		assert.Contains(t, logBuffer.String(), cli.Name()+" branch restack --branch=feature")
 	})
 
 	t.Run("NotTrackedButShouldTrack", func(t *testing.T) {

--- a/internal/handler/delete/handler.go
+++ b/internal/handler/delete/handler.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strings"
 
+	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/graph"
 	"go.abhg.dev/gs/internal/must"
@@ -203,7 +204,7 @@ func (h *Handler) DeleteBranches(ctx context.Context, req *Request) error {
 				// because we've already filtered for that.
 				checkoutDetached = true
 				log.Warnf("%v: checked out in another worktree (%v), will detach HEAD", checkoutTarget, worktreePath)
-				log.Warnf("%v: Use 'gs branch checkout' to pick a branch and exit detached state", checkoutTarget)
+				log.Warnf("%v: Use '%s branch checkout' to pick a branch and exit detached state", checkoutTarget, cli.Name())
 			}
 
 			// This is the only case where user's current HEAD is
@@ -272,7 +273,7 @@ func (h *Handler) DeleteBranches(ctx context.Context, req *Request) error {
 				if worktreePath, ok := branchWorktrees[above]; ok {
 					skipRebase = true
 					log.Warnf("%v: checked out in another worktree (%v), skipping rebase", above, worktreePath)
-					log.Warnf("%v: Run 'gs branch restack' from that worktree to complete the rebase", above)
+					log.Warnf("%v: Run '%s branch restack' from that worktree to complete the rebase", above, cli.Name())
 				}
 			}
 
@@ -355,7 +356,7 @@ func (h *Handler) DeleteBranches(ctx context.Context, req *Request) error {
 		if tracked {
 			if err := branchTx.Delete(ctx, branch); err != nil {
 				log.Warn("Unable to untrack branch", "branch", branch, "error", err)
-				log.Warn("Try manually untracking the branch with 'gs branch untrack'")
+				log.Warnf("Try manually untracking the branch with '%s branch untrack'", cli.Name())
 			} else {
 				untrackedNames = append(untrackedNames, branch)
 			}

--- a/internal/handler/restack/branch_test.go
+++ b/internal/handler/restack/branch_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/spice"
@@ -116,7 +117,7 @@ func TestHandler_RestackBranch(t *testing.T) {
 		err := handler.RestackBranch(context.Background(), "untracked")
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "untracked branch")
-		assert.Contains(t, logBuffer.String(), "untracked: branch not tracked: run 'gs branch track")
+		assert.Contains(t, logBuffer.String(), "untracked: branch not tracked: run '"+cli.Name()+" branch track")
 	})
 
 	t.Run("AlreadyRestacked", func(t *testing.T) {

--- a/internal/handler/restack/handler.go
+++ b/internal/handler/restack/handler.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"slices"
 
+	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/iterutil"
 	"go.abhg.dev/gs/internal/must"
@@ -209,7 +210,7 @@ loop:
 				})
 
 			case errors.Is(err, state.ErrNotExist):
-				h.Log.Errorf("%v: branch not tracked: run 'gs branch track %v' to track it", branch, branch)
+				h.Log.Errorf("%v: branch not tracked: run '%s branch track %v' to track it", branch, cli.Name(), branch)
 				return 0, errors.New("untracked branch")
 
 			case errors.Is(err, spice.ErrAlreadyRestacked):

--- a/internal/handler/split/handler.go
+++ b/internal/handler/split/handler.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/alecthomas/kong"
 	"github.com/charmbracelet/lipgloss"
+	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/silog"
@@ -48,7 +49,7 @@ type Service interface {
 
 var _ Service = (*spice.Service)(nil)
 
-// Handler handles gs's branch split commands.
+// Handler handles git-spice's branch split commands.
 type Handler struct {
 	Log            *silog.Logger                            // required
 	View           ui.View                                  // required
@@ -305,9 +306,9 @@ func (h *Handler) SplitBranch(ctx context.Context, req *BranchRequest) (*BranchR
 
 		var reason string
 		if split.Name == branch {
-			reason = "gs: move branch head"
+			reason = cli.Name() + ": move branch head"
 		} else {
-			reason = "gs: create new branch"
+			reason = cli.Name() + ": create new branch"
 		}
 
 		if err := h.Repository.SetRef(ctx, git.SetRefRequest{
@@ -389,7 +390,7 @@ func (h *Handler) prepareChangeMetadataTransfer(
 		if toUpstreamBranch == fromBranch {
 			pushCmd := fmt.Sprintf("git push -u %v %v:<new name>", remote, fromBranch)
 
-			h.Log.Warnf("%v: If you push this branch with 'git push' instead of 'gs branch submit',", fromBranch)
+			h.Log.Warnf("%v: If you push this branch with 'git push' instead of '%s branch submit',", fromBranch, cli.Name())
 			h.Log.Warnf("%v: remember to use a different upstream branch name with the command:\n\t%s", fromBranch, h.HighlightStyle.Render(pushCmd))
 		}
 	}, nil

--- a/internal/handler/squash/handler.go
+++ b/internal/handler/squash/handler.go
@@ -57,7 +57,7 @@ type RestackHandler interface {
 	RestackUpstack(ctx context.Context, branch string, opts *restack.UpstackOptions) error
 }
 
-// Handler handles gs's squash commands.
+// Handler handles git-spice's squash commands.
 type Handler struct {
 	Log        *silog.Logger  // required
 	Repository GitRepository  // required

--- a/internal/handler/submit/handler.go
+++ b/internal/handler/submit/handler.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"go.abhg.dev/gs/internal/browser"
+	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/iterutil"
@@ -479,15 +480,15 @@ func (h *Handler) submitBranch(
 				branch.Base,
 				h.Store.Trunk(),
 			) {
-				log.Warnf("Branch %s is not restacked."+
-					" Run 'gs branch restack --branch=%s'"+
+				log.Warnf("Branch %[1]s is not restacked."+
+					" Run '%[2]s branch restack --branch=%[1]s'"+
 					" to fix this.",
-					branchToSubmit, branchToSubmit,
+					branchToSubmit, cli.Name(),
 				)
 			} else {
 				log.Errorf("Branch %s needs to be restacked.", branchToSubmit)
 				log.Errorf("Run the following command to fix this:")
-				log.Errorf("  gs branch restack --branch=%s", branchToSubmit)
+				log.Errorf("  %s branch restack --branch=%s", cli.Name(), branchToSubmit)
 				log.Errorf("Or, try again with --force to submit anyway.")
 				return status, errors.New("refusing to submit outdated branch")
 			}
@@ -874,7 +875,7 @@ func (h *Handler) submitBranch(
 			log.Error("No upstream branch was found for branch %v with existing CR %v", branchToSubmit, existingChange.ID)
 			log.Error("We cannot update the CR without an upstream branch name.")
 			log.Error("To fix this, identify the correct upstream branch name and set it with, e.g.:")
-			log.Error("  git branch --set-upstream-to=<remote>/<branch> %v", branchToSubmit)
+			log.Errorf("  git branch --set-upstream-to=<remote>/<branch> %v", branchToSubmit)
 			log.Error("Then, try again.")
 			return status, errors.New("upstream branch not set")
 		}
@@ -1277,7 +1278,7 @@ func (b *preparedBranch) Publish(ctx context.Context) (forge.ChangeID, string, e
 		if errors.Is(err, forge.ErrUnsubmittedBase) {
 			b.log.Errorf("%v: cannot be submitted because base branch %q does not exist in the remote.", b.Name, b.base)
 			b.log.Errorf("Try submitting the base branch first:")
-			b.log.Errorf("  gs branch submit --branch=%s", b.base)
+			b.log.Errorf("  %s branch submit --branch=%s", cli.Name(), b.base)
 			return nil, "", fmt.Errorf("create change: %w", err)
 		}
 		return nil, "", fmt.Errorf("create change: %w", err)

--- a/internal/handler/sync/handler.go
+++ b/internal/handler/sync/handler.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"sync"
 
+	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/graph"
@@ -335,7 +336,7 @@ func (h *Handler) SyncTrunk(ctx context.Context, opts *TrunkOptions) error {
 			}
 
 			log.Infof("Unsupported remote %q (%v)", h.Remote, remoteURL)
-			log.Info("All merged branches may not have been deleted. Use 'gs branch delete' to delete them.")
+			log.Infof("All merged branches may not have been deleted. Use '%s branch delete' to delete them.", cli.Name())
 		}()
 
 		branchesToDelete, err = h.findLocalMergedBranches(ctx, candidates, trunkEndHash)
@@ -431,7 +432,7 @@ func (h *Handler) findForgeFinishedBranches(
 
 	// There are two kinds of branches under consideration:
 	//
-	// 1. Branches that we submitted PRs for with `gs branch submit`.
+	// 1. Branches that we submitted PRs for with `git-spice branch submit`.
 	// 2. Branches that the user submitted PRs for manually
 	//    with 'gh pr create' or similar.
 	//
@@ -769,7 +770,7 @@ func (h *Handler) deleteBranches(ctx context.Context, branchesToDelete []branchD
 
 		if branchInfo.Worktree != "" && branchInfo.Worktree != h.Worktree.RootDir() {
 			h.Log.Warnf("%v: checked out in another worktree (%v), skipping deletion.", branchInfo.Name, branchInfo.Worktree)
-			h.Log.Warn("Run 'gs branch delete' or run 'gs repo sync' again from that worktree to delete it.")
+			h.Log.Warnf("Run '%[1]s branch delete' or run '%[1]s repo sync' again from that worktree to delete it.", cli.Name())
 			continue
 		}
 

--- a/internal/handler/track/branch.go
+++ b/internal/handler/track/branch.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/must"
 	"go.abhg.dev/gs/internal/sliceutil"
@@ -69,7 +70,7 @@ func (h *Handler) TrackBranch(ctx context.Context, req *BranchRequest) error {
 		var restackErr *spice.BranchNeedsRestackError
 		if errors.As(err, &restackErr) {
 			log.Infof("%v: branch is behind its base and needs to be restacked.", req.Branch)
-			log.Infof("%v: run 'gs branch restack --branch=%v' to restack it", req.Branch, req.Branch)
+			log.Infof("%v: run '%s branch restack --branch=%v' to restack it", req.Branch, cli.Name(), req.Branch)
 		} else {
 			log.Warnf("%v: stack state verification failed: %v", req.Branch, err)
 		}

--- a/internal/spice/branch.go
+++ b/internal/spice/branch.go
@@ -99,7 +99,7 @@ func (e *DeletedBranchError) Error() string {
 	return fmt.Sprintf("tracked branch %v was deleted out of band", e.Name)
 }
 
-// LookupBranch returns information about a branch tracked by gs.
+// LookupBranch returns information about a branch tracked by git-spice.
 //
 // It returns [git.ErrNotExist] if the branch is not known to the repository,
 // [state.ErrNotExist] if the branch is not tracked,
@@ -299,7 +299,7 @@ func (s *Service) ForgetBranch(ctx context.Context, name string) error {
 	return nil
 }
 
-// RenameBranch renames a branch tracked by gs.
+// RenameBranch renames a branch tracked by git-spice.
 // This handles both, renaming the branch in the repository,
 // and updating the internal state to reflect the new name.
 func (s *Service) RenameBranch(ctx context.Context, oldName, newName string) error {

--- a/internal/spice/onto.go
+++ b/internal/spice/onto.go
@@ -66,24 +66,24 @@ func (s *Service) BranchOnto(ctx context.Context, req *BranchOntoRequest) error 
 	//
 	// For example, suppose we have:
 	//
-	//           C--D (Current)  (gs: base=OriginalBase)
+	//           C--D (Current)  (git-spice: base=OriginalBase)
 	//          /
 	//     o---X (OriginalBase)
 	//          \
-	//           A--B (NewBase)  (gs: base=OriginalBase)
+	//           A--B (NewBase)  (git-spice: base=OriginalBase)
 	//
-	// If we run 'gs branch onto NewBase' from Current,
+	// If we run 'git-spice branch onto NewBase' from Current,
 	// and there's a conflict, the user will resolve the rebase conflict,
-	// but the gs state will not yet be updated.
+	// but the git-spice state will not yet be updated.
 	//
 	//     o---X (OriginalBase)
 	//          \
-	//           A--B (NewBase)       (gs: base=OriginalBase)
+	//           A--B (NewBase)       (git-spice: base=OriginalBase)
 	//               \
-	//                C--D (Current)  (gs: base=OriginalBase)
+	//                C--D (Current)  (git-spice: base=OriginalBase)
 	//
-	// At that point, 'gs rebase continue' will re-run the original command
-	// 'gs branch onto NewBase' from Current,
+	// At that point, 'git-spice rebase continue' will re-run the original command
+	// 'git-spice branch onto NewBase' from Current,
 	// except the commits it wants (OriginalBase..Current)
 	// now includes commits OriginalBase..NewBase,
 	// which will fail for obvious reasons.

--- a/internal/spice/rebase.go
+++ b/internal/spice/rebase.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/must"
 	"go.abhg.dev/gs/internal/spice/state"
@@ -108,19 +109,19 @@ func (s *Service) RebaseRescue(ctx context.Context, req RebaseRescueRequest) err
 		switch rebaseErr.Kind {
 		case git.RebaseInterruptConflict:
 			var msg strings.Builder
-			fmt.Fprintf(&msg, "There was a conflict while rebasing.\n")
-			fmt.Fprintf(&msg, "Resolve the conflict and run:\n")
-			fmt.Fprintf(&msg, "  gs rebase continue\n")
-			fmt.Fprintf(&msg, "Or abort the operation with:\n")
-			fmt.Fprintf(&msg, "  gs rebase abort\n")
+			fmt.Fprintf(&msg, "There was a conflict while rebasing.\n"+
+				"Resolve the conflict and run:\n"+
+				"  %[1]s rebase continue\n"+
+				"Or abort the operation with:\n"+
+				"  %[1]s rebase abort\n", cli.Name())
 			s.log.Error(msg.String())
 		case git.RebaseInterruptDeliberate:
 			var msg strings.Builder
-			fmt.Fprintf(&msg, "The rebase operation was interrupted with an 'edit' or 'break' command.\n")
-			fmt.Fprintf(&msg, "When you're ready to continue, run:\n")
-			fmt.Fprintf(&msg, "  gs rebase continue\n")
-			fmt.Fprintf(&msg, "Or abort the operation with:\n")
-			fmt.Fprintf(&msg, "  gs rebase abort\n")
+			fmt.Fprintf(&msg, "The rebase operation was interrupted with an 'edit' or 'break' command.\n"+
+				"When you're ready to continue, run:\n"+
+				"  %[1]s rebase continue\n"+
+				"Or abort the operation with:\n"+
+				"  %[1]s rebase abort\n", cli.Name())
 			s.log.Info(msg.String())
 		default:
 			must.Failf("unexpected rebase interrupt kind: %v", rebaseErr.Kind)

--- a/internal/spice/service.go
+++ b/internal/spice/service.go
@@ -63,7 +63,7 @@ var (
 	_ GitWorktree   = (*git.Worktree)(nil)
 )
 
-// Store provides storage for gs.
+// Store provides storage for git-spice.
 // It is a subset of the functionality provided by the state.Store type.
 type Store interface {
 	// Trunk returns the name of the trunk branch.

--- a/internal/spice/service_test.go
+++ b/internal/spice/service_test.go
@@ -27,7 +27,7 @@ func NewTestService(
 	return newService(repo, wt, store, forgeReg, log)
 }
 
-// NewMemoryStore builds gs state storage
+// NewMemoryStore builds git-spice state storage
 // that stores everything in memory.
 // The store is initialized with the trunk "main".
 func NewMemoryStore(t *testing.T) *state.Store {

--- a/internal/spice/state/continue.go
+++ b/internal/spice/state/continue.go
@@ -13,7 +13,7 @@ type rebaseContinueState struct {
 }
 
 type rebaseContinuation struct {
-	// Command is the gs command that will be run.
+	// Command is the git-spice command that will be run.
 	Command []string `json:"command"`
 
 	// Branch on which the command must be run.
@@ -23,7 +23,7 @@ type rebaseContinuation struct {
 // Continuation includes the information needed to resume a
 // rebase operation that was interrupted.
 type Continuation struct {
-	// Command specifies the arguments for the gs operation
+	// Command specifies the arguments for the git-spice operation
 	// that was interrupted.
 	Command []string
 

--- a/internal/spice/state/store.go
+++ b/internal/spice/state/store.go
@@ -1,4 +1,4 @@
-// Package state defines and sores the state for gs.
+// Package state defines and sores the state for git-spice.
 package state
 
 import (
@@ -25,7 +25,7 @@ var _ DB = (*storage.DB)(nil)
 
 //go:generate mockgen -destination mocks_test.go -package state -typed . DB
 
-// Store implements storage for state tracked by gs.
+// Store implements storage for state tracked by git-spice.
 type Store struct {
 	db  DB
 	log *silog.Logger
@@ -91,7 +91,7 @@ func InitStore(ctx context.Context, req InitStoreRequest) (*Store, error) {
 			_, err := store.LookupBranch(ctx, req.Trunk)
 			if err == nil {
 				// TODO: this should all be in 'repo init' implementation.
-				return nil, fmt.Errorf("trunk branch (%q) is tracked by gs; use --reset to clear", req.Trunk)
+				return nil, fmt.Errorf("trunk branch (%q) is tracked by git-spice; use --reset to clear", req.Trunk)
 			}
 
 			// Additionally,

--- a/internal/ui/widget/branch_select.go
+++ b/internal/ui/widget/branch_select.go
@@ -95,7 +95,7 @@ type branchInfo struct {
 
 // BranchTreeSelect is a prompt that allows selecting a branch
 // from a tree-view of branches.
-// The trunk branch is shown at the bottom of the tree similarly to 'gs ls'.
+// The trunk branch is shown at the bottom of the tree similarly to 'git-spice ls'.
 //
 // In addition to arrow-based navigation,
 // it allows fuzzy filtering branches by typing the branch name.

--- a/log.go
+++ b/log.go
@@ -340,15 +340,15 @@ type jsonLogBranch struct {
 
 	// Down is the base branch onto which this branch is stacked.
 	// This is unset if this branch is trunk.
-	// 'gs down' from the current branch will check out this branch.
+	// 'git-spice down' from the current branch will check out this branch.
 	Down *jsonLogDown `json:"down,omitempty"`
 
 	// Ups is a list of branches that are stacked directly above this branch.
-	// 'gs up' from this branch will check out one of these branches.
+	// 'git-spice up' from this branch will check out one of these branches.
 	Ups []jsonLogUp `json:"ups,omitempty"`
 
 	// Commits is a list of commits on this branch.
-	// These are not included unless invoked with 'gs log long'.
+	// These are not included unless invoked with 'git-spice log long'.
 	Commits []jsonLogCommit `json:"commits,omitempty"`
 
 	// Change is the associated change request, if any.

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// gs (git-spice) is a command line tool for stacking Git branches.
+// git-spice is a command line tool for stacking Git branches.
 package main
 
 import (

--- a/mise.toml
+++ b/mise.toml
@@ -148,7 +148,7 @@ go build -o bin/git-spice -tags="
 ln -sf git-spice {{ config_root }}/bin/gs
 """
 wait_for = ["generate"]
-description = "Build the gs binary"
+description = "Build the git-spice binary"
 
 [tasks.tools]
 sources = ["go.mod"]

--- a/profile_disable.go
+++ b/profile_disable.go
@@ -5,7 +5,7 @@ package main
 // ProfileFlags is a placeholder for the profile flags.
 // The corresponding _enable Go file contains the actual implementation.
 //
-// To build gs with profiling enabled, use:
+// To build git-spice with profiling enabled, use:
 //
 //	go build -tags profile
 type ProfileFlags struct{}

--- a/rebase_abort.go
+++ b/rebase_abort.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/spice/state"
@@ -15,17 +16,18 @@ import (
 type rebaseAbortCmd struct{}
 
 func (*rebaseAbortCmd) Help() string {
-	return text.Dedent(`
+	name := cli.Name()
+	return text.Dedent(fmt.Sprintf(`
 		Cancels an ongoing git-spice operation that was interrupted by
 		a git rebase.
-		For example, if 'gs upstack restack' encounters a conflict,
-		cancel the operation with 'gs rebase abort'
-		(or its shorthand 'gs rba'),
+		For example, if '%[1]s upstack restack' encounters a conflict,
+		cancel the operation with '%[1]s rebase abort'
+		(or its shorthand '%[1]s rba'),
 		going back to the state before the rebase.
 
 		The command can be used in place of 'git rebase --abort'
 		even if a git-spice operation is not currently in progress.
-	`)
+	`, name))
 }
 
 func (cmd *rebaseAbortCmd) Run(
@@ -50,7 +52,7 @@ func (cmd *rebaseAbortCmd) Run(
 		}
 	}
 
-	conts, err := store.TakeContinuations(ctx, "gs rebase abort")
+	conts, err := store.TakeContinuations(ctx, cli.Name()+" rebase abort")
 	if err != nil {
 		return fmt.Errorf("take rebase continuations: %w", err)
 	}

--- a/rebase_continue.go
+++ b/rebase_continue.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/alecthomas/kong"
+	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/spice/state"
@@ -18,13 +19,14 @@ type rebaseContinueCmd struct {
 }
 
 func (*rebaseContinueCmd) Help() string {
-	return text.Dedent(`
+	name := cli.Name()
+	return text.Dedent(fmt.Sprintf(`
 		Continues an ongoing git-spice operation interrupted by
 		a git rebase after all conflicts have been resolved.
-		For example, if 'gs upstack restack' gets interrupted
+		For example, if '%[1]s upstack restack' gets interrupted
 		because a conflict arises during the rebase,
-		you can resolve the conflict and run 'gs rebase continue'
-		(or its shorthand 'gs rbc') to continue the operation.
+		you can resolve the conflict and run '%[1]s rebase continue'
+		(or its shorthand '%[1]s rbc') to continue the operation.
 
 		The command can be used in place of 'git rebase --continue'
 		even if a git-spice operation is not currently in progress.
@@ -32,7 +34,7 @@ func (*rebaseContinueCmd) Help() string {
 		Use the --no-edit flag to continue without opening an editor.
 		Make --no-edit the default by setting 'spice.rebaseContinue.edit' to false
 		and use --edit to override it.
-	`)
+	`, name))
 }
 
 func (cmd *rebaseContinueCmd) Run(
@@ -61,7 +63,7 @@ func (cmd *rebaseContinueCmd) Run(
 			var msg strings.Builder
 			fmt.Fprintf(&msg, "There are more conflicts to resolve.\n")
 			fmt.Fprintf(&msg, "Resolve them and run the following command again:\n")
-			fmt.Fprintf(&msg, "  gs rebase continue\n")
+			fmt.Fprintf(&msg, "  %s rebase continue\n", cli.Name())
 			fmt.Fprintf(&msg, "To abort the remaining operations run:\n")
 			fmt.Fprintf(&msg, "  git rebase --abort\n")
 			log.Error(msg.String())
@@ -75,7 +77,7 @@ func (cmd *rebaseContinueCmd) Run(
 	// they will clear the continuation list.
 	// So we'll want to grab the whole list here,
 	// and push the remainder of it back on if a command fails.
-	conts, err := store.TakeContinuations(ctx, "gs rebase continue")
+	conts, err := store.TakeContinuations(ctx, cli.Name()+" rebase continue")
 	if err != nil {
 		return fmt.Errorf("take rebase continuations: %w", err)
 	}

--- a/remote.go
+++ b/remote.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/secret"
@@ -99,7 +100,7 @@ func openRemoteRepository(
 	case errors.As(err, &notLoggedInErr):
 		f := notLoggedInErr.Forge
 		log.Errorf("No authentication token found for %s.", f.ID())
-		log.Errorf("Try running `gs auth login --forge=%s`", f.ID())
+		log.Errorf("Try running `%s auth login --forge=%s`", cli.Name(), f.ID())
 		return nil, err
 
 	default:

--- a/repo_init.go
+++ b/repo_init.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/must"
 	"go.abhg.dev/gs/internal/silog"
@@ -129,7 +130,7 @@ func (cmd *repoInitCmd) Run(
 			git.CommitRangeFrom(upstreamHash).ExcludeFrom(trunkHash))
 		if err == nil && count > 0 {
 			log.Warnf("%v is behind upstream by %d commits", cmd.Trunk, count)
-			log.Warnf("Please run 'gs repo sync' before other git-spice commands.")
+			log.Warnf("Please run '%s repo sync' before other git-spice commands.", cli.Name())
 		}
 	}
 
@@ -155,7 +156,7 @@ func newRepoStorage(repo *git.Repository, log *silog.Logger) *storage.DB {
 }
 
 // ensureStore will open the spice data store in the provided Git repository,
-// initializing it with `gs repo init` if it hasn't already been initialized.
+// initializing it with `git-spice repo init` if it hasn't already been initialized.
 //
 // This allows nearly any other command to work without initialization
 // by auto-initializing the repository at that time.

--- a/script_test.go
+++ b/script_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.abhg.dev/gs/internal/browser"
 	"go.abhg.dev/gs/internal/browser/browsertest"
+	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/forge/shamhub"
 	"go.abhg.dev/gs/internal/git/gittest"
 	"go.abhg.dev/gs/internal/mockedit"
@@ -48,6 +49,7 @@ func TestMain(m *testing.M) {
 
 	testscript.Main(m, map[string]func(){
 		"gs": func() {
+			cli.SetName("gs")
 			logger := silog.New(os.Stderr, &silog.Options{
 				Level: silog.LevelDebug,
 			})

--- a/shell_completion.go
+++ b/shell_completion.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"time"
 
+	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/sliceutil"
@@ -21,23 +23,24 @@ type shellCompletionCmd struct {
 }
 
 func (c *shellCompletionCmd) Help() string {
-	return text.Dedent(`
+	name := cli.Name()
+	return text.Dedent(fmt.Sprintf(`
 		To set up shell completion, eval the output of this command
 		from your shell's rc file.
 		For example:
 
 			# bash
-			eval "$(gs shell completion bash)"
+			eval "$(%[1]s shell completion bash)"
 
 			# zsh
-			eval "$(gs shell completion zsh)"
+			eval "$(%[1]s shell completion zsh)"
 
 			# fish
-			eval "$(gs shell completion fish)"
+			eval "$(%[1]s shell completion fish)"
 
 		If shell name is not provided, the current shell is guessed
 		using a heuristic.
-	`)
+	`, name))
 }
 
 func predictBranches(_ komplete.Args) (predictions []string) {

--- a/stack_restack.go
+++ b/stack_restack.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/spice/state"
@@ -40,8 +41,9 @@ func verifyRestackFromTrunk(
 		return nil
 	}
 
-	desc := fmt.Sprintf("Running 'gs %s restack' from trunk restacks all tracked branches.\n"+
-		"Use 'gs repo restack' to suppress this prompt.", commandName)
+	name := cli.Name()
+	desc := fmt.Sprintf("Running '%[1]s %s restack' from trunk restacks all tracked branches.\n"+
+		"Use '%[1]s repo restack' to suppress this prompt.", name, commandName)
 
 	// Non-interactive mode: print warning and proceed
 	if !ui.Interactive(view) {

--- a/testdata/help/commit_create.txt
+++ b/testdata/help/commit_create.txt
@@ -19,7 +19,8 @@ command, which is preferable when you want to apply changes to an older commit.
 Flags:
   -a, --all             Stage all changes before committing.
       --allow-empty     Create a new commit even if it contains no changes.
-      --fixup=COMMIT    Create a fixup commit. See also 'gs commit fixup'.
+      --fixup=COMMIT    Create a fixup commit. See also 'git-spice commit
+                        fixup'.
   -m, --message=MSG     Use the given message as the commit message.
       --no-verify       Bypass pre-commit and commit-msg hooks.
       --signoff         Add Signed-off-by trailer to the commit message (🔧

--- a/testdata/help/gs.txt
+++ b/testdata/help/gs.txt
@@ -1,6 +1,6 @@
 Usage: gs <command> [flags]
 
-gs (git-spice) is a command line tool for stacking Git branches.
+git-spice is a command line tool for stacking Git branches.
 
 Global Flags:
   -h, --help           Show help for the command

--- a/testdata/script/issue962_branch_submit_minimal_fetch_refspec.txt
+++ b/testdata/script/issue962_branch_submit_minimal_fetch_refspec.txt
@@ -106,6 +106,6 @@ FTL gs: submit branch feature1: remote cannot fetch pushed branch
 ERR No upstream branch was found for branch %v with existing CR %v  feature1=#1
 ERR We cannot update the CR without an upstream branch name.
 ERR To fix this, identify the correct upstream branch name and set it with, e.g.:
-ERR   git branch --set-upstream-to=<remote>/<branch> %v  !BADKEY=feature1
+ERR   git branch --set-upstream-to=<remote>/<branch> feature1
 ERR Then, try again.
 FTL gs: submit branch feature1: upstream branch not set

--- a/upstack_onto.go
+++ b/upstack_onto.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/silog"
@@ -22,7 +23,8 @@ type upstackOntoCmd struct {
 }
 
 func (*upstackOntoCmd) Help() string {
-	return text.Dedent(`
+	name := cli.Name()
+	return text.Dedent(fmt.Sprintf(`
 		The current branch and its upstack will move onto the new base.
 
 		A prompt will allow selecting the new base for the branch.
@@ -30,17 +32,17 @@ func (*upstackOntoCmd) Help() string {
 		Use the --branch flag to target a different branch for the move.
 
 		For example, given the following stack with B checked out,
-		'gs upstack onto main' will have the following effect:
+		'%[1]s upstack onto main' will have the following effect:
 
-			       gs upstack onto main
+			       %[1]s upstack onto main
 
 			    ┌── C                 ┌── C
 			  ┌─┴ B ◀               ┌─┴ B ◀
 			┌─┴ A                   ├── A
 			trunk                   trunk
 
-		Use 'gs branch onto' to leave the branch's upstack alone.
-	`)
+		Use '%[1]s branch onto' to leave the branch's upstack alone.
+	`, name))
 }
 
 func (cmd *upstackOntoCmd) AfterApply(


### PR DESCRIPTION
Messages printed to users should use 'git-spice'
or whatever the binary is named, which can be obtained with cli.Name().