### PR TITLE
fix(ui): scroll branch tree selections

### DIFF
--- a/.changes/unreleased/Fixed-20260311-060727.yaml
+++ b/.changes/unreleased/Fixed-20260311-060727.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Branch selection prompt now scrolls when the terminal is too short to show all matching branches.
+time: 2026-03-11T06:07:27.684554-07:00

--- a/doc/tapes/20260312-branch-checkout-scroll.gif
+++ b/doc/tapes/20260312-branch-checkout-scroll.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a47d0a97f337b2c1422848ce8b0340d0d650f1b52a711d74f0526554f4db85da
+size 79910

--- a/doc/tapes/20260312-branch-checkout-scroll.tape
+++ b/doc/tapes/20260312-branch-checkout-scroll.tape
@@ -1,0 +1,61 @@
+Output "20260312-branch-checkout-scroll.gif"
+Set Shell "bash"
+Set FontSize 16
+Set Width 480
+Set Height 260
+Set Padding 10
+Set CursorBlink false
+
+Hide
+Type "cd $(mktemp -d) && git init && git commit --allow-empty -m 'Initial commit'" Enter
+Type "alias gs=git-spice" Enter
+Type "gs repo init" Enter Sleep 100ms
+Type "git add lion && gs branch create lion -m 'Add lion'" Enter Sleep 100ms
+Type "touch griffin && git add griffin && gs branch create griffin -m 'Add griffin'" Enter Sleep 100ms
+Type "gs branch checkout main" Enter Sleep 100ms
+Type "touch squid && git add squid && gs branch create squid -m 'Add squid'" Enter Sleep 100ms
+Type "touch kraken && git add kraken && gs branch create kraken -m 'Add kraken'" Enter Sleep 100ms
+Type "gs branch checkout main" Enter Sleep 100ms
+Type "touch snake && git add snake && gs branch create snake -m 'Add snake'" Enter Sleep 100ms
+Type "touch basilisk && git add basilisk && gs branch create basilisk -m 'Add basilisk'" Enter Sleep 100ms
+Type "gs branch checkout main" Enter Sleep 100ms
+Type "touch eagle && git add eagle && gs branch create eagle -m 'Add eagle'" Enter Sleep 100ms
+Type "touch phoenix && git add phoenix && gs branch create phoenix -m 'Add phoenix'" Enter Sleep 100ms
+Type "gs branch checkout main" Enter Sleep 100ms
+Type "touch scorpion && git add scorpion && gs branch create scorpion -m 'Add scorpion'" Enter Sleep 100ms
+Type "touch manticore && git add manticore && gs branch create manticore -m 'Add manticore'" Enter Sleep 100ms
+Type "clear" Enter Sleep 100ms
+Show
+
+Sleep 500ms
+
+Type "gs ls" Enter
+Sleep 2s
+
+Type "gs bco" Enter
+Sleep 2s
+
+Down
+Sleep 300ms
+Down
+Sleep 300ms
+Down
+Sleep 300ms
+Down
+Sleep 300ms
+Down
+Sleep 1s
+
+Down
+Sleep 300ms
+Down
+Sleep 1s
+
+Up
+Sleep 1s
+
+Enter
+Sleep 2s
+
+Type "gs ls" Enter
+Sleep 3s

--- a/internal/ui/branchtree/tree.go
+++ b/internal/ui/branchtree/tree.go
@@ -225,6 +225,13 @@ type GraphOptions struct {
 	// HomeDir is used for "~" substitution in worktree paths.
 	// If empty, no substitution is performed.
 	HomeDir string
+
+	// Offset is the number of rendered lines to skip.
+	Offset int
+
+	// Height is the maximum number of rendered lines to show.
+	// Zero or negative means render all lines.
+	Height int
 }
 
 // PushStatusFormat controls how push status is rendered.
@@ -262,18 +269,16 @@ func Write(w io.Writer, g Graph, opts *GraphOptions) error {
 		HomeDir:          opts.HomeDir,
 	}
 
