### PR TITLE
fix(commit-fixup): validate before autostash

### DIFF
--- a/.changes/unreleased/Fixed-20260404-100430.yaml
+++ b/.changes/unreleased/Fixed-20260404-100430.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'commit fixup: Preserve unstaged worktree changes when rejecting an empty index.'
+time: 2026-04-04T10:04:30.828139-07:00

--- a/commit_fixup.go
+++ b/commit_fixup.go
@@ -89,24 +89,6 @@ func (cmd *commitFixupCmd) Run(
 		return fmt.Errorf("determine current branch: %w", err)
 	}
 
-	cleanup, err := autostashHandler.BeginAutostash(ctx, &autostash.Options{
-		Message:   "git-spice: autostash before commit fixup",
-		ResetMode: autostash.ResetWorktree,
-		Branch:    currentBranch,
-	})
-	if err != nil {
-		return err
-	}
-
-	defer func() {
-		if retErr == nil {
-			if err := wt.CheckoutBranch(ctx, currentBranch); err != nil {
-				retErr = fmt.Errorf("restore original branch %q: %w", currentBranch, err)
-			}
-		}
-		cleanup(&retErr)
-	}()
-
 	var (
 		commitHash   git.Hash
 		commitBranch string
@@ -132,6 +114,57 @@ func (cmd *commitFixupCmd) Run(
 		}
 	}
 	must.NotBeBlankf(commitHash, "commit hash not specified, nor set in prompt")
