### PR TITLE
release: Add Homebrew skip flag

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: false
         type: boolean
+      skip_homebrew:
+        description: Skip the Homebrew formula bump step.
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -127,6 +132,7 @@ jobs:
 
     - name: Update Homebrew Formula
       uses: dawidd6/action-homebrew-bump-formula@v7
+      if: inputs.skip_homebrew == false
       with:
         token: ${{ secrets.ROBOT_PAT }}
         user_name: Abhinav Gupta


### PR DESCRIPTION
Allow `publish-release` to run without the Homebrew
formula bump step.
This supports release operations where the workflow should
publish artifacts without updating the tap in the same run.