### PR TITLE
test: cover index lock timeout edges

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/alecthomas/kong"
 	"github.com/stretchr/testify/assert"
@@ -169,6 +170,56 @@ func TestMainSecretBackendConfig_errors(t *testing.T) {
 			for _, msg := range tt.wantErr {
 				assert.ErrorContains(t, err, msg)
 			}
+		})
+	}
+}
+
+func TestMainGitIndexLockTimeoutConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		config string
+		args   []string
+		want   time.Duration
+	}{
+		{
+			name: "Default",
+			args: []string{"version"},
+			want: 5 * time.Second,
+		},
+		{
+			name: "ConfigZero",
+			config: joinLines(
+				`[spice "git"]`,
+				`  indexLockTimeout = 0`,
+			),
+			args: []string{"version"},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spicecfg := loadTestSpiceConfig(t, tt.config)
+
+			var cmd mainCmd
+			logger := silogtest.New(t)
+			var (
+				forges   forge.Registry
+				sigStack sigstack.Stack
+			)
+			parser, err := kong.New(
+				&cmd,
+				kong.Resolvers(spicecfg),
+				kong.Bind(logger, &forges, &sigStack),
+				kong.BindTo(t.Context(), (*context.Context)(nil)),
+				kong.BindTo(spicecfg, (*experiment.Enabler)(nil)),
+				kong.Vars{"defaultPrompt": "false"},
+			)
+			require.NoError(t, err)
+
+			_, err = parser.Parse(tt.args)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, cmd.Git.IndexLockTimeout)
 		})
 	}
 }

--- a/internal/git/rebase_wt_int_test.go
+++ b/internal/git/rebase_wt_int_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.abhg.dev/gs/internal/silog"
+	"go.abhg.dev/gs/internal/xec"
 	"go.uber.org/mock/gomock"
 )
 
@@ -84,6 +85,31 @@ func TestRebase_interactiveRetryPreservesTerminal(t *testing.T) {
 		Interactive: true,
 	})
 	require.NoError(t, err)
+}
+
+func TestRebase_zeroIndexLockTimeoutDisablesRetry(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockExec := NewMockExecer(ctrl)
+	_, wt := newFakeRepositoryWithCommonOptions(t, "", commonOptions{
+		exec:             mockExec,
+		indexLockTimeout: 0,
+	})
+
+	mockExec.EXPECT().
+		Run(gomock.Any()).
+		DoAndReturn(func(cmd *exec.Cmd) error {
+			_, _ = fmt.Fprintln(cmd.Stderr,
+				"fatal: Unable to create '.git/index.lock'")
+			return &exec.ExitError{}
+		}).
+		Times(1)
+
+	err := wt.Rebase(t.Context(), RebaseRequest{
+		Branch:   "feature",
+		Upstream: "main",
+	})
+	require.Error(t, err)
+	assert.ErrorAs(t, err, new(*xec.ExitError))
 }
 
 func TestRebase_recoveryFailureReturnsRecoveryErr(t *testing.T) {

--- a/internal/git/repo_test.go
+++ b/internal/git/repo_test.go
@@ -3,6 +3,7 @@ package git
 import (
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/silog/silogtest"
 	"go.abhg.dev/gs/internal/text"
+	"go.uber.org/mock/gomock"
 )
 
 func NewFakeRepository(t testing.TB, dir string, execer execer) (*Repository, *Worktree) {
@@ -149,4 +151,55 @@ func TestOpen_timeoutResolution(t *testing.T) {
 		assert.Equal(t, timeout, repo.indexLockTimeout)
 		assert.Equal(t, timeout, wt.indexLockTimeout)
 	})
+}
+
+func TestOpenWorktree_timeoutResolution(t *testing.T) {
+	zero := time.Duration(0)
+	negative := -time.Second
+	positive := 250 * time.Millisecond
+
+	tests := []struct {
+		name    string
+		timeout *time.Duration
+		want    time.Duration
+	}{
+		{
+			name: "Default",
+			want: _defaultIndexLockTimeout,
+		},
+		{
+			name:    "ZeroDisablesRetry",
+			timeout: &zero,
+			want:    0,
+		},
+		{
+			name:    "NegativeClampsToZero",
+			timeout: &negative,
+			want:    0,
+		},
+		{
+			name:    "PositiveTimeoutPreserved",
+			timeout: &positive,
+			want:    positive,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExecer := NewMockExecer(gomock.NewController(t))
+			mockExecer.EXPECT().
+				Output(gomock.Any()).
+				DoAndReturn(func(*exec.Cmd) ([]byte, error) {
+					return []byte("/repo\n/repo/.git\n/repo/.git\n"), nil
+				})
+
+			wt, err := OpenWorktree(t.Context(), "/repo", OpenOptions{
+				exec:             mockExecer,
+				IndexLockTimeout: tt.timeout,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, wt.indexLockTimeout)
+			assert.Equal(t, tt.want, wt.Repository().indexLockTimeout)
+		})
+	}
 }


### PR DESCRIPTION
Add coverage for configuring `spice.git.indexLockTimeout`
to `0`, and for preserving that setting in
`OpenWorktree` and `Rebase`.

This keeps the disabled-retry behavior covered at the config
boundary and in the separate rebase retry path.