### PR TITLE
sync: retarget upstack PRs after deleting merged branches

### DIFF
--- a/internal/handler/sync/handler.go
+++ b/internal/handler/sync/handler.go
@@ -355,6 +355,15 @@ func (h *Handler) SyncTrunk(ctx context.Context, opts *TrunkOptions) error {
 		return err
 	}
 
+	// Retarget surviving upstack PRs on the forge
+	// so their base matches the updated local state.
+	if h.RemoteRepository != nil {
+		h.retargetUpstackChanges(ctx,
+			collectRetargetCandidates(
+				branchesToDelete, candidates, trunk,
+			))
+	}
+
 	if opts.Restack {
 		// current branch may have changed after deletion
 		// of merged branches.
@@ -804,4 +813,103 @@ func (h *Handler) deleteBranches(ctx context.Context, branchesToDelete []branchD
 	}
 
 	return nil
+}
+
+// retargetCandidate is a branch whose forge change
+// needs retargeting after a sync deletion.
+type retargetCandidate struct {
+	branch   string
+	changeID forge.ChangeID
+	newBase  string
+}
+
+// collectRetargetCandidates identifies branches
+// that need forge retargeting after sync deletion.
+//
+// It examines pre-deletion branch state to find branches
+// that survive deletion but have a base being deleted.
+// For each, it resolves the nearest surviving ancestor
+// as the new base.
+func collectRetargetCandidates(
+	deletions []branchDeletion,
+	candidates []spice.LoadBranchItem,
+	trunk string,
+) []retargetCandidate {
+	deletedNames := make(map[string]struct{}, len(deletions))
+	for _, d := range deletions {
+		deletedNames[d.BranchName] = struct{}{}
+	}
+
+	baseOf := make(map[string]string, len(candidates))
+	for _, c := range candidates {
+		baseOf[c.Name] = c.Base
+	}
+
+	var result []retargetCandidate
+	for _, c := range candidates {
+		if _, deleted := deletedNames[c.Name]; deleted {
+			continue
+		}
+		if c.Change == nil {
+			continue
+		}
+		if _, baseDeleted := deletedNames[c.Base]; !baseDeleted {
+			continue
+		}
+
+		result = append(result, retargetCandidate{
+			branch:   c.Name,
+			changeID: c.Change.ChangeID(),
+			newBase: survivingAncestor(
+				c.Base, baseOf, deletedNames, trunk,
+			),
+		})
+	}
+	return result
+}
+
+// survivingAncestor walks up the base chain
+// to find the nearest ancestor not being deleted.
+func survivingAncestor(
+	base string,
+	baseOf map[string]string,
+	deletedNames map[string]struct{},
+	trunk string,
+) string {
+	visited := make(map[string]struct{})
+	for {
+		if _, cycle := visited[base]; cycle {
+			return trunk
+		}
+		visited[base] = struct{}{}
+
+		parent, ok := baseOf[base]
+		if !ok {
+			return trunk
+		}
+		if _, deleted := deletedNames[parent]; !deleted {
+			return parent
+		}
+		base = parent
+	}
+}
+
+// retargetUpstackChanges retargets forge changes
+// for upstack branches surviving deletion.
+func (h *Handler) retargetUpstackChanges(
+	ctx context.Context,
+	candidates []retargetCandidate,
+) {
+	for _, c := range candidates {
+		h.Log.Infof("Retargeting %s to %s...",
+			c.branch, c.newBase)
+		err := h.RemoteRepository.EditChange(
+			ctx, c.changeID,
+			forge.EditChangeOptions{Base: c.newBase},
+		)
+		if err != nil {
+			h.Log.Warn("Retarget failed",
+				"branch", c.branch, "error", err)
+		}
+	}
 }

