### PR TITLE
fix(termtest): serialize PTY shutdown

### DIFF
--- a/internal/termtest/with_term.go
+++ b/internal/termtest/with_term.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"syscall"
 	"time"
 
 	"github.com/creack/pty"
@@ -124,10 +125,11 @@ func WithTerm() {
 }
 
 type terminalEmulator struct {
-	cmd  *exec.Cmd
-	pty  *os.File
-	logf func(string, ...any)
-	emu  *uitest.EmulatorView
+	cmd      *exec.Cmd
+	pty      *os.File
+	logf     func(string, ...any)
+	emu      *uitest.EmulatorView
+	readDone chan struct{}
 }
 
 func newVT100Emulator(
@@ -148,13 +150,16 @@ func newVT100Emulator(
 			Cols:         cols,
 			NoAutoResize: noAutoResize,
 		}),
-		logf: logf,
+		logf:     logf,
+		readDone: make(chan struct{}),
 	}
 	go m.Start()
 	return &m
 }
 
 func (m *terminalEmulator) Start() {
+	defer close(m.readDone)
+
 	var buffer [1024]byte
 loop:
 	for {
@@ -166,7 +171,9 @@ loop:
 			}
 		}
 		if err != nil {
-			if !errors.Is(err, io.EOF) && !errors.Is(err, os.ErrClosed) {
+			if !errors.Is(err, io.EOF) &&
+				!errors.Is(err, os.ErrClosed) &&
+				!errors.Is(err, syscall.EIO) {
 				m.logf("read error: %v", err)
 			}
 			break loop
@@ -189,9 +196,15 @@ func (m *terminalEmulator) Close() error {
 	case <-time.After(3 * time.Second):
 		waitErr = fmt.Errorf("timeout waiting for %v", m.cmd)
 		_ = m.cmd.Process.Kill()
+		waitErr = errors.Join(waitErr, <-waitErrc)
 	}
 
 	closeErr := m.pty.Close()
+	select {
+	case <-m.readDone:
+	case <-time.After(3 * time.Second):
+		waitErr = errors.Join(waitErr, errors.New("timeout waiting for PTY reader"))
+	}
 
 	return errors.Join(waitErr, closeErr, writeErr)
 }


### PR DESCRIPTION
`with-term` started a reader goroutine that continuously called
`m.pty.Read`, while `Close` closed the same PTY after sending
EOT.

Race before:

```text
goroutine Start            main goroutine Close
------------------------   ----------------------------
Read(m.pty)                Write(EOT)
  -> os.(*File).Fd()       Wait()
                           Close(m.pty)
                             -> FD.destroy()
```

That let the race detector observe one goroutine reading the PTY
while another destroyed the same file descriptor during teardown.

Fix it by tracking the reader with `readDone`, waiting for the
child process to exit, then closing the PTY and waiting for the
reader to drain.

```go
type terminalEmulator struct {
    // ...
    readDone chan struct{}
}
```

After:

```text
reader goroutine           main goroutine
------------------------   ----------------------------
Read(m.pty)                Write(EOT)
EOF / EIO                  Wait()
close(readDone)            Close(m.pty)
                           Wait(readDone)
```

The reader also treats PTY `EIO` shutdowns as expected so
teardown does not log a spurious read failure after the slave side
exits.