### PR TITLE
git: retry on index.lock contention, set GIT_OPTIONAL_LOCKS=0

### DIFF
--- a/internal/git/cmd.go
+++ b/internal/git/cmd.go
@@ -6,7 +6,10 @@ package git
 
 import (
 	"context"
+	"errors"
 	"strings"
+	"sync"
+	"time"
 
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/xec"
@@ -30,7 +33,8 @@ func (ec *extraConfig) args() []string {
 		args = append(args, "-c", "core.editor="+ec.Editor)
 	}
 	if ec.MergeConflictStyle != "" {
-		args = append(args, "-c", "merge.conflictStyle="+ec.MergeConflictStyle)
+		args = append(args, "-c",
+			"merge.conflictStyle="+ec.MergeConflictStyle)
 	}
 	return args
 }
@@ -49,6 +53,114 @@ func (ec *extraConfig) WithArgs(cmd *xec.Cmd) *xec.Cmd {
 	return cmd.WithArgs(newArgs...)
 }
 
+// _readOnlyGitCmds is the set of git subcommands
+// that do not require write access to the index.
+// These commands receive GIT_OPTIONAL_LOCKS=0
+// to avoid contending with concurrent writers.
+var _readOnlyGitCmds = map[string]struct{}{
+	"cat-file":     {},
+	"config":       {},
+	"diff":         {},
+	"diff-files":   {},
+	"diff-index":   {},
+	"diff-tree":    {},
+	"for-each-ref": {},
+	"log":          {},
+	"ls-files":     {},
+	"ls-remote":    {},
+	"ls-tree":      {},
+	"merge-base":   {},
+	"merge-tree":   {},
+	"remote":       {},
+	"rev-list":     {},
+	"rev-parse":    {},
+	"show":         {},
+	"symbolic-ref": {},
+	"var":          {},
+	"worktree":     {},
+}
+
+// _writeGitCmds is the set of git subcommands
+// that may acquire the index lock.
+// These commands are retried on index.lock contention.
+//
+// NOTE: "rebase" is intentionally excluded.
+// A failed rebase leaves .git/rebase-merge/ state behind,
+// so blindly re-running the command produces
+// "rebase already in progress" errors.
+// Rebase index.lock recovery is handled at a higher level
+// by [Worktree.Rebase].
+var _writeGitCmds = map[string]struct{}{
+	"checkout":   {},
+	"commit":     {},
+	"pull":       {},
+	"reset":      {},
+	"stash":      {},
+	"write-tree": {},
+}
+
+// Index lock retry configuration.
+// Controlled by spice.indexLockTimeout.
+var (
+	_indexLockMu      sync.RWMutex
+	_indexLockTimeout = 5 * time.Second
+)
+
+// SetIndexLockTimeout sets the maximum time to spend
+// retrying git commands that fail due to index.lock
+// contention.
+//
+// Value semantics match git's core.filesRefLockTimeout:
+// 0 disables retry, negative retries indefinitely.
+//
+// This is typically called once from main
+// after reading spice.indexLockTimeout from git config.
+func SetIndexLockTimeout(d time.Duration) {
+	_indexLockMu.Lock()
+	defer _indexLockMu.Unlock()
+	_indexLockTimeout = d
+}
+
+func indexLockTimeout() time.Duration {
+	_indexLockMu.RLock()
+	defer _indexLockMu.RUnlock()
+	return _indexLockTimeout
+}
+
+// isIndexLockErr reports whether err indicates
+// that git could not acquire the index lock.
+func isIndexLockErr(err error) bool {
+	if strings.Contains(err.Error(), "index.lock") {
+		return true
+	}
+	var exitErr *xec.ExitError
+	if errors.As(err, &exitErr) {
+		return strings.Contains(
+			string(exitErr.Stderr), "index.lock",
+		)
+	}
+	return false
+}
+
+// firstSubcmd returns the git subcommand
+// from the argument list, or "" if none is found.
+//
+// Git global options like -c key=value and -C dir
+// that appear before the subcommand are skipped.
+func firstSubcmd(args []string) string {
+	for i := 0; i < len(args); i++ {
+		if !strings.HasPrefix(args[i], "-") {
+			return args[i]
+		}
+		// -c key=value and -C dir consume
+		// the next argument.
+		if args[i] == "-c" || args[i] == "-C" {
+			i++
+		}
+	}
+	return ""
+}
+
 // newGitCmd builds a new Git command with the given arguments.
 // The first argument is the Git subcommand to run.
 //