+
+	head, err := wt.Head(ctx)
+	if err != nil {
+		return fmt.Errorf("determine HEAD: %w", err)
+	}
+
+	// Target commit must be an ancestor of HEAD.
+	if !repo.IsAncestor(ctx, commitHash, head) {
+		log.Errorf("Target commit (%v) is not reachable from HEAD (%v)", commitHash, head)
+		return errors.New("fixup commit must be an ancestor of HEAD")
+	}
+
+	// But it must be more recent than trunk.
+	//
+	// TODO:
+	// Non-restack version of this command that works for detached HEAD
+	// would also support fixing up commits that are already in trunk.
+	if trunkHash, err := repo.PeelToCommit(ctx, svc.Trunk()); err == nil {
+		if repo.IsAncestor(ctx, commitHash, trunkHash) {
+			log.Errorf("Target commit (%v) is already in trunk (%v)", commitHash, trunkHash)
+			return errors.New("cannot fixup a commit that has been merged into trunk")
+		}
+	}
+
+	// There must be something to commit.
+	if diff, err := wt.DiffIndex(ctx, head.String()); err != nil {
+		return fmt.Errorf("diff index: %w", err)
+	} else if len(diff) == 0 {
+		return errors.New("no changes staged for commit")
+	}
+
+	// Delay autostash until validation is complete so that
+	// rejections leave unstaged worktree changes untouched.
+	cleanup, err := autostashHandler.BeginAutostash(ctx, &autostash.Options{
+		Message:   "git-spice: autostash before commit fixup",
+		ResetMode: autostash.ResetWorktree,
+		Branch:    currentBranch,
+	})
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if retErr == nil {
+			if err := wt.CheckoutBranch(ctx, currentBranch); err != nil {
+				retErr = fmt.Errorf("restore original branch %q: %w", currentBranch, err)
+			}
+		}
+		cleanup(&retErr)
+	}()
+
 	req := &fixup.Request{
 		Options:      &cmd.Options,
 		TargetHash:   commitHash,

--- a/internal/handler/fixup/handler.go
+++ b/internal/handler/fixup/handler.go
@@ -77,6 +77,9 @@ type Options struct {
 // Request holds parameters for fixing up a commit.
 type Request struct {
 	// TargetHash is the commit to fixup with the staged changes.
+	//
+	// The caller must already have verified that this commit
+	// is reachable from HEAD and has not already been merged into trunk.
 	TargetHash git.Hash // required
 
 	// TargetBranch is the branch that [TargetHash] belongs to.
@@ -85,6 +88,9 @@ type Request struct {
 	TargetBranch string // optional
 
 	// HeadBranch is the current branch.
+	//
+	// The caller must already have verified that HEAD has staged changes
+	// to apply to TargetHash.
 	HeadBranch string // required
 
 	Options *Options // optional
@@ -98,31 +104,6 @@ func (h *Handler) FixupCommit(ctx context.Context, req *Request) error {
 	head, err := h.Worktree.Head(ctx)
 	if err != nil {
 		return fmt.Errorf("determine HEAD: %w", err)
-	}
-
-	// Target commit must be an ancestor of HEAD.
-	if !h.Repository.IsAncestor(ctx, req.TargetHash, head) {
-		h.Log.Errorf("Target commit (%v) is not reachable from HEAD (%v)", req.TargetHash, head)
-		return errors.New("fixup commit must be an ancestor of HEAD")
-	}
-
-	// But it must be more recent than trunk.
-	//
-	// TODO:
-	// Non-restack version of this command that works for detached HEAD
-	// would also support fixing up commits that are already in trunk.
-	if trunkHash, err := h.Repository.PeelToCommit(ctx, h.Service.Trunk()); err == nil {
-		if h.Repository.IsAncestor(ctx, req.TargetHash, trunkHash) {
-			h.Log.Errorf("Target commit (%v) is already in trunk (%v)", req.TargetHash, trunkHash)
-			return errors.New("cannot fixup a commit that has been merged into trunk")
-		}
-	}
-
-	// There must be something to commit.
-	if diff, err := h.Worktree.DiffIndex(ctx, head.String()); err != nil {
-		return fmt.Errorf("diff index: %w", err)
-	} else if len(diff) == 0 {
-		return errors.New("no changes staged for commit")
 	}
 
 	// If a branch name is not provided,

--- a/internal/handler/fixup/handler_test.go
+++ b/internal/handler/fixup/handler_test.go
@@ -41,8 +41,8 @@ func TestFixupCommit_errors(t *testing.T) {
 		assert.ErrorContains(t, err, "determine HEAD")
 	})
 
-	// Target commit is not an ancestor of HEAD.
-	t.Run("TargetNotAncestor", func(t *testing.T) {
+	// Error reading the target commit.
+	t.Run("ReadTargetCommitError", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 
 		mockWorktree := NewMockGitWorktree(mockCtrl)
@@ -52,8 +52,8 @@ func TestFixupCommit_errors(t *testing.T) {
 
 		mockRepo := NewMockGitRepository(mockCtrl)
 		mockRepo.EXPECT().
-			IsAncestor(gomock.Any(), git.Hash("abc123"), git.Hash("def456")).
-			Return(false)
+			ReadCommit(gomock.Any(), "abc123").
+			Return(nil, assert.AnError)
 
 		err := (&Handler{
 			Log:        silogtest.New(t),
@@ -67,11 +67,43 @@ func TestFixupCommit_errors(t *testing.T) {
 			HeadBranch:   "feat2",
 		})
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "fixup commit must be an ancestor of HEAD")
+		assert.ErrorContains(t, err, "read target commit")
 	})
 
-	// Target commit is on the trunk branch.
-	t.Run("AlreadyOnTrunk", func(t *testing.T) {
+	// Error writing the staged changes to a tree.
+	t.Run("WriteIndexTreeError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+
+		mockWorktree := NewMockGitWorktree(mockCtrl)
+		mockWorktree.EXPECT().
+			Head(gomock.Any()).
+			Return("def456", nil)
+		mockWorktree.EXPECT().
+			WriteIndexTree(gomock.Any()).
+			Return(git.Hash(""), assert.AnError)
+
+		mockRepo := NewMockGitRepository(mockCtrl)
+		mockRepo.EXPECT().
+			ReadCommit(gomock.Any(), "abc123").
+			Return(&git.CommitObject{}, nil)
+
+		err := (&Handler{
+			Log:        silogtest.New(t),
+			Restack:    NewMockRestackHandler(mockCtrl),
+			Worktree:   mockWorktree,
+			Repository: mockRepo,
+			Service:    NewMockService(mockCtrl),
+		}).FixupCommit(t.Context(), &Request{
+			TargetHash:   "abc123",
+			TargetBranch: "feat1",
+			HeadBranch:   "feat2",
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "write staged changes to tree")
+	})
+
+	// Error loading the branch graph if the target branch must be inferred.
+	t.Run("BranchGraphError", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 
 		mockWorktree := NewMockGitWorktree(mockCtrl)
@@ -81,122 +113,51 @@ func TestFixupCommit_errors(t *testing.T) {
 
 		mockService := NewMockService(mockCtrl)
 		mockService.EXPECT().
-			Trunk().
-			Return("main").
-			AnyTimes()
-
-		mockRepo := NewMockGitRepository(mockCtrl)
-		mockRepo.EXPECT().
-			IsAncestor(gomock.Any(), git.Hash("abc123"), git.Hash("def456")).
-			Return(true)
-		mockRepo.EXPECT().
-			PeelToCommit(gomock.Any(), "main").
-			Return(git.Hash("789abc"), nil)
-		mockRepo.EXPECT().
-			IsAncestor(gomock.Any(), git.Hash("abc123"), git.Hash("789abc")).
-			Return(true)
-
-		err := (&Handler{
-			Log:        silogtest.New(t),
-			Restack:    NewMockRestackHandler(mockCtrl),
-			Worktree:   mockWorktree,
-			Repository: mockRepo,
-			Service:    mockService,
-		}).FixupCommit(t.Context(), &Request{
-			TargetHash:   "abc123",
-			TargetBranch: "feat1",
-			HeadBranch:   "feat2",
-		})
-		require.Error(t, err)
-		assert.ErrorContains(t, err, "cannot fixup a commit that has been merged into trunk")
-	})
-
-	// No changes staged for commit.
-	t.Run("NoStagedChanges", func(t *testing.T) {
-		mockCtrl := gomock.NewController(t)
-
-		mockWorktree := NewMockGitWorktree(mockCtrl)
-		mockWorktree.EXPECT().
-			Head(gomock.Any()).
-			Return("def456", nil)
-		mockWorktree.EXPECT().
-			DiffIndex(gomock.Any(), "def456").
-			Return([]git.FileStatus{}, nil)
-
-		mockService := NewMockService(mockCtrl)
-		mockService.EXPECT().
-			Trunk().
-			Return("main").
-			AnyTimes()
-
-		mockRepo := NewMockGitRepository(mockCtrl)
-		mockRepo.EXPECT().
-			IsAncestor(gomock.Any(), git.Hash("abc123"), git.Hash("def456")).
-			Return(true)
-		mockRepo.EXPECT().
-			PeelToCommit(gomock.Any(), "main").
-			Return(git.Hash("789abc"), nil)
-		mockRepo.EXPECT().
-			IsAncestor(gomock.Any(), git.Hash("abc123"), git.Hash("789abc")).
-			Return(false)
-
-		err := (&Handler{
-			Log:        silogtest.New(t),
-			Restack:    NewMockRestackHandler(mockCtrl),
-			Worktree:   mockWorktree,
-			Repository: mockRepo,
-			Service:    mockService,
-		}).FixupCommit(t.Context(), &Request{
-			TargetHash:   "abc123",
-			TargetBranch: "feat1",
-			HeadBranch:   "feat2",
-		})
-		require.Error(t, err)
-		assert.ErrorContains(t, err, "no changes staged for commit")
-	})
-
-	// Error diffing index.
-	t.Run("DiffIndexError", func(t *testing.T) {
-		mockCtrl := gomock.NewController(t)
-
-		mockWorktree := NewMockGitWorktree(mockCtrl)
-		mockWorktree.EXPECT().
-			Head(gomock.Any()).
-			Return("def456", nil)
-		mockWorktree.EXPECT().
-			DiffIndex(gomock.Any(), "def456").
+			BranchGraph(gomock.Any(), nil).
 			Return(nil, assert.AnError)
 
+		err := (&Handler{
+			Log:        silogtest.New(t),
+			Restack:    NewMockRestackHandler(mockCtrl),
+			Worktree:   mockWorktree,
+			Repository: NewMockGitRepository(mockCtrl),
+			Service:    mockService,
+		}).FixupCommit(t.Context(), &Request{
+			TargetHash:   "abc123",
+			TargetBranch: "",
+			HeadBranch:   "feat2",
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "fetch branch graph")
+	})
+
+	// Error identifying the target branch from the graph.
+	t.Run("FindCommitBranchError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+
+		mockWorktree := NewMockGitWorktree(mockCtrl)
+		mockWorktree.EXPECT().
+			Head(gomock.Any()).
+			Return("def456", nil)
+
 		mockService := NewMockService(mockCtrl)
 		mockService.EXPECT().
-			Trunk().
-			Return("main").
-			AnyTimes()
-
-		mockRepo := NewMockGitRepository(mockCtrl)
-		mockRepo.EXPECT().
-			IsAncestor(gomock.Any(), git.Hash("abc123"), git.Hash("def456")).
-			Return(true)
-		mockRepo.EXPECT().
-			PeelToCommit(gomock.Any(), "main").
-			Return(git.Hash("789abc"), nil)
-		mockRepo.EXPECT().
-			IsAncestor(gomock.Any(), git.Hash("abc123"), git.Hash("789abc")).
-			Return(false)
+			BranchGraph(gomock.Any(), nil).
+			Return(&spice.BranchGraph{}, nil)
 
 		err := (&Handler{
 			Log:        silogtest.New(t),
 			Restack:    NewMockRestackHandler(mockCtrl),
 			Worktree:   mockWorktree,
-			Repository: mockRepo,
+			Repository: NewMockGitRepository(mockCtrl),
 			Service:    mockService,
 		}).FixupCommit(t.Context(), &Request{
 			TargetHash:   "abc123",
-			TargetBranch: "feat1",
+			TargetBranch: "",
 			HeadBranch:   "feat2",
 		})
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "diff index")
+		assert.ErrorContains(t, err, "try using the prompt to select a commit")
 	})
 }
 

--- a/testdata/script/issue1059_commit_fixup_empty_index_preserves_unstaged.txt
+++ b/testdata/script/issue1059_commit_fixup_empty_index_preserves_unstaged.txt
@@ -1,0 +1,53 @@
+# Regression test for https://github.com/abhinav/git-spice/issues/1059
+#
+# If 'gs commit fixup' is run with no staged changes
+# but with unstaged changes in the worktree,
+# it must report the empty-index error
+# without discarding the unstaged edits.
+
+[!git:2.45.0] skip # feature requires git 2.45
+
+as 'Test <test@example.com>'
+at '2026-03-12T21:50:00Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+git config spice.experiment.commitFixup true
+
+# Create main -> next.
+git add initial.txt
+gs cc -m 'initial commit'
+
+git add next.txt
+gs bc next -m 'next'
+
+# Leave an edit unstaged.
+cp $WORK/extra/next_dirty.txt next.txt
+git status --porcelain
+cmp stdout $WORK/golden/status_before.txt
+
+# Fixup should reject the empty index,
+# and must not discard the unstaged change.
+! gs commit fixup HEAD
+stderr 'no changes staged for commit'
+
+git status --porcelain
+cmp stdout $WORK/golden/status_after.txt
+cmp next.txt $WORK/extra/next_dirty.txt
+
+git stash list
+cmp stdout $WORK/golden/stash_list.txt
+
+-- repo/initial.txt --
+initial file
+-- repo/next.txt --
+next file
+-- extra/next_dirty.txt --
+update file
+-- golden/status_before.txt --
+ M next.txt
+-- golden/status_after.txt --
+ M next.txt
+-- golden/stash_list.txt --


### PR DESCRIPTION
Move the `commit fixup` eligibility checks into `commit_fixup.Run`
so the command can reject empty-index requests before it starts
an autostash session.

This changes the boundary between the command and the handler.
`Run` now performs the last validation that can fail safely,
while the fixup handler assumes the request is already eligible
and focuses on the rewrite path.

That ordering is required to resolve issue #1059.
Previously, the empty-index check ran only after autostash had
already reset the worktree, which made unstaged edits disappear
from the checkout before the command returned the rejection.

Add a script regression for that case and keep the existing
fixup coverage green after the validation move.

Resolves #1059