### PR TITLE
Add comment counts option to git-spice log command

### DIFF
--- a/.changes/unreleased/Added-20260306-071753.yaml
+++ b/.changes/unreleased/Added-20260306-071753.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'log: Display comment and resolution counts in branch listings'
+time: 2026-03-06T07:17:53.547539-05:00

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -190,9 +190,10 @@ See https://abhinav.github.io/git-spice/cli/json/ for details.
 
 * `-a`, `--all` ([:material-wrench:{ .middle title="spice.log.all" }](/cli/config.md#spicelogall)): Show all tracked branches, not just the current stack.
 * `-S`, `--[no-]cr-status` ([:material-wrench:{ .middle title="spice.log.crStatus" }](/cli/config.md#spicelogcrstatus)): Request and include information about the Change Request
+* `-c`, `--[no-]comments` ([:material-wrench:{ .middle title="spice.log.comments" }](/cli/config.md#spicelogcomments)): Include comment resolution counts for changes
 * `--json`: Write to stdout as a stream of JSON objects in an unspecified order <span class="mdx-badge"><span class="mdx-badge__icon">:material-tag:{ title="Released in version" }</span><span class="mdx-badge__text">[v0.18.0](/changelog.md#v0.18.0)</span>
 
-**Configuration**: [spice.log.all](/cli/config.md#spicelogall), [spice.log.crFormat](/cli/config.md#spicelogcrformat), [spice.log.crStatus](/cli/config.md#spicelogcrstatus), [spice.log.pushStatusFormat](/cli/config.md#spicelogpushstatusformat), [spice.logLong.crFormat](/cli/config.md#spiceloglongcrformat), [spice.logShort.crFormat](/cli/config.md#spicelogshortcrformat)
+**Configuration**: [spice.log.all](/cli/config.md#spicelogall), [spice.log.comments](/cli/config.md#spicelogcomments), [spice.log.crFormat](/cli/config.md#spicelogcrformat), [spice.log.crStatus](/cli/config.md#spicelogcrstatus), [spice.log.pushStatusFormat](/cli/config.md#spicelogpushstatusformat), [spice.logLong.crFormat](/cli/config.md#spiceloglongcrformat), [spice.logShort.crFormat](/cli/config.md#spicelogshortcrformat)
 
 ### git-spice log long {#gs-log-long}
 
@@ -213,9 +214,10 @@ See https://abhinav.github.io/git-spice/cli/json/ for details.
 
 * `-a`, `--all` ([:material-wrench:{ .middle title="spice.log.all" }](/cli/config.md#spicelogall)): Show all tracked branches, not just the current stack.
 * `-S`, `--[no-]cr-status` ([:material-wrench:{ .middle title="spice.log.crStatus" }](/cli/config.md#spicelogcrstatus)): Request and include information about the Change Request
+* `-c`, `--[no-]comments` ([:material-wrench:{ .middle title="spice.log.comments" }](/cli/config.md#spicelogcomments)): Include comment resolution counts for changes
 * `--json`: Write to stdout as a stream of JSON objects in an unspecified order <span class="mdx-badge"><span class="mdx-badge__icon">:material-tag:{ title="Released in version" }</span><span class="mdx-badge__text">[v0.18.0](/changelog.md#v0.18.0)</span>
 
-**Configuration**: [spice.log.all](/cli/config.md#spicelogall), [spice.log.crFormat](/cli/config.md#spicelogcrformat), [spice.log.crStatus](/cli/config.md#spicelogcrstatus), [spice.log.pushStatusFormat](/cli/config.md#spicelogpushstatusformat), [spice.logLong.crFormat](/cli/config.md#spiceloglongcrformat), [spice.logShort.crFormat](/cli/config.md#spicelogshortcrformat)
+**Configuration**: [spice.log.all](/cli/config.md#spicelogall), [spice.log.comments](/cli/config.md#spicelogcomments), [spice.log.crFormat](/cli/config.md#spicelogcrformat), [spice.log.crStatus](/cli/config.md#spicelogcrstatus), [spice.log.pushStatusFormat](/cli/config.md#spicelogpushstatusformat), [spice.logLong.crFormat](/cli/config.md#spiceloglongcrformat), [spice.logShort.crFormat](/cli/config.md#spicelogshortcrformat)
 
 ## Stack
 

--- a/internal/forge/bitbucket/api_types.go
+++ b/internal/forge/bitbucket/api_types.go
@@ -89,6 +89,26 @@ type apiComment struct {
 	Content apiContent `json:"content"`
 	User    apiUser    `json:"user"`
 	Links   apiPRLinks `json:"links"`
+
+	// Inline is set for code review (diff) comments.
+	// Only inline comments are resolvable.
+	Inline *apiInline `json:"inline,omitempty"`
+
+	// Resolution is set when the comment has been resolved.
+	// Nil means unresolved, non-nil means resolved.
+	Resolution *apiResolution `json:"resolution,omitempty"`
+}
+
+// apiInline identifies inline (code review) comment location.
+type apiInline struct {
+	Path string `json:"path"`
+	From *int   `json:"from,omitempty"`
+	To   *int   `json:"to,omitempty"`
+}
+
+// apiResolution indicates a comment has been resolved.
+type apiResolution struct {
+	Type string `json:"type"`
 }
 
 // apiContent represents comment content.

--- a/internal/forge/bitbucket/comment_counts.go
+++ b/internal/forge/bitbucket/comment_counts.go
@@ -1,0 +1,72 @@
+package bitbucket
+
+import (
+	"context"
+	"fmt"
+
+	"go.abhg.dev/gs/internal/forge"
+)
+
+// CommentCountsByChange retrieves comment resolution counts for multiple PRs.
+func (r *Repository) CommentCountsByChange(
+	ctx context.Context,
+	ids []forge.ChangeID,
+) ([]*forge.CommentCounts, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	results := make([]*forge.CommentCounts, len(ids))
+	for i, id := range ids {
+		counts, err := r.commentCounts(ctx, mustPR(id).Number)
+		if err != nil {
+			return nil, fmt.Errorf("get counts for %v: %w", id, err)
+		}
+		results[i] = counts
+	}
+
+	return results, nil
+}
+
+func (r *Repository) commentCounts(
+	ctx context.Context,
+	prID int64,
+) (*forge.CommentCounts, error) {
+	var total, resolved int
+
+	path := fmt.Sprintf(
+		"/repositories/%s/%s/pullrequests/%d/comments?pagelen=%d",
+		r.workspace, r.repo, prID, _listChangeCommentsPageSize,
+	)
+
+	for path != "" {
+		comments, nextPath, err := r.fetchCommentPage(ctx, path)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, c := range comments {
+			if !isResolvable(&c) {
+				continue
+			}
+			total++
+			if c.Resolution != nil {
+				resolved++
+			}
+		}
+
+		path = nextPath
+	}
+
+	return &forge.CommentCounts{
+		Total:      total,
+		Resolved:   resolved,
+		Unresolved: total - resolved,
+	}, nil
+}
+
+// isResolvable checks if a comment is resolvable.
+// Only inline (code review) comments are resolvable in Bitbucket.
+func isResolvable(c *apiComment) bool {
+	return c.Inline != nil
+}

--- a/internal/forge/bitbucket/integration_test.go
+++ b/internal/forge/bitbucket/integration_test.go
@@ -62,6 +62,7 @@ func TestIntegration(t *testing.T) {
 			if source == forgetest.CredentialSourceGCM {
 				authType = bitbucket.AuthTypeGCM
 			}
+
 			return bitbucket.NewRepositoryForTest(
 				&bitbucketForge,
 				bitbucket.DefaultURL,

--- a/internal/forge/bitbucket/testdata/TestIntegration/CommentCountsByChange/branch
+++ b/internal/forge/bitbucket/testdata/TestIntegration/CommentCountsByChange/branch
@@ -1,0 +1,1 @@
+"ESNhWqeC"

--- a/internal/forge/bitbucket/testdata/fixtures/TestIntegration/CommentCountsByChange.yaml
+++ b/internal/forge/bitbucket/testdata/fixtures/TestIntegration/CommentCountsByChange.yaml
@@ -1,0 +1,59 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 152
+        host: api.bitbucket.org
+        body: '{"title":"Testing ESNhWqeC","description":"Test PR for comment counts","source":{"branch":{"name":"ESNhWqeC"}},"destination":{"branch":{"name":"main"}}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.bitbucket.org/2.0/repositories/test-owner/test-owner/pullrequests
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 4362
+        body: '{"comment_count": 0, "task_count": 0, "type": "pullrequest", "id": 101, "title": "Testing ESNhWqeC", "description": "Test PR for comment counts", "rendered": {"title": {"type": "rendered", "raw": "Testing ESNhWqeC", "markup": "markdown", "html": "<p>Testing ESNhWqeC</p>"}, "description": {"type": "rendered", "raw": "Test PR for comment counts", "markup": "markdown", "html": "<p>Test PR for comment counts</p>"}}, "state": "OPEN", "draft": false, "merge_commit": null, "close_source_branch": false, "closed_by": null, "author": {"display_name": "Ed Kohlwey", "links": {"self": {"href": "https://api.bitbucket.org/2.0/users/%7Bb473f550-fefb-4fe3-8c5a-9695bbd31ed1%7D"}, "avatar": {"href": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/70121:2fb6ef7e-ae8b-4607-812d-06464301ba51/2afd832e-e6fa-409f-91c9-5d0980e60586/128"}, "html": {"href": "https://bitbucket.org/%7Bb473f550-fefb-4fe3-8c5a-9695bbd31ed1%7D/"}}, "type": "user", "uuid": "{b473f550-fefb-4fe3-8c5a-9695bbd31ed1}", "account_id": "70121:2fb6ef7e-ae8b-4607-812d-06464301ba51", "nickname": "Ed Kohlwey"}, "reason": "", "created_on": "2026-01-31T12:54:52.866564+00:00", "updated_on": "2026-01-31T12:54:53.293226+00:00", "destination": {"branch": {"name": "main"}, "commit": {"hash": "5934bca3d15f", "links": {"self": {"href": "https://api.bitbucket.org/2.0/repositories/test-owner/test-owner/commit/5934bca3d15f"}, "html": {"href": "https://bitbucket.org/test-owner/test-owner/commits/5934bca3d15f"}}, "type": "commit"}, "repository": {"type": "repository", "full_name": "test-owner/test-owner", "links": {"self": {"href": "https://api.bitbucket.org/2.0/repositories/test-owner/test-owner"}, "html": {"href": "https://bitbucket.org/test-owner/test-owner"}, "avatar": {"href": "https://bytebucket.org/ravatar/%7Bbabb7b39-ab80-4015-999f-ebd75db36c15%7D?ts=default"}}, "name": "test-owner", "uuid": "{babb7b39-ab80-4015-999f-ebd75db36c15}"}}, "source": {"branch": {"name": "ESNhWqeC", "links": {}, "sync_strategies": ["merge_commit", "rebase"]}, "commit": {"hash": "298e9b999046", "links": {"self": {"href": "https://api.bitbucket.org/2.0/repositories/test-owner/test-owner/commit/298e9b999046"}, "html": {"href": "https://bitbucket.org/test-owner/test-owner/commits/298e9b999046"}}, "type": "commit"}, "repository": {"type": "repository", "full_name": "test-owner/test-owner", "links": {"self": {"href": "https://api.bitbucket.org/2.0/repositories/test-owner/test-owner"}, "html": {"href": "https://bitbucket.org/test-owner/test-owner"}, "avatar": {"href": "https://bytebucket.org/ravatar/%7Bbabb7b39-ab80-4015-999f-ebd75db36c15%7D?ts=default"}}, "name": "test-owner", "uuid": "{babb7b39-ab80-4015-999f-ebd75db36c15}"}}, "reviewers": [], "participants": [], "links": {"self": {"href": "https://api.bitbucket.org/2.0/repositories/test-owner/test-owner/pullrequests/101"}, "html": {"href": "https://bitbucket.org/test-owner/test-owner/pull-requests/101"}, "commits": {"href": "https://api.bitbucket.org/2.0/repositories/test-owner/test-owner/pullrequests/101/commits"}, "approve": {"href": "https://api.bitbucket.org/2.0/repositories/test-owner/test-owner/pullrequests/101/approve"}, "request-changes": {"href": "https://api.bitbucket.org/2.0/repositories/test-owner/test-owner/pullrequests/101/request-changes"}, "diff": {"href": "https://api.bitbucket.org/2.0/repositories/test-owner/test-owner/diff/test-owner/test-owner:298e9b999046%0D5934bca3d15f?from_pullrequest_id=101&topic=true"}, "diffstat": {"href": "https://api.bitbucket.org/2.0/repositories/test-owner/test-owner/diffstat/test-owner/test-owner:298e9b999046%0D5934bca3d15f?from_pullrequest_id=101&topic=true"}, "comments": {"href": "https://api.bitbucket.org/2.0/repositories/test-owner/test-owner/pullrequests/101/comments"}, "activity": {"href": "https://api.bitbucket.org/2.0/repositories/test-owner/test-owner/pullrequests/101/activity"}, "merge": {"href": "https://api.bitbucket.org/2.0/repositories/test-owner/test-owner/pullrequests/101/merge"}, "decline": {"href": "https://api.bitbucket.org/2.0/repositories/test-owner/test-owner/pullrequests/101/decline"}, "statuses": {"href": "https://api.bitbucket.org/2.0/repositories/test-owner/test-owner/pullrequests/101/statuses"}}, "summary": {"type": "rendered", "raw": "Test PR for comment counts", "markup": "markdown", "html": "<p>Test PR for comment counts</p>"}}'
+        headers:
+            Content-Length:
+                - "4362"
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 1.028642417s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.bitbucket.org
+        form:
+            pagelen:
+                - "100"
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.bitbucket.org/2.0/repositories/test-owner/test-owner/pullrequests/101/comments?pagelen=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 52
+        body: '{"values": [], "pagelen": 100, "size": 0, "page": 1}'
+        headers:
+            Content-Length:
+                - "52"
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 266.13975ms

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -237,6 +237,7 @@ type Repository interface {
 	FindChangesByBranch(ctx context.Context, branch string, opts FindChangesOptions) ([]*FindChangeItem, error)
 	FindChangeByID(ctx context.Context, id ChangeID) (*FindChangeItem, error)
 	ChangesStates(ctx context.Context, ids []ChangeID) ([]ChangeState, error)
+	CommentCountsByChange(ctx context.Context, ids []ChangeID) ([]*CommentCounts, error)
 
 	// Post, update, and delete comments on changes.
 	PostChangeComment(context.Context, ChangeID, string) (ChangeCommentID, error)
@@ -450,6 +451,18 @@ type ChangeTemplate struct {
 
 	// Body is the content of the template file.
 	Body string
+}
+
+// CommentCounts represents comment/thread resolution counts on a change.
+type CommentCounts struct {
+	// Total is the total number of resolvable comments or threads.
+	Total int
+
+	// Resolved is the number of resolved comments or threads.
+	Resolved int
+
+	// Unresolved is the number of unresolved comments or threads.
+	Unresolved int
 }
 
 // ChangeState is the current state of a change.

--- a/internal/forge/forgetest/integration.go
+++ b/internal/forge/forgetest/integration.go
@@ -108,7 +108,7 @@ func loadStashToken(t *testing.T, forgeURL string) string {
 	return tok.AccessToken
 }
 
-// CredentialSource identifies where credentials were loaded from.
+// CredentialSource indicates where credentials were obtained from.
 type CredentialSource int
 
 const (
@@ -116,9 +116,14 @@ const (
 	// These are typically API tokens using Bearer auth.
 	CredentialSourceEnv CredentialSource = iota
 
-	// CredentialSourceGCM indicates credentials from git-credential-manager.
-	// These are typically OAuth tokens using Bearer auth.
+	// CredentialSourceGCM indicates credentials
+	// from git-credential-manager.
+	// These are OAuth tokens requiring Bearer auth.
 	CredentialSourceGCM
+
+	// CredentialSourceReplay indicates dummy credentials
+	// for replay mode.
+	CredentialSourceReplay
 )
 
 // Credential retrieves full authentication credentials (username and password)
@@ -127,29 +132,34 @@ const (
 //
 // In update mode, it tries environment variables first,
 // then falls back to GCM.
-// In replay mode, it returns dummy credentials
-// with [CredentialSourceEnv].
+// In replay mode, it returns dummy credentials.
+//
+// Returns the credential source so callers can select
+// the appropriate auth type (Bearer for API tokens or OAuth).
 func Credential(
 	t *testing.T,
 	forgeURL, userEnvVar, passEnvVar string,
 ) (username, password string, source CredentialSource) {
 	if !Update() {
-		return "user@example.com", "token", CredentialSourceEnv
+		return "user@example.com", "token", CredentialSourceReplay
 	}
 
 	// Try environment variables first for explicit override.
 	user := os.Getenv(userEnvVar)
 	pass := os.Getenv(passEnvVar)
 	if user != "" && pass != "" {
-		t.Logf("Using %s/%s from environment", userEnvVar, passEnvVar)
+		t.Logf("Using %s/%s from environment",
+			userEnvVar, passEnvVar)
 		return user, pass, CredentialSourceEnv
 	}
 
 	// Try GCM.
 	cred, err := forge.LoadGCMCredential(t.Context(), forgeURL)
 	if err == nil {
-		t.Logf("Using credentials from git-credential-manager for %s",
-			forgeURL)
+		t.Logf(
+			"Using credentials from git-credential-manager for %s",
+			forgeURL,
+		)
 		return cred.Username, cred.Password, CredentialSourceGCM
 	}
 
@@ -158,7 +168,7 @@ func Credential(
 			"set %s/%s or configure git-credential-manager",
 		forgeURL, userEnvVar, passEnvVar,
 	)
-	return "", "", CredentialSourceEnv
+	return "", "", CredentialSourceReplay
 }
 
 // NewHTTPRecorder creates a new HTTP recorder for the given test and name.
@@ -282,6 +292,10 @@ type IntegrationConfig struct {
 	// Sanitizers are applied to recorded HTTP fixtures.
 	// Use ConfigSanitizers to create sanitizers from test configuration.
 	Sanitizers []httptest.Sanitizer // optional
+
+	// SkipCommentCounts skips the CommentCountsByChange test.
+	// Set to true for forges that don't support comment resolution tracking.
+	SkipCommentCounts bool // optional
 }
 
 // RunIntegration runs integration tests with the given configuration.
@@ -303,6 +317,7 @@ func RunIntegration(t *testing.T, config IntegrationConfig) {
 		skipReviewers:         config.SkipReviewers,
 		skipMerge:             config.SkipMerge,
 		skipCommentPagination: config.SkipCommentPagination,
+		skipCommentCounts:     config.SkipCommentCounts,
 	}
 
 	t.Run("SubmitEditChange", func(t *testing.T) {
@@ -384,6 +399,14 @@ func RunIntegration(t *testing.T, config IntegrationConfig) {
 
 		suite.TestChangeComments(t)
 	})
+
+	if !config.SkipCommentCounts {
+		t.Run("CommentCountsByChange", func(t *testing.T) {
+			t.Parallel()
+
+			suite.TestCommentCountsByChange(t)
+		})
+	}
 }
 
 type integrationSuite struct {
@@ -428,6 +451,9 @@ type integrationSuite struct {
 
 	// skipCommentPagination skips pagination test.
 	skipCommentPagination bool
+
+	// skipCommentCounts skips comment counts test.
+	skipCommentCounts bool
 
 	openRepository func(*testing.T, *http.Client) forge.Repository
 }
@@ -1418,6 +1444,57 @@ func (s *integrationSuite) TestChangeComments(t *testing.T) {
 
 		assert.Equal(t, []string{comments[0]}, gotBodies)
 	})
+}
+
+// TestCommentCountsByChange tests the CommentCountsByChange method.
+// This test creates a PR and verifies that comment counts can be retrieved.
+// Note: Creating resolvable review threads requires forge-specific operations,
+// so this test verifies the method works but may return zero counts.
+func (s *integrationSuite) TestCommentCountsByChange(t *testing.T) {
+	branchFixture := fixturetest.New(s.Fixtures, "branch", func() string {
+		return randomString(8)
+	})
+	branchName := branchFixture.Get(t)
+	t.Logf("Creating branch: %s", branchName)
+
+	if Update() {
+		testRepo := newTestRepository(t, s.RemoteURL)
+
+		testRepo.CreateBranch(branchName)
+		testRepo.CheckoutBranch(branchName)
+		testRepo.WriteFile(branchName+".txt", randomString(32))
+		testRepo.AddAllAndCommit("commit from test")
+		testRepo.Push(branchName)
+
+		t.Cleanup(func() {
+			testRepo.DeleteRemoteBranch(branchName)
+		})
+	}
+
+	repo := s.OpenRepository(t)
+
+	change, err := repo.SubmitChange(t.Context(), forge.SubmitChangeRequest{
+		Subject: "Testing " + branchName,
+		Body:    "Test PR for comment counts",
+		Base:    "main",
+		Head:    branchName,
+	})
+	require.NoError(t, err, "error creating PR")
+
+	// Call CommentCountsByChange with the new change.
+	counts, err := repo.CommentCountsByChange(t.Context(), []forge.ChangeID{change.ID})
+	require.NoError(t, err, "error getting comment counts")
+	require.Len(t, counts, 1, "expected one result")
+
+	// Verify the counts structure is valid.
+	// We can't guarantee there are comments, but the counts should be non-negative.
+	result := counts[0]
+	require.NotNil(t, result, "comment counts should not be nil")
+	assert.GreaterOrEqual(t, result.Total, 0, "total should be non-negative")
+	assert.GreaterOrEqual(t, result.Resolved, 0, "resolved should be non-negative")
+	assert.GreaterOrEqual(t, result.Unresolved, 0, "unresolved should be non-negative")
+	assert.Equal(t, result.Total, result.Resolved+result.Unresolved,
+		"total should equal resolved + unresolved")
 }
 
 // testRepository manages a local Git repository clone for testing.

--- a/internal/forge/forgetest/mocks.go
+++ b/internal/forge/forgetest/mocks.go
@@ -710,6 +710,45 @@ func (c *MockRepositoryChangesStatesCall) DoAndReturn(f func(context.Context, []
 	return c
 }
 
+// CommentCountsByChange mocks base method.
+func (m *MockRepository) CommentCountsByChange(ctx context.Context, ids []forge.ChangeID) ([]*forge.CommentCounts, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CommentCountsByChange", ctx, ids)
+	ret0, _ := ret[0].([]*forge.CommentCounts)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CommentCountsByChange indicates an expected call of CommentCountsByChange.
+func (mr *MockRepositoryMockRecorder) CommentCountsByChange(ctx, ids any) *MockRepositoryCommentCountsByChangeCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommentCountsByChange", reflect.TypeOf((*MockRepository)(nil).CommentCountsByChange), ctx, ids)
+	return &MockRepositoryCommentCountsByChangeCall{Call: call}
+}
+
+// MockRepositoryCommentCountsByChangeCall wrap *gomock.Call
+type MockRepositoryCommentCountsByChangeCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockRepositoryCommentCountsByChangeCall) Return(arg0 []*forge.CommentCounts, arg1 error) *MockRepositoryCommentCountsByChangeCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockRepositoryCommentCountsByChangeCall) Do(f func(context.Context, []forge.ChangeID) ([]*forge.CommentCounts, error)) *MockRepositoryCommentCountsByChangeCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockRepositoryCommentCountsByChangeCall) DoAndReturn(f func(context.Context, []forge.ChangeID) ([]*forge.CommentCounts, error)) *MockRepositoryCommentCountsByChangeCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // DeleteChangeComment mocks base method.
 func (m *MockRepository) DeleteChangeComment(arg0 context.Context, arg1 forge.ChangeCommentID) error {
 	m.ctrl.T.Helper()

--- a/internal/forge/github/comment_counts.go
+++ b/internal/forge/github/comment_counts.go
@@ -1,0 +1,166 @@
+package github
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/shurcooL/githubv4"
+	"go.abhg.dev/gs/internal/forge"
+)
+
+// CommentCountsByChange retrieves comment resolution counts for multiple PRs.
+func (r *Repository) CommentCountsByChange(
+	ctx context.Context,
+	ids []forge.ChangeID,
+) ([]*forge.CommentCounts, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	gqlIDs, err := r.resolveGraphQLIDs(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+
+	threads, err := r.queryReviewThreads(ctx, gqlIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.countReviewThreads(ctx, threads, gqlIDs)
+}
+
+func (r *Repository) resolveGraphQLIDs(
+	ctx context.Context,
+	ids []forge.ChangeID,
+) ([]githubv4.ID, error) {
+	gqlIDs := make([]githubv4.ID, len(ids))
+	for i, id := range ids {
+		pr := mustPR(id)
+		var err error
+		gqlIDs[i], err = r.graphQLID(ctx, pr)
+		if err != nil {
+			return nil, fmt.Errorf("resolve ID %v: %w", id, err)
+		}
+	}
+	return gqlIDs, nil
+}
+
+// _reviewThreadsPageSize is the number of review threads
+// fetched per page when counting comment resolutions.
+const _reviewThreadsPageSize = 100
+
+type reviewThreadNode struct {
+	PullRequest struct {
+		ReviewThreads reviewThreadsConnection `graphql:"reviewThreads(first: 100)"`
+	} `graphql:"... on PullRequest"`
+}
+
+type reviewThreadsConnection struct {
+	TotalCount int
+	PageInfo   struct {
+		EndCursor   githubv4.String `graphql:"endCursor"`
+		HasNextPage bool            `graphql:"hasNextPage"`
+	} `graphql:"pageInfo"`
+	Nodes []struct {
+		IsResolved bool
+	}
+}
+
+func (r *Repository) queryReviewThreads(
+	ctx context.Context,
+	gqlIDs []githubv4.ID,
+) ([]reviewThreadNode, error) {
+	var q struct {
+		Nodes []reviewThreadNode `graphql:"nodes(ids: $ids)"`
+	}
+
+	err := r.client.Query(ctx, &q, map[string]any{"ids": gqlIDs})
+	if err != nil {
+		return nil, fmt.Errorf("query review threads: %w", err)
+	}
+
+	return q.Nodes, nil
+}
+
+func (r *Repository) countReviewThreads(
+	ctx context.Context,
+	nodes []reviewThreadNode,
+	gqlIDs []githubv4.ID,
+) ([]*forge.CommentCounts, error) {
+	results := make([]*forge.CommentCounts, len(nodes))
+	for i, node := range nodes {
+		threads := node.PullRequest.ReviewThreads
+		resolved := countResolved(threads.Nodes)
+
+		// If there are more threads than the first page,
+		// paginate to count all resolved threads.
+		if threads.PageInfo.HasNextPage {
+			remaining, err := r.countRemainingResolved(
+				ctx, gqlIDs[i], threads.PageInfo.EndCursor,
+			)
+			if err != nil {
+				return nil, err
+			}
+			resolved += remaining
+		}
+
+		results[i] = &forge.CommentCounts{
+			Total:      threads.TotalCount,
+			Resolved:   resolved,
+			Unresolved: threads.TotalCount - resolved,
+		}
+	}
+	return results, nil
+}
+
+// countRemainingResolved paginates through the remaining
+// review threads for a single PR and counts resolved ones.
+func (r *Repository) countRemainingResolved(
+	ctx context.Context,
+	gqlID githubv4.ID,
+	cursor githubv4.String,
+) (int, error) {
+	var q struct {
+		Node struct {
+			PullRequest struct {
+				ReviewThreads reviewThreadsConnection `graphql:"reviewThreads(first: $first, after: $after)"`
+			} `graphql:"... on PullRequest"`
+		} `graphql:"node(id: $id)"`
+	}
+
+	variables := map[string]any{
+		"id":    gqlID,
+		"first": githubv4.Int(_reviewThreadsPageSize),
+		"after": cursor,
+	}
+
+	resolved := 0
+	for pageNum := 2; ; pageNum++ {
+		if err := r.client.Query(ctx, &q, variables); err != nil {
+			return 0, fmt.Errorf(
+				"review threads (page %d): %w", pageNum, err,
+			)
+		}
+
+		threads := q.Node.PullRequest.ReviewThreads
+		resolved += countResolved(threads.Nodes)
+
+		if !threads.PageInfo.HasNextPage {
+			break
+		}
+		variables["after"] = threads.PageInfo.EndCursor
+	}
+
+	return resolved, nil
+}
+
+func countResolved(nodes []struct{ IsResolved bool }) int {
+	count := 0
+	for _, n := range nodes {
+		if n.IsResolved {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/forge/github/comment_counts_test.go
+++ b/internal/forge/github/comment_counts_test.go
@@ -1,0 +1,156 @@
+package github
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/shurcooL/githubv4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/silog/silogtest"
+)
+
+func TestCommentCountsByChange(t *testing.T) {
+	t.Run("NoPagination", func(t *testing.T) {
+		srv := httptest.NewServer(
+			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				enc := json.NewEncoder(w)
+				assert.NoError(t, enc.Encode(map[string]any{
+					"data": map[string]any{
+						"nodes": []map[string]any{
+							{
+								"reviewThreads": map[string]any{
+									"totalCount": 2,
+									"pageInfo": map[string]any{
+										"endCursor":   nil,
+										"hasNextPage": false,
+									},
+									"nodes": []map[string]any{
+										{"isResolved": true},
+										{"isResolved": false},
+									},
+								},
+							},
+						},
+					},
+				}))
+			}),
+		)
+		defer srv.Close()
+
+		repo, err := newRepository(
+			t.Context(), new(Forge),
+			"owner", "repo",
+			silogtest.New(t),
+			githubv4.NewEnterpriseClient(srv.URL, nil),
+			"repoID",
+		)
+		require.NoError(t, err)
+
+		counts, err := repo.CommentCountsByChange(
+			t.Context(),
+			[]forge.ChangeID{
+				&PR{Number: 1, GQLID: "prID1"},
+			},
+		)
+		require.NoError(t, err)
+		require.Len(t, counts, 1)
+		assert.Equal(t, 2, counts[0].Total)
+		assert.Equal(t, 1, counts[0].Resolved)
+		assert.Equal(t, 1, counts[0].Unresolved)
+	})
+
+	t.Run("WithPagination", func(t *testing.T) {
+		requestNum := 0
+		srv := httptest.NewServer(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				assert.NoError(t, err)
+				query := string(body)
+
+				enc := json.NewEncoder(w)
+
+				switch {
+				case strings.Contains(query, "nodes(ids:"):
+					// Batch query: return first page
+					// with hasNextPage=true.
+					requestNum++
+					assert.NoError(t, enc.Encode(map[string]any{
+						"data": map[string]any{
+							"nodes": []map[string]any{
+								{
+									"reviewThreads": map[string]any{
+										"totalCount": 3,
+										"pageInfo": map[string]any{
+											"endCursor":   "cursor1",
+											"hasNextPage": true,
+										},
+										"nodes": []map[string]any{
+											{"isResolved": true},
+											{"isResolved": false},
+										},
+									},
+								},
+							},
+						},
+					}))
+
+				case strings.Contains(query, "node(id:"):
+					// Pagination query:
+					// return remaining threads.
+					requestNum++
+					assert.NoError(t, enc.Encode(map[string]any{
+						"data": map[string]any{
+							"node": map[string]any{
+								"reviewThreads": map[string]any{
+									"totalCount": 3,
+									"pageInfo": map[string]any{
+										"endCursor":   nil,
+										"hasNextPage": false,
+									},
+									"nodes": []map[string]any{
+										{"isResolved": true},
+									},
+								},
+							},
+						},
+					}))
+
+				default:
+					t.Fatalf("unexpected query: %s", query)
+				}
+			}),
+		)
+		defer srv.Close()
+
+		repo, err := newRepository(
+			t.Context(), new(Forge),
+			"owner", "repo",
+			silogtest.New(t),
+			githubv4.NewEnterpriseClient(srv.URL, nil),
+			"repoID",
+		)
+		require.NoError(t, err)
+
+		counts, err := repo.CommentCountsByChange(
+			t.Context(),
+			[]forge.ChangeID{
+				&PR{Number: 1, GQLID: "prID1"},
+			},
+		)
+		require.NoError(t, err)
+		require.Len(t, counts, 1)
+		assert.Equal(t, 3, counts[0].Total)
+		assert.Equal(t, 2, counts[0].Resolved)
+		assert.Equal(t, 1, counts[0].Unresolved)
+
+		// Verify both the batch and pagination queries
+		// were made.
+		assert.Equal(t, 2, requestNum)
+	})
+}

--- a/internal/forge/github/testdata/TestIntegration/CommentCountsByChange/branch
+++ b/internal/forge/github/testdata/TestIntegration/CommentCountsByChange/branch
@@ -1,0 +1,1 @@
+"vHZqxJvm"

--- a/internal/forge/github/testdata/fixtures/TestIntegration/CommentCountsByChange.yaml
+++ b/internal/forge/github/testdata/fixtures/TestIntegration/CommentCountsByChange.yaml
@@ -1,0 +1,84 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 146
+        host: api.github.com
+        body: |
+            {"query":"query($owner:String!$repo:String!){repository(owner: $owner, name: $repo){id}}","variables":{"owner":"test-owner","repo":"test-repo"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"repository":{"id":"R_kgDORFeuHw"}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 186.669709ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 278
+        host: api.github.com
+        body: |
+            {"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDORFeuHw","baseRefName":"main","headRefName":"vHZqxJvm","title":"Testing vHZqxJvm","body":"Test PR for comment counts"}}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDORFeuH87Auysf","number":64,"url":"https://github.com/test-owner/test-repo/pull/64"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 673.188375ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 219
+        host: api.github.com
+        body: |
+            {"query":"query($ids:[ID!]!){nodes(ids: $ids){... on PullRequest{reviewThreads(first: 100){totalCount,pageInfo{endCursor,hasNextPage},nodes{isResolved}}}}}","variables":{"ids":["PR_kwDORFeuH87Auysf"]}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"nodes":[{"reviewThreads":{"totalCount":0,"pageInfo":{"endCursor":null,"hasNextPage":false},"nodes":[]}}]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 204.997417ms

--- a/internal/forge/gitlab/client.go
+++ b/internal/forge/gitlab/client.go
@@ -10,6 +10,7 @@ import (
 )
 
 type gitlabClient struct {
+	Discussions      discussionsService
 	MergeRequests    mergeRequestsService
 	Notes            notesService
 	Projects         projectsService
@@ -51,6 +52,7 @@ func newGitLabClient(ctx context.Context, baseURL string, tok *AuthenticationTok
 		return nil, err
 	}
 	return &gitlabClient{
+		Discussions:      client.Discussions,
 		MergeRequests:    client.MergeRequests,
 		Notes:            client.Notes,
 		ProjectTemplates: client.ProjectTemplates,
@@ -175,4 +177,14 @@ type usersService interface {
 		opt *gitlab.ListUsersOptions,
 		options ...gitlab.RequestOptionFunc,
 	) ([]*gitlab.User, *gitlab.Response, error)
+}
+
+// discussionsService allows listing discussions on merge requests.
+type discussionsService interface {
+	ListMergeRequestDiscussions(
+		pid any,
+		mergeRequest int64,
+		opt *gitlab.ListMergeRequestDiscussionsOptions,
+		options ...gitlab.RequestOptionFunc,
+	) ([]*gitlab.Discussion, *gitlab.Response, error)
 }

--- a/internal/forge/gitlab/comment_counts.go
+++ b/internal/forge/gitlab/comment_counts.go
@@ -1,0 +1,81 @@
+package gitlab
+
+import (
+	"context"
+	"fmt"
+
+	gitlab "gitlab.com/gitlab-org/api/client-go"
+	"go.abhg.dev/gs/internal/forge"
+)
+
+// CommentCountsByChange retrieves comment resolution counts for multiple MRs.
+func (r *Repository) CommentCountsByChange(
+	ctx context.Context,
+	ids []forge.ChangeID,
+) ([]*forge.CommentCounts, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	results := make([]*forge.CommentCounts, len(ids))
+	for i, id := range ids {
+		counts, err := r.discussionCounts(ctx, mustMR(id).Number)
+		if err != nil {
+			return nil, fmt.Errorf("get counts for %v: %w", id, err)
+		}
+		results[i] = counts
+	}
+
+	return results, nil
+}
+
+func (r *Repository) discussionCounts(
+	ctx context.Context,
+	mrNumber int64,
+) (*forge.CommentCounts, error) {
+	var total, resolved int
+
+	opts := &gitlab.ListMergeRequestDiscussionsOptions{
+		ListOptions: gitlab.ListOptions{PerPage: 100},
+	}
+
+	for {
+		discussions, resp, err := r.client.Discussions.ListMergeRequestDiscussions(
+			r.repoID, mrNumber, opts,
+			gitlab.WithContext(ctx),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("list discussions: %w", err)
+		}
+
+		for _, disc := range discussions {
+			if !isResolvable(disc) {
+				continue
+			}
+			total++
+			if disc.Notes[0].Resolved {
+				resolved++
+			}
+		}
+
+		if resp.CurrentPage >= resp.TotalPages {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	return &forge.CommentCounts{
+		Total:      total,
+		Resolved:   resolved,
+		Unresolved: total - resolved,
+	}, nil
+}
+
+// isResolvable checks if a discussion is resolvable.
+// Diff discussions (code review comments) are resolvable.
+func isResolvable(disc *gitlab.Discussion) bool {
+	if len(disc.Notes) == 0 {
+		return false
+	}
+	return disc.Notes[0].Resolvable
+}

--- a/internal/forge/gitlab/integration_test.go
+++ b/internal/forge/gitlab/integration_test.go
@@ -64,6 +64,7 @@ func newGitLabClient(
 	client, err := gogitlab.NewClient(token, gogitlab.WithHTTPClient(httpClient))
 	require.NoError(t, err)
 	return &gitlab.Client{
+		Discussions:      client.Discussions,
 		MergeRequests:    client.MergeRequests,
 		Notes:            client.Notes,
 		ProjectTemplates: client.ProjectTemplates,

--- a/internal/forge/gitlab/testdata/TestIntegration/CommentCountsByChange/branch
+++ b/internal/forge/gitlab/testdata/TestIntegration/CommentCountsByChange/branch
@@ -1,0 +1,1 @@
+"heloFybt"

--- a/internal/forge/gitlab/testdata/fixtures/TestIntegration/CommentCountsByChange.yaml
+++ b/internal/forge/gitlab/testdata/fixtures/TestIntegration/CommentCountsByChange.yaml
@@ -1,0 +1,117 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            User-Agent:
+                - go-gitlab
+        url: https://gitlab.com/api/v4/projects/test-owner%2Ftest-repo
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":78127113,"description":null,"name":"test-repo","name_with_namespace":"Edmund Kohlwey / test-repo","path":"test-repo","path_with_namespace":"test-owner/test-repo","created_at":"2026-01-31T01:19:16.445Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:test-owner/test-repo.git","http_url_to_repo":"https://gitlab.com/test-owner/test-repo.git","web_url":"https://gitlab.com/test-owner/test-repo","readme_url":"https://gitlab.com/test-owner/test-repo/-/blob/main/README.md","forks_count":0,"avatar_url":null,"star_count":0,"last_activity_at":"2026-02-01T12:20:31.945Z","visibility":"public","namespace":{"id":82737059,"name":"Edmund Kohlwey","path":"test-owner","kind":"user","full_path":"test-owner","parent_id":null,"avatar_url":"https://secure.gravatar.com/avatar/904b5f6e9cd719f41942b80d93aec6206005ec5e4db7114a60b29dcbec6a1be2?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner"},"container_registry_image_prefix":"registry.gitlab.com/test-owner/test-repo","_links":{"self":"https://gitlab.com/api/v4/projects/78127113","issues":"https://gitlab.com/api/v4/projects/78127113/issues","merge_requests":"https://gitlab.com/api/v4/projects/78127113/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/78127113/repository/branches","labels":"https://gitlab.com/api/v4/projects/78127113/labels","events":"https://gitlab.com/api/v4/projects/78127113/events","members":"https://gitlab.com/api/v4/projects/78127113/members","cluster_agents":"https://gitlab.com/api/v4/projects/78127113/cluster_agents"},"marked_for_deletion_at":null,"marked_for_deletion_on":null,"packages_enabled":true,"empty_repo":false,"archived":false,"owner":{"id":20151226,"username":"test-owner","public_email":null,"name":"Edmund Kohlwey","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/904b5f6e9cd719f41942b80d93aec6206005ec5e4db7114a60b29dcbec6a1be2?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner"},"resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2026-02-01T01:19:16.470Z"},"repository_object_format":"sha1","issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"contact-project+test-owner-test-repo-78127113-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","analytics_access_level":"enabled","container_registry_access_level":"enabled","security_and_compliance_access_level":"private","releases_access_level":"enabled","environments_access_level":"enabled","feature_flags_access_level":"enabled","infrastructure_access_level":"enabled","monitor_access_level":"enabled","model_experiments_access_level":"enabled","model_registry_access_level":"enabled","package_registry_access_level":"enabled","emails_disabled":false,"emails_enabled":true,"show_diff_preview_in_email":true,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":20151226,"import_url":null,"import_type":null,"import_status":"none","import_error":null,"open_issues_count":0,"description_html":"","updated_at":"2026-02-01T12:20:31.945Z","ci_default_git_depth":20,"ci_delete_pipelines_in_seconds":null,"ci_forward_deployment_enabled":true,"ci_forward_deployment_rollback_allowed":true,"ci_job_token_scope_enabled":false,"ci_separated_caches":true,"ci_allow_fork_pipelines_to_run_in_parent_project":true,"ci_id_token_sub_claim_components":["project_path","ref_type","ref"],"build_git_strategy":"fetch","keep_latest_artifact":true,"restrict_user_defined_variables":false,"ci_pipeline_variables_minimum_override_role":"developer","runner_token_expiration_interval":null,"group_runners_enabled":true,"resource_group_default_process_mode":"unordered","auto_cancel_pending_pipelines":"enabled","build_timeout":3600,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","ci_push_repository_for_job_token_allowed":false,"runners_token":"GR1348941JBEZfhjSnQYz5Vztxrca","ci_config_path":"","public_jobs":true,"shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","merge_request_title_regex":null,"merge_request_title_regex_description":null,"squash_option":"default_off","enforce_auth_checks_on_uploads":true,"suggestion_commit_message":null,"merge_commit_template":null,"squash_commit_template":null,"issue_branch_template":null,"warn_about_potentially_unwanted_characters":true,"autoclose_referenced_issues":true,"max_artifacts_size":null,"external_authorization_classification_label":"","requirements_enabled":false,"requirements_access_level":"enabled","security_and_compliance_enabled":true,"compliance_frameworks":[],"duo_remote_flows_enabled":true,"duo_foundational_flows_enabled":true,"web_based_commit_signing_enabled":false,"permissions":{"project_access":{"access_level":50,"notification_level":3},"group_access":null}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 317.064208ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            User-Agent:
+                - go-gitlab
+        url: https://gitlab.com/api/v4/user
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":20151226,"username":"test-owner","public_email":null,"name":"Edmund Kohlwey","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/904b5f6e9cd719f41942b80d93aec6206005ec5e4db7114a60b29dcbec6a1be2?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner","created_at":"2024-02-17T17:06:48.005Z","bio":"","location":"","linkedin":"","twitter":"","discord":"","website_url":"","github":"","job_title":"","pronouns":null,"organization":"","bot":false,"work_information":null,"local_time":null,"last_sign_in_at":"2025-04-12T13:29:26.841Z","confirmed_at":"2024-02-17T17:08:03.138Z","last_activity_on":"2026-02-01","email":"ed@irl.llc","theme_id":3,"color_scheme_id":1,"projects_limit":100000,"current_sign_in_at":"2026-01-31T01:18:18.160Z","identities":[{"provider":"google_oauth2","extern_uid":"114476474281350880464","saml_provider_id":null},{"provider":"group_saml","extern_uid":"ed@irl.llc","saml_provider_id":1006019}],"can_create_group":true,"can_create_project":true,"two_factor_enabled":false,"external":false,"private_profile":false,"commit_email":"ed@irl.llc","preferred_language":"en","shared_runners_minutes_limit":null,"extra_shared_runners_minutes_limit":null,"scim_identities":[]}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 147.391458ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 121
+        host: gitlab.com
+        body: '{"title":"Testing heloFybt","description":"Test PR for comment counts","source_branch":"heloFybt","target_branch":"main"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - go-gitlab
+        url: https://gitlab.com/api/v4/projects/78127113/merge_requests
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1953
+        body: '{"id":451077580,"iid":34,"project_id":78127113,"title":"Testing heloFybt","description":"Test PR for comment counts","state":"opened","created_at":"2026-02-01T16:28:03.727Z","updated_at":"2026-02-01T16:28:03.727Z","merged_by":null,"merge_user":null,"merged_at":null,"closed_by":null,"closed_at":null,"target_branch":"main","source_branch":"heloFybt","user_notes_count":0,"upvotes":0,"downvotes":0,"author":{"id":20151226,"username":"test-owner","public_email":null,"name":"Edmund Kohlwey","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/904b5f6e9cd719f41942b80d93aec6206005ec5e4db7114a60b29dcbec6a1be2?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner"},"assignees":[],"assignee":null,"reviewers":[],"source_project_id":78127113,"target_project_id":78127113,"labels":[],"draft":false,"imported":false,"imported_from":"none","work_in_progress":false,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"checking","detailed_merge_status":"preparing","merge_after":null,"sha":"4b9ad7ef00e89ac573f76b518fc71de4442e92e5","merge_commit_sha":null,"squash_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":null,"prepared_at":null,"reference":"!34","references":{"short":"!34","relative":"!34","full":"test-owner/test-repo!34"},"web_url":"https://gitlab.com/test-owner/test-repo/-/merge_requests/34","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":false,"squash_on_merge":false,"task_completion_status":{"count":0,"completed_count":0},"has_conflicts":false,"blocking_discussions_resolved":true,"approvals_before_merge":null,"subscribed":true,"changes_count":null,"latest_build_started_at":null,"latest_build_finished_at":null,"first_deployed_to_production_at":null,"pipeline":null,"head_pipeline":null,"diff_refs":null,"merge_error":null,"user":{"can_merge":true}}'
+        headers:
+            Content-Length:
+                - "1953"
+            Content-Type:
+                - application/json
+        status: 201 Created
+        code: 201
+        duration: 526.956209ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        form:
+            per_page:
+                - "100"
+        headers:
+            User-Agent:
+                - go-gitlab
+        url: https://gitlab.com/api/v4/projects/78127113/merge_requests/34/discussions?per_page=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 2
+        body: '[]'
+        headers:
+            Content-Length:
+                - "2"
+            Content-Type:
+                - application/json
+            X-Next-Page:
+                - ""
+            X-Page:
+                - "1"
+            X-Total-Pages:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 268.317959ms

--- a/internal/forge/shamhub/comment.go
+++ b/internal/forge/shamhub/comment.go
@@ -63,6 +63,12 @@ type shamComment struct {
 	ID     int
 	Change int
 	Body   string
+
+	// Resolvable indicates this is a code review comment that can be resolved.
+	Resolvable bool
+
+	// Resolved indicates this comment has been resolved.
+	Resolved bool
 }
 
 var (

--- a/internal/forge/shamhub/comment_counts.go
+++ b/internal/forge/shamhub/comment_counts.go
@@ -1,0 +1,87 @@
+package shamhub
+
+import (
+	"context"
+	"fmt"
+
+	"go.abhg.dev/gs/internal/forge"
+)
+
+type commentCountsRequest struct {
+	Owner string `path:"owner" json:"-"`
+	Repo  string `path:"repo" json:"-"`
+
+	IDs []ChangeID `json:"ids"`
+}
+
+type commentCountsResponse struct {
+	Counts []commentCountsItem `json:"counts"`
+}
+
+type commentCountsItem struct {
+	Total      int `json:"total"`
+	Resolved   int `json:"resolved"`
+	Unresolved int `json:"unresolved"`
+}
+
+var _ = shamhubRESTHandler("POST /{owner}/{repo}/change/comment-counts", (*ShamHub).handleCommentCounts)
+
+func (sh *ShamHub) handleCommentCounts(_ context.Context, req *commentCountsRequest) (*commentCountsResponse, error) {
+	sh.mu.RLock()
+	defer sh.mu.RUnlock()
+
+	counts := make([]commentCountsItem, len(req.IDs))
+	for i, changeID := range req.IDs {
+		counts[i] = sh.countCommentsForChange(int(changeID))
+	}
+
+	return &commentCountsResponse{Counts: counts}, nil
+}
+
+func (sh *ShamHub) countCommentsForChange(changeNum int) commentCountsItem {
+	var total, resolved int
+	for _, c := range sh.comments {
+		if c.Change != changeNum || !c.Resolvable {
+			continue
+		}
+		total++
+		if c.Resolved {
+			resolved++
+		}
+	}
+	return commentCountsItem{
+		Total:      total,
+		Resolved:   resolved,
+		Unresolved: total - resolved,
+	}
+}
+
+// CommentCountsByChange retrieves comment resolution counts for multiple changes.
+func (r *forgeRepository) CommentCountsByChange(
+	ctx context.Context,
+	fids []forge.ChangeID,
+) ([]*forge.CommentCounts, error) {
+	ids := make([]ChangeID, len(fids))
+	for i, fid := range fids {
+		ids[i] = fid.(ChangeID)
+	}
+
+	u := r.apiURL.JoinPath(r.owner, r.repo, "change", "comment-counts")
+	req := commentCountsRequest{IDs: ids}
+
+	var res commentCountsResponse
+	if err := r.client.Post(ctx, u.String(), req, &res); err != nil {
+		return nil, fmt.Errorf("get comment counts: %w", err)
+	}
+
+	counts := make([]*forge.CommentCounts, len(res.Counts))
+	for i, c := range res.Counts {
+		counts[i] = &forge.CommentCounts{
+			Total:      c.Total,
+			Resolved:   c.Resolved,
+			Unresolved: c.Unresolved,
+		}
+	}
+
+	return counts, nil
+}

--- a/internal/forge/shamhub/testdata/TestIntegration/CommentCountsByChange/branch
+++ b/internal/forge/shamhub/testdata/TestIntegration/CommentCountsByChange/branch
@@ -1,0 +1,1 @@
+"FIphqcit"

--- a/internal/forge/shamhub/testdata/fixtures/TestIntegration/CommentCountsByChange.yaml
+++ b/internal/forge/shamhub/testdata/fixtures/TestIntegration/CommentCountsByChange.yaml
@@ -1,0 +1,64 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 98
+        host: 127.0.0.1:57651
+        body: '{"subject":"Testing FIphqcit","body":"Test PR for comment counts","base":"main","head":"FIphqcit"}'
+        url: http://127.0.0.1:57651/abhinav/test-repo/changes
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 80
+        body: |
+            {
+              "number": 6,
+              "url": "http://127.0.0.1:57652/abhinav/test-repo/change/6"
+            }
+        headers:
+            Content-Length:
+                - "80"
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 72.612459ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 11
+        host: 127.0.0.1:57651
+        body: '{"ids":[6]}'
+        url: http://127.0.0.1:57651/abhinav/test-repo/change/comment-counts
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 95
+        body: |
+            {
+              "counts": [
+                {
+                  "total": 0,
+                  "resolved": 0,
+                  "unresolved": 0
+                }
+              ]
+            }
+        headers:
+            Content-Length:
+                - "95"
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 2.928708ms

--- a/internal/ui/branchtree/tree.go
+++ b/internal/ui/branchtree/tree.go
@@ -55,6 +55,10 @@ type Item struct {
 	// nil indicates state is not available.
 	ChangeState *forge.ChangeState
 
+	// CommentCounts holds comment resolution counts for the change.
+	// If non-nil and Total > 0, rendered as " [Resolved/Total]☑".
+	CommentCounts *forge.CommentCounts
+
 	// Worktree is the absolute path where this branch is checked out.
 	// If non-empty and differs from GraphOptions.CurrentWorktree,
 	// rendered as "[wt: path]".
@@ -134,6 +138,13 @@ type Style struct {
 	// Each style must include the text via SetString.
 	ChangeState ChangeStateStyle
 
+	// CommentCounts styles the comment counts indicator.
+	CommentCounts ui.Style
+
+	// CommentCountsResolved styles comment counts
+	// when all comments are resolved.
+	CommentCountsResolved ui.Style
+
 	// Worktree styles the worktree indicator.
 	Worktree ui.Style
 
@@ -191,6 +202,8 @@ var DefaultStyle = Style{
 		Closed: ui.NewStyle().Foreground(ui.Gray).SetString("closed"),
 		Merged: ui.NewStyle().Foreground(ui.Magenta).SetString("merged"),
 	},
+	CommentCounts:         ui.NewStyle().Foreground(ui.Yellow),
+	CommentCountsResolved: ui.NewStyle().Foreground(ui.Green),
 	Worktree:              ui.NewStyle().Faint(true),
 	PushStatus:            ui.NewStyle().Foreground(ui.Yellow).Faint(true),
 	NeedsRestack:          ui.NewStyle().Foreground(ui.Gray).SetString(" (needs restack)"), // TODO: drop leading space
@@ -316,6 +329,10 @@ func (r *branchTreeRenderer) item(sb *strings.Builder, item *Item) {
 		r.changeID(sb, item.ChangeID, item.ChangeIDHighlights, item.ChangeState)
 	}
 
+	if cc := item.CommentCounts; cc != nil && cc.Total > 0 {
+		r.commentCounts(sb, cc)
+	}
+
 	if wt := item.Worktree; wt != "" && wt != r.CurrentWorktree {
 		r.worktree(sb, item.Worktree, item.WorktreeHighlights)
 	}
@@ -371,6 +388,19 @@ func (r *branchTreeRenderer) changeID(
 			sb.WriteString(r.Style.ChangeState.Merged.String())
 		}
 	}
+}
+
+func (r *branchTreeRenderer) commentCounts(
+	sb *strings.Builder,
+	cc *forge.CommentCounts,
+) {
+	style := r.Style.CommentCounts
+	if cc.Resolved == cc.Total {
+		style = r.Style.CommentCountsResolved
+	}
+	sb.WriteString(style.Render(
+		fmt.Sprintf(" [%d/%d]☑", cc.Resolved, cc.Total),
+	))
 }
 
 func (r *branchTreeRenderer) worktree(
@@ -483,6 +513,8 @@ type branchTreeStyle struct {
 	BranchDisabled        lipgloss.Style
 	ChangeID              lipgloss.Style
 	ChangeState           changeStateStyle
+	CommentCounts         lipgloss.Style
+	CommentCountsResolved lipgloss.Style
 	Worktree              lipgloss.Style
 	PushStatus            lipgloss.Style
 	NeedsRestack          lipgloss.Style
@@ -500,6 +532,8 @@ func (s Style) resolve(theme ui.Theme) branchTreeStyle {
 		BranchDisabled:        s.BranchDisabled.Resolve(theme),
 		ChangeID:              s.ChangeID.Resolve(theme),
 		ChangeState:           s.ChangeState.resolve(theme),
+		CommentCounts:         s.CommentCounts.Resolve(theme),
+		CommentCountsResolved: s.CommentCountsResolved.Resolve(theme),
 		Worktree:              s.Worktree.Resolve(theme),
 		PushStatus:            s.PushStatus.Resolve(theme),
 		NeedsRestack:          s.NeedsRestack.Resolve(theme),

--- a/log.go
+++ b/log.go
@@ -67,6 +67,8 @@ type branchLogCmd struct {
 	CRStatus bool `name:"cr-status" short:"S" config:"log.crStatus" help:"Request and include information about the Change Request" default:"false" negatable:""`
 	// TODO: When needed, add a crStatusFormat config to control presentation.
 
+	Comments bool `name:"comments" short:"c" config:"log.comments" help:"Include comment resolution counts for changes" default:"false" negatable:""`
+
 	PushStatusFormat pushStatusFormat `config:"log.pushStatusFormat" help:"Show indicator for branches that are out of sync with their remotes. One of 'true', 'false' and 'aheadbehind'." hidden:"" default:"true"`
 
 	JSON bool `name:"json" released:"v0.18.0" help:"Write to stdout as a stream of JSON objects in an unspecified order"`
@@ -91,12 +93,13 @@ func (cmd *branchLogCmd) run(
 	}
 
 	var presenter logPresenter
-	var wantChangeURL, wantPushStatus, wantChangeState bool
+	var wantChangeURL, wantPushStatus, wantChangeState, wantCommentCounts bool
 	if cmd.JSON {
-		// JSON always wants URLs and push status, but respects --status for change state.
+		// JSON always wants URLs and push status, but respects flags for change state/comments.
 		wantChangeURL = true
 		wantPushStatus = true
 		wantChangeState = cmd.CRStatus
+		wantCommentCounts = cmd.Comments
 
 		presenter = &jsonLogPresenter{
 			Stdout:          kctx.Stdout,
@@ -115,15 +118,17 @@ func (cmd *branchLogCmd) run(
 		wantChangeURL = changeFormat == changeFormatURL
 		wantPushStatus = cmd.PushStatusFormat.Enabled()
 		wantChangeState = cmd.CRStatus
+		wantCommentCounts = cmd.Comments
 
 		stderrView := ui.NewFileView(kctx.Stderr)
 		presenter = &graphLogPresenter{
-			Stderr:           stderrView,
-			Theme:            stderrView.Theme(),
-			ChangeFormat:     changeFormat,
-			ShowCRStatus:     wantChangeState,
-			PushStatusFormat: cmd.PushStatusFormat,
-			CurrentWorktree:  wt.RootDir(),
+			Stderr:            stderrView,
+			Theme:             stderrView.Theme(),
+			ChangeFormat:      changeFormat,
+			ShowCRStatus:      wantChangeState,
+			ShowCommentCounts: wantCommentCounts,
+			PushStatusFormat:  cmd.PushStatusFormat,
+			CurrentWorktree:   wt.RootDir(),
 		}
 	}
 
@@ -143,6 +148,9 @@ func (cmd *branchLogCmd) run(
 	if wantPushStatus {
 		req.Include |= list.IncludePushStatus
 	}
+	if wantCommentCounts {
+		req.Include |= list.IncludeCommentCounts
+	}
 
 	res, err := listHandler.ListBranches(ctx, &req)
 	if err != nil {
@@ -157,12 +165,13 @@ type logPresenter interface {
 }
 
 type graphLogPresenter struct {
-	Stderr           ui.View          // required
-	Theme            ui.Theme         // required
-	ChangeFormat     changeFormat     // required
-	ShowCRStatus     bool             // required
-	PushStatusFormat pushStatusFormat // required
-	CurrentWorktree  string           // required
+	Stderr            ui.View          // required
+	Theme             ui.Theme         // required
+	ChangeFormat      changeFormat     // required
+	ShowCRStatus      bool             // required
+	ShowCommentCounts bool             // required
+	PushStatusFormat  pushStatusFormat // required
+	CurrentWorktree   string           // required
 }
 
 func (p *graphLogPresenter) Present(res *list.BranchesResponse, currentBranch string) error {
@@ -194,6 +203,11 @@ func (p *graphLogPresenter) Present(res *list.BranchesResponse, currentBranch st
 			// Include change state if requested.
 			if p.ShowCRStatus && b.ChangeState != 0 {
 				item.ChangeState = &b.ChangeState
+			}
+
+			// Include comment counts if requested and available.
+			if p.ShowCommentCounts && b.CommentCounts != nil {
+				item.CommentCounts = b.CommentCounts
 			}
 		}
 
@@ -310,6 +324,13 @@ func (p *jsonLogPresenter) Present(res *list.BranchesResponse, currentBranch str
 					jc.Status = "merged"
 				}
 			}
+			if cc := branch.CommentCounts; cc != nil {
+				jc.Comments = &jsonLogComments{
+					Total:      cc.Total,
+					Resolved:   cc.Resolved,
+					Unresolved: cc.Unresolved,
+				}
+			}
 			logBranch.Change = jc
 		}
 
@@ -407,6 +428,20 @@ type jsonLogChange struct {
 
 	// Status is the current state of the change (open|closed|merged).
 	Status string `json:"status,omitempty"`
+
+	// Comments contains comment resolution counts for the change.
+	Comments *jsonLogComments `json:"comments,omitempty"`
+}
+
+type jsonLogComments struct {
+	// Total is the total number of resolvable comments or threads.
+	Total int `json:"total"`
+
+	// Resolved is the number of resolved comments or threads.
+	Resolved int `json:"resolved"`
+
+	// Unresolved is the number of unresolved comments or threads.
+	Unresolved int `json:"unresolved"`
 }
 
 type jsonLogPushStatus struct {

--- a/log_graph_test.go
+++ b/log_graph_test.go
@@ -15,12 +15,13 @@ func TestGraphLogPresenter_Present(t *testing.T) {
 	var buf bytes.Buffer
 	stderrView := ui.NewFileView(&buf)
 	presenter := &graphLogPresenter{
-		Stderr:           stderrView,
-		Theme:            stderrView.Theme(),
-		ChangeFormat:     changeFormatID,
-		ShowCRStatus:     false,
-		PushStatusFormat: pushStatusDisabled,
-		CurrentWorktree:  "/repo",
+		Stderr:            stderrView,
+		Theme:             stderrView.Theme(),
+		ChangeFormat:      changeFormatID,
+		ShowCRStatus:      false,
+		ShowCommentCounts: false,
+		PushStatusFormat:  pushStatusDisabled,
+		CurrentWorktree:   "/repo",
 	}
 
 	res := &list.BranchesResponse{
@@ -47,12 +48,13 @@ func TestGraphLogPresenter_Present_preservesColor(t *testing.T) {
 		Profile: colorprofile.TrueColor,
 	})
 	presenter := &graphLogPresenter{
-		Stderr:           stderrView,
-		Theme:            stderrView.Theme(),
-		ChangeFormat:     changeFormatID,
-		ShowCRStatus:     false,
-		PushStatusFormat: pushStatusDisabled,
-		CurrentWorktree:  "/repo",
+		Stderr:            stderrView,
+		Theme:             stderrView.Theme(),
+		ChangeFormat:      changeFormatID,
+		ShowCRStatus:      false,
+		ShowCommentCounts: false,
+		PushStatusFormat:  pushStatusDisabled,
+		CurrentWorktree:   "/repo",
 	}
 
 	res := &list.BranchesResponse{

--- a/testdata/help/log_long.txt
+++ b/testdata/help/log_long.txt
@@ -13,6 +13,8 @@ Flags:
                           (🔧 spice.log.all)
   -S, --[no-]cr-status    Request and include information about the Change
                           Request (🔧 spice.log.crStatus)
+  -c, --[no-]comments     Include comment resolution counts for changes (🔧
+                          spice.log.comments)
       --json              Write to stdout as a stream of JSON objects in an
                           unspecified order
 

--- a/testdata/help/log_short.txt
+++ b/testdata/help/log_short.txt
@@ -13,6 +13,8 @@ Flags:
                           (🔧 spice.log.all)
   -S, --[no-]cr-status    Request and include information about the Change
                           Request (🔧 spice.log.crStatus)
+  -c, --[no-]comments     Include comment resolution counts for changes (🔧
+                          spice.log.comments)
       --json              Write to stdout as a stream of JSON objects in an
                           unspecified order
 


### PR DESCRIPTION
Add an optional comment count output to the log command, to allow users to see the total number of comments and number resolved on a particular branch. Because this command uses network to fetch comment counts (unlike the "normal" log command) it is under a flag.