### PR TITLE
fix(github): correct PAT permission guidance

### DIFF
--- a/.changes/unreleased/Fixed-20260406-090004.yaml
+++ b/.changes/unreleased/Fixed-20260406-090004.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'github: Fix the advertised permission scopes for fine-grained personal access token authentication'
+time: 2026-04-06T09:00:04.940807-07:00

--- a/internal/forge/github/auth.go
+++ b/internal/forge/github/auth.go
@@ -327,7 +327,8 @@ func patDesc(theme ui.Theme, focused bool) string {
 	return text.Dedentf(`
 	Enter a classic or fine-grained Personal Access Token generated from %[1]s.
 	Classic tokens need at least one of the following scopes: %[2]s or %[3]s.
-	Fine-grained tokens need read/write access to Repository %[4]s and %[5]s.
+	Fine-grained tokens need read/write access to Repository %[4]s and %[5]s,
+	and read-only access to Organization %[6]s.
 	You can use this method if you do not have the ability to install a GitHub or OAuth App on your repositories.
 	`,
 		urlStyle.Render(theme, "https://github.com/settings/tokens"),
@@ -335,6 +336,7 @@ func patDesc(theme ui.Theme, focused bool) string {
 		scopeStyle.Render(theme, "public_repo"),
 		scopeStyle.Render(theme, "Contents"),
 		scopeStyle.Render(theme, "Pull requests"),
+		scopeStyle.Render(theme, "Members"),
 	)
 }
 

--- a/internal/forge/github/auth_test.go
+++ b/internal/forge/github/auth_test.go
@@ -225,7 +225,8 @@ func TestSelectAuthenticator(t *testing.T) {
   Classic tokens need at least one of the following scopes: repo or
   public_repo.
   Fine-grained tokens need read/write access to Repository Contents and Pull
-  requests.
+  requests,
+  and read-only access to Organization Members.
   You can use this method if you do not have the ability to install a GitHub
   or OAuth App on your repositories.
 
@@ -267,7 +268,8 @@ func TestSelectAuthenticator(t *testing.T) {
   Classic tokens need at least one of the following scopes: repo or
   public_repo.
   Fine-grained tokens need read/write access to Repository Contents and Pull
-  requests.
+  requests,
+  and read-only access to Organization Members.
   You can use this method if you do not have the ability to install a GitHub
   or OAuth App on your repositories.
 
@@ -320,7 +322,8 @@ func TestAuthenticationFlow_PAT(t *testing.T) {
   Classic tokens need at least one of the following scopes: repo or
   public_repo.
   Fine-grained tokens need read/write access to Repository Contents and Pull
-  requests.
+  requests,
+  and read-only access to Organization Members.
   You can use this method if you do not have the ability to install a GitHub
   or OAuth App on your repositories.
 


### PR DESCRIPTION
Update the GitHub personal access token prompt to advertise
all required fine-grained token permissions for
fine-grained personal access tokens.

Resolves #1070.