### PR TITLE
commit: add `-F/--file` message support

### DIFF
--- a/.changes/unreleased/Added-20260416-195359.yaml
+++ b/.changes/unreleased/Added-20260416-195359.yaml
@@ -1,0 +1,4 @@
+kind: Added
+body: >-
+  commit: Add '-F'/'--file' flag to read a commit message from a file.
+time: 2026-04-16T19:53:59.613718-07:00

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,10 @@ This project has two kinds of tests:
   in a shell-like syntax (note: NOT actual shell scripts).
   The syntax for these is described in testdata/script/README.md.
 
+  Name test scripts using the `<command>_<scenario>.txt` convention.
+  Reserve `issue123_...` prefixes for regression tests
+  that are specifically tied to that issue.
+
 ### Unit tests
 
 #### Testing best practices

--- a/branch_create.go
+++ b/branch_create.go
@@ -28,8 +28,9 @@ type branchCreateCmd struct {
 	Below  bool   `help:"Place the branch below the target branch and restack its upstack"`
 	Target string `short:"t" placeholder:"BRANCH" help:"Branch to create the new branch above/below"`
 
-	All     bool   `short:"a" help:"Automatically stage modified and deleted files"`
-	Message string `short:"m" placeholder:"MSG" help:"Commit message"`
+	All         bool   `short:"a" help:"Automatically stage modified and deleted files"`
+	Message     string `short:"m" xor:"commit-message-source" placeholder:"MSG" help:"Commit message"`
+	MessageFile string `short:"F" xor:"commit-message-source" placeholder:"FILE" help:"Read the commit message from the given file."`
 
 	NoVerify bool `help:"Bypass pre-commit and commit-msg hooks."`
 	Signoff  bool `config:"commit.signoff" help:"Add Signed-off-by trailer to the commit message"`
@@ -45,7 +46,7 @@ func (*branchCreateCmd) Help() string {
 		Use -a/--all to automatically stage modified and deleted files,
 		just like 'git commit -a'.
 		Use --no-commit to create the branch without committing.
-		-m/--message always implies --commit.
+		-m/--message and -F/--file always imply --commit.
 
 		If a branch name is not provided,
 		it will be generated from the commit message.
@@ -106,7 +107,7 @@ func (cmd *branchCreateCmd) Run(
 	restackHandler RestackHandler,
 ) (err error) {
 	// If a message is specified, automatically enable commits
-	if cmd.Message != "" {
+	if cmd.Message != "" || cmd.MessageFile != "" {
 		cmd.Commit = true
 	}
 
@@ -351,11 +352,12 @@ func (cmd *branchCreateCmd) commit(
 	}
 
 	if err := wt.Commit(ctx, git.CommitRequest{
-		AllowEmpty: len(diff) == 0,
-		Message:    cmd.Message,
-		NoVerify:   cmd.NoVerify,
-		All:        cmd.All,
-		Signoff:    cmd.Signoff,
+		AllowEmpty:  len(diff) == 0,
+		Message:     cmd.Message,
+		MessageFile: cmd.MessageFile,
+		NoVerify:    cmd.NoVerify,
+		All:         cmd.All,
+		Signoff:     cmd.Signoff,
 	}); err != nil {
 		if err := wt.CheckoutBranch(ctx, baseName); err != nil {
 			log.Warn("Could not restore original branch. You may need to reset manually.", "error", err)

--- a/branch_squash.go
+++ b/branch_squash.go
@@ -21,7 +21,8 @@ func (*branchSquashCmd) Help() string {
 		and restack upstack branches.
 
 		An editor will open to edit the commit message of the squashed commit.
-		Use the -m/--message flag to specify a commit message without editing.
+		Use the -m/--message or -F/--file flag
+		to specify a commit message without editing.
 	`)
 }
 

--- a/commit_amend.go
+++ b/commit_amend.go
@@ -18,9 +18,10 @@ import (
 type commitAmendCmd struct {
 	branchCreateConfig // TODO: find a way to avoid this
 
-	All        bool   `short:"a" help:"Stage all changes before committing."`
-	AllowEmpty bool   `help:"Create a commit even if it contains no changes."`
-	Message    string `short:"m" placeholder:"MSG" help:"Use the given message as the commit message."`
+	All         bool   `short:"a" help:"Stage all changes before committing."`
+	AllowEmpty  bool   `help:"Create a commit even if it contains no changes."`
+	Message     string `short:"m" xor:"commit-message-source" placeholder:"MSG" help:"Use the given message as the commit message."`
+	MessageFile string `short:"F" xor:"commit-message-source" placeholder:"FILE" help:"Read the commit message from the given file."`
 
 	NoEdit   bool `help:"Don't edit the commit message"`
 	NoVerify bool `help:"Bypass pre-commit and commit-msg hooks."`
@@ -40,8 +41,8 @@ func (*commitAmendCmd) Help() string {
 
 		An editor is opened to edit the commit message
 		unless the --no-edit flag is given.
-		Use the -m/--message option to specify the message
-		on the command line.
+		Use the -m/--message or -F/--file option
+		to specify the message without opening an editor.
 		Git hooks are run unless the --no-verify flag is given.
 
 		Use the -a/--all flag to stage all changes before committing.
@@ -124,6 +125,7 @@ func (cmd *commitAmendCmd) Run(
 					All:                cmd.All,
 					NoVerify:           cmd.NoVerify,
 					Message:            cmd.Message,
+					MessageFile:        cmd.MessageFile,
 					Signoff:            cmd.Signoff,
 					Commit:             true,
 				}).Run(ctx, log, repo, wt, store, svc, restackHandler)
@@ -184,13 +186,14 @@ func (cmd *commitAmendCmd) Run(
 	}
 
 	if err := wt.Commit(ctx, git.CommitRequest{
-		Message:    cmd.Message,
-		AllowEmpty: cmd.AllowEmpty,
-		Amend:      true,
-		NoEdit:     cmd.NoEdit,
-		NoVerify:   cmd.NoVerify,
-		All:        cmd.All,
-		Signoff:    cmd.Signoff,
+		Message:     cmd.Message,
+		MessageFile: cmd.MessageFile,
+		AllowEmpty:  cmd.AllowEmpty,
+		Amend:       true,
+		NoEdit:      cmd.NoEdit,
+		NoVerify:    cmd.NoVerify,
+		All:         cmd.All,
+		Signoff:     cmd.Signoff,
 	}); err != nil {
 		return fmt.Errorf("commit: %w", err)
 	}

--- a/commit_create.go
+++ b/commit_create.go
@@ -13,12 +13,13 @@ import (
 )
 
 type commitCreateCmd struct {
-	All        bool   `short:"a" help:"Stage all changes before committing."`
-	AllowEmpty bool   `help:"Create a new commit even if it contains no changes."`
-	Fixup      string `help:"Create a fixup commit. See also 'git-spice commit fixup'." placeholder:"COMMIT"`
-	Message    string `short:"m" placeholder:"MSG" help:"Use the given message as the commit message."`
-	NoVerify   bool   `help:"Bypass pre-commit and commit-msg hooks."`
-	Signoff    bool   `config:"commit.signoff" help:"Add Signed-off-by trailer to the commit message"`
+	All         bool   `short:"a" help:"Stage all changes before committing."`
+	AllowEmpty  bool   `help:"Create a new commit even if it contains no changes."`
+	Fixup       string `help:"Create a fixup commit. See also 'git-spice commit fixup'." placeholder:"COMMIT"`
+	Message     string `short:"m" xor:"commit-message-source" placeholder:"MSG" help:"Use the given message as the commit message."`
+	MessageFile string `short:"F" xor:"commit-message-source" placeholder:"FILE" help:"Read the commit message from the given file."`
+	NoVerify    bool   `help:"Bypass pre-commit and commit-msg hooks."`
+	Signoff     bool   `config:"commit.signoff" help:"Add Signed-off-by trailer to the commit message"`
 }
 
 func (*commitCreateCmd) Help() string {
@@ -30,7 +31,7 @@ func (*commitCreateCmd) Help() string {
 		followed by '%[1]s upstack restack'.
 
 		An editor is opened to edit the commit message.
-		Use the -m/--message option to specify the message
+		Use the -m/--message or -F/--file option to specify the message
 		without opening an editor.
 		Git hooks are run unless the --no-verify flag is given.
 
@@ -50,12 +51,13 @@ func (cmd *commitCreateCmd) Run(
 	restackHandler RestackHandler,
 ) error {
 	if err := wt.Commit(ctx, git.CommitRequest{
-		Message:    cmd.Message,
-		All:        cmd.All,
-		AllowEmpty: cmd.AllowEmpty,
-		Fixup:      cmd.Fixup,
-		NoVerify:   cmd.NoVerify,
-		Signoff:    cmd.Signoff,
+		Message:     cmd.Message,
+		MessageFile: cmd.MessageFile,
+		All:         cmd.All,
+		AllowEmpty:  cmd.AllowEmpty,
+		Fixup:       cmd.Fixup,
+		NoVerify:    cmd.NoVerify,
+		Signoff:     cmd.Signoff,
 	}); err != nil {
 		return fmt.Errorf("commit: %w", err)
 	}

--- a/commit_split.go
+++ b/commit_split.go
@@ -12,8 +12,9 @@ import (
 )
 
 type commitSplitCmd struct {
-	Message  string `short:"m" placeholder:"MSG" help:"Use the given message as the commit message."`
-	NoVerify bool   `help:"Bypass pre-commit and commit-msg hooks."`
+	Message     string `short:"m" xor:"commit-message-source" placeholder:"MSG" help:"Use the given message as the commit message."`
+	MessageFile string `short:"F" xor:"commit-message-source" placeholder:"FILE" help:"Read the commit message from the given file."`
+	NoVerify    bool   `help:"Bypass pre-commit and commit-msg hooks."`
 }
 
 func (*commitSplitCmd) Help() string {
@@ -70,8 +71,9 @@ func (cmd *commitSplitCmd) Run(
 	}
 
 	if err := wt.Commit(ctx, git.CommitRequest{
-		Message:  cmd.Message,
-		NoVerify: cmd.NoVerify,
+		Message:     cmd.Message,
+		MessageFile: cmd.MessageFile,
+		NoVerify:    cmd.NoVerify,
 	}); err != nil {
 		return fmt.Errorf("commit: %w", err)
 	}

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -664,7 +664,7 @@ If there are no staged changes, an empty commit will be created.
 Use -a/--all to automatically stage modified and deleted files,
 just like 'git commit -a'.
 Use --no-commit to create the branch without committing.
--m/--message always implies --commit.
+-m/--message and -F/--file always imply --commit.
 
 If a branch name is not provided,
 it will be generated from the commit message.
@@ -724,6 +724,7 @@ target (A) to the specified branch:
 * `-t`, `--target=BRANCH`: Branch to create the new branch above/below
 * `-a`, `--all`: Automatically stage modified and deleted files
 * `-m`, `--message=MSG`: Commit message
+* `-F`, `--message-file=FILE`: Read the commit message from the given file.
 * `--no-verify`: Bypass pre-commit and commit-msg hooks.
 * `--signoff` ([:material-wrench:{ .middle title="spice.commit.signoff" }](/cli/config.md#spicecommitsignoff)): Add Signed-off-by trailer to the commit message
 * `--[no-]commit` ([:material-wrench:{ .middle title="spice.branchCreate.commit" }](/cli/config.md#spicebranchcreatecommit)): Commit staged changes to the new branch, or create an empty commit
@@ -841,13 +842,15 @@ Squash all commits in the current branch into a single commit
 and restack upstack branches.
 
 An editor will open to edit the commit message of the squashed commit.
-Use the -m/--message flag to specify a commit message without editing.
+Use the -m/--message or -F/--file flag
+to specify a commit message without editing.
 
 **Flags**
 
 * `--no-verify`: Bypass pre-commit and commit-msg hooks.
 * `--no-edit`: Do not open an editor to edit the squashed commit message. Only applicable if --message is not used. <span class="mdx-badge"><span class="mdx-badge__icon">:material-tag:{ title="Released in version" }</span><span class="mdx-badge__text">[v0.16.0](/changelog.md#v0.16.0)</span>
 * `-m`, `--message=MSG`: Use the given message as the commit message.
+* `-F`, `--message-file=FILE`: Read the commit message from the given file.
 * `--branch=NAME`: Branch to squash. Defaults to current branch. <span class="mdx-badge"><span class="mdx-badge__icon">:material-tag:{ title="Released in version" }</span><span class="mdx-badge__text">[v0.16.0](/changelog.md#v0.16.0)</span>
 
 ### git-spice branch edit {#gs-branch-edit}
@@ -1044,7 +1047,7 @@ Use this as a shortcut for 'git commit'
 followed by 'gs upstack restack'.
 
 An editor is opened to edit the commit message.
-Use the -m/--message option to specify the message
+Use the -m/--message or -F/--file option to specify the message
 without opening an editor.
 Git hooks are run unless the --no-verify flag is given.
 
@@ -1061,6 +1064,7 @@ when you want to apply changes to an older commit.
 * `--allow-empty`: Create a new commit even if it contains no changes.
 * `--fixup=COMMIT`: Create a fixup commit. See also 'git-spice commit fixup'.
 * `-m`, `--message=MSG`: Use the given message as the commit message.
+* `-F`, `--message-file=FILE`: Read the commit message from the given file.
 * `--no-verify`: Bypass pre-commit and commit-msg hooks.
 * `--signoff` ([:material-wrench:{ .middle title="spice.commit.signoff" }](/cli/config.md#spicecommitsignoff)): Add Signed-off-by trailer to the commit message
 
@@ -1084,8 +1088,8 @@ that are further downstack.
 
 An editor is opened to edit the commit message
 unless the --no-edit flag is given.
-Use the -m/--message option to specify the message
-on the command line.
+Use the -m/--message or -F/--file option
+to specify the message without opening an editor.
 Git hooks are run unless the --no-verify flag is given.
 
 Use the -a/--all flag to stage all changes before committing.
@@ -1099,6 +1103,7 @@ The --no-prompt flag can be used to skip this prompt in scripts.
 * `-a`, `--all`: Stage all changes before committing.
 * `--allow-empty`: Create a commit even if it contains no changes.
 * `-m`, `--message=MSG`: Use the given message as the commit message.
+* `-F`, `--message-file=FILE`: Read the commit message from the given file.
 * `--no-edit`: Don't edit the commit message
 * `--no-verify`: Bypass pre-commit and commit-msg hooks.
 * `--signoff` ([:material-wrench:{ .middle title="spice.commit.signoff" }](/cli/config.md#spicecommitsignoff)): Add Signed-off-by trailer to the commit message
@@ -1120,6 +1125,7 @@ Branches upstack are restacked as needed.
 **Flags**
 
 * `-m`, `--message=MSG`: Use the given message as the commit message.
+* `-F`, `--message-file=FILE`: Read the commit message from the given file.
 * `--no-verify`: Bypass pre-commit and commit-msg hooks.
 
 ### git-spice commit fixup {#gs-commit-fixup}

--- a/internal/git/commit_wt.go
+++ b/internal/git/commit_wt.go
@@ -15,6 +15,9 @@ type CommitRequest struct {
 	// $EDITOR is opened to edit the message.
 	Message string
 
+	// MessageFile reads the commit message from the given file.
+	MessageFile string
+
 	// ReuseMessage uses the commit message from the given commitish
 	// as the commit message.
 	ReuseMessage string
@@ -63,6 +66,9 @@ func (w *Worktree) Commit(ctx context.Context, req CommitRequest) error {
 	}
 	if req.Message != "" {
 		args = append(args, "-m", req.Message)
+	}
+	if req.MessageFile != "" {
+		args = append(args, "-F", req.MessageFile)
 	}
 	if req.Template != "" {
 		f, err := os.CreateTemp("", "commit-template-")

--- a/internal/git/commit_wt_test.go
+++ b/internal/git/commit_wt_test.go
@@ -91,6 +91,15 @@ Signed-off-by: Test Committer <signer@example.com>`))
 }
 
 func TestWorktree_Commit_messageFile(t *testing.T) {
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	t.Setenv("USER", "testuser")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("GIT_COMMITTER_NAME", "Test Committer")
+	t.Setenv("GIT_COMMITTER_EMAIL", "committer@example.com")
+	t.Setenv("GIT_AUTHOR_NAME", "Test Author")
+	t.Setenv("GIT_AUTHOR_EMAIL", "author@example.com")
+
 	fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
 		at '2025-08-30T21:28:29Z'
 		as 'Test Owner <test@example.com>'

--- a/internal/git/commit_wt_test.go
+++ b/internal/git/commit_wt_test.go
@@ -1,6 +1,8 @@
 package git_test
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -86,4 +88,39 @@ Signed-off-by: Test Committer <committer@example.com>`))
 Signed-off-by: Test Committer <committer@example.com>
 Signed-off-by: Test Committer <signer@example.com>`))
 	})
+}
+
+func TestWorktree_Commit_messageFile(t *testing.T) {
+	fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+		at '2025-08-30T21:28:29Z'
+		as 'Test Owner <test@example.com>'
+
+		git init
+		git commit --allow-empty -m 'Initial commit'
+
+		git add file.txt
+
+		-- file.txt --
+		test content
+	`)))
+	require.NoError(t, err)
+	t.Cleanup(fixture.Cleanup)
+
+	ctx := t.Context()
+	worktree, err := git.OpenWorktree(ctx, fixture.Dir(), git.OpenOptions{
+		Log: silogtest.New(t),
+	})
+	require.NoError(t, err)
+
+	messageFile := filepath.Join(fixture.Dir(), "message.txt")
+	require.NoError(t, os.WriteFile(messageFile, []byte("Add test file\n\nFrom file.\n"), 0o644))
+
+	require.NoError(t, worktree.Commit(ctx, git.CommitRequest{
+		MessageFile: messageFile,
+	}))
+
+	commit, err := worktree.Repository().ReadCommit(ctx, "HEAD")
+	require.NoError(t, err)
+	require.Equal(t, "Add test file", commit.Subject)
+	require.Equal(t, "From file.\n", commit.Body)
 }

--- a/internal/handler/squash/handler.go
+++ b/internal/handler/squash/handler.go
@@ -77,7 +77,8 @@ type Options struct {
 
 	NoEdit bool `released:"v0.16.0" help:"Do not open an editor to edit the squashed commit message. Only applicable if --message is not used."`
 
-	Message string `short:"m" placeholder:"MSG" help:"Use the given message as the commit message."`
+	Message     string `short:"m" xor:"commit-message-source" placeholder:"MSG" help:"Use the given message as the commit message."`
+	MessageFile string `short:"F" xor:"commit-message-source" placeholder:"FILE" help:"Read the commit message from the given file."`
 }
 
 // SquashBranch squashes all commits in the given branch into a single commit.
@@ -105,7 +106,7 @@ func (h *Handler) SquashBranch(ctx context.Context, branchName string, opts *Opt
 	// combine the commit messages of all commits in the branch
 	// to form the initial commit message for the squashed commit.
 	var commitTemplate string
-	if opts.Message == "" {
+	if opts.Message == "" && opts.MessageFile == "" {
 		commitMessages, err := h.Repository.CommitMessageRange(ctx, branch.Head.String(), branch.BaseHash.String())
 		if err != nil {
 			return fmt.Errorf("get commit messages: %w", err)
@@ -157,9 +158,10 @@ func (h *Handler) SquashBranch(ctx context.Context, branchName string, opts *Opt
 	}
 
 	if err := h.Worktree.Commit(ctx, git.CommitRequest{
-		Message:  opts.Message,
-		Template: commitTemplate,
-		NoVerify: opts.NoVerify,
+		Message:     opts.Message,
+		MessageFile: opts.MessageFile,
+		Template:    commitTemplate,
+		NoVerify:    opts.NoVerify,
 	}); err != nil {
 		return fmt.Errorf("commit squashed changes: %w", err)
 	}

--- a/internal/handler/squash/handler_test.go
+++ b/internal/handler/squash/handler_test.go
@@ -244,6 +244,66 @@ func TestHandler_SquashBranch(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("MessageFile", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		branchName := "feature"
+		baseHash := git.Hash("abc123")
+		headHash := git.Hash("def456")
+
+		mockService := NewMockService(ctrl)
+		mockService.EXPECT().
+			VerifyRestacked(t.Context(), branchName).
+			Return(nil)
+		mockService.EXPECT().
+			LookupBranch(t.Context(), branchName).
+			Return(&spice.LookupBranchResponse{
+				Head:     headHash,
+				BaseHash: baseHash,
+			}, nil)
+
+		mockRepo := NewMockGitRepository(ctrl)
+		mockRepo.EXPECT().
+			SetRef(t.Context(), gomock.Any()).
+			Return(nil)
+
+		mockWorktree := NewMockGitWorktree(ctrl)
+		mockWorktree.EXPECT().
+			DetachHead(t.Context(), branchName).
+			Return(nil)
+		mockWorktree.EXPECT().
+			Reset(t.Context(), baseHash.String(), git.ResetOptions{Mode: git.ResetSoft}).
+			Return(nil)
+		mockWorktree.EXPECT().
+			Commit(t.Context(), git.CommitRequest{MessageFile: "message.txt"}).
+			Return(nil)
+		mockWorktree.EXPECT().
+			Head(t.Context()).
+			Return(git.Hash("new123"), nil)
+		mockWorktree.EXPECT().
+			CheckoutBranch(t.Context(), branchName).
+			Return(nil)
+
+		mockRestack := NewMockRestackHandler(ctrl)
+		mockRestack.EXPECT().
+			RestackUpstack(t.Context(), branchName, nil).
+			Return(nil)
+
+		handler := &Handler{
+			Log:        silog.Nop(),
+			Repository: mockRepo,
+			Worktree:   mockWorktree,
+			Store:      mockStore,
+			Service:    mockService,
+			Restack:    mockRestack,
+		}
+
+		err := handler.SquashBranch(t.Context(), branchName, &Options{
+			MessageFile: "message.txt",
+		})
+		assert.NoError(t, err)
+	})
+
 	t.Run("NoMessage", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 

--- a/testdata/help/branch_create.txt
+++ b/testdata/help/branch_create.txt
@@ -5,7 +5,7 @@ Create a new branch
 Staged changes will be committed to the new branch. If there are no staged
 changes, an empty commit will be created. Use -a/--all to automatically stage
 modified and deleted files, just like 'git commit -a'. Use --no-commit to create
-the branch without committing. -m/--message always implies --commit.
+the branch without committing. -m/--message and -F/--file always imply --commit.
 
 If a branch name is not provided, it will be generated from the
 commit message. If the 'spice.branchCreate.prefix' configuration
@@ -56,18 +56,19 @@ Arguments:
   [<name>]    Name of the new branch
 
 Flags:
-      --insert           Restack the upstack of the target branch onto the new
-                         branch
-      --below            Place the branch below the target branch and restack
-                         its upstack
-  -t, --target=BRANCH    Branch to create the new branch above/below
-  -a, --all              Automatically stage modified and deleted files
-  -m, --message=MSG      Commit message
-      --no-verify        Bypass pre-commit and commit-msg hooks.
-      --signoff          Add Signed-off-by trailer to the commit message (🔧
-                         spice.commit.signoff)
-      --[no-]commit      Commit staged changes to the new branch, or create an
-                         empty commit (🔧 spice.branchCreate.commit)
+      --insert               Restack the upstack of the target branch onto the
+                             new branch
+      --below                Place the branch below the target branch and
+                             restack its upstack
+  -t, --target=BRANCH        Branch to create the new branch above/below
+  -a, --all                  Automatically stage modified and deleted files
+  -m, --message=MSG          Commit message
+  -F, --message-file=FILE    Read the commit message from the given file.
+      --no-verify            Bypass pre-commit and commit-msg hooks.
+      --signoff              Add Signed-off-by trailer to the commit message (🔧
+                             spice.commit.signoff)
+      --[no-]commit          Commit staged changes to the new branch, or create
+                             an empty commit (🔧 spice.branchCreate.commit)
 
 Global Flags:
   -h, --help           Show help for the command

--- a/testdata/help/branch_squash.txt
+++ b/testdata/help/branch_squash.txt
@@ -6,14 +6,15 @@ Squash all commits in the current branch into a single commit and restack
 upstack branches.
 
 An editor will open to edit the commit message of the squashed commit. Use the
--m/--message flag to specify a commit message without editing.
+-m/--message or -F/--file flag to specify a commit message without editing.
 
 Flags:
-      --no-verify      Bypass pre-commit and commit-msg hooks.
-      --no-edit        Do not open an editor to edit the squashed commit
-                       message. Only applicable if --message is not used.
-  -m, --message=MSG    Use the given message as the commit message.
-      --branch=NAME    Branch to squash. Defaults to current branch.
+      --no-verify            Bypass pre-commit and commit-msg hooks.
+      --no-edit              Do not open an editor to edit the squashed commit
+                             message. Only applicable if --message is not used.
+  -m, --message=MSG          Use the given message as the commit message.
+  -F, --message-file=FILE    Read the commit message from the given file.
+      --branch=NAME          Branch to squash. Defaults to current branch.
 
 Global Flags:
   -h, --help           Show help for the command

--- a/testdata/help/commit_amend.txt
+++ b/testdata/help/commit_amend.txt
@@ -9,8 +9,8 @@ restacked if necessary. This is a shortcut for 'git commit --amend' followed by
 Use 'gs commit fixup' to amend commits that are further downstack.
 
 An editor is opened to edit the commit message unless the --no-edit flag is
-given. Use the -m/--message option to specify the message on the command line.
-Git hooks are run unless the --no-verify flag is given.
+given. Use the -m/--message or -F/--file option to specify the message without
+opening an editor. Git hooks are run unless the --no-verify flag is given.
 
 Use the -a/--all flag to stage all changes before committing.
 
@@ -19,13 +19,14 @@ confirmation when amending on trunk. The --no-prompt flag can be used to skip
 this prompt in scripts.
 
 Flags:
-  -a, --all            Stage all changes before committing.
-      --allow-empty    Create a commit even if it contains no changes.
-  -m, --message=MSG    Use the given message as the commit message.
-      --no-edit        Don't edit the commit message
-      --no-verify      Bypass pre-commit and commit-msg hooks.
-      --signoff        Add Signed-off-by trailer to the commit message (🔧
-                       spice.commit.signoff)
+  -a, --all                  Stage all changes before committing.
+      --allow-empty          Create a commit even if it contains no changes.
+  -m, --message=MSG          Use the given message as the commit message.
+  -F, --message-file=FILE    Read the commit message from the given file.
+      --no-edit              Don't edit the commit message
+      --no-verify            Bypass pre-commit and commit-msg hooks.
+      --signoff              Add Signed-off-by trailer to the commit message (🔧
+                             spice.commit.signoff)
 
 Global Flags:
   -h, --help           Show help for the command

--- a/testdata/help/commit_create.txt
+++ b/testdata/help/commit_create.txt
@@ -6,9 +6,9 @@ Staged changes are committed to the current branch. Branches upstack are
 restacked if necessary. Use this as a shortcut for 'git commit' followed by 'gs
 upstack restack'.
 
-An editor is opened to edit the commit message. Use the -m/--message option
-to specify the message without opening an editor. Git hooks are run unless the
---no-verify flag is given.
+An editor is opened to edit the commit message. Use the -m/--message or
+-F/--file option to specify the message without opening an editor. Git hooks are
+run unless the --no-verify flag is given.
 
 Use the -a/--all flag to stage all changes before committing.
 
@@ -17,14 +17,15 @@ commit when run with 'git rebase --autosquash'. See also, the 'gs commit fixup'
 command, which is preferable when you want to apply changes to an older commit.
 
 Flags:
-  -a, --all             Stage all changes before committing.
-      --allow-empty     Create a new commit even if it contains no changes.
-      --fixup=COMMIT    Create a fixup commit. See also 'git-spice commit
-                        fixup'.
-  -m, --message=MSG     Use the given message as the commit message.
-      --no-verify       Bypass pre-commit and commit-msg hooks.
-      --signoff         Add Signed-off-by trailer to the commit message (🔧
-                        spice.commit.signoff)
+  -a, --all                  Stage all changes before committing.
+      --allow-empty          Create a new commit even if it contains no changes.
+      --fixup=COMMIT         Create a fixup commit. See also 'git-spice commit
+                             fixup'.
+  -m, --message=MSG          Use the given message as the commit message.
+  -F, --message-file=FILE    Read the commit message from the given file.
+      --no-verify            Bypass pre-commit and commit-msg hooks.
+      --signoff              Add Signed-off-by trailer to the commit message (🔧
+                             spice.commit.signoff)
 
 Global Flags:
   -h, --help           Show help for the command

--- a/testdata/help/commit_split.txt
+++ b/testdata/help/commit_split.txt
@@ -6,8 +6,9 @@ Interactively select hunks from the current commit to split into new commits
 below it. Branches upstack are restacked as needed.
 
 Flags:
-  -m, --message=MSG    Use the given message as the commit message.
-      --no-verify      Bypass pre-commit and commit-msg hooks.
+  -m, --message=MSG          Use the given message as the commit message.
+  -F, --message-file=FILE    Read the commit message from the given file.
+      --no-verify            Bypass pre-commit and commit-msg hooks.
 
 Global Flags:
   -h, --help           Show help for the command

--- a/testdata/script/commit_message_file.txt
+++ b/testdata/script/commit_message_file.txt
@@ -1,0 +1,80 @@
+# Regression test for https://github.com/abhinav/git-spice/issues/1108.
+# Commands that create commits should accept -F/--file.
+
+as 'Test <test@example.com>'
+at '2026-04-16T19:00:00Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# -m and -F should be mutually exclusive.
+! gs commit create -m 'bad' -F $WORK/input/commit-create.txt
+stderr '--message and --message-file'
+
+# branch create should accept -F.
+git add branch-create.txt
+gs branch create feature -F $WORK/input/branch-create.txt
+git log --format=%B -1
+cmp stdout $WORK/golden/branch-create-msg.txt
+
+# commit create should accept -F.
+git add commit-create.txt
+gs commit create -F $WORK/input/commit-create.txt
+git log --format=%B -1
+cmp stdout $WORK/golden/commit-create-msg.txt
+
+# commit amend should accept -F.
+git add commit-amend.txt
+gs commit amend -F $WORK/input/commit-amend.txt
+git log --format=%B -1
+stdout 'Amend commit from file'
+stdout 'Amend body.'
+
+# branch squash should accept -F.
+git add squash1.txt
+gs commit create -m 'Add squash1'
+git add squash2.txt
+gs commit create -m 'Add squash2'
+gs branch squash -F $WORK/input/branch-squash.txt
+git log --format=%B -1
+stdout 'Squash branch from file'
+stdout 'Squash body.'
+
+-- repo/branch-create.txt --
+branch create content
+-- repo/commit-create.txt --
+commit create content
+-- repo/commit-amend.txt --
+commit amend content
+-- repo/squash1.txt --
+squash content 1
+-- repo/squash2.txt --
+squash content 2
+-- input/branch-create.txt --
+Create feature from file
+
+Branch body.
+-- input/commit-create.txt --
+Add another commit from file
+
+Create body.
+-- input/commit-amend.txt --
+Amend commit from file
+
+Amend body.
+-- input/branch-squash.txt --
+Squash branch from file
+
+Squash body.
+-- golden/branch-create-msg.txt --
+Create feature from file
+
+Branch body.
+
+-- golden/commit-create-msg.txt --
+Add another commit from file
+
+Create body.
+

--- a/testdata/script/commit_split_message_file.txt
+++ b/testdata/script/commit_split_message_file.txt
@@ -1,0 +1,56 @@
+# Regression test for https://github.com/abhinav/git-spice/issues/1108.
+# commit split should accept -F/--file.
+
+[!unix] skip # pending github.com/creack/pty/pull/155
+[!git:2.52] skip # git add -p output is fixed to Git version
+
+as 'Test <test@example.com>'
+at '2026-04-16T19:00:01Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git add feature1.txt feature2.txt
+gs branch create features -m 'Add features'
+
+git add feature3.txt
+gs branch create feature3 -m 'Add feature 3'
+gs down
+
+with-term -final exit $WORK/input.txt -- gs commit split -F $WORK/input/message.txt
+
+git log --format=%s -2
+cmp stdout $WORK/golden/subjects.txt
+
+git log --format=%s -1 HEAD^
+cmp stdout $WORK/golden/split-subject.txt
+
+git log --format=%b -1 HEAD^
+stdout 'Split body.'
+
+-- repo/feature1.txt --
+feature 1
+
+-- repo/feature2.txt --
+feature 2
+
+-- repo/feature3.txt --
+feature 3
+
+-- input.txt --
+await feature1
+feed y\r
+await feature2
+feed q\r
+
+-- input/message.txt --
+Add feature 1 from file
+
+Split body.
+-- golden/subjects.txt --
+Add features
+Add feature 1 from file
+-- golden/split-subject.txt --
+Add feature 1 from file


### PR DESCRIPTION
Add `-F/--file` support to the commands that create commits,
and cover the mutual-exclusion contract with `-m` in script tests.

Resolves #1108.