### PR TITLE
fix(gitlab): parse dotted glab tokens

### DIFF
--- a/.changes/unreleased/Fixed-20260404-100332.yaml
+++ b/.changes/unreleased/Fixed-20260404-100332.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'gitlab: Accept dots in glab CLI authentication tokens'
+time: 2026-04-04T10:03:32.205763-07:00

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@
 | Run all test scripts     | `mise run test:script` (use sparingly; slow)    |
 | Run specific test script | `mise run test:script --run $name`              |
 | Update test script       | `mise run test:script --run $name --update`     |
-| Add changelog entry      | `changie new --kind $kind --body $body`         |
+| Add changelog entry      | `mise run changie new --kind $kind --body $body` |
 
 ## Overview
 
@@ -97,7 +97,7 @@ unless explicitly stated otherwise:
         Ask if unsure.
 
         ```bash
-        changie new --kind $kind --body $body
+        mise run changie new --kind $kind --body $body
         ```
 
     6. Commit
@@ -318,7 +318,7 @@ Unreleased changes are stored in the .changes/unreleased directory.
 To add a changelog entry for a user-facing change, run:
 
 ```
-changie new --kind $kind --body $body
+mise run changie new --kind $kind --body $body
 ```
 
 Where:

--- a/internal/forge/gitlab/auth.go
+++ b/internal/forge/gitlab/auth.go
@@ -517,7 +517,7 @@ func (gc *glabCLI) Status(ctx context.Context, host string) (ok bool, err error)
 	return true, nil
 }
 
-var _tokenRe = regexp.MustCompile(`(?m)^\W+Token(?:\s+found)?:\s+([\w\-]+)\s*$`)
+var _tokenRe = regexp.MustCompile(`(?m)^\W+Token(?:\s+found)?:\s+([\w\.\-]+)\s*$`)
 
 // Token returns the authentication token from the GitLab CLI.
 func (gc *glabCLI) Token(ctx context.Context, host string) (string, error) {

--- a/internal/forge/gitlab/auth_test.go
+++ b/internal/forge/gitlab/auth_test.go
@@ -580,6 +580,11 @@ func TestCLITokenParsing(t *testing.T) {
 			want: "abc-def-ghi",
 		},
 		{
+			name: "Dots",
+			give: "  ✓ Token found: glpat-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.01.0xxxxxxxx\n",
+			want: "glpat-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.01.0xxxxxxxx",
+		},
+		{
 			name: "NoToken",
 			give: "  ✓ Token: \n",
 		},


### PR DESCRIPTION
Accept `glab auth status --show-token` output when the token
contains dots.

This keeps GitLab CLI authentication working for valid
`glpat-...` tokens and adds a regression test for the parser.

Fixes #1068