--- a/internal/handler/sync/retarget_test.go
+++ b/internal/handler/sync/retarget_test.go
@@ -1,0 +1,175 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/spice"
+)
+
+// fakeChangeID is a string-based ChangeID for testing.
+type fakeChangeID string
+
+func (f fakeChangeID) String() string { return string(f) }
+
+// fakeChangeMetadata implements forge.ChangeMetadata for testing.
+type fakeChangeMetadata struct {
+	id forge.ChangeID
+}
+
+func (m *fakeChangeMetadata) ForgeID() string          { return "fake" }
+func (m *fakeChangeMetadata) ChangeID() forge.ChangeID { return m.id }
+
+func (m *fakeChangeMetadata) NavigationCommentID() forge.ChangeCommentID {
+	return nil
+}
+
+func (m *fakeChangeMetadata) SetNavigationCommentID(forge.ChangeCommentID) {}
+
+func TestCollectRetargetCandidates(t *testing.T) {
+	t.Run("SingleDeletion", func(t *testing.T) {
+		// main -> A -> B; A deleted, B survives with change.
+		got := collectRetargetCandidates(
+			[]branchDeletion{{BranchName: "A"}},
+			[]spice.LoadBranchItem{
+				{Name: "A", Base: "main"},
+				{
+					Name:   "B",
+					Base:   "A",
+					Change: &fakeChangeMetadata{id: fakeChangeID("pr-2")},
+				},
+			},
+			"main",
+		)
+
+		assert.Equal(t, []retargetCandidate{
+			{branch: "B", changeID: fakeChangeID("pr-2"), newBase: "main"},
+		}, got)
+	})
+
+	t.Run("MultiLevel", func(t *testing.T) {
+		// main -> A -> B -> C; A and B deleted, C survives.
+		got := collectRetargetCandidates(
+			[]branchDeletion{
+				{BranchName: "A"},
+				{BranchName: "B"},
+			},
+			[]spice.LoadBranchItem{
+				{Name: "A", Base: "main"},
+				{Name: "B", Base: "A"},
+				{
+					Name:   "C",
+					Base:   "B",
+					Change: &fakeChangeMetadata{id: fakeChangeID("pr-3")},
+				},
+			},
+			"main",
+		)
+
+		assert.Equal(t, []retargetCandidate{
+			{branch: "C", changeID: fakeChangeID("pr-3"), newBase: "main"},
+		}, got)
+	})
+
+	t.Run("NoChange", func(t *testing.T) {
+		// A deleted, B survives but has no published change.
+		got := collectRetargetCandidates(
+			[]branchDeletion{{BranchName: "A"}},
+			[]spice.LoadBranchItem{
+				{Name: "A", Base: "main"},
+				{Name: "B", Base: "A"},
+			},
+			"main",
+		)
+
+		assert.Empty(t, got)
+	})
+
+	t.Run("UpstackAlsoDeleted", func(t *testing.T) {
+		// A and B both deleted — no retarget candidates.
+		got := collectRetargetCandidates(
+			[]branchDeletion{
+				{BranchName: "A"},
+				{BranchName: "B"},
+			},
+			[]spice.LoadBranchItem{
+				{Name: "A", Base: "main"},
+				{
+					Name:   "B",
+					Base:   "A",
+					Change: &fakeChangeMetadata{id: fakeChangeID("pr-2")},
+				},
+			},
+			"main",
+		)
+
+		assert.Empty(t, got)
+	})
+
+	t.Run("BaseNotDeleted", func(t *testing.T) {
+		// A is not deleted; B's base is not in the deletion set.
+		got := collectRetargetCandidates(
+			[]branchDeletion{{BranchName: "X"}},
+			[]spice.LoadBranchItem{
+				{Name: "A", Base: "main"},
+				{
+					Name:   "B",
+					Base:   "A",
+					Change: &fakeChangeMetadata{id: fakeChangeID("pr-2")},
+				},
+			},
+			"main",
+		)
+
+		assert.Empty(t, got)
+	})
+
+	t.Run("CyclicBases", func(t *testing.T) {
+		// A -> B -> A (cycle), both deleted, C survives.
+		// Should fall back to trunk instead of looping.
+		got := collectRetargetCandidates(
+			[]branchDeletion{
+				{BranchName: "A"},
+				{BranchName: "B"},
+			},
+			[]spice.LoadBranchItem{
+				{Name: "A", Base: "B"},
+				{Name: "B", Base: "A"},
+				{
+					Name:   "C",
+					Base:   "A",
+					Change: &fakeChangeMetadata{id: fakeChangeID("pr-3")},
+				},
+			},
+			"main",
+		)
+
+		assert.Equal(t, []retargetCandidate{
+			{branch: "C", changeID: fakeChangeID("pr-3"), newBase: "main"},
+		}, got)
+	})
+
+	t.Run("SurvivingNonTrunkAncestor", func(t *testing.T) {
+		// main -> A -> B -> C; B deleted, A survives.
+		// C should retarget to A, not main.
+		got := collectRetargetCandidates(
+			[]branchDeletion{{BranchName: "B"}},
+			[]spice.LoadBranchItem{
+				{Name: "A", Base: "main"},
+				{Name: "B", Base: "A"},
+				{
+					Name:   "C",
+					Base:   "B",
+					Change: &fakeChangeMetadata{id: fakeChangeID("pr-3")},
+				},
+			},
+			"main",
+		)
+
+		assert.Equal(t, []retargetCandidate{
+			{branch: "C", changeID: fakeChangeID("pr-3"), newBase: "A"},
+		}, got)
+	})
+}

