### PR TITLE
test: add VCR sanitation infrastructure and testconfig support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ cover.out
 cover.html
 /.idea
 .mise
+
+# Test configuration (contains environment-specific values)
+internal/forge/forgetest/testconfig.yaml

--- a/internal/forge/bitbucket/comment.go
+++ b/internal/forge/bitbucket/comment.go
@@ -73,6 +73,33 @@ func (r *Repository) updateComment(
 	return nil
 }
 
+// DeleteChangeComment deletes a comment on a pull request.
+func (r *Repository) DeleteChangeComment(
+	ctx context.Context,
+	id forge.ChangeCommentID,
+) error {
+	comment := mustPRComment(id)
+	if comment.PRID == 0 {
+		return fmt.Errorf("comment %d missing PR ID: %w",
+			comment.ID, forge.ErrCommentCannotUpdate)
+	}
+	return r.deleteComment(ctx, comment.PRID, comment.ID)
+}
+
+func (r *Repository) deleteComment(
+	ctx context.Context,
+	prID, commentID int64,
+) error {
+	path := fmt.Sprintf(
+		"/repositories/%s/%s/pullrequests/%d/comments/%d",
+		r.workspace, r.repo, prID, commentID,
+	)
+	if err := r.client.do(ctx, "DELETE", path, nil, nil); err != nil {
+		return fmt.Errorf("delete comment: %w", err)
+	}
+	return nil
+}
+
 // ListChangeComments lists comments on a pull request.
 func (r *Repository) ListChangeComments(
 	ctx context.Context,

--- a/internal/forge/bitbucket/repository.go
+++ b/internal/forge/bitbucket/repository.go
@@ -48,17 +48,6 @@ func (r *Repository) ChangeURL(id forge.ChangeID) string {
 	return fmt.Sprintf("%s/%s/%s/pull-requests/%d", r.url, r.workspace, r.repo, prNum)
 }
 
-// DeleteChangeComment deletes an existing comment.
-// Bitbucket API supports comment deletion but it's rarely needed.
-func (r *Repository) DeleteChangeComment(
-	_ context.Context,
-	_ forge.ChangeCommentID,
-) error {
-	// Not implemented - comment deletion is rarely needed
-	// and can be done manually if required.
-	return nil
-}
-
 // NewChangeMetadata returns the metadata for a pull request.
 func (r *Repository) NewChangeMetadata(
 	_ context.Context,

--- a/internal/forge/forgetest/testconfig.example.yaml
+++ b/internal/forge/forgetest/testconfig.example.yaml
@@ -1,0 +1,42 @@
+# Test configuration for forge integration tests.
+#
+# Copy this file to testconfig.yaml and fill in your values.
+# This file is required only when recording fixtures (using the -update flag).
+#
+# Authentication tokens are NOT stored here - they use the existing mechanisms:
+#   - Environment variables (GITHUB_TOKEN, GITLAB_TOKEN, BITBUCKET_TOKEN)
+#   - git-credential-manager
+#   - gs auth login credentials
+#
+# The values in this file will be sanitized in recorded fixtures,
+# replaced with canonical placeholders for portability.
+
+github:
+  # Repository owner (your GitHub username or organization)
+  owner: "your-github-username"
+  # Test repository name (should be a repo you have write access to)
+  repo: "your-test-repo"
+  # A GitHub user who can be added as a reviewer (can be a bot account)
+  reviewer: "another-github-user"
+  # A GitHub user who can be assigned to PRs (can be the same as reviewer)
+  assignee: "another-github-user"
+
+gitlab:
+  # Project namespace (your GitLab username or group)
+  owner: "your-gitlab-username"
+  # Test project name
+  repo: "your-test-repo"
+  # A GitLab user who can be added as a reviewer
+  reviewer: "another-gitlab-user"
+  # A GitLab user who can be assigned to MRs
+  assignee: "another-gitlab-user"
+
+bitbucket:
+  # Bitbucket workspace
+  owner: "your-bitbucket-workspace"
+  # Test repository name
+  repo: "your-test-repo"
+  # A Bitbucket user who can be added as a reviewer
+  reviewer: "another-bitbucket-user"
+  # Bitbucket does not support assignees, leave empty
+  assignee: ""

--- a/internal/forge/forgetest/testconfig.go
+++ b/internal/forge/forgetest/testconfig.go
@@ -1,0 +1,162 @@
+package forgetest
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+
+	"go.abhg.dev/gs/internal/httptest"
+	"gopkg.in/yaml.v3"
+)
+
+// TestConfig holds configuration for integration tests.
+// This configuration is loaded from testconfig.yaml in update mode,
+// and uses canonical placeholders in replay mode.
+type TestConfig struct {
+	GitHub    ForgeConfig `yaml:"github"`
+	GitLab    ForgeConfig `yaml:"gitlab"`
+	Bitbucket ForgeConfig `yaml:"bitbucket"`
+}
+
+// ForgeConfig holds per-forge test configuration.
+type ForgeConfig struct {
+	// Owner is the repository owner (GitHub/GitLab) or workspace (Bitbucket).
+	Owner string `yaml:"owner"`
+
+	// Repo is the repository name.
+	Repo string `yaml:"repo"`
+
+	// Reviewer is a username that can be added as a reviewer to changes.
+	Reviewer string `yaml:"reviewer"`
+
+	// Assignee is a username that can be assigned to changes.
+	Assignee string `yaml:"assignee"`
+}
+
+type configState struct {
+	config *TestConfig
+	loadE  error
+}
+
+var (
+	_configOnce  sync.Once
+	_configState configState
+)
+
+// Config returns the test configuration.
+// In replay mode, it returns canonical placeholders.
+// In update mode, it loads from testconfig.yaml.
+func Config(t *testing.T) *TestConfig {
+	// In replay mode, always use canonical config.
+	// This ensures requests match the sanitized fixtures.
+	if !Update() {
+		return canonicalConfig()
+	}
+
+	// In update mode, load from testconfig.yaml.
+	_configOnce.Do(func() {
+		_configState.config, _configState.loadE = loadConfig()
+	})
+
+	if _configState.loadE != nil {
+		t.Fatalf("Failed to load test config: %v", _configState.loadE)
+	}
+
+	return _configState.config
+}
+
+// canonicalConfig returns the canonical placeholders used in VCR fixtures.
+func canonicalConfig() *TestConfig {
+	return &TestConfig{
+		GitHub:    CanonicalGitHubConfig(),
+		GitLab:    CanonicalGitLabConfig(),
+		Bitbucket: CanonicalBitbucketConfig(),
+	}
+}
+
+// CanonicalGitHubConfig returns canonical placeholders for GitHub fixtures.
+func CanonicalGitHubConfig() ForgeConfig {
+	return ForgeConfig{
+		Owner:    CanonicalOwner,
+		Repo:     CanonicalRepo,
+		Reviewer: "test-owner-robot",
+		Assignee: "test-owner-robot",
+	}
+}
+
+// CanonicalGitLabConfig returns canonical placeholders for GitLab fixtures.
+// Note: Uses the same value for Reviewer and Assignee because users often use
+// the same account for both in test configurations. This prevents sanitization
+// conflicts when both have the same value.
+func CanonicalGitLabConfig() ForgeConfig {
+	return ForgeConfig{
+		Owner:    CanonicalOwner,
+		Repo:     CanonicalRepo,
+		Reviewer: "test-reviewer",
+		Assignee: "test-reviewer", // Same as reviewer to handle value collisions
+	}
+}
+
+// CanonicalBitbucketConfig returns canonical placeholders for Bitbucket fixtures.
+// Note: Uses CanonicalOwner for both Owner and Repo because Bitbucket workspaces
+// often have the same name as their primary repository (e.g., workspace "foo" with
+// repo "foo"). This prevents sanitization conflicts when both have the same value.
+func CanonicalBitbucketConfig() ForgeConfig {
+	return ForgeConfig{
+		Owner:    CanonicalOwner,
+		Repo:     CanonicalOwner, // Same as owner to handle workspace/repo name collisions
+		Reviewer: "Test Reviewer",
+		Assignee: "",
+	}
+}
+
+// loadConfig loads the test configuration from testconfig.yaml.
+func loadConfig() (*TestConfig, error) {
+	configPath := configFilePath()
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var config TestConfig
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}
+
+// configFilePath returns the path to testconfig.yaml.
+func configFilePath() string {
+	_, thisFile, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(thisFile)
+	return filepath.Join(dir, "testconfig.yaml")
+}
+
+// ConfigSanitizers returns sanitizers for the given forge configuration.
+// These replace actual values with canonical placeholders in VCR fixtures.
+func ConfigSanitizers(cfg ForgeConfig, canonical ForgeConfig) []Sanitizer {
+	var sanitizers []Sanitizer
+
+	addSanitizer := func(actual, canonical string) {
+		if actual != "" && actual != canonical {
+			sanitizers = append(sanitizers, Sanitizer{
+				Replace: actual,
+				With:    canonical,
+			})
+		}
+	}
+
+	addSanitizer(cfg.Owner, canonical.Owner)
+	addSanitizer(cfg.Repo, canonical.Repo)
+	addSanitizer(cfg.Reviewer, canonical.Reviewer)
+	addSanitizer(cfg.Assignee, canonical.Assignee)
+
+	return sanitizers
+}
+
+// Sanitizer is re-exported from httptest for convenience.
+type Sanitizer = httptest.Sanitizer

--- a/internal/forge/gitlab/comment.go
+++ b/internal/forge/gitlab/comment.go
@@ -133,6 +133,12 @@ func (r *Repository) ListChangeComments(
 	options *forge.ListChangeCommentsOptions,
 ) iter.Seq2[*forge.ListChangeCommentItem, error] {
 	var filters []func(gitlab.Note) (keep bool)
+
+	// Always filter out system notes (e.g., "restored source branch").
+	filters = append(filters, func(note gitlab.Note) bool {
+		return !note.System
+	})
+
 	if options != nil {
 		if len(options.BodyMatchesAll) != 0 {
 			for _, re := range options.BodyMatchesAll {

--- a/internal/httptest/recorder.go
+++ b/internal/httptest/recorder.go
@@ -15,13 +15,28 @@ import (
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/recorder"
 )
 
+// Sanitizer replaces sensitive or environment-specific values in recorded
+// fixtures with canonical placeholders. This makes fixtures portable across
+// different test environments.
+type Sanitizer struct {
+	// Replace is the string to search for in the fixture.
+	Replace string
+	// With is the canonical placeholder to substitute.
+	With string
+}
+
 // TransportRecorderOptions contains options for creating a new
 // [TransportRecorder].
 type TransportRecorderOptions struct {
 	// Update specifies whether the Recorder should update fixtures.
 	Update func() bool
 
+	// Matcher customizes how requests are matched to recorded interactions.
 	Matcher func(*http.Request, cassette.Request) bool
+
+	// Sanitizers are applied to recorded fixtures in update mode.
+	// They replace environment-specific values with canonical placeholders.
+	Sanitizers []Sanitizer
 }
 
 // NewTransportRecorder builds a new HTTP request recorder/replayer
@@ -37,39 +52,8 @@ func NewTransportRecorder(
 	t.Helper()
 
 	mode := recorder.ModeReplayOnly
-	realTransport := http.DefaultTransport
-	afterCaptureHook := func(*cassette.Interaction) error {
-		return nil
-	}
-
 	if opts.Update != nil && opts.Update() {
 		mode = recorder.ModeRecordOnly
-
-		// Paranoid mode:
-		// maintain an allowlist of headers to keep in the fixtures
-		// so as not to accidentally record sensitive data.
-		afterCaptureHook = func(i *cassette.Interaction) error {
-			allHeaders := make(http.Header)
-			maps.Copy(allHeaders, i.Request.Headers)
-			maps.Copy(allHeaders, i.Response.Headers)
-
-			var toRemove []string
-			for k := range allHeaders {
-				switch strings.ToLower(k) {
-				case "content-type", "content-length", "user-agent", "x-next-page", "x-total-pages", "x-page":
-					// ok
-				default:
-					toRemove = append(toRemove, k)
-				}
-			}
-
-			for _, k := range toRemove {
-				delete(i.Request.Headers, k)
-				delete(i.Response.Headers, k)
-			}
-
-			return nil
-		}
 	}
 
 	matcher := cassette.DefaultMatcher
@@ -77,11 +61,20 @@ func NewTransportRecorder(
 		matcher = opts.Matcher
 	}
 
+	// BeforeSaveHook runs before saving to disk, sanitizing recorded data.
+	// This ensures real API responses are returned to tests during recording,
+	// while fixtures contain canonical placeholders.
+	beforeSaveHook := func(i *cassette.Interaction) error {
+		sanitizeHeaders(i)
+		applySanitizers(i, opts.Sanitizers)
+		return nil
+	}
+
 	rec, err := recorder.New(filepath.Join("testdata", "fixtures", name),
 		recorder.WithMode(mode),
-		recorder.WithRealTransport(realTransport),
+		recorder.WithRealTransport(http.DefaultTransport),
 		recorder.WithSkipRequestLatency(true),
-		recorder.WithHook(afterCaptureHook, recorder.AfterCaptureHook),
+		recorder.WithHook(beforeSaveHook, recorder.BeforeSaveHook),
 		recorder.WithMatcher(matcher),
 	)
 	require.NoError(t, err)
@@ -90,4 +83,38 @@ func NewTransportRecorder(
 	})
 
 	return rec
+}
+
+// sanitizeHeaders removes sensitive headers from the recorded interaction,
+// keeping only an allowlist of safe headers.
+func sanitizeHeaders(i *cassette.Interaction) {
+	allHeaders := make(http.Header)
+	maps.Copy(allHeaders, i.Request.Headers)
+	maps.Copy(allHeaders, i.Response.Headers)
+
+	var toRemove []string
+	for k := range allHeaders {
+		switch strings.ToLower(k) {
+		case "content-type", "content-length", "user-agent",
+			"x-next-page", "x-total-pages", "x-page":
+			// ok
+		default:
+			toRemove = append(toRemove, k)
+		}
+	}
+
+	for _, k := range toRemove {
+		delete(i.Request.Headers, k)
+		delete(i.Response.Headers, k)
+	}
+}
+
+// applySanitizers replaces environment-specific values with canonical
+// placeholders in URLs and bodies.
+func applySanitizers(i *cassette.Interaction, sanitizers []Sanitizer) {
+	for _, s := range sanitizers {
+		i.Request.URL = strings.ReplaceAll(i.Request.URL, s.Replace, s.With)
+		i.Request.Body = strings.ReplaceAll(i.Request.Body, s.Replace, s.With)
+		i.Response.Body = strings.ReplaceAll(i.Response.Body, s.Replace, s.With)
+	}
 }


### PR DESCRIPTION
This adds new features for integration testing forge implementations:

- Adds test sanitation so if multiple maintainers run VCR tests on different implementations, they don't wind up clobbering each-other's recording files needlessly
- Adds a test config to allow maintainers to use their own testing repos to which they have access
- Adds the ability to use GCM-managed credentials when recording VCR tests (convenience)

The non-generated code changes for this change are in this PR. The VCR tests need to be re-recorded, which is a lot of generated code, so that will be in a follow on PR (#1043); you'll probably just want to merge that one directly.