### PR TITLE
forge/gitlab: use !NNN+ nav reference to expand MR titles inline

### DIFF
--- a/.changes/unreleased/Changed-20260417-160000.yaml
+++ b/.changes/unreleased/Changed-20260417-160000.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'submit: GitLab MR references in stack navigation now use GitLab''s "+" reference expansion so the MR title renders inline.'
+time: 2026-04-17T16:00:00.000000-07:00

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -271,6 +271,22 @@ type WithChangeURL interface {
 	ChangeURL(id ChangeID) string
 }
 
+// WithNavigationReference is an optional interface that repositories can
+// implement to customize how a change is referenced inside stack
+// navigation (comments or descriptions).
+//
+// Forges like GitLab support reference expansion (e.g. "!123+") that
+// renders the change title inline when the markdown is rendered.
+// Repositories that implement this interface take precedence over
+// [WithChangeURL] for navigation rendering.
+type WithNavigationReference interface {
+	Repository
+
+	// NavigationReference returns the markdown snippet used to reference
+	// the given change ID in stack navigation content.
+	NavigationReference(id ChangeID) string
+}
+
 // ChangeID is a unique identifier for a change in a repository.
 type ChangeID interface {
 	String() string

--- a/internal/forge/gitlab/repository.go
+++ b/internal/forge/gitlab/repository.go
@@ -28,7 +28,19 @@ type Repository struct {
 	removeSourceBranchOnMerge bool
 }
 
-var _ forge.Repository = (*Repository)(nil)
+var (
+	_ forge.Repository              = (*Repository)(nil)
+	_ forge.WithNavigationReference = (*Repository)(nil)
+)
+
+// NavigationReference returns the GitLab reference to the given merge
+// request with the "+" expansion suffix.
+// GitLab renders "!NNN+" as the MR title inline with a link to it,
+// making stack navigation listings more informative than bare "!NNN"
+// references.
+func (r *Repository) NavigationReference(id forge.ChangeID) string {
+	return mustMR(id).String() + "+"
+}
 
 type repositoryOptions struct {
 	RepositoryID *int64 // if nil, repository ID will be looked up

--- a/internal/forge/gitlab/repository_test.go
+++ b/internal/forge/gitlab/repository_test.go
@@ -16,3 +16,8 @@ func TestAccessValueName(t *testing.T) {
 		assert.Equal(t, "999", accessValueName(gitlab.AccessLevelValue(999)))
 	})
 }
+
+func TestRepository_NavigationReference(t *testing.T) {
+	repo := &Repository{}
+	assert.Equal(t, "!42+", repo.NavigationReference(&MR{Number: 42}))
+}

--- a/internal/handler/submit/nav_comment.go
+++ b/internal/handler/submit/nav_comment.go
@@ -107,12 +107,19 @@ func updateNavigationComments(
 		return fmt.Errorf("get remote repository: %w", err)
 	}
 
-	// Create URL formatter for forges that need explicit links.
-	// Forges like GitHub auto-link "#123" to PRs, but Bitbucket doesn't.
+	// Build a reference formatter for forges that customize navigation.
+	// Forges like GitHub auto-link "#123" and need no formatter.
+	// GitLab implements WithNavigationReference to append "+" so the MR
+	// title is rendered inline.
+	// Bitbucket doesn't auto-link "#123", so WithChangeURL wraps the
+	// reference in an explicit markdown link.
 	var urlFormatter func(forge.ChangeID) string
-	if repo, ok := remoteRepo.(forge.WithChangeURL); ok {
+	switch r := remoteRepo.(type) {
+	case forge.WithNavigationReference:
+		urlFormatter = r.NavigationReference
+	case forge.WithChangeURL:
 		urlFormatter = func(id forge.ChangeID) string {
-			return fmt.Sprintf("[%s](%s)", id.String(), repo.ChangeURL(id))
+			return fmt.Sprintf("[%s](%s)", id.String(), r.ChangeURL(id))
 		}
 	}
 

--- a/internal/handler/submit/nav_comment_test.go
+++ b/internal/handler/submit/nav_comment_test.go
@@ -814,6 +814,29 @@ func TestGenerateStackNavigationComment(t *testing.T) {
 			_commentMarker + "\n"
 		assert.Equal(t, want, got)
 	})
+
+	t.Run("UrlFormatter", func(t *testing.T) {
+		// Simulates a forge that customizes navigation references,
+		// e.g. GitLab's "!NNN+" expansion.
+		fmtRef := func(id forge.ChangeID) string {
+			return id.String() + "+"
+		}
+		graph := []*stackedChange{
+			{Change: _changeID("123"), Base: -1, urlFormatter: fmtRef},
+			{Change: _changeID("124"), Base: 0, urlFormatter: fmtRef},
+		}
+		graph[0].Aboves = []int{1}
+
+		got := generateStackNavigationComment(graph, 1, "", nil)
+		want := _commentHeader + "\n\n" +
+			joinLines(
+				"- #123+",
+				"    - #124+ ◀",
+			) + "\n" +
+			_commentFooter + "\n" +
+			_commentMarker + "\n"
+		assert.Equal(t, want, got)
+	})
 }
 
 func TestNavigationCommentWhen_StringMarshal(t *testing.T) {


### PR DESCRIPTION
Since 2021, Gitlab can render MR titles, by adding + at the end of MR id.

https://about.gitlab.com/releases/2021/12/22/gitlab-14-6-released/#render-the-title-of-a-referenced-issue-within-
markdown