@@ -59,19 +171,44 @@ func (ec *extraConfig) WithArgs(cmd *xec.Cmd) *xec.Cmd {
 //
 // This allows for a nicer, less noisy UX for expected errors:
 //
-//   - if a Git command was expected to fail, and the error is never logged,
+//   - if a Git command was expected to fail,
+//     and the error is never logged,
 //     its stderr output will not be shown to the user.
-//   - if the error is logged, the stderr output will be shown to the user.
+//   - if the error is logged,
+//     the stderr output will be shown to the user.
 //   - if the program is running in verbose mode,
 //     the stderr output will always be shown to the user,
 //     but it won't be duplicated in the error message.
-func newGitCmd(ctx context.Context, log *silog.Logger, exec execer, args ...string) *xec.Cmd {
+func newGitCmd(
+	ctx context.Context,
+	log *silog.Logger,
+	exec execer,
+	args ...string,
+) *xec.Cmd {
+	subcmd := firstSubcmd(args)
 	prefix := "git"
-	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
-		prefix += " " + args[0]
+	if subcmd != "" {
+		prefix += " " + subcmd
 	}
 
-	return xec.Command(ctx, log, "git", args...).
+	cmd := xec.Command(ctx, log, "git", args...).
 		WithExecer(exec).
 		WithLogPrefix(prefix)
+
+	if _, ok := _readOnlyGitCmds[subcmd]; ok {
+		cmd.AppendEnv("GIT_OPTIONAL_LOCKS=0")
+	}
+
+	if _, ok := _writeGitCmds[subcmd]; ok {
+		timeout := indexLockTimeout()
+		if timeout != 0 {
+			cmd.WithRetry(&xec.RetryPolicy{
+				Match:     isIndexLockErr,
+				Timeout:   timeout,
+				BaseDelay: 100 * time.Millisecond,
+			})
+		}
+	}
+
+	return cmd
 }

--- a/internal/git/cmd_test.go
+++ b/internal/git/cmd_test.go
@@ -2,11 +2,15 @@ package git
 
 import (
 	"bytes"
+	"errors"
+	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/xec/xectest"
+	"go.uber.org/mock/gomock"
 )
 
 var NewMockExecer = xectest.NewMockExecer
@@ -47,4 +51,172 @@ func TestGitCmd_logPrefix(t *testing.T) {
 
 		assert.Contains(t, logBuffer.String(), " different: ")
 	})
+}
+
+func TestNewGitCmd_optionalLocks(t *testing.T) {
+	t.Run("ReadOnlyGetsOptionalLocks", func(t *testing.T) {
+		for _, subcmd := range []string{
+			"rev-parse", "merge-base", "for-each-ref",
+			"config", "log", "diff",
+		} {
+			t.Run(subcmd, func(t *testing.T) {
+				cmd := newGitCmd(
+					t.Context(), silog.Nop(),
+					_realExec, subcmd,
+				)
+				out, _ := cmd.
+					WithDir(t.TempDir()).
+					AppendEnv("GIT_OPTIONAL_LOCKS_CHECK=1").
+					OutputChomp()
+				// We can't easily inspect env,
+				// but we can verify it compiles and runs.
+				_ = out
+			})
+		}
+	})
+
+	t.Run("WriteDoesNotGetOptionalLocks", func(t *testing.T) {
+		for _, subcmd := range []string{
+			"checkout", "commit", "reset",
+		} {
+			t.Run(subcmd, func(t *testing.T) {
+				// Verify the command is constructed
+				// without error.
+				_ = newGitCmd(
+					t.Context(), silog.Nop(),
+					_realExec, subcmd,
+				)
+			})
+		}
+	})
+}
+
+func TestIsIndexLockErr(t *testing.T) {
+	t.Run("MatchesErrorString", func(t *testing.T) {
+		err := errors.New(
+			"Unable to create " +
+				"'/repo/.git/index.lock': File exists",
+		)
+		assert.True(t, isIndexLockErr(err))
+	})
+
+	t.Run("MatchesExitErrorStderr", func(t *testing.T) {
+		err := &exec.ExitError{
+			Stderr: []byte(
+				"error: Unable to create " +
+					"'/repo/.git/index.lock': " +
+					"File exists.\n",
+			),
+		}
+		assert.True(t, isIndexLockErr(err))
+	})
+
+	t.Run("DoesNotMatchUnrelated", func(t *testing.T) {
+		err := errors.New("some other error")
+		assert.False(t, isIndexLockErr(err))
+	})
+
+	t.Run("DoesNotMatchUnrelatedExitError", func(t *testing.T) {
+		err := &exec.ExitError{
+			Stderr: []byte("merge conflict\n"),
+		}
+		assert.False(t, isIndexLockErr(err))
+	})
+}
+
+// TestNewGitCmd_retryWithDashC verifies that write commands
+// preceded by -c options still get the index.lock retry policy.
+func TestNewGitCmd_retryWithDashC(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockExec := NewMockExecer(ctrl)
+
+	lockErr := errors.New(
+		"Unable to create " +
+			"'/repo/.git/index.lock': File exists",
+	)
+
+	// First attempt fails with index.lock;
+	// second attempt succeeds.
+	first := mockExec.EXPECT().
+		Run(gomock.Any()).
+		Return(lockErr)
+	mockExec.EXPECT().
+		Run(gomock.Any()).
+		After(first.Call).
+		Return(nil)
+
+	cmd := newGitCmd(
+		t.Context(), silog.Nop(), mockExec,
+		"-c", "core.editor=true", "checkout",
+	)
+	require.NoError(t, cmd.Run())
+}
+
+// TestNewGitCmd_rebaseNoGenericRetry verifies that rebase
+// does not use the generic retry mechanism.
+// Rebase recovery is handled at a higher level
+// by [Worktree.Rebase].
+func TestNewGitCmd_rebaseNoGenericRetry(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockExec := NewMockExecer(ctrl)
+
+	lockErr := errors.New(
+		"Unable to create " +
+			"'/repo/.git/index.lock': File exists",
+	)
+
+	// Only one attempt: no retry for rebase.
+	mockExec.EXPECT().
+		Run(gomock.Any()).
+		Return(lockErr)
+
+	cmd := newGitCmd(
+		t.Context(), silog.Nop(), mockExec,
+		"-c", "advice.mergeConflict=false", "rebase",
+	)
+	err := cmd.Run()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "index.lock")
+}
+
+func TestFirstSubcmd(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"Subcommand", []string{"rev-parse"}, "rev-parse"},
+		{"Flag", []string{"--version"}, ""},
+		{"Empty", nil, ""},
+		{
+			"DashC",
+			[]string{"-c", "k=v", "rebase"},
+			"rebase",
+		},
+		{
+			"DashCapitalC",
+			[]string{"-C", "/dir", "status"},
+			"status",
+		},
+		{
+			"MultipleDashC",
+			[]string{"-c", "k=v", "-c", "k2=v2", "rebase"},
+			"rebase",
+		},
+		{
+			"DashCThenFlag",
+			[]string{"-c", "k=v", "--version"},
+			"",
+		},
+		{
+			"DashCOnly",
+			[]string{"-c", "k=v"},
+			"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, firstSubcmd(tt.args))
+		})
+	}
 }

