### PR TITLE
refactor(git): pass subcommands explicitly

### DIFF
--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -46,9 +46,7 @@ func (r *Repository) LocalBranches(ctx context.Context, opts *LocalBranchesOptio
 		opts = &LocalBranchesOptions{}
 	}
 
-	args := []string{
-		"for-each-ref", "--format=%(refname) %(objectname) %(worktreepath)",
-	}
+	args := []string{"--format=%(refname) %(objectname) %(worktreepath)"}
 	if opts.Sort != "" {
 		args = append(args, "--sort="+opts.Sort)
 	}
@@ -61,7 +59,7 @@ func (r *Repository) LocalBranches(ctx context.Context, opts *LocalBranchesOptio
 	}
 
 	return func(yield func(LocalBranch, error) bool) {
-		cmd := r.gitCmd(ctx, args...)
+		cmd := r.gitCmd(ctx, "for-each-ref", args...)
 		for bs, err := range cmd.Lines() {
 			if err != nil {
 				yield(LocalBranch{}, fmt.Errorf("git for-each-ref: %w", err))
@@ -116,14 +114,14 @@ type CreateBranchRequest struct {
 func (r *Repository) CreateBranch(ctx context.Context, req CreateBranchRequest) error {
 	r.log.Debug("Creating branch", "name", req.Name, "head", req.Head)
 
-	args := []string{"branch", req.Name}
+	args := []string{req.Name}
 	if req.Force {
 		args = append(args, "--force")
 	}
 	if req.Head != "" {
 		args = append(args, req.Head)
 	}
-	if err := r.gitCmd(ctx, args...).Run(); err != nil {
+	if err := r.gitCmd(ctx, "branch", args...).Run(); err != nil {
 		return fmt.Errorf("git branch: %w", err)
 	}
 	return nil
@@ -156,7 +154,7 @@ func (r *Repository) DeleteBranch(
 ) error {
 	r.log.Debug("Deleting branch", "name", branch)
 
-	args := []string{"branch", "--delete"}
+	args := []string{"--delete"}
 	if opts.Force {
 		args = append(args, "--force")
 	}
@@ -165,7 +163,7 @@ func (r *Repository) DeleteBranch(
 	}
 	args = append(args, branch)
 
-	if err := r.gitCmd(ctx, args...).Run(); err != nil {
+	if err := r.gitCmd(ctx, "branch", args...).Run(); err != nil {
 		return fmt.Errorf("git branch: %w", err)
 	}
 	return nil
@@ -184,8 +182,8 @@ type RenameBranchRequest struct {
 func (r *Repository) RenameBranch(ctx context.Context, req RenameBranchRequest) error {
 	r.log.Debug("Renaming branch", "old", req.OldName, "new", req.NewName)
 
-	args := []string{"branch", "--move", req.OldName, req.NewName}
-	if err := r.gitCmd(ctx, args...).Run(); err != nil {
+	args := []string{"--move", req.OldName, req.NewName}
+	if err := r.gitCmd(ctx, "branch", args...).Run(); err != nil {
 		return fmt.Errorf("git branch: %w", err)
 	}
 	return nil
@@ -216,7 +214,7 @@ func (r *Repository) SetBranchUpstream(
 	ctx context.Context,
 	branch, upstream string,
 ) error {
-	args := []string{"branch"}
+	var args []string
 	if upstream == "" {
 		r.log.Debug("Unsetting branch upstream", "name", branch)
 		args = append(args, "--unset-upstream")
@@ -226,7 +224,7 @@ func (r *Repository) SetBranchUpstream(
 	}
 	args = append(args, branch)
 
-	if err := r.gitCmd(ctx, args...).Run(); err != nil {
+	if err := r.gitCmd(ctx, "branch", args...).Run(); err != nil {
 		return fmt.Errorf("git branch: %w", err)
 	}
 	return nil

--- a/internal/git/branch_wt.go
+++ b/internal/git/branch_wt.go
@@ -34,11 +34,11 @@ func (w *Worktree) CurrentBranch(ctx context.Context) (string, error) {
 func (w *Worktree) DetachHead(ctx context.Context, commitish string) error {
 	w.log.Debug("Detaching HEAD", "commit", commitish)
 
-	args := []string{"checkout", "--detach"}
+	args := []string{"--detach"}
 	if len(commitish) > 0 {
 		args = append(args, commitish)
 	}
-	if err := w.gitCmd(ctx, args...).Run(); err != nil {
+	if err := w.gitCmd(ctx, "checkout", args...).Run(); err != nil {
 		return fmt.Errorf("git checkout: %w", err)
 	}
 	return nil

--- a/internal/git/checkout_wt.go
+++ b/internal/git/checkout_wt.go
@@ -23,7 +23,7 @@ type CheckoutFilesRequest struct {
 // CheckoutFiles checks out files from the specified tree-ish to the working directory.
 // This wraps 'git checkout [<tree-ish>] -- [<pathspec>...]'.
 func (w *Worktree) CheckoutFiles(ctx context.Context, req *CheckoutFilesRequest) error {
-	args := []string{"checkout"}
+	var args []string
 	if req.Overlay {
 		args = append(args, "--overlay")
 	} else {
@@ -36,7 +36,7 @@ func (w *Worktree) CheckoutFiles(ctx context.Context, req *CheckoutFilesRequest)
 
 	args = append(args, "--")
 	args = append(args, req.Pathspecs...)
-	if err := w.gitCmd(ctx, args...).Run(); err != nil {
+	if err := w.gitCmd(ctx, "checkout", args...).Run(); err != nil {
 		return fmt.Errorf("git checkout: %w", err)
 	}
 	return nil

--- a/internal/git/cmd.go
+++ b/internal/git/cmd.go
@@ -7,9 +7,9 @@ package git
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"io"
 	"iter"
-	"strings"
 
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/xec"
@@ -25,6 +25,8 @@ type extraConfig struct {
 	Editor string // core.editor
 
 	MergeConflictStyle string // merge.conflictStyle
+
+	AdviceMergeConflict *bool // advice.mergeConflict
 }
 
 // args builds the git -c flags for the configured values.
@@ -35,6 +37,10 @@ func (ec *extraConfig) args() []string {
 	}
 	if ec.MergeConflictStyle != "" {
 		args = append(args, "-c", "merge.conflictStyle="+ec.MergeConflictStyle)
+	}
+	if ec.AdviceMergeConflict != nil {
+		args = append(args, "-c",
+			fmt.Sprintf("advice.mergeConflict=%t", *ec.AdviceMergeConflict))
 	}
 	return args
 }
@@ -48,8 +54,8 @@ type gitCmd struct {
 	cmd *xec.Cmd
 }
 
-// newGitCmd builds a new Git command with the given arguments.
-// The first argument is the Git subcommand to run.
+// newGitCmd builds a new Git command for the given Git subcommand
+// and arguments.
 //
 // If the logger is at Debug level or lower,
 // stderr of the command will be written to the logger.
@@ -58,9 +64,11 @@ type gitCmd struct {
 //
 // This allows for a nicer, less noisy UX for expected errors:
 //
-//   - if a Git command was expected to fail, and the error is never logged,
+//   - if a Git command was expected to fail,
+//     and the error is never logged,
 //     its stderr output will not be shown to the user.
-//   - if the error is logged, the stderr output will be shown to the user.
+//   - if the error is logged,
+//     the stderr output will be shown to the user.
 //   - if the program is running in verbose mode,
 //     the stderr output will always be shown to the user,
 //     but it won't be duplicated in the error message.
@@ -68,14 +76,16 @@ func newGitCmd(
 	ctx context.Context,
 	log *silog.Logger,
 	exec execer,
+	subcmd string,
 	args ...string,
 ) *gitCmd {
 	prefix := "git"
-	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
-		prefix += " " + args[0]
+	if subcmd != "" {
+		prefix += " " + subcmd
 	}
 
-	cmd := xec.Command(ctx, log, "git", args...).
+	argv := append([]string{subcmd}, args...)
+	cmd := xec.Command(ctx, log, "git", argv...).
 		WithExecer(exec).
 		WithLogPrefix(prefix)
 
@@ -168,12 +178,6 @@ func (c *gitCmd) WithArgs(args ...string) *gitCmd {
 // WithDir sets the working directory for the wrapped command.
 func (c *gitCmd) WithDir(dir string) *gitCmd {
 	c.cmd.WithDir(dir)
-	return c
-}
-
-// WithLogPrefix overrides the log prefix used by the wrapped command.
-func (c *gitCmd) WithLogPrefix(prefix string) *gitCmd {
-	c.cmd.WithLogPrefix(prefix)
 	return c
 }
 

--- a/internal/git/cmd_test.go
+++ b/internal/git/cmd_test.go
@@ -17,16 +17,6 @@ func TestGitCmd_logPrefix(t *testing.T) {
 		Level: silog.LevelDebug,
 	})
 
-	t.Run("DefaultPrefixNoCommand", func(t *testing.T) {
-		defer logBuffer.Reset()
-
-		_ = newGitCmd(t.Context(), log, _realExec, "--unknown-flag").
-			WithDir(t.TempDir()).
-			Run()
-
-		assert.Contains(t, logBuffer.String(), " git: ")
-	})
-
 	t.Run("DefaultPrefixCommand", func(t *testing.T) {
 		defer logBuffer.Reset()
 
@@ -36,17 +26,6 @@ func TestGitCmd_logPrefix(t *testing.T) {
 
 		assert.Contains(t, logBuffer.String(), " git unknown-cmd: ")
 	})
-
-	t.Run("LogPrefixAfterwards", func(t *testing.T) {
-		defer logBuffer.Reset()
-
-		_ = newGitCmd(t.Context(), log, _realExec, "whatever").
-			WithDir(t.TempDir()).
-			WithLogPrefix("different").
-			Run()
-
-		assert.Contains(t, logBuffer.String(), " different: ")
-	})
 }
 
 func TestGitCmd_WithExtraConfig(t *testing.T) {
@@ -55,13 +34,15 @@ func TestGitCmd_WithExtraConfig(t *testing.T) {
 			t.Context(), silog.Nop(), _realExec,
 			"rebase", "--continue",
 		).WithExtraConfig(&extraConfig{
-			Editor:             "vim",
-			MergeConflictStyle: "zdiff3",
+			Editor:              "vim",
+			MergeConflictStyle:  "zdiff3",
+			AdviceMergeConflict: new(false),
 		})
 
 		assert.Equal(t, []string{
 			"-c", "core.editor=vim",
 			"-c", "merge.conflictStyle=zdiff3",
+			"-c", "advice.mergeConflict=false",
 			"rebase", "--continue",
 		}, cmd.Args())
 	})
@@ -75,4 +56,15 @@ func TestGitCmd_WithExtraConfig(t *testing.T) {
 		assert.Equal(t, cmd, cmd.WithExtraConfig(nil))
 		assert.Equal(t, []string{"rev-parse", "HEAD"}, cmd.Args())
 	})
+}
+
+func TestNewGitCmd_args(t *testing.T) {
+	cmd := newGitCmd(
+		t.Context(), silog.Nop(), _realExec,
+		"rev-parse", "--verify", "HEAD",
+	)
+
+	assert.Equal(t, []string{
+		"rev-parse", "--verify", "HEAD",
+	}, cmd.Args())
 }

--- a/internal/git/commit.go
+++ b/internal/git/commit.go
@@ -75,8 +75,7 @@ func (r *Repository) CommitTree(ctx context.Context, req CommitTreeRequest) (Has
 		return ZeroHash, errors.New("empty commit message")
 	}
 
-	args := make([]string, 0, 2+2*len(req.Parents))
-	args = append(args, "commit-tree")
+	args := make([]string, 0, 1+2*len(req.Parents))
 	for _, parent := range req.Parents {
 		args = append(args, "-p", parent.String())
 	}
@@ -89,7 +88,7 @@ func (r *Repository) CommitTree(ctx context.Context, req CommitTreeRequest) (Has
 	env = req.Author.appendEnv("AUTHOR", env)
 	env = req.Committer.appendEnv("COMMITTER", env)
 
-	cmd := r.gitCmd(ctx, args...).
+	cmd := r.gitCmd(ctx, "commit-tree", args...).
 		AppendEnv(env...).
 		WithStdinString(req.Message)
 	out, err := cmd.OutputChomp()

--- a/internal/git/commit_wt.go
+++ b/internal/git/commit_wt.go
@@ -57,7 +57,7 @@ type CommitRequest struct {
 // Commit runs the 'git commit' command,
 // allowing the user to commit changes.
 func (w *Worktree) Commit(ctx context.Context, req CommitRequest) error {
-	args := []string{"commit"}
+	var args []string
 	if req.All {
 		args = append(args, "-a")
 	}
@@ -103,7 +103,7 @@ func (w *Worktree) Commit(ctx context.Context, req CommitRequest) error {
 		args = append(args, "--signoff")
 	}
 
-	cmd := w.gitCmd(ctx, args...).
+	cmd := w.gitCmd(ctx, "commit", args...).
 		WithStdin(os.Stdin).
 		WithStdout(os.Stdout).
 		WithStderr(os.Stderr)

--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -147,9 +147,9 @@ var _newline = []byte("\n")
 
 func (cfg *Config) list(ctx context.Context, args ...string) iter.Seq2[ConfigEntry, error] {
 	log := cfg.log
-	args = append([]string{"config", "--null"}, args...)
+	args = append([]string{"--null"}, args...)
 	return func(yield func(ConfigEntry, error) bool) {
-		cmd := newGitCmd(ctx, cfg.log, cfg.exec, args...).
+		cmd := newGitCmd(ctx, cfg.log, cfg.exec, "config", args...).
 			WithDir(cfg.dir).
 			AppendEnv(cfg.env...)
 

--- a/internal/git/config_test.go
+++ b/internal/git/config_test.go
@@ -263,8 +263,8 @@ func TestIntegrationConfigListRegexp(t *testing.T) {
 			ctx := t.Context()
 			log := silogtest.New(t)
 			for _, set := range tt.sets {
-				args := append([]string{"config", "--global"}, set...)
-				err := newGitCmd(ctx, log, _realExec, args...).
+				args := append([]string{"--global"}, set...)
+				err := newGitCmd(ctx, log, _realExec, "config", args...).
 					WithDir(home).
 					AppendEnv(env...).
 					Run()

--- a/internal/git/fetch.go
+++ b/internal/git/fetch.go
@@ -30,7 +30,7 @@ func (r *Repository) Fetch(ctx context.Context, opts FetchOptions) error {
 
 	r.log.Debug("Fetching from remote", silog.NonZero("name", opts.Remote))
 
-	args := []string{"fetch"}
+	var args []string
 	if opts.Remote != "" {
 		args = append(args, opts.Remote)
 	}
@@ -38,7 +38,7 @@ func (r *Repository) Fetch(ctx context.Context, opts FetchOptions) error {
 		args = append(args, refspec.String())
 	}
 
-	if err := r.gitCmd(ctx, args...).Run(); err != nil {
+	if err := r.gitCmd(ctx, "fetch", args...).Run(); err != nil {
 		return fmt.Errorf("fetch: %w", err)
 	}
 

--- a/internal/git/files_wt.go
+++ b/internal/git/files_wt.go
@@ -20,14 +20,14 @@ type ListFilesOptions struct {
 // using the given options to filter.
 func (w *Worktree) ListFilesPaths(ctx context.Context, opts *ListFilesOptions) iter.Seq2[string, error] {
 	opts = cmp.Or(opts, &ListFilesOptions{})
-	args := []string{"ls-files", "-z", "--format=%(path)"}
+	args := []string{"-z", "--format=%(path)"}
 	if opts.Unmerged {
 		args = append(args, "--unmerged")
 	}
 
 	shown := make(map[string]struct{})
 	return func(yield func(string, error) bool) {
-		cmd := w.gitCmd(ctx, args...)
+		cmd := w.gitCmd(ctx, "ls-files", args...)
 		for line, err := range cmd.Scan(scanutil.SplitNull) {
 			if err != nil {
 				yield("", fmt.Errorf("git ls-files: %w", err))

--- a/internal/git/merge_tree.go
+++ b/internal/git/merge_tree.go
@@ -100,7 +100,6 @@ func (e *MergeTreeConflictError) Error() string {
 func (r *Repository) MergeTree(ctx context.Context, req MergeTreeRequest) (_ Hash, retErr error) {
 	// TODO: support multiple requests now that we're using stdin
 	args := []string{
-		"merge-tree",
 		"--write-tree", // other mode is deprecated
 		"--stdin",      // pass input on stdin
 		"-z",
@@ -114,7 +113,7 @@ func (r *Repository) MergeTree(ctx context.Context, req MergeTreeRequest) (_ Has
 	}
 	_, _ = fmt.Fprintf(&stdin, "%v %v\n", req.Branch1, req.Branch2)
 
-	cmd := r.gitCmd(ctx, args...).WithStdinString(stdin.String())
+	cmd := r.gitCmd(ctx, "merge-tree", args...).WithStdinString(stdin.String())
 	if req.conflictStyle != "" {
 		cmd = cmd.WithExtraConfig(&extraConfig{
 			MergeConflictStyle: req.conflictStyle,

--- a/internal/git/pull_wt.go
+++ b/internal/git/pull_wt.go
@@ -25,7 +25,7 @@ func (w *Worktree) Pull(ctx context.Context, opts PullOptions) error {
 
 	w.log.Debug("Pulling from remote", silog.NonZero("name", opts.Remote))
 
-	args := []string{"pull"}
+	var args []string
 	if opts.Rebase {
 		args = append(args, "--rebase")
 	}
@@ -39,7 +39,7 @@ func (w *Worktree) Pull(ctx context.Context, opts PullOptions) error {
 		args = append(args, opts.Refspec.String())
 	}
 
-	if err := w.gitCmd(ctx, args...).Run(); err != nil {
+	if err := w.gitCmd(ctx, "pull", args...).Run(); err != nil {
 		return fmt.Errorf("git pull: %w", err)
 	}
 

--- a/internal/git/push_wt.go
+++ b/internal/git/push_wt.go
@@ -46,7 +46,7 @@ func (w *Worktree) Push(ctx context.Context, opts PushOptions) error {
 		silog.NonZero("force", opts.Force),
 		silog.NonZero("lease", forceWithLease(opts.ForceWithLease)))
 
-	args := []string{"push"}
+	var args []string
 	if lease := opts.ForceWithLease; lease != "" {
 		args = append(args, "--force-with-lease="+lease)
 	}
@@ -63,7 +63,7 @@ func (w *Worktree) Push(ctx context.Context, opts PushOptions) error {
 		args = append(args, opts.Refspec.String())
 	}
 
-	cmd := w.gitCmd(ctx, args...).CaptureStdout()
+	cmd := w.gitCmd(ctx, "push", args...).CaptureStdout()
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("push: %w", err)
 	}

--- a/internal/git/rebase_wt.go
+++ b/internal/git/rebase_wt.go
@@ -96,12 +96,7 @@ type RebaseRequest struct {
 // Rebase runs a git rebase operation with the specified parameters.
 // It returns [RebaseInterruptError] for known rebase interruptions,
 func (w *Worktree) Rebase(ctx context.Context, req RebaseRequest) (retErr error) {
-	args := []string{
-		// Never include advice on how to resolve merge conflicts.
-		// We'll do that ourselves.
-		"-c", "advice.mergeConflict=false",
-		"rebase",
-	}
+	var args []string
 	if req.Interactive {
 		args = append(args, "--interactive")
 	}
@@ -158,7 +153,14 @@ func (w *Worktree) Rebase(ctx context.Context, req RebaseRequest) (retErr error)
 		silog.NonZero("upstream", req.Upstream),
 	)
 
-	cmd := w.gitCmd(ctx, args...).WithLogPrefix("git rebase")
+	extraCfg := &extraConfig{
+		// Never include advice on how to resolve merge conflicts.
+		// We'll do that ourselves.
+		AdviceMergeConflict: new(false),
+	}
+
+	cmd := w.gitCmd(ctx, "rebase", args...).
+		WithExtraConfig(extraCfg)
 	if req.Interactive {
 		cmd.WithStdin(os.Stdin).WithStdout(os.Stdout).WithStderr(os.Stderr)
 	}

--- a/internal/git/ref.go
+++ b/internal/git/ref.go
@@ -87,7 +87,7 @@ func (r *Repository) SetRef(ctx context.Context, req SetRefRequest) error {
 	)
 
 	// git update-ref [-m <reason>] <rev> <newvalue> [<oldvalue>]
-	args := []string{"update-ref"}
+	var args []string
 	if req.Reason != "" {
 		args = append(args, "-m", req.Reason)
 	}
@@ -95,5 +95,5 @@ func (r *Repository) SetRef(ctx context.Context, req SetRefRequest) error {
 	if req.OldHash != "" {
 		args = append(args, string(req.OldHash))
 	}
-	return r.gitCmd(ctx, args...).Run()
+	return r.gitCmd(ctx, "update-ref", args...).Run()
 }

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -114,7 +114,7 @@ func (r *Repository) ListRemoteRefs(
 		opts = &ListRemoteRefsOptions{}
 	}
 
-	args := []string{"ls-remote", "--quiet"}
+	args := []string{"--quiet"}
 	if opts.Heads {
 		args = append(args, "--heads")
 	}
@@ -122,7 +122,7 @@ func (r *Repository) ListRemoteRefs(
 	args = append(args, opts.Patterns...)
 
 	return func(yield func(RemoteRef, error) bool) {
-		cmd := r.gitCmd(ctx, args...)
+		cmd := r.gitCmd(ctx, "ls-remote", args...)
 
 		for bs, err := range cmd.Lines() {
 			if err != nil {

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -175,6 +175,6 @@ func (r *Repository) WithLogger(log *silog.Logger) *Repository {
 
 // gitCmd returns a Git command wrapper
 // configured to run in this repository.
-func (r *Repository) gitCmd(ctx context.Context, args ...string) *gitCmd {
-	return newGitCmd(ctx, r.log, r.exec, args...).WithDir(r.gitDir)
+func (r *Repository) gitCmd(ctx context.Context, subcmd string, args ...string) *gitCmd {
+	return newGitCmd(ctx, r.log, r.exec, subcmd, args...).WithDir(r.gitDir)
 }

--- a/internal/git/reset_wt.go
+++ b/internal/git/reset_wt.go
@@ -65,7 +65,7 @@ type ResetOptions struct {
 // Reset resets the index and optionally the working tree
 // to the specified commit.
 func (w *Worktree) Reset(ctx context.Context, commit string, opts ResetOptions) error {
-	args := []string{"reset"}
+	var args []string
 	if opts.Quiet {
 		args = append(args, "--quiet")
 	}
@@ -97,7 +97,7 @@ func (w *Worktree) Reset(ctx context.Context, commit string, opts ResetOptions) 
 		w.log.Debug("Resetting repository", "commit", commit, "mode", opts.Mode)
 	}
 
-	cmd := w.gitCmd(ctx, args...)
+	cmd := w.gitCmd(ctx, "reset", args...)
 	if opts.Patch {
 		cmd.WithStdin(os.Stdin)
 		cmd.WithStdout(os.Stdout)

--- a/internal/git/rev_list.go
+++ b/internal/git/rev_list.go
@@ -94,15 +94,14 @@ func (r *Repository) ListCommitsDetails(ctx context.Context, commits CommitRange
 //
 // See git-log(1) for details on the format string.
 func (r *Repository) listCommitsFormat(ctx context.Context, commits CommitRange, format string) iter.Seq2[string, error] {
-	args := make([]string, 0, len(commits)+3)
-	args = append(args, "rev-list")
+	args := make([]string, 0, len(commits)+2)
 	if format != "" {
 		args = append(args, "--format="+format)
 	}
 	args = append(args, []string(commits)...)
 
 	return func(yield func(string, error) bool) {
-		cmd := r.gitCmd(ctx, args...)
+		cmd := r.gitCmd(ctx, "rev-list", args...)
 
 		var sawCommitHeader bool
 		for bs, err := range cmd.Lines() {
@@ -141,11 +140,10 @@ func (r *Repository) listCommitsFormat(ctx context.Context, commits CommitRange,
 // CountCommits reports the number of commits matched by the given range.
 func (r *Repository) CountCommits(ctx context.Context, commits CommitRange) (int, error) {
 	args := make([]string, 0, len(commits)+1)
-	args = append(args, "rev-list")
 	args = append(args, []string(commits)...)
 	args = append(args, "--count")
 
-	cmd := r.gitCmd(ctx, args...)
+	cmd := r.gitCmd(ctx, "rev-list", args...)
 	out, err := cmd.OutputChomp()
 	if err != nil {
 		return 0, fmt.Errorf("rev-list: %w", err)

--- a/internal/git/stash.go
+++ b/internal/git/stash.go
@@ -13,12 +13,12 @@ var ErrNoChanges = errors.New("no changes to stash")
 // It does not store the stash in the stash reflog.
 // Returns ErrNoChanges if there are no changes to stash.
 func (w *Worktree) StashCreate(ctx context.Context, message string) (Hash, error) {
-	args := []string{"stash", "create"}
+	args := []string{"create"}
 	if message != "" {
 		args = append(args, message)
 	}
 
-	out, err := w.gitCmd(ctx, args...).OutputChomp()
+	out, err := w.gitCmd(ctx, "stash", args...).OutputChomp()
 	if err != nil {
 		return ZeroHash, fmt.Errorf("stash create: %w", err)
 	}
@@ -32,13 +32,13 @@ func (w *Worktree) StashCreate(ctx context.Context, message string) (Hash, error
 
 // StashStore stores a stash created by StashCreate in the stash reflog.
 func (w *Worktree) StashStore(ctx context.Context, stashHash Hash, message string) error {
-	args := []string{"stash", "store"}
+	args := []string{"store"}
 	if message != "" {
 		args = append(args, "-m", message)
 	}
 	args = append(args, stashHash.String())
 
-	if err := w.gitCmd(ctx, args...).Run(); err != nil {
+	if err := w.gitCmd(ctx, "stash", args...).Run(); err != nil {
 		return fmt.Errorf("stash store: %w", err)
 	}
 
@@ -49,12 +49,12 @@ func (w *Worktree) StashStore(ctx context.Context, stashHash Hash, message strin
 // If stash is not supplied, the most recent stash is applied.
 // Unlike 'stash pop', this accepts a hash string to identify the stash.
 func (w *Worktree) StashApply(ctx context.Context, stash string) error {
-	args := []string{"stash", "apply"}
+	args := []string{"apply"}
 	if stash != "" {
 		args = append(args, stash)
 	}
 
-	if err := w.gitCmd(ctx, args...).CaptureStdout().Run(); err != nil {
+	if err := w.gitCmd(ctx, "stash", args...).CaptureStdout().Run(); err != nil {
 		return fmt.Errorf("stash apply: %w", err)
 	}
 

--- a/internal/git/tree.go
+++ b/internal/git/tree.go
@@ -153,7 +153,6 @@ func (r *Repository) ListTree(
 	opts ListTreeOptions,
 ) iter.Seq2[TreeEntry, error] {
 	args := []string{
-		"ls-tree",
 		"-z",          // NUL-terminate entries for proper handling of special characters
 		"--full-tree", // don't limit listing to the current working directory
 	}
@@ -163,7 +162,7 @@ func (r *Repository) ListTree(
 	args = append(args, tree.String())
 
 	return func(yield func(TreeEntry, error) bool) {
-		cmd := r.gitCmd(ctx, args...)
+		cmd := r.gitCmd(ctx, "ls-tree", args...)
 		for line, err := range cmd.Scan(scanutil.SplitNull) {
 			if err != nil {
 				yield(TreeEntry{}, fmt.Errorf("git ls-tree: %w", err))

--- a/internal/git/wt.go
+++ b/internal/git/wt.go
@@ -35,8 +35,8 @@ func newWorktree(gitDir, rootDir string, repo *Repository, log *silog.Logger, ex
 
 // gitCmd returns a Git command wrapper
 // configured to run inside this worktree.
-func (w *Worktree) gitCmd(ctx context.Context, args ...string) *gitCmd {
-	return newGitCmd(ctx, w.log, w.exec, args...).WithDir(w.rootDir)
+func (w *Worktree) gitCmd(ctx context.Context, subcmd string, args ...string) *gitCmd {
+	return newGitCmd(ctx, w.log, w.exec, subcmd, args...).WithDir(w.rootDir)
 }
 
 // RootDir returns the absolute path to the root directory of the worktree.


### PR DESCRIPTION
Make `newGitCmd`, `Repository.gitCmd`, and `Worktree.gitCmd`
accept the Git subcommand separately from the remaining argv.

This removes the need to try to extract the subcommand
from the leading arguments, which was hacky and fragile.
This obviates the need for gitCmd.WithLogPrefix,
since the log prefix is now always "git <subcmd>".

[skip changelog]: no user visible change