### PR TITLE
internal/git: reintroduce gitCmd

### DIFF
--- a/internal/git/cmd.go
+++ b/internal/git/cmd.go
@@ -5,7 +5,10 @@
 package git
 
 import (
+	"bufio"
 	"context"
+	"io"
+	"iter"
 	"strings"
 
 	"go.abhg.dev/gs/internal/silog"
@@ -24,6 +27,7 @@ type extraConfig struct {
 	MergeConflictStyle string // merge.conflictStyle
 }
 
+// args builds the git -c flags for the configured values.
 func (ec *extraConfig) args() []string {
 	var args []string
 	if ec.Editor != "" {
@@ -35,18 +39,13 @@ func (ec *extraConfig) args() []string {
 	return args
 }
 
-func (ec *extraConfig) WithArgs(cmd *xec.Cmd) *xec.Cmd {
-	if ec == nil {
-		return nil
-	}
-
-	newArgs := ec.args()
-	if len(newArgs) == 0 {
-		return cmd
-	}
-
-	newArgs = append(newArgs, cmd.Args()...)
-	return cmd.WithArgs(newArgs...)
+// gitCmd is a package-local wrapper around [xec.Cmd]
+// for Git CLI operations issued by this package.
+//
+// It centralizes Git-specific command policy in [newGitCmd]
+// while preserving the fluent API that internal/git callers expect.
+type gitCmd struct {
+	cmd *xec.Cmd
 }
 
 // newGitCmd builds a new Git command with the given arguments.
@@ -65,13 +64,152 @@ func (ec *extraConfig) WithArgs(cmd *xec.Cmd) *xec.Cmd {
 //   - if the program is running in verbose mode,
 //     the stderr output will always be shown to the user,
 //     but it won't be duplicated in the error message.
-func newGitCmd(ctx context.Context, log *silog.Logger, exec execer, args ...string) *xec.Cmd {
+func newGitCmd(
+	ctx context.Context,
+	log *silog.Logger,
+	exec execer,
+	args ...string,
+) *gitCmd {
 	prefix := "git"
 	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
 		prefix += " " + args[0]
 	}
 
-	return xec.Command(ctx, log, "git", args...).
+	cmd := xec.Command(ctx, log, "git", args...).
 		WithExecer(exec).
 		WithLogPrefix(prefix)
+
+	return &gitCmd{cmd: cmd}
+}
+
+// WithExtraConfig prepends transient git -c configuration
+// to the wrapped command.
+//
+// This is the package-local mechanism for applying per-command Git settings
+// such as core.editor or merge.conflictStyle.
+func (c *gitCmd) WithExtraConfig(ec *extraConfig) *gitCmd {
+	if ec == nil {
+		return c
+	}
+
+	args := ec.args()
+	if len(args) == 0 {
+		return c
+	}
+
+	args = append(args, c.Args()...)
+	return c.WithArgs(args...)
+}
+
+// Run runs the wrapped command, blocking until it completes.
+func (c *gitCmd) Run() error {
+	return c.cmd.Run()
+}
+
+// Start starts the wrapped command, returning immediately.
+func (c *gitCmd) Start() error {
+	return c.cmd.Start()
+}
+
+// Wait waits for a started command to complete.
+func (c *gitCmd) Wait() error {
+	return c.cmd.Wait()
+}
+
+// Output runs the wrapped command and returns its stdout.
+func (c *gitCmd) Output() ([]byte, error) {
+	return c.cmd.Output()
+}
+
+// OutputChomp runs the wrapped command
+// and returns stdout with trailing whitespace removed.
+func (c *gitCmd) OutputChomp() (string, error) {
+	return c.cmd.OutputChomp()
+}
+
+// Scan runs the wrapped command
+// and yields stdout tokens split by the provided function.
+func (c *gitCmd) Scan(split bufio.SplitFunc) iter.Seq2[[]byte, error] {
+	return c.cmd.Scan(split)
+}
+
+// Lines runs the wrapped command
+// and yields stdout line by line.
+func (c *gitCmd) Lines() iter.Seq2[[]byte, error] {
+	return c.cmd.Lines()
+}
+
+// StdoutPipe returns a pipe connected to the command's stdout.
+func (c *gitCmd) StdoutPipe() (io.ReadCloser, error) {
+	return c.cmd.StdoutPipe()
+}
+
+// StdinPipe returns a pipe connected to the command's stdin.
+func (c *gitCmd) StdinPipe() (io.WriteCloser, error) {
+	return c.cmd.StdinPipe()
+}
+
+// Kill terminates a started command.
+func (c *gitCmd) Kill() error {
+	return c.cmd.Kill()
+}
+
+// Args reports the command arguments, excluding the git binary name.
+func (c *gitCmd) Args() []string {
+	return c.cmd.Args()
+}
+
+// WithArgs replaces the wrapped command's arguments.
+func (c *gitCmd) WithArgs(args ...string) *gitCmd {
+	c.cmd.WithArgs(args...)
+	return c
+}
+
+// WithDir sets the working directory for the wrapped command.
+func (c *gitCmd) WithDir(dir string) *gitCmd {
+	c.cmd.WithDir(dir)
+	return c
+}
+
+// WithLogPrefix overrides the log prefix used by the wrapped command.
+func (c *gitCmd) WithLogPrefix(prefix string) *gitCmd {
+	c.cmd.WithLogPrefix(prefix)
+	return c
+}
+
+// WithStdout redirects the command's stdout to the provided writer.
+func (c *gitCmd) WithStdout(w io.Writer) *gitCmd {
+	c.cmd.WithStdout(w)
+	return c
+}
+
+// WithStderr redirects the command's stderr to the provided writer.
+func (c *gitCmd) WithStderr(w io.Writer) *gitCmd {
+	c.cmd.WithStderr(w)
+	return c
+}
+
+// WithStdin supplies the command's stdin from the provided reader.
+func (c *gitCmd) WithStdin(r io.Reader) *gitCmd {
+	c.cmd.WithStdin(r)
+	return c
+}
+
+// WithStdinString supplies the command's stdin from the provided string.
+func (c *gitCmd) WithStdinString(s string) *gitCmd {
+	c.cmd.WithStdinString(s)
+	return c
+}
+
+// AppendEnv appends environment variables to the wrapped command.
+func (c *gitCmd) AppendEnv(env ...string) *gitCmd {
+	c.cmd.AppendEnv(env...)
+	return c
+}
+
+// CaptureStdout captures stdout for logging
+// and inclusion in any returned error.
+func (c *gitCmd) CaptureStdout() *gitCmd {
+	c.cmd.CaptureStdout()
+	return c
 }

--- a/internal/git/cmd_test.go
+++ b/internal/git/cmd_test.go
@@ -48,3 +48,31 @@ func TestGitCmd_logPrefix(t *testing.T) {
 		assert.Contains(t, logBuffer.String(), " different: ")
 	})
 }
+
+func TestGitCmd_WithExtraConfig(t *testing.T) {
+	t.Run("PrependsConfigArgs", func(t *testing.T) {
+		cmd := newGitCmd(
+			t.Context(), silog.Nop(), _realExec,
+			"rebase", "--continue",
+		).WithExtraConfig(&extraConfig{
+			Editor:             "vim",
+			MergeConflictStyle: "zdiff3",
+		})
+
+		assert.Equal(t, []string{
+			"-c", "core.editor=vim",
+			"-c", "merge.conflictStyle=zdiff3",
+			"rebase", "--continue",
+		}, cmd.Args())
+	})
+
+	t.Run("NilIsNoOp", func(t *testing.T) {
+		cmd := newGitCmd(
+			t.Context(), silog.Nop(), _realExec,
+			"rev-parse", "HEAD",
+		)
+
+		assert.Equal(t, cmd, cmd.WithExtraConfig(nil))
+		assert.Equal(t, []string{"rev-parse", "HEAD"}, cmd.Args())
+	})
+}

--- a/internal/git/hash.go
+++ b/internal/git/hash.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-
-	"go.abhg.dev/gs/internal/xec"
 )
 
 // ErrNotExist is returned when a Git object does not exist.
@@ -100,7 +98,7 @@ func (r *Repository) revParse(ctx context.Context, ref string) (Hash, error) {
 	return Hash(out), nil
 }
 
-func (r *Repository) revParseCmd(ctx context.Context, ref string) *xec.Cmd {
+func (r *Repository) revParseCmd(ctx context.Context, ref string) *gitCmd {
 	return r.gitCmd(ctx, "rev-parse",
 		"--verify",         // fail if the object does not exist
 		"--quiet",          // no output if object does not exist

--- a/internal/git/hash_wt.go
+++ b/internal/git/hash_wt.go
@@ -1,10 +1,6 @@
 package git
 
-import (
-	"context"
-
-	"go.abhg.dev/gs/internal/xec"
-)
+import "context"
 
 // Head reports the commit hash of HEAD.
 func (w *Worktree) Head(ctx context.Context) (Hash, error) {
@@ -26,6 +22,6 @@ func (w *Worktree) revParse(ctx context.Context, ref string) (Hash, error) {
 	return Hash(out), nil
 }
 
-func (w *Worktree) revParseCmd(ctx context.Context, ref string) *xec.Cmd {
+func (w *Worktree) revParseCmd(ctx context.Context, ref string) *gitCmd {
 	return w.repo.revParseCmd(ctx, ref).WithDir(w.rootDir)
 }

--- a/internal/git/merge_tree.go
+++ b/internal/git/merge_tree.go
@@ -116,7 +116,9 @@ func (r *Repository) MergeTree(ctx context.Context, req MergeTreeRequest) (_ Has
 
 	cmd := r.gitCmd(ctx, args...).WithStdinString(stdin.String())
 	if req.conflictStyle != "" {
-		cmd = (&extraConfig{MergeConflictStyle: req.conflictStyle}).WithArgs(cmd)
+		cmd = cmd.WithExtraConfig(&extraConfig{
+			MergeConflictStyle: req.conflictStyle,
+		})
 	}
 
 	stdout, err := cmd.StdoutPipe()

--- a/internal/git/rebase_wt.go
+++ b/internal/git/rebase_wt.go
@@ -181,7 +181,7 @@ func (w *Worktree) RebaseContinue(ctx context.Context, opts *RebaseContinueOptio
 	opts = cmp.Or(opts, &RebaseContinueOptions{})
 	cmd := w.gitCmd(ctx, "rebase", "--continue").WithStdin(os.Stdin).WithStdout(os.Stdout)
 	if opts.Editor != "" {
-		cmd = (&extraConfig{Editor: opts.Editor}).WithArgs(cmd)
+		cmd = cmd.WithExtraConfig(&extraConfig{Editor: opts.Editor})
 	}
 	if err := cmd.Run(); err != nil {
 		return w.handleRebaseError(ctx, err)

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"go.abhg.dev/gs/internal/silog"
-	"go.abhg.dev/gs/internal/xec"
 )
 
 // InitOptions configures the behavior of Init.
@@ -174,8 +173,8 @@ func (r *Repository) WithLogger(log *silog.Logger) *Repository {
 	return &newR
 }
 
-// gitCmd returns a gitCmd that will run
-// with the repository's root as the working directory.
-func (r *Repository) gitCmd(ctx context.Context, args ...string) *xec.Cmd {
+// gitCmd returns a Git command wrapper
+// configured to run in this repository.
+func (r *Repository) gitCmd(ctx context.Context, args ...string) *gitCmd {
 	return newGitCmd(ctx, r.log, r.exec, args...).WithDir(r.gitDir)
 }

--- a/internal/git/wt.go
+++ b/internal/git/wt.go
@@ -9,7 +9,6 @@ import (
 
 	"go.abhg.dev/gs/internal/scanutil"
 	"go.abhg.dev/gs/internal/silog"
-	"go.abhg.dev/gs/internal/xec"
 )
 
 // Worktree is a checkout of a Git repository at a specific path.
@@ -34,7 +33,9 @@ func newWorktree(gitDir, rootDir string, repo *Repository, log *silog.Logger, ex
 	}
 }
 
-func (w *Worktree) gitCmd(ctx context.Context, args ...string) *xec.Cmd {
+// gitCmd returns a Git command wrapper
+// configured to run inside this worktree.
+func (w *Worktree) gitCmd(ctx context.Context, args ...string) *gitCmd {
 	return newGitCmd(ctx, w.log, w.exec, args...).WithDir(w.rootDir)
 }
 


### PR DESCRIPTION
For #1074, we need to add a bunch of functionality
around command execution for Git operations.
Introduce the gitCmd wrapper around xec.Cmd to make these easier.

[skip changelog]: no user facing changes