--- a/internal/git/rebase_wt.go
+++ b/internal/git/rebase_wt.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"go.abhg.dev/gs/internal/must"
 	"go.abhg.dev/gs/internal/silog"
@@ -157,10 +158,33 @@ func (w *Worktree) Rebase(ctx context.Context, req RebaseRequest) (err error) {
 
 	cmd := w.gitCmd(ctx, args...).WithLogPrefix("git rebase")
 	if req.Interactive {
-		cmd.WithStdin(os.Stdin).WithStdout(os.Stdout).WithStderr(os.Stderr)
+		cmd.WithStdin(os.Stdin).
+			WithStdout(os.Stdout).
+			WithStderr(os.Stderr)
 	}
 
 	if err := cmd.Run(); err != nil {
+		// Check if the failure was likely caused
+		// by index.lock contention.
+		// We check both the lock file on disk
+		// and the error message because:
+		//   - the lock file check works regardless
+		//     of log level (debug mode streams stderr
+		//     and doesn't capture it in the error)
+		//   - the error message check catches cases
+		//     where the lock was released before we
+		//     could check the file
+		lockPath := filepath.Join(w.gitDir, "index.lock")
+		_, lockExists := os.Stat(lockPath)
+		if lockExists == nil || isIndexLockErr(err) {
+			if contErr := w.recoverRebaseIndexLock(
+				ctx, args,
+			); contErr == nil {
+				return w.handleRebaseFinish(ctx)
+			}
+			// If recovery fails,
+			// fall through to normal error handling.
+		}
 		return w.handleRebaseError(ctx, err)
 	}
 	return w.handleRebaseFinish(ctx)
@@ -221,6 +245,108 @@ func (w *Worktree) handleRebaseFinish(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// recoverRebaseIndexLock attempts to recover
+// from an index.lock error during a rebase operation.
+//
+// When a rebase fails mid-pick because an external process
+// holds the index lock, git reschedules the pick
+// and leaves .git/rebase-merge/ state behind.
+// This method waits for the lock to be released,
+// then continues the rebase with 'git rebase --continue'.
+//
+// If the rebase failed before creating any state
+// (e.g., the lock was held during the initial checkout),
+// the original rebase command is re-run instead.
+//
+// rebaseArgs are the original arguments passed to git
+// (e.g., ["-c", "advice.mergeConflict=false", "rebase", ...]).
+//
+// Returns nil if recovery succeeds,
+// or the error from the recovery attempt if it fails
+// for reasons other than index.lock contention.
+func (w *Worktree) recoverRebaseIndexLock(
+	ctx context.Context,
+	rebaseArgs []string,
+) error {
+	lockPath := filepath.Join(w.gitDir, "index.lock")
+	timeout := indexLockTimeout()
+	if timeout == 0 {
+		return errors.New("index lock retry disabled")
+	}
+
+	baseDelay := 100 * time.Millisecond
+	var deadline time.Time
+	if timeout > 0 {
+		deadline = time.Now().Add(timeout)
+	}
+
+	for attempt := 0; ; attempt++ {
+		// Wait for the lock file to be removed.
+		delay := baseDelay << attempt
+		if timeout > 0 {
+			remaining := time.Until(deadline)
+			if remaining <= 0 {
+				return errors.New(
+					"timed out waiting for index.lock",
+				)
+			}
+			if delay > remaining {
+				delay = remaining
+			}
+		}
+
+		w.log.Debug("Waiting for index.lock to clear",
+			"attempt", attempt+1,
+			"delay", delay,
+		)
+
+		timer := time.NewTimer(delay)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		}
+
+		// Check if the lock file is still present.
+		if _, err := os.Stat(lockPath); err == nil {
+			continue // still locked
+		}
+
+		// Lock is gone. Pick recovery strategy
+		// based on whether git left rebase state.
+		var err error
+		if _, stateErr := w.RebaseState(ctx); stateErr == nil {
+			// Rebase state exists:
+			// the sequencer started but a pick failed.
+			// Continue from where it left off.
+			err = w.gitCmd(ctx, "rebase", "--continue").
+				WithLogPrefix("git rebase").
+				Run()
+		} else {
+			// No rebase state:
+			// git failed before the sequencer started
+			// (e.g., during initial checkout).
+			// Re-run the original rebase command.
+			err = w.gitCmd(ctx, rebaseArgs...).
+				WithLogPrefix("git rebase").
+				Run()
+		}
+		if err == nil {
+			return nil
+		}
+
+		// If the recovery also hit index.lock,
+		// loop back and wait again.
+		if isIndexLockErr(err) {
+			continue
+		}
+
+		// Non-lock error from recovery.
+		return err
+	}
 }
 
 // RebaseAbort aborts an ongoing rebase operation.

--- a/internal/git/rebase_wt_test.go
+++ b/internal/git/rebase_wt_test.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -385,6 +386,95 @@ func TestRebase_autostashSuccess(t *testing.T) {
 		wt.ListFilesPaths(ctx, &git.ListFilesOptions{Unmerged: true}))
 	require.NoError(t, err)
 	assert.Empty(t, unmergedFiles)
+}
+
+func TestRebase_indexLockRecovery(t *testing.T) {
+	// Verify that Rebase recovers from index.lock errors
+	// by waiting for the lock to clear
+	// and then continuing the rebase.
+	fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+		as 'Test <test@example.com>'
+		at '2024-05-21T20:30:40Z'
+
+		git init
+		git commit --allow-empty -m 'Initial commit'
+
+		git add foo.txt
+		git commit -m 'Add foo'
+
+		git checkout -b feature
+		git add bar.txt
+		git commit -m 'Add bar'
+
+		git checkout main
+		git add baz.txt
+		git commit -m 'Add baz'
+
+		-- foo.txt --
+		Contents of foo
+
+		-- bar.txt --
+		Contents of bar
+
+		-- baz.txt --
+		Contents of baz
+	`)))
+	require.NoError(t, err)
+	t.Cleanup(fixture.Cleanup)
+
+	login(t, "foo")
+
+	gitDir := filepath.Join(fixture.Dir(), ".git")
+	lockPath := filepath.Join(gitDir, "index.lock")
+
+	t.Run("LockBeforeSequencer", func(t *testing.T) {
+		// Create the lock file before the rebase starts.
+		// Git fails before the sequencer runs,
+		// so no .git/rebase-merge/ state is created.
+		// Recovery must re-run the original rebase
+		// after the lock clears.
+		require.NoError(t,
+			os.WriteFile(lockPath, nil, 0o644))
+
+		// Remove the lock after a short delay
+		// so the recovery has time to detect the error
+		// and then find the lock gone.
+		go func() {
+			time.Sleep(200 * time.Millisecond)
+			_ = os.Remove(lockPath)
+		}()
+
+		wt, err := git.OpenWorktree(
+			t.Context(), fixture.Dir(),
+			git.OpenOptions{
+				Log: silogtest.New(t),
+			},
+		)
+		require.NoError(t, err)
+
+		err = wt.Rebase(t.Context(), git.RebaseRequest{
+			Branch:   "feature",
+			Upstream: "main",
+			Quiet:    true,
+		})
+		require.NoError(t, err,
+			"rebase should recover from index.lock")
+
+		// Clean up: reset to pre-rebase state
+		// for the next subtest.
+		resetCmd := exec.Command(
+			"git", "checkout", "main",
+		)
+		resetCmd.Dir = fixture.Dir()
+		require.NoError(t, resetCmd.Run())
+
+		resetFeature := exec.Command(
+			"git", "branch", "-f", "feature",
+			"feature@{1}",
+		)
+		resetFeature.Dir = fixture.Dir()
+		_ = resetFeature.Run()
+	})
 }
 
 func login(t testing.TB, username string) (home string) {

--- a/internal/spice/config.go
+++ b/internal/spice/config.go
@@ -195,6 +195,25 @@ func LoadConfig(ctx context.Context, cfg GitConfigLister, opts ConfigOptions) (*
 	}, nil
 }
 
+// IndexLockTimeout returns the configured timeout
+// for retrying git commands that fail due to index.lock
+// contention, or -1 if not configured.
+//
+// The value is read from spice.indexLockTimeout
+// and is in milliseconds.
+// See [git.SetIndexLockTimeout] for semantics.
+func (c *Config) IndexLockTimeout() (int, bool) {
+	values := c.items["spice.indexlocktimeout"]
+	if len(values) == 0 {
+		return 0, false
+	}
+	ms, err := strconv.Atoi(values[len(values)-1])
+	if err != nil {
+		return 0, false
+	}
+	return ms, true
+}
+
 // ExperimentEnabled reports whether the given experimental feature is enabled.
 func (c *Config) ExperimentEnabled(name string) bool {
 	_, ok := c.experiments[strings.ToLower(name)]

--- a/internal/xec/cmd.go
+++ b/internal/xec/cmd.go
@@ -40,6 +40,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"go.abhg.dev/gs/internal/silog"
 )
@@ -56,6 +57,22 @@ type Cmd struct {
 
 	// Wraps an error with stderr output.
 	wrap func(error) error
+
+	// retry, if non-nil, enables automatic retry
+	// on transient failures.
+	retry *RetryPolicy
+
+	// params stores construction values
+	// needed to rebuild the command on retry.
+	params cmdParams
+}
+
+// cmdParams holds parameters needed
+// to reconstruct an [exec.Cmd] for retry.
+type cmdParams struct {
+	ctx  context.Context
+	name string
+	args []string
 }
 
 // Command constructs a Cmd to execute a program with the given arguments.
@@ -79,6 +96,11 @@ func Command(ctx context.Context, log *silog.Logger, name string, args ...string
 		log:     logger,
 		wrap:    wrap,
 		_execer: DefaultExecer,
+		params: cmdParams{
+			ctx:  ctx,
+			name: name,
+			args: append([]string(nil), args...),
+		},
 	}
 }
 
@@ -96,11 +118,80 @@ func (c *Cmd) execer() Execer {
 	return DefaultExecer
 }
 
+// WithRetry enables automatic retry
+// on transient failures matching the policy.
+//
+// Retry applies only to [Cmd.Run] and [Cmd.Output].
+// Streaming methods ([Cmd.Start], [Cmd.Scan]) are unaffected.
+func (c *Cmd) WithRetry(p *RetryPolicy) *Cmd {
+	c.retry = p
+	return c
+}
+
 // Run runs the command, blocking until it completes.
 //
 // It returns an error if the command fails with a non-zero exit code.
 func (c *Cmd) Run() error {
-	return c.wrap(c.execer().Run(c.cmd))
+	if c.retry == nil || c.retry.Timeout == 0 {
+		return c.wrap(c.execer().Run(c.cmd))
+	}
+	return c.runRetrying()
+}
+
+func (c *Cmd) runRetrying() error {
+	var deadline time.Time
+	for attempt := 0; ; attempt++ {
+		err := c.wrap(c.execer().Run(c.cmd))
+		if err == nil || !c.retry.Match(err) {
+			return err
+		}
+
+		c.log.Log(silog.LevelDebug,
+			"retrying after transient failure",
+			"attempt", attempt+1, "error", err)
+
+		// Set deadline on first matchable failure,
+		// not before execution.
+		// The command itself may run for a long time
+		// before encountering a transient error.
+		if attempt == 0 {
+			deadline = c.retryDeadline()
+		}
+		if !c.retry.backoff(c.params.ctx, attempt, deadline) {
+			return err
+		}
+		c.rebuild()
+	}
+}
+
+func (c *Cmd) retryDeadline() time.Time {
+	if c.retry.Timeout <= 0 {
+		// Negative timeout: retry indefinitely.
+		return time.Time{}
+	}
+	return c.retry.now().Add(c.retry.Timeout)
+}
+
+// rebuild reconstructs the underlying [exec.Cmd]
+// so the command can be retried.
+//
+// Only the stderr capture is rebuilt;
+// dir, env, stdin, and stdout are preserved
+// from the current command.
+func (c *Cmd) rebuild() {
+	stderr, wrap := outputLogWriter("stderr", c.log)
+	fresh := exec.CommandContext(
+		c.params.ctx,
+		c.params.name,
+		c.params.args...,
+	)
+	fresh.Dir = c.cmd.Dir
+	fresh.Env = append([]string(nil), c.cmd.Env...)
+	fresh.Stdin = c.cmd.Stdin
+	fresh.Stdout = c.cmd.Stdout
+	fresh.Stderr = stderr
+	c.cmd = fresh
+	c.wrap = wrap
 }
 
 // Start starts the command, returning immediately.
@@ -123,7 +214,37 @@ func (c *Cmd) Kill() error {
 // Output runs the command and returns its stdout.
 // It returns an error if the command fails with a non-zero exit code.
 func (c *Cmd) Output() ([]byte, error) {
-	return c.execer().Output(c.cmd)
+	if c.retry == nil || c.retry.Timeout == 0 {
+		return c.execer().Output(c.cmd)
+	}
+	return c.outputRetrying()
+}
+
+func (c *Cmd) outputRetrying() ([]byte, error) {
+	var deadline time.Time
+	for attempt := 0; ; attempt++ {
+		out, err := c.execer().Output(c.cmd)
+		if err == nil || !c.retry.Match(err) {
+			return out, err
+		}
+
+		c.log.Log(silog.LevelDebug,
+			"retrying after transient failure",
+			"attempt", attempt+1, "error", err)
+
+		// Set deadline on first matchable failure,
+		// not before execution.
+		if attempt == 0 {
+			deadline = c.retryDeadline()
+		}
+		if !c.retry.backoff(c.params.ctx, attempt, deadline) {
+			return out, err
+		}
+		// Clear stdout before rebuild because Output()
+		// sets it internally on each call.
+		c.cmd.Stdout = nil
+		c.rebuild()
+	}
 }
 
 // Args returns the arguments passed to the command,

--- a/internal/xec/retry.go
+++ b/internal/xec/retry.go
@@ -1,0 +1,67 @@
+package xec
+
+import (
+	"context"
+	"time"
+)
+
+// RetryPolicy controls retry behavior
+// for transient command failures.
+type RetryPolicy struct {
+	// Match reports whether an error
+	// is eligible for retry.
+	Match func(error) bool
+
+	// Timeout is the maximum total wall-clock time
+	// to spend retrying. 0 disables retry.
+	// Negative values retry indefinitely.
+	Timeout time.Duration
+
+	// BaseDelay is the initial delay
+	// between retry attempts.
+	// Each subsequent delay doubles.
+	BaseDelay time.Duration
+
+	// nowFunc returns the current time.
+	// Defaults to [time.Now] if nil.
+	nowFunc func() time.Time
+}
+
+func (p *RetryPolicy) now() time.Time {
+	if p.nowFunc != nil {
+		return p.nowFunc()
+	}
+	return time.Now()
+}
+
+// backoff sleeps for an exponentially increasing duration
+// based on the attempt number.
+// Returns false if the timeout has been exceeded
+// or the context was cancelled.
+func (p *RetryPolicy) backoff(
+	ctx context.Context,
+	attempt int,
+	deadline time.Time,
+) bool {
+	delay := p.BaseDelay << attempt
+
+	// Cap delay to remaining time if timeout is positive.
+	if p.Timeout > 0 {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return false
+		}
+		if delay > remaining {
+			delay = remaining
+		}
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}

--- a/internal/xec/retry_test.go
+++ b/internal/xec/retry_test.go
@@ -1,0 +1,243 @@
+package xec
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/silog"
+)
+
+func TestCmd_RunWithRetry(t *testing.T) {
+	t.Run("SucceedsFirstTry", func(t *testing.T) {
+		cmd := Command(t.Context(), silog.Nop(), "true").
+			WithRetry(&RetryPolicy{
+				Match:     func(error) bool { return true },
+				Timeout:   time.Second,
+				BaseDelay: 10 * time.Millisecond,
+			})
+
+		require.NoError(t, cmd.Run())
+	})
+
+	t.Run("RetriesOnMatch", func(t *testing.T) {
+		// First attempt fails, second succeeds.
+		attempt := 0
+		cmd := Command(t.Context(), silog.Nop(),
+			"sh", "-c", "exit 1").
+			WithRetry(&RetryPolicy{
+				Match: func(error) bool {
+					attempt++
+					return attempt <= 1
+				},
+				Timeout:   time.Second,
+				BaseDelay: 10 * time.Millisecond,
+			})
+
+		// The second attempt still runs "exit 1"
+		// so it fails, but Match returns false
+		// so it's not retried.
+		err := cmd.Run()
+		assert.Error(t, err)
+		assert.Equal(t, 2, attempt)
+	})
+
+	t.Run("NoRetryOnNonMatch", func(t *testing.T) {
+		attempt := 0
+		cmd := Command(t.Context(), silog.Nop(),
+			"sh", "-c", "exit 1").
+			WithRetry(&RetryPolicy{
+				Match: func(error) bool {
+					attempt++
+					return false
+				},
+				Timeout:   time.Second,
+				BaseDelay: 10 * time.Millisecond,
+			})
+
+		err := cmd.Run()
+		assert.Error(t, err)
+		assert.Equal(t, 1, attempt)
+	})
+
+	t.Run("ExhaustsTimeout", func(t *testing.T) {
+		attempts := 0
+		now := time.Now()
+		cmd := Command(t.Context(), silog.Nop(),
+			"sh", "-c", "exit 1").
+			WithRetry(&RetryPolicy{
+				Match: func(error) bool {
+					attempts++
+					return true
+				},
+				Timeout:   150 * time.Millisecond,
+				BaseDelay: 50 * time.Millisecond,
+				nowFunc:   func() time.Time { return now },
+			})
+
+		err := cmd.Run()
+		assert.Error(t, err)
+		// 50ms + 100ms = 150ms fills the timeout,
+		// so we expect ~3 attempts
+		// (first immediate, then 50ms, then 100ms).
+		assert.GreaterOrEqual(t, attempts, 2)
+	})
+
+	// Verifies that the retry deadline starts
+	// after the first command failure,
+	// not before command execution.
+	// A long-running command that exceeds the timeout
+	// should still get at least one retry.
+	t.Run("DeadlineStartsAfterFirstFailure", func(t *testing.T) {
+		attempts := 0
+		cmd := Command(t.Context(), silog.Nop(),
+			"sh", "-c",
+			// Sleep longer than the retry timeout,
+			// then fail.
+			"sleep 0.2; exit 1").
+			WithRetry(&RetryPolicy{
+				Match: func(error) bool {
+					attempts++
+					return true
+				},
+				// Timeout is shorter than
+				// the command's execution time.
+				Timeout:   100 * time.Millisecond,
+				BaseDelay: 10 * time.Millisecond,
+			})
+
+		err := cmd.Run()
+		assert.Error(t, err)
+		// The command itself takes 200ms,
+		// longer than the 100ms timeout.
+		// Retry must still fire at least once
+		// because the deadline is set
+		// after the first failure.
+		assert.GreaterOrEqual(t, attempts, 2,
+			"should retry even when command "+
+				"runs longer than timeout")
+	})
+
+	t.Run("RespectsContext", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		attempts := 0
+		cmd := Command(ctx, silog.Nop(),
+			"sh", "-c", "exit 1").
+			WithRetry(&RetryPolicy{
+				Match: func(error) bool {
+					attempts++
+					// Cancel after first attempt.
+					cancel()
+					return true
+				},
+				Timeout:   5 * time.Second,
+				BaseDelay: time.Second,
+			})
+
+		err := cmd.Run()
+		assert.Error(t, err)
+		assert.Equal(t, 1, attempts)
+	})
+
+	t.Run("ZeroTimeoutDisablesRetry", func(t *testing.T) {
+		attempts := 0
+		cmd := Command(t.Context(), silog.Nop(),
+			"sh", "-c", "exit 1").
+			WithRetry(&RetryPolicy{
+				Match: func(error) bool {
+					attempts++
+					return true
+				},
+				Timeout:   0,
+				BaseDelay: 10 * time.Millisecond,
+			})
+
+		err := cmd.Run()
+		assert.Error(t, err)
+		assert.Equal(t, 0, attempts)
+	})
+
+	t.Run("NegativeTimeoutRetriesIndefinitely", func(t *testing.T) {
+		attempts := 0
+		cmd := Command(t.Context(), silog.Nop(),
+			"sh", "-c", "exit 1").
+			WithRetry(&RetryPolicy{
+				Match: func(error) bool {
+					attempts++
+					// Stop matching after 3 attempts
+					// to avoid infinite loop.
+					return attempts < 3
+				},
+				Timeout:   -1,
+				BaseDelay: 10 * time.Millisecond,
+			})
+
+		err := cmd.Run()
+		assert.Error(t, err)
+		assert.Equal(t, 3, attempts)
+	})
+
+	t.Run("SucceedsAfterTransientFailure", func(t *testing.T) {
+		// Use a file to track state across processes.
+		marker := t.TempDir() + "/marker"
+		cmd := Command(t.Context(), silog.Nop(),
+			"sh", "-c",
+			// First call creates marker and fails;
+			// second call sees marker and succeeds.
+			"if [ -f "+marker+" ]; then exit 0; "+
+				"else touch "+marker+"; exit 1; fi").
+			WithRetry(&RetryPolicy{
+				Match:     func(error) bool { return true },
+				Timeout:   time.Second,
+				BaseDelay: 10 * time.Millisecond,
+			})
+
+		require.NoError(t, cmd.Run())
+	})
+}
+
+func TestCmd_OutputWithRetry(t *testing.T) {
+	t.Run("SucceedsAfterTransientFailure", func(t *testing.T) {
+		marker := t.TempDir() + "/marker"
+		cmd := Command(t.Context(), silog.Nop(),
+			"sh", "-c",
+			"if [ -f "+marker+" ]; then echo ok; exit 0; "+
+				"else touch "+marker+"; exit 1; fi").
+			WithRetry(&RetryPolicy{
+				Match:     func(error) bool { return true },
+				Timeout:   time.Second,
+				BaseDelay: 10 * time.Millisecond,
+			})
+
+		out, err := cmd.OutputChomp()
+		require.NoError(t, err)
+		assert.Equal(t, "ok", out)
+	})
+
+	t.Run("MatchesExitError", func(t *testing.T) {
+		matched := false
+		cmd := Command(t.Context(), silog.Nop(),
+			"sh", "-c",
+			"echo 'index.lock' >&2; exit 1").
+			WithRetry(&RetryPolicy{
+				Match: func(err error) bool {
+					var exitErr *exec.ExitError
+					if errors.As(err, &exitErr) {
+						matched = true
+					}
+					return false
+				},
+				Timeout:   time.Second,
+				BaseDelay: 10 * time.Millisecond,
+			})
+
+		_, err := cmd.Output()
+		assert.Error(t, err)
+		assert.True(t, matched,
+			"Match should receive *exec.ExitError")
+	})
+}

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"time"
 
 	"github.com/alecthomas/kong"
 	"github.com/charmbracelet/colorprofile"
@@ -115,6 +116,12 @@ func main() {
 	)
 	if err != nil {
 		logger.Error("Error loading spice configuration; continuing without it.", "error", err)
+	}
+
+	if ms, ok := spiceConfig.IndexLockTimeout(); ok {
+		git.SetIndexLockTimeout(
+			time.Duration(ms) * time.Millisecond,
+		)
 	}
 
 	secretStash := &secret.FallbackStash{


### PR DESCRIPTION
Fix for lockfile issues I encountered while developing a VSCode extension for git-spice. The extension makes background reads and they occasionally cause git-spice to fail. This stops advisory index lock creation for commands that don't need it, and adds backoff incase another process has created a lock.

- Read-only git commands now set GIT_OPTIONAL_LOCKS=0 to avoid contending with concurrent index lock holders
- Write commands (checkout, commit, reset, etc.) automatically retry with exponential backoff when they fail due to index.lock contention
- Rebase operations have specialized recovery that detects whether the sequencer started and either continues or re-runs the rebase after the lock clears
- New spice.indexLockTimeout config option controls retry timeout (in milliseconds; default 5s, 0 disables, negative retries indefinitely)
- Generic retry infrastructure added to xec.Cmd via RetryPolicy with match function, timeout, and exponential backoff

[skip changelog]: fix only