--- a/testdata/script/repo_sync_retarget_deep_stack.txt
+++ b/testdata/script/repo_sync_retarget_deep_stack.txt
@@ -1,0 +1,59 @@
+# 'repo sync' retargets upstack PRs correctly
+# when multiple stacked branches are merged.
+
+as 'Test <test@example.com>'
+at '2026-03-04T18:00:00Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# create a stack: main -> A -> B -> C
+git add a.txt
+gs bc feature-a -m 'Add feature A'
+git add b.txt
+gs bc feature-b -m 'Add feature B'
+git add c.txt
+gs bc feature-c -m 'Add feature C'
+
+# submit the full stack
+gs downstack submit --fill
+stderr 'Created #1'
+stderr 'Created #2'
+stderr 'Created #3'
+
+# verify feature-c targets feature-b initially
+shamhub dump change 3
+stdout '"ref": "feature-b"'
+
+# merge A and B externally
+shamhub merge alice/example 1
+shamhub merge alice/example 2
+
+# sync should detect both merges
+# and retarget feature-c's PR to main.
+gs repo sync
+stderr 'feature-a: #1 was merged'
+stderr 'feature-b: #2 was merged'
+stderr 'Retargeting feature-c to main'
+
+# verify feature-c's PR now targets main
+shamhub dump change 3
+stdout '"ref": "main"'
+
+-- repo/a.txt --
+Feature A
+-- repo/b.txt --
+Feature B
+-- repo/c.txt --
+Feature C

--- a/testdata/script/repo_sync_retarget_upstack.txt
+++ b/testdata/script/repo_sync_retarget_upstack.txt
@@ -1,0 +1,52 @@
+# 'repo sync' retargets upstack PRs on the forge
+# after deleting merged branches.
+
+as 'Test <test@example.com>'
+at '2026-03-04T18:00:00Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# create a stack: main -> feature1 -> feature2
+git add feature1.txt
+gs bc feature1 -m 'Add feature 1'
+git add feature2.txt
+gs bc feature2 -m 'Add feature 2'
+
+# submit the stack
+gs downstack submit --fill
+stderr 'Created #1'
+stderr 'Created #2'
+
+# verify feature2 targets feature1 initially
+shamhub dump change 2
+stdout '"ref": "feature1"'
+
+# merge feature1 externally
+shamhub merge alice/example 1
+
+# sync should detect the merge, delete feature1,
+# and retarget feature2's PR to main.
+gs repo sync
+stderr 'feature1: #1 was merged'
+stderr 'Retargeting feature2 to main'
+
+# verify feature2's PR now targets main
+shamhub dump change 2
+stdout '"ref": "main"'
+
+-- repo/feature1.txt --
+This is feature 1
+-- repo/feature2.txt --
+This is feature 2


### PR DESCRIPTION
Fixes a "bug" I discovered while testing my branch merge implementation where syncs could cause weird state that would mess up future merges.

- After `repo sync` deletes merged branches, surviving upstack PRs are retargeted on the forge so their base matches the updated local state
- Walks the base chain to find the nearest surviving ancestor, falling back to trunk for cycles or missing entries
- Covers multi-level deletions (e.g., A and B merged, C retargets to main)

[skip changelog]: bug fix only