-	treeStyle := &fliptree.Style[*Item]{
-		Joint: ui.NewStyle().Faint(true),
-		NodeMarker: func(item *Item) ui.Style {
-			switch {
-			case item.Disabled:
-				return opts.Style.NodeMarkerDisabled
-			case item.Highlighted:
-				return opts.Style.NodeMarkerHighlighted
-			default:
-				return opts.Style.NodeMarker
-			}
-		},
+	treeStyle := fliptree.DefaultStyle[*Item]()
+	treeStyle.NodeMarker = func(item *Item) ui.Style {
+		switch {
+		case item.Disabled:
+			return opts.Style.NodeMarkerDisabled
+		case item.Highlighted:
+			return opts.Style.NodeMarkerHighlighted
+		default:
+			return opts.Style.NodeMarker
+		}
 	}
 
 	return fliptree.Write(w, fliptree.Graph[*Item]{
@@ -282,8 +287,10 @@ func Write(w io.Writer, g Graph, opts *GraphOptions) error {
 		Edges:  func(item *Item) []int { return item.Aboves },
 		View:   renderer.RenderItem,
 	}, fliptree.Options[*Item]{
-		Theme: opts.Theme,
-		Style: treeStyle,
+		Theme:  opts.Theme,
+		Style:  treeStyle,
+		Offset: opts.Offset,
+		Height: opts.Height,
 	})
 }
 

--- a/internal/ui/fliptree/tree.go
+++ b/internal/ui/fliptree/tree.go
@@ -13,6 +13,8 @@ package fliptree
 
 import (
 	"bufio"
+	"bytes"
+	"fmt"
 	"io"
 	"slices"
 	"strings"
@@ -23,6 +25,18 @@ import (
 
 // DefaultNodeMarker is the marker used for each node in the tree.
 var DefaultNodeMarker = ui.NewStyle().SetString("□")
+
+// DefaultScrollUpMarker is the marker shown
+// when content is scrolled out above the viewport.
+var DefaultScrollUpMarker = ui.NewStyle().
+	Foreground(ui.Gray).
+	SetString("▲▲▲")
+
+// DefaultScrollDownMarker is the marker shown
+// when content is scrolled out below the viewport.
+var DefaultScrollDownMarker = ui.NewStyle().
+	Foreground(ui.Gray).
+	SetString("▼▼▼")
 
 // Graph defines a directed graph.
 type Graph[T any] struct {
@@ -49,6 +63,15 @@ type Graph[T any] struct {
 type Options[T any] struct {
 	Theme ui.Theme
 	Style *Style[T]
+
+	// Offset states the number of lines to skip before rendering the tree,
+	// and Height states the maximum number of lines to render after that.
+	//
+	// Use these together to render a view of a larger tree.
+	//
+	// A height <= 0 indicates no limit.
+	// Scroll markers are rendered for a height > 0.
+	Offset, Height int
 }
 
 // Style configures the visual appearance of the tree.
@@ -61,6 +84,14 @@ type Style[T any] struct {
 	//
 	// By default, all nodes are marked with [DefaultNodeMarker].
 	NodeMarker func(T) ui.Style
+
+	// ScrollUpMarker is shown above the viewport
+	// when content exists above it.
+	ScrollUpMarker ui.Style
+
+	// ScrollDownMarker is shown below the viewport
+	// when content exists below it.
+	ScrollDownMarker ui.Style
 }
 
 // DefaultStyle returns the default style for rendering trees.
@@ -70,6 +101,8 @@ func DefaultStyle[T any]() *Style[T] {
 		NodeMarker: func(T) ui.Style {
 			return DefaultNodeMarker
 		},
+		ScrollUpMarker:   DefaultScrollUpMarker,
+		ScrollDownMarker: DefaultScrollDownMarker,
 	}
 }
 
@@ -80,12 +113,20 @@ func Write[T any](w io.Writer, g Graph[T], opts Options[T]) error {
 	}
 
 	tw := treeWriter[T]{
-		w:     bufio.NewWriter(w),
-		g:     g,
-		style: newTreeStyle(opts.Style, opts.Theme),
+		w:      bufio.NewWriter(w),
+		g:      g,
+		style:  newTreeStyle(opts.Style, opts.Theme),
+		offset: max(0, opts.Offset),
+		height: opts.Height,
 	}
 	for _, root := range g.Roots {
 		if err := tw.writeTree(root, nil, nil); err != nil {
+			return err
+		}
+	}
+
+	if tw.truncatedBelow {
+		if _, err := fmt.Fprintln(tw.w, tw.style.ScrollDownMarker.String()); err != nil {
 			return err
 		}
 	}
@@ -97,12 +138,38 @@ type treeWriter[T any] struct {
 	g Graph[T]
 
 	lineNum int
-	style   treeStyle[T]
+
+	// Number of rendered tree lines to skip before starting the viewport.
+	offset int
+	// Maximum number of tree content lines to write.
+	// Zero or negative means no viewport limit.
+	height int
+
+	// Number of tree content lines written to the viewport,
+	// excluding scroll markers.
+	wroteLines int
+
+	// Whether the top scroll marker has already been emitted.
+	// This is shown once when offset > 0 and the first viewport line is written.
+	wroteScrollUp bool
+
+	// Whether tree content was cut off at the bottom.
+	// This is true if height > 0,
+	// and the number of lines to write exceeds the height limit.
+	//
+	// This informs the caller whether a bottom scroll marker
+	// should be emitted after the tree is fully rendered.
+	truncatedBelow bool
+	// TODO: maybe we can fold this into the render loop
+
+	style treeStyle[T]
 }
 
 type treeStyle[T any] struct {
-	Joint      lipgloss.Style
-	NodeMarker func(T) lipgloss.Style
+	Joint            lipgloss.Style
+	NodeMarker       func(T) lipgloss.Style
+	ScrollUpMarker   lipgloss.Style
+	ScrollDownMarker lipgloss.Style
 }
 
 func newTreeStyle[T any](s *Style[T], theme ui.Theme) treeStyle[T] {
@@ -111,6 +178,8 @@ func newTreeStyle[T any](s *Style[T], theme ui.Theme) treeStyle[T] {
 		NodeMarker: func(v T) lipgloss.Style {
 			return s.NodeMarker(v).Resolve(theme)
 		},
+		ScrollUpMarker:   s.ScrollUpMarker.Resolve(theme),
+		ScrollDownMarker: s.ScrollDownMarker.Resolve(theme),
 	}
 }
 
@@ -225,25 +294,58 @@ func (tw *treeWriter[T]) writeTree(nodeIdx int, path []int, pathNodeIxes []int) 
 		lastJoint = string(_verticalRight) + string(_horizontal)
 	}
 
-	lines := strings.Split(tw.g.View(nodeValue), "\n")
-	for idx, line := range lines {
+	var lineBuffer bytes.Buffer
+	firstLine := true
+	for line := range strings.SplitSeq(tw.g.View(nodeValue), "\n") {
+		lineBuffer.Reset()
+
 		// The text may be multi-line.
 		// Only the first line has a title marker.
-		if idx == 0 {
-			tw.pipes(path, lastJoint, titlePrefix)
+		if firstLine {
+			firstLine = false
+			tw.pipes(&lineBuffer, path, lastJoint, titlePrefix)
 		} else {
-			tw.pipes(path, string(_vertical)+" ", bodyPrefix)
+			tw.pipes(&lineBuffer, path, string(_vertical)+" ", bodyPrefix)
 		}
 
-		_, _ = tw.w.WriteString(line)
-		_, _ = tw.w.WriteString("\n")
-		tw.lineNum++
+		lineBuffer.WriteString(line)
+		tw.writeLine(lineBuffer.Bytes())
 	}
 
 	return nil
 }
 
-func (tw *treeWriter[T]) pipes(path []int, joint string, marker string) {
+// writeLine writes a line of the tree to the output,
+// respecting the scroll offset and height limits.
+//
+// This performs necessary bookkeeping internally.
+func (tw *treeWriter[T]) writeLine(line []byte) {
+	lineNum := tw.lineNum
+	tw.lineNum++
+
+	if lineNum < tw.offset {
+		return
+	}
+
+	if tw.height > 0 && tw.wroteLines >= tw.height {
+		tw.truncatedBelow = true
+		return
+	}
+
+	// If content above the viewport is getting cut off,
+	// we need to add a scroll marker.
+	if !tw.wroteScrollUp && tw.offset > 0 {
+		_, _ = fmt.Fprintln(tw.w, tw.style.ScrollUpMarker.String())
+		tw.wroteScrollUp = true
+	}
+
+	_, _ = tw.w.Write(line)
+	_ = tw.w.WriteByte('\n')
+
+	tw.wroteLines++
+}
+
+func (tw *treeWriter[T]) pipes(buf *bytes.Buffer, path []int, joint string, marker string) {
 	if len(path) == 0 {
 		return
 	}
@@ -254,15 +356,16 @@ func (tw *treeWriter[T]) pipes(path []int, joint string, marker string) {
 	// needs just connecting pipes.
 	for _, pos := range path[:len(path)-1] {
 		if pos > 0 {
-			_, _ = tw.w.WriteString(
+			buf.WriteString(
 				style.Render(string(_vertical) + " "),
 			)
 		} else {
-			_, _ = tw.w.WriteString("  ")
+			buf.WriteString("  ")
 		}
 	}
 
-	_, _ = tw.w.WriteString(style.Render(joint) + marker)
+	buf.WriteString(style.Render(joint))
+	buf.WriteString(marker)
 }
 
 // CycleError is returned when a cycle is detected in the tree.

--- a/internal/ui/fliptree/tree_test.go
+++ b/internal/ui/fliptree/tree_test.go
@@ -27,7 +27,51 @@ func plainStyle() *Style[string] {
 		NodeMarker: func(string) ui.Style {
 			return ui.NewStyle().SetString("□")
 		},
+		ScrollUpMarker:   ui.NewStyle().SetString("▲▲▲"),
+		ScrollDownMarker: ui.NewStyle().SetString("▼▼▼"),
 	}
+}
+
+func TestWrite_Viewport(t *testing.T) {
+	g := Graph[string]{
+		Values: []string{"main", "alpha", "bravo", "charlie", "delta", "echo"},
+		Roots:  []int{0},
+		View:   func(n string) string { return n },
+		Edges: func(n string) []int {
+			switch n {
+			case "main":
+				return []int{1}
+			case "alpha":
+				return []int{2}
+			case "bravo":
+				return []int{3}
+			case "charlie":
+				return []int{4}
+			case "delta":
+				return []int{5}
+			default:
+				return nil
+			}
+		},
+	}
+
+	var sb strings.Builder
+	err := Write(&sb, g, Options[string]{
+		Theme:  ui.DefaultThemeLight(),
+		Style:  plainStyle(),
+		Offset: 1,
+		Height: 3,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, stripTrailingSpaces(strings.Join([]string{
+		"▲▲▲",
+		"      ┏━┻□ delta",
+		"    ┏━┻□ charlie",
+		"  ┏━┻□ bravo",
+		"▼▼▼",
+		"",
+	}, "\n")), stripTrailingSpaces(sb.String()))
 }
 
 func TestWrite(t *testing.T) {

--- a/internal/ui/uitest/script.go
+++ b/internal/ui/uitest/script.go
@@ -92,9 +92,27 @@ func RunScripts(
 
 		t := ts.Value(tKey{}).(testing.TB)
 
+		rows := opts.Rows
+		if _, err := os.Stat(ts.MkAbs("rows")); err == nil {
+			rowsText := strings.TrimSpace(ts.ReadFile("rows"))
+			rows, err = strconv.Atoi(rowsText)
+			if err != nil {
+				ts.Fatalf("read rows: %v", err)
+			}
+		}
+
+		cols := opts.Cols
+		if _, err := os.Stat(ts.MkAbs("cols")); err == nil {
+			colsText := strings.TrimSpace(ts.ReadFile("cols"))
+			cols, err = strconv.Atoi(colsText)
+			if err != nil {
+				ts.Fatalf("read cols: %v", err)
+			}
+		}
+
 		emu := NewEmulatorView(&EmulatorViewOptions{
-			Rows: opts.Rows,
-			Cols: opts.Cols,
+			Rows: rows,
+			Cols: cols,
 			Logf: ts.Logf,
 		})
 		done := make(chan struct{})

--- a/internal/ui/widget/branch_select.go
+++ b/internal/ui/widget/branch_select.go
@@ -89,6 +89,7 @@ type branchInfo struct {
 
 	Index              int   // index in all
 	Aboves             []int // indexes of branches in 'all' with this as base
+	VisibleAboves      []int // visible children to render above this branch
 	BranchHighlights   []int // indexes of runes in Branch name to highlight
 	ChangeIDHighlights []int // indexes of runes in ChangeID to highlight
 	WorktreeHighlights []int // indexes of runes in Worktree to highlight
@@ -109,8 +110,12 @@ type BranchTreeSelect struct {
 	roots     []int          // indexes in 'all' of root branches
 	idxByName map[string]int // index in 'all' by branch name
 
-	selectable []int // indexes that can be selected and are visible
-	focused    int   // index in 'selectable' of the currently focused branch
+	selectable   []int // indexes that can be selected and are visible
+	visibleRoots []int // visible root indexes after filtering hidden intermediates
+	visibleOrder []int // visible branch indexes in render order
+	focused      int   // index in 'selectable' of the currently focused branch
+	visible      int   // number of visible rows in the branch list
+	offset       int   // offset of the first visible row
 
 	filter []rune // filter text
 	err    error
@@ -236,6 +241,7 @@ func (b *BranchTreeSelect) Init() tea.Cmd {
 	if selected >= 0 {
 		b.focused = max(slices.Index(b.selectable, selected), 0)
 	}
+	b.syncViewport()
 
 	return nil
 }
@@ -285,47 +291,52 @@ func (b *BranchTreeSelect) WithItems(items ...BranchTreeItem) *BranchTreeSelect 
 
 // Update updates the state of the widget based on a bubbletea message.
 func (b *BranchTreeSelect) Update(msg tea.Msg) tea.Cmd {
-	keyMsg, ok := msg.(tea.KeyMsg)
-	if !ok {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		b.visible = max(1, msg.Height-5)
+		b.syncViewport()
 		return nil
-	}
 
-	var filterChanged bool
-	switch {
-	case key.Matches(keyMsg, b.KeyMap.Up):
-		b.moveCursor(-1)
+	case tea.KeyMsg:
+		var filterChanged bool
+		switch {
+		case key.Matches(msg, b.KeyMap.Up):
+			b.moveCursor(-1)
 
-	case key.Matches(keyMsg, b.KeyMap.Down):
-		b.moveCursor(1)
+		case key.Matches(msg, b.KeyMap.Down):
+			b.moveCursor(1)
 
-	case key.Matches(keyMsg, b.KeyMap.Accept):
-		if b.focused >= 0 && b.focused < len(b.selectable) {
-			*b.value = b.all[b.selectable[b.focused]].Branch
-			b.accepted = true
-			return ui.AcceptField
-		}
+		case key.Matches(msg, b.KeyMap.Accept):
+			if b.focused >= 0 && b.focused < len(b.selectable) {
+				*b.value = b.all[b.selectable[b.focused]].Branch
+				b.accepted = true
+				return ui.AcceptField
+			}
 
-	case key.Matches(keyMsg, b.KeyMap.Delete):
-		if len(b.filter) > 0 {
-			b.filter = b.filter[:len(b.filter)-1]
+		case key.Matches(msg, b.KeyMap.Delete):
+			if len(b.filter) > 0 {
+				b.filter = b.filter[:len(b.filter)-1]
+				filterChanged = true
+			}
+
+		case key.Matches(msg, b.KeyMap.Discard):
+			if len(b.filter) > 0 {
+				b.filter = b.filter[:0]
+				filterChanged = true
+			}
+
+		case msg.Key().Text != "":
+			for _, r := range msg.Key().Text {
+				b.filter = append(b.filter, unicode.ToLower(r))
+			}
 			filterChanged = true
 		}
 
-	case key.Matches(keyMsg, b.KeyMap.Discard):
-		if len(b.filter) > 0 {
-			b.filter = b.filter[:0]
-			filterChanged = true
+		if filterChanged {
+			b.updateSelectable()
 		}
 
-	case keyMsg.Key().Text != "":
-		for _, r := range keyMsg.Key().Text {
-			b.filter = append(b.filter, unicode.ToLower(r))
-		}
-		filterChanged = true
-	}
-
-	if filterChanged {
-		b.updateSelectable()
+		b.syncViewport()
 	}
 
 	return nil
@@ -351,24 +362,62 @@ func (b *BranchTreeSelect) updateSelectable() {
 		selected = b.selectable[b.focused]
 	}
 
+	// Rebuild all filtered tree state from the full branch graph.
+	//
+	// Given roots main -> feat1 -> feat1.1,
+	// if only feat1.1 matches, the derived visible tree is:
+	//   visibleRoots = [feat1.1]
+	//   visibleOrder = [feat1.1]
+	//   selectable = [feat1.1] if it is not disabled
+	//
+	// At the end of this method:
+	//   - bi.Visible reports whether the branch itself matched
+	//   - bi.VisibleAboves lists visible children rendered beneath that branch
+	//   - visibleRoots is the filtered forest passed to Render
+	//   - visibleOrder is the tree order used for viewport sync
+	//   - selectable is the focusable subset of visibleOrder
 	b.selectable = b.selectable[:0]
-	var visit func(int)
-	visit = func(idx int) {
-		for _, above := range b.all[idx].Aboves {
-			visit(above)
+	b.visibleRoots = b.visibleRoots[:0]
+	b.visibleOrder = b.visibleOrder[:0]
+
+	// visit takes the index of a branch in the full tree.
+	// It returns that branch if it is visible,
+	// otherwise it returns the branch's visible descendants.
+	//
+	// In either case, the branch's state (Visible, VisibleAboves, etc.)
+	// is updated based on the filter.
+	var visit func(int) []int
+	visit = func(idx int) []int {
+		bi := b.all[idx]
+
+		var visibleChildren []int
+		for _, above := range bi.Aboves {
+			visibleChildren = append(visibleChildren, visit(above)...)
 		}
 
-		visible := b.matchesFilter(b.all[idx])
-		b.all[idx].Visible = visible
-		if visible && !b.all[idx].Disabled {
-			b.selectable = append(b.selectable, idx)
+		bi.Visible = b.matchesFilter(bi)
+		if bi.Visible {
+			// Visible branches stay in the rendered tree
+			// and keep the visible descendants found under them.
+			bi.VisibleAboves = append(bi.VisibleAboves[:0], visibleChildren...)
+			b.visibleOrder = append(b.visibleOrder, idx)
+			if !bi.Disabled {
+				b.selectable = append(b.selectable, idx)
+			}
+			return []int{idx}
 		}
+
+		// Hidden branches are removed from the rendered tree,
+		// but their visible descendants are promoted upward
+		// to the nearest visible ancestor or the root list.
+		bi.VisibleAboves = bi.VisibleAboves[:0]
+		return visibleChildren
 	}
 
 	// Depth-first traversal gives us the same order
 	// as the tree view.
 	for _, root := range b.roots {
-		visit(root)
+		b.visibleRoots = append(b.visibleRoots, visit(root)...)
 	}
 
 	if len(b.selectable) == 0 {
@@ -381,13 +430,19 @@ func (b *BranchTreeSelect) updateSelectable() {
 		b.focused = max(slices.Index(b.selectable, selected), 0)
 		return
 	}
+
+	if selectedIdx := slices.Index(b.selectable, selected); selectedIdx >= 0 {
+		b.focused = selectedIdx
+		return
+	}
+
 	// rank the selectable branches
 	branches := make([]string, len(b.selectable))
 	for i, idx := range b.selectable {
 		branches[i] = b.all[idx].Branch
 	}
 	matches := fuzzy.Find(string(b.filter), branches)
-	bestSelectable := selected
+	bestSelectable := b.selectable[0]
 	if len(matches) > 0 {
 		bestSelectable = b.selectable[matches[0].Index]
 	}
@@ -448,21 +503,6 @@ func (b *BranchTreeSelect) Render(w ui.Writer, theme ui.Theme) {
 		w.WriteString("\n")
 	}
 
-	// visibleDescendants fills dst with the indexes of visible descendants
-	// of the branches in start.
-	// If a branch is visible, it is added; otherwise, its children are checked.
-	var visibleDescendants func([]int, []int) []int
-	visibleDescendants = func(starts []int, visibles []int) []int {
-		for _, idx := range starts {
-			if b.all[idx].Visible {
-				visibles = append(visibles, idx)
-				continue
-			}
-			visibles = visibleDescendants(b.all[idx].Aboves, visibles)
-		}
-		return visibles
-	}
-
 	selected := -1
 	if b.focused >= 0 && b.focused < len(b.selectable) {
 		selected = b.selectable[b.focused]
@@ -475,7 +515,7 @@ func (b *BranchTreeSelect) Render(w ui.Writer, theme ui.Theme) {
 			Branch:             bi.Branch,
 			ChangeID:           bi.ChangeID,
 			Worktree:           bi.Worktree,
-			Aboves:             visibleDescendants(bi.Aboves, nil),
+			Aboves:             bi.VisibleAboves,
 			Highlighted:        bi.Index == selected,
 			Disabled:           bi.Disabled,
 			BranchHighlights:   bi.BranchHighlights,
@@ -486,7 +526,7 @@ func (b *BranchTreeSelect) Render(w ui.Writer, theme ui.Theme) {
 
 	g := branchtree.Graph{
 		Items: items,
-		Roots: visibleDescendants(b.roots, nil),
+		Roots: b.visibleRoots,
 	}
 
 	var home string
@@ -499,5 +539,48 @@ func (b *BranchTreeSelect) Render(w ui.Writer, theme ui.Theme) {
 		Style:           cmp.Or(b.Style, &DefaultBranchSelectStyle),
 		CurrentWorktree: b.currentWorktree,
 		HomeDir:         home,
+		Offset:          b.offset,
+		Height:          b.visible,
 	})
+}
+
+func (b *BranchTreeSelect) syncViewport() {
+	if b.visible <= 0 {
+		b.offset = 0
+		return
+	}
+
+	if len(b.visibleOrder) == 0 {
+		b.offset = 0
+		return
+	}
+
+	// Clamp the offset first so window resizes
+	// cannot leave the viewport beyond the rendered tree.
+	maxOffset := max(0, len(b.visibleOrder)-b.visible)
+	b.offset = min(b.offset, maxOffset)
+
+	if b.focused < 0 || b.focused >= len(b.selectable) {
+		return
+	}
+
+	// The cursor tracks an index into selectable branches,
+	// but the viewport scrolls over the full rendered tree.
+	selected := b.selectable[b.focused]
+	focused := slices.Index(b.visibleOrder, selected)
+	if focused < 0 {
+		// The focused branch should always be part of the visible tree.
+		// If it is not, leave the viewport unchanged rather than
+		// applying a bogus offset.
+		return
+	}
+
+	// Keep the focused branch inside the viewport
+	// while preserving the existing scroll position when possible.
+	switch {
+	case focused < b.offset:
+		b.offset = focused // scroll up
+	case focused >= b.offset+b.visible:
+		b.offset = focused - b.visible + 1 // scroll down
+	}
 }

--- a/internal/ui/widget/branch_select_test.go
+++ b/internal/ui/widget/branch_select_test.go
@@ -18,6 +18,7 @@ import (
 //
 //   - want: name of the branch expected to be selected at the end
 //   - branches: branches available in the list. See below for format.
+//   - selected (optional): preselected branch name
 //   - desc (optional): prompt description
 //   - home (optional): user's home directory
 //   - worktree (optional): current worktree
@@ -46,7 +47,7 @@ func TestBranchTreeSelect_Script(t *testing.T) {
 
 			worktree := readOptionalFile(ts, "worktree")
 
-			var gotBranch string
+			gotBranch := readOptionalFile(ts, "selected")
 			widget := NewBranchTreeSelect().
 				WithTitle("Select a branch").
 				WithItems(input...).

--- a/internal/ui/widget/testdata/script/branch_tree_select/filter_selected_bottom.txt
+++ b/internal/ui/widget/testdata/script/branch_tree_select/filter_selected_bottom.txt
@@ -1,0 +1,46 @@
+init
+
+await Select a branch
+snapshot
+cmp stdout prompt
+
+feed a
+await
+snapshot
+cmp stdout filter
+
+feed <Enter>
+
+-- rows --
+10
+-- branches --
+[
+  {"branch": "echo"},
+  {"branch": "alpha"},
+  {"branch": "bravo"},
+  {"branch": "charlie"},
+  {"branch": "delta"},
+  {"branch": "gamma"},
+  {"branch": "hotel"},
+  {"branch": "lambda"}
+]
+-- selected --
+lambda
+-- want --
+lambda
+-- prompt --
+Select a branch:
+▲▲▲
+charlie
+delta
+gamma
+hotel
+lambda ◀
+-- filter --
+Select a branch:
+▲▲▲
+bravo
+charlie
+delta
+gamma
+lambda ◀

--- a/internal/ui/widget/testdata/script/branch_tree_select/filter_selected_middle.txt
+++ b/internal/ui/widget/testdata/script/branch_tree_select/filter_selected_middle.txt
@@ -1,0 +1,46 @@
+init
+
+await Select a branch
+snapshot
+cmp stdout prompt
+
+feed a
+await
+snapshot
+cmp stdout filter
+
+feed <Enter>
+
+-- rows --
+10
+-- branches --
+[
+  {"branch": "echo"},
+  {"branch": "alpha"},
+  {"branch": "bravo"},
+  {"branch": "charlie"},
+  {"branch": "delta"},
+  {"branch": "gamma"},
+  {"branch": "hotel"},
+  {"branch": "lambda"}
+]
+-- selected --
+delta
+-- want --
+delta
+-- prompt --
+Select a branch:
+echo
+alpha
+bravo
+charlie
+delta ◀
+▼▼▼
+-- filter --
+Select a branch:
+alpha
+bravo
+charlie
+delta ◀
+gamma
+▼▼▼

--- a/internal/ui/widget/testdata/script/branch_tree_select/filter_selected_top.txt
+++ b/internal/ui/widget/testdata/script/branch_tree_select/filter_selected_top.txt
@@ -1,0 +1,46 @@
+init
+
+await Select a branch
+snapshot
+cmp stdout prompt
+
+feed a
+await
+snapshot
+cmp stdout filter
+
+feed <Enter>
+
+-- rows --
+10
+-- branches --
+[
+  {"branch": "echo"},
+  {"branch": "alpha"},
+  {"branch": "bravo"},
+  {"branch": "charlie"},
+  {"branch": "delta"},
+  {"branch": "gamma"},
+  {"branch": "hotel"},
+  {"branch": "lambda"}
+]
+-- selected --
+alpha
+-- want --
+alpha
+-- prompt --
+Select a branch:
+echo
+alpha ◀
+bravo
+charlie
+delta
+▼▼▼
+-- filter --
+Select a branch:
+alpha ◀
+bravo
+charlie
+delta
+gamma
+▼▼▼

--- a/internal/ui/widget/testdata/script/branch_tree_select/scroll.txt
+++ b/internal/ui/widget/testdata/script/branch_tree_select/scroll.txt
@@ -1,0 +1,83 @@
+init
+
+await Select a branch
+snapshot
+cmp stdout prompt
+
+feed -r 5 <Down>
+await
+snapshot
+cmp stdout scrolled
+
+feed -r 3 <Down>
+await
+snapshot
+cmp stdout wrapped
+
+feed a
+await
+snapshot
+cmp stdout filtered
+
+feed <Up>
+await
+snapshot
+cmp stdout filtered_wrapped
+
+feed <Enter>
+
+-- rows --
+10
+-- branches --
+[
+  {"branch": "echo"},
+  {"branch": "alpha"},
+  {"branch": "bravo"},
+  {"branch": "charlie"},
+  {"branch": "delta"},
+  {"branch": "gamma"},
+  {"branch": "lambda"}
+]
+-- want --
+lambda
+-- prompt --
+Select a branch:
+echo ◀
+alpha
+bravo
+charlie
+delta
+▼▼▼
+-- scrolled --
+Select a branch:
+▲▲▲
+alpha
+bravo
+charlie
+delta
+gamma ◀
+▼▼▼
+-- wrapped --
+Select a branch:
+echo
+alpha ◀
+bravo
+charlie
+delta
+▼▼▼
+-- filtered --
+Select a branch:
+alpha ◀
+bravo
+charlie
+delta
+gamma
+▼▼▼
+-- filtered_wrapped --
+Select a branch:
+▲▲▲
+bravo
+charlie
+delta
+gamma
+lambda ◀


### PR DESCRIPTION
Implement scrolling for branch selection prompts
when the terminal cannot show all matching branches.

Add viewport support to `fliptree`
as the renderer that owns line-by-line tree output,
including scroll marker rendering.
Keep `branchtree` as the branch-specific adapter
that passes viewport settings through,
and keep `BranchTreeSelect` responsible for
selection state, filter matching,
and choosing the viewport offset.

Extend the UI script harness
to accept per-script terminal sizes,
and add regression coverage for
constrained-height scrolling
and preserving an already selected branch
when filtering still matches it.