### PR TITLE
auth: disable git terminal prompt when loading GCM credentials

### DIFF
--- a/.changes/unreleased/Fixed-20260422-170432.yaml
+++ b/.changes/unreleased/Fixed-20260422-170432.yaml
@@ -1,3 +1,5 @@
 kind: Fixed
-body: 'auth: Prevent git credential fill from prompting when no credential helper is configured'
+body: >-
+  auth: Disable prompting when querying Git Credential Manager (GCM).
+  With prompting enabled, GCM may block the authentication flow.
 time: 2026-04-22T17:04:32.29156277Z

--- a/.changes/unreleased/Fixed-20260422-170432.yaml
+++ b/.changes/unreleased/Fixed-20260422-170432.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'auth: Prevent git credential fill from prompting when no credential helper is configured'
+time: 2026-04-22T17:04:32.29156277Z

--- a/internal/forge/gcm.go
+++ b/internal/forge/gcm.go
@@ -29,6 +29,7 @@ func LoadGCMCredential(ctx context.Context, forgeURL string) (*GCMCredential, er
 	input := fmt.Sprintf("protocol=https\nhost=%s\n\n", host)
 
 	output, err := xec.Command(ctx, nil, "git", "credential", "fill").
+		AppendEnv("GIT_TERMINAL_PROMPT=0").
 		WithStdinString(input).
 		Output()
 	if err != nil {

--- a/internal/forge/gcm_test.go
+++ b/internal/forge/gcm_test.go
@@ -1,6 +1,10 @@
 package forge
 
 import (
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -127,4 +131,60 @@ func TestExtractHost(t *testing.T) {
 			assert.Equal(t, tt.wantOut, extractHost(tt.rawURL))
 		})
 	}
+}
+
+func TestLoadGCMCredential_disablesTerminalPrompt(t *testing.T) {
+	// Regression test for issue #1120:
+	// https://github.com/abhinav/git-spice/issues/1120
+	dir := t.TempDir()
+	gitPath := filepath.Join(dir, "git")
+	if runtime.GOOS == "windows" {
+		gitPath += ".exe"
+	}
+
+	testExe, err := os.Executable()
+	require.NoError(t, err)
+	createFakeGitExecutable(t, testExe, gitPath)
+
+	t.Setenv(
+		"PATH",
+		dir+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+	t.Setenv("GS_GCM_TEST_FAKE_GIT_MODE", "gcm-fill")
+
+	cred, err := LoadGCMCredential(
+		t.Context(),
+		"https://github.com/git-spice/git-spice",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "test-user", cred.Username)
+	assert.Equal(t, "test-token", cred.Password)
+}
+
+func createFakeGitExecutable(
+	t *testing.T,
+	testExe string,
+	gitPath string,
+) {
+	t.Helper()
+
+	if err := os.Symlink(testExe, gitPath); err == nil {
+		return
+	}
+
+	src, err := os.Open(testExe)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, src.Close())
+	}()
+
+	dst, err := os.Create(gitPath)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, dst.Close())
+	}()
+
+	_, err = io.Copy(dst, src)
+	require.NoError(t, err)
+	require.NoError(t, os.Chmod(gitPath, 0o755))
 }

--- a/internal/forge/main_test.go
+++ b/internal/forge/main_test.go
@@ -1,0 +1,49 @@
+package forge
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	name := filepath.Base(os.Args[0])
+	if runtime.GOOS == "windows" {
+		name = strings.TrimSuffix(strings.ToLower(name), ".exe")
+	}
+
+	if name == "git" {
+		if os.Getenv("GS_GCM_TEST_FAKE_GIT_MODE") == "gcm-fill" {
+			fakeGitCredentialFill()
+			os.Exit(0)
+		}
+
+		_, _ = os.Stderr.WriteString(
+			"fake git invoked without configured helper mode\n")
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}
+
+func fakeGitCredentialFill() {
+	if len(os.Args) != 3 || os.Args[1] != "credential" || os.Args[2] != "fill" {
+		_, _ = os.Stderr.WriteString("unexpected args\n")
+		os.Exit(1)
+	}
+
+	if os.Getenv("GIT_TERMINAL_PROMPT") != "0" {
+		_, _ = os.Stderr.WriteString(
+			"GIT_TERMINAL_PROMPT was not disabled\n")
+		os.Exit(1)
+	}
+
+	fmt.Print(`protocol=https
+host=github.com
+username=test-user
+password=test-token
+`)
+}


### PR DESCRIPTION
Prevent `git credential fill` from prompting for input when no credential helper is configured,
which could hang or block flows that expect non-interactive behavior.

This is easy enough by setting `GIT_TERMINAL_PROMPT=0` when invoking `git credential fill`.

The regression test is pretty narrow, just testing that the env var was set.
Worth considering an end-to-end test for the broken flow as well
as part of the fuller fix for the issue.

Refs #1120