### PR TITLE
fix(submit): honor upstream intent on resubmit

### DIFF
--- a/.changes/unreleased/Fixed-20260406-100211.yaml
+++ b/.changes/unreleased/Fixed-20260406-100211.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'submit: Respect renamed branch upstream changes when recreating a closed change request.'
+time: 2026-04-06T10:02:11.010247-07:00

--- a/internal/handler/submit/handler.go
+++ b/internal/handler/submit/handler.go
@@ -516,24 +516,12 @@ func (h *Handler) submitBranch(
 		return status, fmt.Errorf("get remote: %w", err)
 	}
 
-	// TODO:
-	// Encapsulate (localBranch, upstreamBranch) in a struct.
-
 	// Prefer the upstream branch name stored in the data store if available.
 	// This is how we account for branches that have been renamed after submitting.
-	upstreamBranch := branch.UpstreamBranch
-	if upstreamBranch == "" {
-		// If the branch doesn't have an upstream branch name,
-		// but has been manually pushed with an upstream branch name
-		// to the same remote, use that.
-		if upstream, err := h.Repository.BranchUpstream(ctx, branchToSubmit); err == nil {
-			// origin/branch -> branch
-			if b, ok := strings.CutPrefix(upstream, remote+"/"); ok {
-				upstreamBranch = b
-				log.Infof("%v: Using upstream name '%v'", branchToSubmit, upstreamBranch)
-				log.Infof("%v: If this is incorrect, cancel this operation and run 'git branch --unset-upstream %v'.", branchToSubmit, branchToSubmit)
-			}
-		}
+	storedUpstream := branch.UpstreamBranch
+	upstreamBranch, err := h.resolveUpstreamBranch(ctx, remote, branchToSubmit, storedUpstream)
+	if err != nil {
+		return status, fmt.Errorf("resolve upstream branch: %w", err)
 	}
 
 	// Similarly, if the branch's base has a different name upstream,
@@ -673,6 +661,16 @@ func (h *Handler) submitBranch(
 			}
 
 			log.Infof("%v: Ignoring CR %v as it was %s: %v", branchToSubmit, change.ID, state, change.URL)
+			// A closed CR means the previously recorded upstream branch name
+			// may no longer reflect the user's intent for a replacement CR.
+			// Re-read the branch's current upstream configuration and prefer it
+			// over the stored upstream branch name for the new submission.
+			upstreamBranch, err = h.resolveUpstreamBranch(ctx, remote, branchToSubmit, "")
+			if err != nil {
+				upstreamBranch = cmp.Or(storedUpstream, branchToSubmit)
+			} else if upstreamBranch == "" {
+				upstreamBranch = branchToSubmit
+			}
 			// TODO:
 			// We could offer to reopen the CR if it was closed,
 			// but not if it was merged.
@@ -1028,6 +1026,46 @@ func (h *Handler) submitBranch(
 	}
 
 	return status, nil
+}
+
+// resolveUpstreamBranch determines the effective upstream branch name to use
+// for submission.
+//
+// Precedence order:
+//  1. A stored upstream branch name recorded in git-spice state.
+//  2. The current Git upstream branch, if it points to the selected remote.
+//  3. No upstream branch name.
+func (h *Handler) resolveUpstreamBranch(
+	ctx context.Context,
+	remote string,
+	branch string,
+	storedUpstream string,
+) (string, error) {
+	// Stored upstream branch state wins because it reflects the branch name
+	// previously used for submission, even if the local branch was renamed.
+	if storedUpstream != "" {
+		return storedUpstream, nil
+	}
+
+	// Otherwise, fall back to the branch's current Git upstream, but only
+	// if it points at the remote we are submitting to.
+	upstream, err := h.Repository.BranchUpstream(ctx, branch)
+	if err != nil {
+		if errors.Is(err, git.ErrNotExist) {
+			// No upstream configured.
+			return "", nil
+		}
+		return "", err
+	}
+
+	if b, ok := strings.CutPrefix(upstream, remote+"/"); ok {
+		h.Log.Infof("%v: Using upstream name '%v'", branch, b)
+		h.Log.Infof("%v: If this is incorrect, cancel this operation and run 'git branch --unset-upstream %v'.", branch, branch)
+		return b, nil
+	}
+
+	// Ignore upstreams that point to a different remote.
+	return "", nil
 }
 
 func (h *Handler) prepareBranch(

--- a/testdata/script/issue1041_stack_submit_closed_pr_renamed_branch_immediate.txt
+++ b/testdata/script/issue1041_stack_submit_closed_pr_renamed_branch_immediate.txt
@@ -1,0 +1,63 @@
+# Resubmitting a renamed branch with a closed PR immediately
+# reuses the old remote branch name.
+#
+# https://github.com/abhinav/git-spice/issues/1041
+
+as 'Test <test@example.com>'
+at '2024-09-04T05:06:07Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+git add feat1.txt
+gs bc -m 'Add feature 1' feat1
+gs ss --fill
+stderr 'Created #1'
+
+# Close the PR, rename the branch, and submit again immediately.
+shamhub reject alice/example 1
+gs branch rename feat1-renamed
+
+gs ss --fill
+stderr 'Ignoring CR #1 as it was closed'
+stderr 'Created #2'
+
+shamhub dump change 2
+cmpenvJSON stdout $WORK/golden/change-2.json
+
+-- repo/feat1.txt --
+Contents of feature 1
+-- golden/change-2.json --
+{
+  "number": 2,
+  "html_url": "$SHAMHUB_URL/alice/example/change/2",
+  "state": "open",
+  "title": "Add feature 1",
+  "body": "",
+  "base": {
+    "repository": {
+      "owner": "alice",
+      "name": "example"
+    },
+    "ref": "main",
+    "sha": "c649f748239dea65932c853775c6121d7cc79029"
+  },
+  "head": {
+    "repository": {
+      "owner": "alice",
+      "name": "example"
+    },
+    "ref": "feat1",
+    "sha": "11aef079d2994b11b4349ee4c7e2f8502ba3586c"
+  }
+}

--- a/testdata/script/issue1041_stack_submit_closed_pr_renamed_branch_new_upstream.txt
+++ b/testdata/script/issue1041_stack_submit_closed_pr_renamed_branch_new_upstream.txt
@@ -1,0 +1,64 @@
+# Resubmitting a renamed branch with a closed PR after pushing to a new
+# upstream should use the new branch name.
+#
+# https://github.com/abhinav/git-spice/issues/1041
+
+as 'Test <test@example.com>'
+at '2024-09-04T05:06:07Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+git add feat1.txt
+gs bc -m 'Add feature 1' feat1
+gs ss --fill
+stderr 'Created #1'
+
+# Close the PR, rename the branch, push to a new upstream, and submit again.
+shamhub reject alice/example 1
+gs branch rename feat1-renamed
+git push -u origin feat1-renamed
+
+gs ss --fill
+stderr 'Ignoring CR #1 as it was closed'
+stderr 'Created #2'
+
+shamhub dump change 2
+cmpenvJSON stdout $WORK/golden/change-2.json
+
+-- repo/feat1.txt --
+Contents of feature 1
+-- golden/change-2.json --
+{
+  "number": 2,
+  "html_url": "$SHAMHUB_URL/alice/example/change/2",
+  "state": "open",
+  "title": "Add feature 1",
+  "body": "",
+  "base": {
+    "repository": {
+      "owner": "alice",
+      "name": "example"
+    },
+    "ref": "main",
+    "sha": "c649f748239dea65932c853775c6121d7cc79029"
+  },
+  "head": {
+    "repository": {
+      "owner": "alice",
+      "name": "example"
+    },
+    "ref": "feat1-renamed",
+    "sha": "11aef079d2994b11b4349ee4c7e2f8502ba3586c"
+  }
+}

--- a/testdata/script/issue1041_stack_submit_closed_pr_renamed_branch_unset_upstream.txt
+++ b/testdata/script/issue1041_stack_submit_closed_pr_renamed_branch_unset_upstream.txt
@@ -1,0 +1,64 @@
+# Resubmitting a renamed branch with a closed PR after unsetting upstream
+# should use the new branch name.
+#
+# https://github.com/abhinav/git-spice/issues/1041
+
+as 'Test <test@example.com>'
+at '2024-09-04T05:06:07Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+git add feat1.txt
+gs bc -m 'Add feature 1' feat1
+gs ss --fill
+stderr 'Created #1'
+
+# Close the PR, rename the branch, remove tracking, and submit again.
+shamhub reject alice/example 1
+gs branch rename feat1-renamed
+git branch --unset-upstream
+
+gs ss --fill
+stderr 'Ignoring CR #1 as it was closed'
+stderr 'Created #2'
+
+shamhub dump change 2
+cmpenvJSON stdout $WORK/golden/change-2.json
+
+-- repo/feat1.txt --
+Contents of feature 1
+-- golden/change-2.json --
+{
+  "number": 2,
+  "html_url": "$SHAMHUB_URL/alice/example/change/2",
+  "state": "open",
+  "title": "Add feature 1",
+  "body": "",
+  "base": {
+    "repository": {
+      "owner": "alice",
+      "name": "example"
+    },
+    "ref": "main",
+    "sha": "c649f748239dea65932c853775c6121d7cc79029"
+  },
+  "head": {
+    "repository": {
+      "owner": "alice",
+      "name": "example"
+    },
+    "ref": "feat1-renamed",
+    "sha": "11aef079d2994b11b4349ee4c7e2f8502ba3586c"
+  }
+}


### PR DESCRIPTION
Recompute the effective upstream branch name when recreating a
change request after the previously recorded one was closed.
This keeps renamed branches on the old upstream by default,
but lets explicit upstream changes from `git branch --unset-upstream`
or `git push -u` control replacement submissions.

Add script coverage for the three renamed-branch scenarios from
issue 1041 to lock the behavior in place.

Resolves #1041.