### PR TITLE
docs: update Bitbucket docs

### DIFF
--- a/auth_login.go
+++ b/auth_login.go
@@ -24,6 +24,7 @@ func (*authLoginCmd) Help() string {
 
 		- OAuth: Web-based authentication flow
 		- GitHub App (GitHub only): Authenticate using a GitHub App installation
+		- Git Credential Manager: Reuse credentials already stored for Git
 		- Personal Access Token: Directly provide a personal access token
 		- CLI: Use the GitHub or GitLab CLI tool for authentication (if installed)
 

--- a/doc/hooks/replace.py
+++ b/doc/hooks/replace.py
@@ -10,10 +10,13 @@ from mkdocs.structure.pages import Page
 REPLACEMENTS = {
     '<!-- gs:github -->': ':simple-github: GitHub',
     '<!-- gs:gitlab -->': ':simple-gitlab: GitLab',
-    '<!-- gs:bitbucket -->': ':simple-bitbucket: BitBucket',
+    '<!-- gs:bitbucket -->': ':simple-bitbucket: Bitbucket',
+    '<!-- gs:icon:github -->': ':simple-github:',
+    '<!-- gs:icon:gitlab -->': ':simple-gitlab:',
+    '<!-- gs:icon:bitbucket -->': ':simple-bitbucket:',
     '<!-- gs:badge:github ': '<!-- gs:badge simple-github GitHub ',
     '<!-- gs:badge:gitlab ': '<!-- gs:badge simple-gitlab GitLab ',
-    '<!-- gs:badge:bitbucket ': '<!-- gs:badge simple-bitbucket BitBucket ',
+    '<!-- gs:badge:bitbucket ': '<!-- gs:badge simple-bitbucket Bitbucket ',
 }
 
 

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -59,6 +59,7 @@ Available methods include:
 
 - OAuth: Web-based authentication flow
 - GitHub App (GitHub only): Authenticate using a GitHub App installation
+- Git Credential Manager: Reuse credentials already stored for Git
 - Personal Access Token: Directly provide a personal access token
 - CLI: Use the GitHub or GitLab CLI tool for authentication (if installed)
 

--- a/doc/src/community/faq.md
+++ b/doc/src/community/faq.md
@@ -40,7 +40,7 @@ keeping them up-to-date and in sync with each other.
 
 ## Where is the authentication token stored?
 
-git-spice stores the GitHub authentication in a system-specific secure storage.
+git-spice stores authentication tokens in a system-specific secure storage.
 See [Authentication > Safety](../setup/auth.md#safety) for details.
 
 ## Why doesn't git-spice create one CR per commit?
@@ -48,7 +48,8 @@ See [Authentication > Safety](../setup/auth.md#safety) for details.
 With tooling like this, there are two options:
 each commit is an atomic unit of work, or each branch is.
 While the former might be more in line with Git's original philosophy,
-the latter is more practical for most teams with GitHub or GitLab-based workflows.
+the latter is more practical for most teams
+with GitHub, GitLab, or Bitbucket-based workflows.
 
 With a PR per commit, when a PR gets review feedback,
 you must amend that commit with fixes and force-push.
@@ -81,7 +82,8 @@ and leave them as-is.
 
 ## Will git-spice add support for other Git hosting services?
 
-As of writing this, git-spice supports GitHub and GitLab.
+As of writing this, git-spice supports
+GitHub, GitLab, and Bitbucket Cloud.
 It is specifically designed to support other forges;
 most of the code is forge-agnostic,
 with forge-specific code is isolated to their own directories inside
@@ -90,8 +92,14 @@ with forge-specific code is isolated to their own directories inside
 In fact,
 
 - git-spice's own integration tests run against a simulated forge
-  that acts similarly to GitHub and GitLab;
+  that acts similarly to supported hosted forges;
 - [GitLab support was added by an external contributor](https://github.com/abhinav/git-spice/pull/477)
+  without meaningful changes to the rest of the codebase;
+- Bitbucket support was added across several pull requests:
+  [#1020](https://github.com/abhinav/git-spice/pull/1020),
+  [#1021](https://github.com/abhinav/git-spice/pull/1021),
+  [#1030](https://github.com/abhinav/git-spice/pull/1030),
+  and [#1052](https://github.com/abhinav/git-spice/pull/1052),
   without meaningful changes to the rest of the codebase
 
 Therefore we're confident that adding support for other forges is feasible.

--- a/doc/src/guide/concepts.md
+++ b/doc/src/guide/concepts.md
@@ -84,12 +84,12 @@ text "Sibling" with s at F.n
 
 **Change Request**
 :   Change Request refers to a single merge-able unit of work
-    submitted to GitHub or GitLab.
+    submitted to GitHub, GitLab, or Bitbucket.
     Each Change Request corresponds to a branch.
-    On GitHub, these are called Pull Requests,
+    On GitHub and Bitbucket, these are called Pull Requests,
     and on GitLab, they are called Merge Requests.
-    Since git-spice supports both platforms,
-    the term Change Request is used to refer to both.
+    Since git-spice supports all three platforms,
+    the term Change Request is used to refer to all of them.
 
 **Stack**
 :   A stack is a collection of branches stacked on top of each other

--- a/doc/src/guide/cr.md
+++ b/doc/src/guide/cr.md
@@ -14,6 +14,7 @@ description: >-
 
     - <!-- gs:github -->
     - <!-- gs:gitlab --> (<!-- gs:version v0.9.0 -->)
+    - <!-- gs:bitbucket --> (<!-- gs:version unreleased -->)
 
     If you're using a different service,
     you can still use git-spice,
@@ -29,7 +30,7 @@ description: >-
 !!! info
 
     git-spice uses the term *Change Request* to refer to submitted branches.
-    These corespond to Pull Requests on GitHub,
+    These correspond to Pull Requests on GitHub and Bitbucket,
     and to Merge Requests on GitLab.
 
 When your local changes are ready,

--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -15,7 +15,7 @@ description: >-
 git-spice is a tool for stacking Git branches.
 It lets you manage and navigate stacks of branches,
 conveniently modify and rebase them, and create
-<!-- gs:github --> *Pull Requests* or
+<!-- gs:github --> <!-- gs:bitbucket --> *Pull Requests* or
 <!-- gs:gitlab --> *Merge Requests* from them.
 
 It works with Git instead of trying to replace Git.
@@ -95,7 +95,7 @@ $ gs repo sync
     you can keep your stack in sync with the trunk branch,
     automatically rebase dependent branches, and more.
 
--   [:octicons-git-pull-request-16:{ .lg .middle } __Submit change requests__](guide/cr.md) <!-- gs:github --> <!-- gs:gitlab -->
+-   [:octicons-git-pull-request-16:{ .lg .middle } __Submit change requests__](guide/cr.md) <!-- gs:icon:github --> <!-- gs:icon:gitlab --> <!-- gs:icon:bitbucket -->
 
     ---
 
@@ -122,7 +122,8 @@ $ gs repo sync
     ---
 
     git-spice operates entirely locally.
-    It talks directly to Git, and when you ask for it, to GitHub/GitLab.
+    It talks directly to Git, and when you ask for it,
+    to GitHub/GitLab/Bitbucket.
     All state is stored locally in your Git repository.
     A network connection is not required, except when pushing or pulling.
 

--- a/doc/src/setup/auth.md
+++ b/doc/src/setup/auth.md
@@ -38,7 +38,8 @@ Take the following steps to authenticate with a service:
 !!! tip
 
     Skip prompt (2) by running $$gs auth login$$
-    inside a Git repository cloned from GitHub or GitLab.
+    inside a Git repository cloned from
+    GitHub, GitLab, or Bitbucket.
 
 ## Authentication methods
 
@@ -47,8 +48,7 @@ Each supported service supports different authentication methods.
 - [OAuth](#oauth): <!-- gs:badge:github --> <!-- gs:badge:gitlab -->
 - [GitHub App](#github-app): <!-- gs:badge:github -->
 - [Git Credential Manager](#git-credential-manager): <!-- gs:badge:github --> <!-- gs:badge:bitbucket -->
-- [Personal Access Token](#personal-access-token): <!-- gs:badge:github --> <!-- gs:badge:gitlab -->
-- [API Token](#api-token): <!-- gs:badge:bitbucket -->
+- [Personal Access Token](#personal-access-token): <!-- gs:badge:github --> <!-- gs:badge:gitlab --> <!-- gs:badge:bitbucket -->
 - [Service CLI](#service-cli): <!-- gs:badge:github --> <!-- gs:badge:gitlab -->
 - [Environment variable](#environment-variable): <!-- gs:badge:github --> <!-- gs:badge:gitlab --> <!-- gs:badge:bitbucket -->
 
@@ -179,33 +179,9 @@ git-spice will automatically fall back to GCM credentials
 when no other authentication token is available—even
 without running `gs auth login`.
 
-### API Token
-
-**Supported by** <!-- gs:badge:bitbucket -->
-
-Bitbucket API tokens provide a way to authenticate
-without using your main account password.
-To use an API token with git-spice:
-
-1. Go to <https://bitbucket.org/account/settings/api-tokens/>.
-2. Click "Create token".
-3. Enter a descriptive label.
-4. Select the following scopes:
-    - **pullrequest:write** - create and edit pull requests
-    - **account** - read workspace members for reviewer lookup
-5. Click "Create" and copy the generated token.
-
-```freeze language="terminal"
-{green}${reset} gs auth login
-Select an authentication method: {red}API Token{reset}
-{green}Enter Atlassian account email{reset}: user@example.com
-{green}Enter API token{reset}:
-{green}INF{reset} bitbucket: successfully logged in
-```
-
 ### Personal Access Token
 
-**Supported by** <!-- gs:badge:github --> <!-- gs:badge:gitlab -->
+**Supported by** <!-- gs:badge:github --> <!-- gs:badge:gitlab --> <!-- gs:badge:bitbucket -->
 
 To use a Personal Access Token with git-spice,
 you will generate a Personal Access Token on the website
@@ -276,6 +252,32 @@ Select an authentication method: {red}Personal Access Token{reset}
         - pick a descriptive name for the token
         - pick an expiration date if needed
         - select the `api` scope
+
+=== "<!-- gs:bitbucket -->"
+
+    Bitbucket calls these **API tokens**,
+    but they serve the same role as a Personal Access Token.
+
+    1. Go to <https://bitbucket.org/account/settings/api-tokens/>.
+    2. Click "Create token".
+    3. Enter a descriptive label.
+    4. Select the following scopes:
+
+        - **pullrequest:write** - create and edit pull requests
+        - **account** - read workspace members for reviewer lookup
+
+    5. Click "Create" and copy the generated token.
+
+    In the login prompt, this method may still appear as `API Token`.
+    git-spice will then ask for your Atlassian account email and token:
+
+    ```freeze language="terminal"
+    {green}${reset} gs auth login
+    Select an authentication method: {red}API Token{reset}
+    {green}Enter Atlassian account email{reset}: user@example.com
+    {green}Enter API token{reset}:
+    {green}INF{reset} bitbucket: successfully logged in
+    ```
 
 After you have a token, enter it into the prompt.
 
@@ -381,7 +383,7 @@ The $$gs auth login$$ operation will always fail if you use this method.
     Bitbucket's OAuth flow and handles token refresh automatically.
     This is convenient if you already have GCM installed for git operations.
 
-    [API Token](#api-token) is flexible and secure.
+    [Personal Access Token](#personal-access-token) is flexible and secure.
     It requires manual token management but works without additional tools.
 
 [Environment variable](#environment-variable) is the least convenient
@@ -505,4 +507,3 @@ reporting the full path to the secrets file.
 ```
 
 </details>
-

--- a/doc/src/start/submit.md
+++ b/doc/src/start/submit.md
@@ -11,7 +11,8 @@ next_page: ../guide/index.md
 # Your first stacked Change Requests
 
 This page will walk you through creating and updating
-*GitHub Pull Requests* or *GitLab Merge Requests* with git-spice.
+*GitHub Pull Requests*, *GitLab Merge Requests*,
+or *Bitbucket Pull Requests* with git-spice.
 git-spice refers to these as *Change Requests* (CRs).
 
 ## Prerequisites
@@ -29,12 +30,12 @@ git-spice refers to these as *Change Requests* (CRs).
       text "feat2"
       ```
 
-- [x] Set up a GitHub or GitLab repository.
+- [x] Set up a GitHub, GitLab, or Bitbucket repository.
 
     ??? info "Optional: Create an experimental repository"
 
         If you're following along with the tutorial,
-        you may want to create a new repository on GitHub
+        you may want to create a new repository
         to experiment with instead of using a real project.
 
         To do this, if you have the GitHub or GitLab CLI installed,

--- a/testdata/help/auth_login.txt
+++ b/testdata/help/auth_login.txt
@@ -5,10 +5,11 @@ Log in to a service
 A prompt will allow selecting between available authentication methods.
 Available methods include:
 
-- OAuth: Web-based authentication flow - GitHub App (GitHub only):
-Authenticate using a GitHub App installation - Personal Access Token: Directly
-provide a personal access token - CLI: Use the GitHub or GitLab CLI tool for
-authentication (if installed)
+- OAuth: Web-based authentication flow - GitHub App (GitHub only): Authenticate
+using a GitHub App installation - Git Credential Manager: Reuse credentials
+already stored for Git - Personal Access Token: Directly provide a personal
+access token - CLI: Use the GitHub or GitLab CLI tool for authentication (if
+installed)
 
 The differences between them are explained in the prompt.
 


### PR DESCRIPTION
Cover the remaining Bitbucket gaps in the docs and FAQ,
including forge terminology, auth guidance, and support history.

Also update `gs auth login` help so generated CLI reference text
matches the supported authentication methods and Bitbucket token
terminology.