### PR TITLE
test/with-term: log output before close

### DIFF
--- a/internal/termtest/with_term.go
+++ b/internal/termtest/with_term.go
@@ -93,6 +93,11 @@ func WithTerm() {
 			if err := emu.Close(); err != nil {
 				log.Printf("%v: %v", cmd, err)
 				exitCode = 1
+
+				log.Printf("## output before close:")
+				for _, line := range emu.Rows() {
+					log.Printf("## %v", line)
+				}
 			}
 
 			if *finalSnapshot != "" {


### PR DESCRIPTION
We're seeing flakiness on tests relying on with-term.
Output doesn't include what went wrong because it's all going
to the terminal emulator.

Log the output on failure.