### PR TITLE
fix(rebase): report probe failures

### DIFF
--- a/.changes/unreleased/Fixed-20260404-111906.yaml
+++ b/.changes/unreleased/Fixed-20260404-111906.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'restack: Failures during an internal `git ls-files` check are now reported with a clearer error message instead of an unhelpful unmerged-file report.'
+time: 2026-04-04T11:19:06.350853-07:00

--- a/internal/git/files_wt_test.go
+++ b/internal/git/files_wt_test.go
@@ -104,6 +104,72 @@ func TestListFilesPaths_unmerged(t *testing.T) {
 	})
 }
 
+func TestListFilesPaths_unmergedSpecialCharacters(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping test on Windows")
+	}
+
+	fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+		as 'Test <test@example.com>'
+		at '2025-06-21T09:27:19Z'
+
+		git init
+		mv just-blank.txt ' '
+		git add ' '
+		git add 'file with spaces.txt'
+		git commit -m 'Initial commit'
+
+		git checkout -b feature
+		cp $WORK/blank-feature.txt ' '
+		cp $WORK/spaces-feature.txt 'file with spaces.txt'
+		git add ' '
+		git add 'file with spaces.txt'
+		git commit -m 'Feature changes'
+
+		git checkout main
+		cp $WORK/blank-main.txt ' '
+		cp $WORK/spaces-main.txt 'file with spaces.txt'
+		git add ' '
+		git add 'file with spaces.txt'
+		git commit -m 'Main changes'
+
+		! git merge feature
+
+		-- just-blank.txt --
+		base blank file
+
+		-- file with spaces.txt --
+		base spaced file
+
+		-- blank-feature.txt --
+		feature blank file
+
+		-- blank-main.txt --
+		main blank file
+
+		-- spaces-feature.txt --
+		feature spaced file
+
+		-- spaces-main.txt --
+		main spaced file
+	`)))
+	require.NoError(t, err)
+	t.Cleanup(fixture.Cleanup)
+
+	wt, err := git.OpenWorktree(t.Context(), fixture.Dir(), git.OpenOptions{
+		Log: silogtest.New(t),
+	})
+	require.NoError(t, err)
+
+	paths, err := sliceutil.CollectErr(
+		wt.ListFilesPaths(t.Context(), &git.ListFilesOptions{Unmerged: true}))
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []string{" ", "file with spaces.txt"}, paths)
+}
+
 func TestListFilesPaths_specialCharacters(t *testing.T) {
 	t.Parallel()
 

--- a/internal/git/main_test.go
+++ b/internal/git/main_test.go
@@ -1,6 +1,10 @@
-package git_test
+package git
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/rogpeppe/go-internal/testscript"
@@ -8,6 +12,23 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	name := filepath.Base(os.Args[0])
+	if runtime.GOOS == "windows" {
+		name = strings.TrimSuffix(strings.ToLower(name), ".exe")
+	}
+
+	if name == "git" {
+		switch os.Getenv("GIT_ISSUE_1083_HELPER") {
+		case "1":
+			gitIssue1083()
+			os.Exit(0)
+		default:
+			_, _ = os.Stderr.WriteString(
+				"fake git invoked without configured helper mode\n")
+			os.Exit(1)
+		}
+	}
+
 	testscript.Main(m, map[string]func(){
 		// mockedit <input>:
 		"mockedit": mockedit.Main,

--- a/internal/git/rebase_wt.go
+++ b/internal/git/rebase_wt.go
@@ -12,6 +12,7 @@ import (
 
 	"go.abhg.dev/gs/internal/must"
 	"go.abhg.dev/gs/internal/silog"
+	"go.abhg.dev/gs/internal/sliceutil"
 	"go.abhg.dev/gs/internal/xec"
 )
 
@@ -94,7 +95,7 @@ type RebaseRequest struct {
 
 // Rebase runs a git rebase operation with the specified parameters.
 // It returns [RebaseInterruptError] for known rebase interruptions,
-func (w *Worktree) Rebase(ctx context.Context, req RebaseRequest) (err error) {
+func (w *Worktree) Rebase(ctx context.Context, req RebaseRequest) (retErr error) {
 	args := []string{
 		// Never include advice on how to resolve merge conflicts.
 		// We'll do that ourselves.
@@ -115,13 +116,15 @@ func (w *Worktree) Rebase(ctx context.Context, req RebaseRequest) (err error) {
 		// So we need to check if we're left with any unmerged files
 		// separately and fail the operation if so.
 		defer func() {
-			if err != nil {
+			if retErr != nil {
 				return
 			}
 
-			var unmergedFiles []string
-			for path := range w.ListFilesPaths(ctx, &ListFilesOptions{Unmerged: true}) {
-				unmergedFiles = append(unmergedFiles, path)
+			unmergedFiles, err := sliceutil.CollectErr(
+				w.ListFilesPaths(ctx, &ListFilesOptions{Unmerged: true}))
+			if err != nil {
+				retErr = fmt.Errorf("list unmerged files: %w", err)
+				return
 			}
 			if len(unmergedFiles) == 0 {
 				return
@@ -136,7 +139,7 @@ func (w *Worktree) Rebase(ctx context.Context, req RebaseRequest) (err error) {
 			w.log.Error("Resolve the conflict and run 'git stash drop' to remove the stash entry.")
 			w.log.Error("Or change to a branch where the stash can apply, and run 'git stash pop'.")
 
-			err = fmt.Errorf("%v: dirty changes could not be re-applied", req.Branch)
+			retErr = fmt.Errorf("%v: dirty changes could not be re-applied", req.Branch)
 		}()
 	}
 	if req.Quiet {

--- a/internal/git/rebase_wt_int_test.go
+++ b/internal/git/rebase_wt_int_test.go
@@ -1,0 +1,86 @@
+package git
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/silog"
+)
+
+// TestRebase_issue1083_lsFilesError covers
+// https://github.com/abhinav/git-spice/issues/1083.
+//
+// If the post-rebase 'git ls-files --unmerged' probe fails,
+// Rebase must surface that probe error directly.
+// Before the fix, the iterator error was ignored,
+// and the zero-value path was treated like a real file.
+// That produced a blank bullet in the user-facing conflict report.
+func TestRebase_issue1083_lsFilesError(t *testing.T) {
+	installFakeGit(t)
+	t.Setenv("GIT_ISSUE_1083_HELPER", "1")
+
+	var logBuf bytes.Buffer
+	log := silog.New(&logBuf, nil)
+
+	_, wt := NewFakeRepositoryWithLogger(t, "", _realExec, log)
+
+	err := wt.Rebase(t.Context(), RebaseRequest{
+		Branch:    "feature",
+		Upstream:  "main",
+		Autostash: true,
+	})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "list unmerged files")
+	assert.ErrorContains(t, err, "git ls-files")
+	assert.NotErrorAs(t, err, new(*RebaseInterruptError))
+	assert.NotContains(t, err.Error(), "dirty changes could not be re-applied")
+	assert.Empty(t, logBuf.String())
+}
+
+func gitIssue1083() {
+	subcommand := ""
+	for i := 1; i < len(os.Args); i++ {
+		if os.Args[i] == "-c" {
+			i++
+			continue
+		}
+		subcommand = os.Args[i]
+		break
+	}
+
+	switch subcommand {
+	case "rebase":
+		// Skip the real rebase machinery.
+		// This test only exercises failure in the follow-up ls-files probe.
+		return
+	case "ls-files":
+		fmt.Fprintln(os.Stderr, "fatal: synthetic ls-files failure")
+		os.Exit(1)
+	default:
+		fmt.Fprintf(os.Stderr, "unexpected git command %q: %v\n",
+			subcommand, os.Args)
+		os.Exit(1)
+	}
+}
+
+func installFakeGit(t testing.TB) {
+	t.Helper()
+
+	dir := t.TempDir()
+	exe, err := os.Executable()
+	require.NoError(t, err)
+
+	name := "git"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	require.NoError(t, os.Symlink(exe, filepath.Join(dir, name)))
+
+	t.Setenv("PATH", dir+string(filepath.ListSeparator)+os.Getenv("PATH"))
+}

--- a/internal/git/repo_test.go
+++ b/internal/git/repo_test.go
@@ -9,11 +9,21 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.abhg.dev/gs/internal/git/gittest"
+	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/silog/silogtest"
 	"go.abhg.dev/gs/internal/text"
 )
 
 func NewFakeRepository(t testing.TB, dir string, execer execer) (*Repository, *Worktree) {
+	return NewFakeRepositoryWithLogger(t, dir, execer, nil)
+}
+
+func NewFakeRepositoryWithLogger(
+	t testing.TB,
+	dir string,
+	execer execer,
+	log *silog.Logger,
+) (*Repository, *Worktree) {
 	if dir == "" {
 		dir = t.TempDir()
 	}
@@ -24,8 +34,12 @@ func NewFakeRepository(t testing.TB, dir string, execer execer) (*Repository, *W
 		}
 	}
 
-	repo := newRepository(gitDir, silogtest.New(t), execer)
-	wt := newWorktree(gitDir, dir, repo, silogtest.New(t), execer)
+	if log == nil {
+		log = silogtest.New(t)
+	}
+
+	repo := newRepository(gitDir, log, execer)
+	wt := newWorktree(gitDir, dir, repo, log, execer)
 	return repo, wt
 }
 


### PR DESCRIPTION
When restack hit this path, users saw a misleading
unmerged-file error report with no useful file name,
even though the underlying failure came from a follow-up
`git ls-files` probe after rebase.

Surface that probe failure directly and add regression
coverage for the case. The exact reason `git ls-files`
fails in the original report is still unknown.

Resolves #1083