### PR TITLE
auth: stop implicit GCM credential fallback

### DIFF
--- a/.changes/unreleased/Changed-20260422-204815.yaml
+++ b/.changes/unreleased/Changed-20260422-204815.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'auth: git-spice will no longer automatically fall back to Git Credential Manager-managed credentials without running ''gs auth login''.'
+time: 2026-04-22T20:48:15.839391-07:00

--- a/.changes/unreleased/Fixed-20260422-170432.yaml
+++ b/.changes/unreleased/Fixed-20260422-170432.yaml
@@ -1,5 +1,5 @@
 kind: Fixed
 body: >-
-  auth: Disable prompting when querying Git Credential Manager (GCM).
-  With prompting enabled, GCM may block the authentication flow.
+  auth: Disable prompting when querying 'git credential',
+  as it may block authentication flow otherwise.
 time: 2026-04-22T17:04:32.29156277Z

--- a/.changes/unreleased/Fixed-20260422-205327.yaml
+++ b/.changes/unreleased/Fixed-20260422-205327.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: >-
+  auth: Fix 'git credential' being queried
+  even when Git Credential Manager is not explicitly selected.
+time: 2026-04-22T20:53:27.892730204Z

--- a/doc/src/setup/auth.md
+++ b/doc/src/setup/auth.md
@@ -140,7 +140,7 @@ You **must** install the GitHub App to access repositories with git-spice.
 [Git Credential Manager](https://github.com/git-credential-manager/git-credential-manager)
 (GCM) is a secure credential storage system for Git.
 If you already have GCM configured for GitHub or Bitbucket,
-git-spice can reuse those credentials automatically.
+git-spice can reuse those credentials.
 
 ```freeze language="terminal"
 {green}${reset} gs auth login
@@ -173,11 +173,6 @@ To set up GCM:
    This triggers the OAuth flow in your browser.
 
 After that, git-spice will use the stored OAuth token automatically.
-
-Additionally, if you have GCM configured,
-git-spice will automatically fall back to GCM credentials
-when no other authentication token is available—even
-without running `gs auth login`.
 
 ### Personal Access Token
 
@@ -347,8 +342,6 @@ The $$gs auth login$$ operation will always fail if you use this method.
 
     [Git Credential Manager](#git-credential-manager)
     is convenient if you already have GCM installed for git operations.
-    git-spice can reuse your existing GCM credentials automatically,
-    and will fall back to them even without explicit login.
 
     [Service CLI](#service-cli) is the most convenient method
     if you already have the GitHub CLI installed and authenticated.

--- a/internal/forge/bitbucket/auth.go
+++ b/internal/forge/bitbucket/auth.go
@@ -37,6 +37,9 @@ type AuthenticationToken struct {
 	AuthType AuthType `json:"auth_type"`
 
 	// AccessToken is the Bitbucket API token.
+	//
+	// Not used if AuthType is AuthTypeGCM,
+	// as the token is loaded from git-credential-manager on demand.
 	AccessToken string `json:"access_token,omitempty"`
 }
 
@@ -130,15 +133,14 @@ func apiTokenAuthDescription(theme ui.Theme, focused bool) string {
 }
 
 func (f *Forge) gcmAuth(ctx context.Context, log *silog.Logger) (*AuthenticationToken, error) {
-	token, err := f.loadGCMCredentials(ctx)
-	if err != nil {
+	if _, err := f.loadGCMCredentials(ctx); err != nil {
 		log.Error("Could not load credentials from git-credential-manager.")
 		log.Error("Ensure GCM is installed and you have authenticated to Bitbucket.")
 		return nil, fmt.Errorf("load GCM credentials: %w", err)
 	}
 
 	log.Info("Successfully loaded credentials from git-credential-manager.")
-	return token, nil
+	return &AuthenticationToken{AuthType: AuthTypeGCM}, nil
 }
 
 func (f *Forge) apiTokenAuth(_ context.Context, view ui.View) (*AuthenticationToken, error) {
@@ -202,7 +204,9 @@ func (f *Forge) SaveAuthenticationToken(
 // Priority order:
 //  1. Environment variable (BITBUCKET_TOKEN)
 //  2. Stored token in secret stash
-//  3. git-credential-manager (GCM)
+//
+// For a stored token configured to use GCM, the access token is loaded from
+// git-credential-manager on demand.
 func (f *Forge) LoadAuthenticationToken(stash secret.Stash) (forge.AuthenticationToken, error) {
 	// Environment variable takes highest precedence.
 	if f.Options.Token != "" {
@@ -212,26 +216,21 @@ func (f *Forge) LoadAuthenticationToken(stash secret.Stash) (forge.Authenticatio
 		}, nil
 	}
 
-	var errs []error
-
 	// Try stored token next.
-	if token, err := f.loadStoredToken(stash); err != nil {
-		errs = append(errs, fmt.Errorf("load stored token: %w", err))
-	} else {
-		return token, nil
+	token, err := f.loadStoredToken(stash)
+	if err != nil {
+		return nil, fmt.Errorf("load stored token: %w", err)
 	}
 
-	// Fall back to git-credential-manager.
-	// No caller-provided context here; use Background.
-	if token, err := f.loadGCMCredentials(context.Background()); err != nil {
-		errs = append(errs, fmt.Errorf("load GCM credentials: %w", err))
-	} else {
-		f.logger().Debug("Using credentials from git-credential-manager")
-		return token, nil
+	if token.AuthType == AuthTypeGCM {
+		gcmToken, err := f.loadGCMCredentials(context.Background())
+		if err != nil {
+			return nil, fmt.Errorf("load GCM credentials: %w", err)
+		}
+		return gcmToken, nil
 	}
 
-	return nil, fmt.Errorf("no authentication token available:\n%w",
-		errors.Join(errs...))
+	return token, nil
 }
 
 func (f *Forge) loadStoredToken(stash secret.Stash) (*AuthenticationToken, error) {
@@ -247,11 +246,6 @@ func (f *Forge) loadStoredToken(stash secret.Stash) (*AuthenticationToken, error
 	return &token, nil
 }
 
-// ClearAuthenticationToken removes the authentication token from the stash.
-func (f *Forge) ClearAuthenticationToken(stash secret.Stash) error {
-	return stash.DeleteSecret(f.URL(), "token")
-}
-
 // loadGCMCredentials attempts to load OAuth credentials
 // from git-credential-manager.
 // Returns an error if GCM credentials are not available.
@@ -265,4 +259,9 @@ func (f *Forge) loadGCMCredentials(ctx context.Context) (*AuthenticationToken, e
 		AuthType:    AuthTypeGCM,
 		AccessToken: cred.Password,
 	}, nil
+}
+
+// ClearAuthenticationToken removes the authentication token from the stash.
+func (f *Forge) ClearAuthenticationToken(stash secret.Stash) error {
+	return stash.DeleteSecret(f.URL(), "token")
 }

--- a/internal/forge/bitbucket/auth_test.go
+++ b/internal/forge/bitbucket/auth_test.go
@@ -1,10 +1,17 @@
 package bitbucket
 
 import (
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/secret"
+	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/ui"
 )
 
@@ -15,4 +22,82 @@ func TestAPITokenAuthDescription_usesThemeForFocusedURL(t *testing.T) {
 
 	assert.Contains(t, got, "\x1b[")
 	assert.Contains(t, ansi.Strip(got), "https://bitbucket.org/account/settings/api-tokens/")
+}
+
+func TestLoadAuthenticationToken_noStoredTokenDoesNotFallbackToGCM(
+	t *testing.T,
+) {
+	f := Forge{Log: silog.Nop()}
+	var stash secret.MemoryStash
+
+	putFakeGitOnPath(t)
+
+	_, err := f.LoadAuthenticationToken(&stash)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "load stored token")
+}
+
+func TestLoadAuthenticationToken_storedUseGCM(t *testing.T) {
+	f := Forge{Log: silog.Nop()}
+	var stash secret.MemoryStash
+
+	putFakeGitOnPath(t)
+
+	err := stash.SaveSecret(
+		f.URL(),
+		"token",
+		`{"auth_type":1}`,
+	)
+	require.NoError(t, err)
+
+	got, err := f.LoadAuthenticationToken(&stash)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		&AuthenticationToken{
+			AuthType:    AuthTypeGCM,
+			AccessToken: "test-token",
+		},
+		got,
+	)
+}
+
+func putFakeGitOnPath(t *testing.T) {
+	t.Helper()
+
+	dir := t.TempDir()
+	gitPath := filepath.Join(dir, "git")
+	if runtime.GOOS == "windows" {
+		gitPath += ".exe"
+	}
+
+	testExe, err := os.Executable()
+	require.NoError(t, err)
+	linkTestBinary(t, testExe, gitPath)
+
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func linkTestBinary(t *testing.T, testExe, gitPath string) {
+	t.Helper()
+
+	if err := os.Symlink(testExe, gitPath); err == nil {
+		return
+	}
+
+	src, err := os.Open(testExe)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, src.Close())
+	}()
+
+	dst, err := os.Create(gitPath)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, dst.Close())
+	}()
+
+	_, err = io.Copy(dst, src)
+	require.NoError(t, err)
+	require.NoError(t, os.Chmod(gitPath, 0o755))
 }

--- a/internal/forge/bitbucket/main_test.go
+++ b/internal/forge/bitbucket/main_test.go
@@ -1,0 +1,32 @@
+package bitbucket
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	name := filepath.Base(os.Args[0])
+	if runtime.GOOS == "windows" {
+		name = strings.TrimSuffix(strings.ToLower(name), ".exe")
+	}
+
+	if name == "git" {
+		if len(os.Args) == 3 && os.Args[1] == "credential" && os.Args[2] == "fill" {
+			fmt.Print(`protocol=https
+host=bitbucket.org
+username=test-user
+password=test-token
+`)
+			os.Exit(0)
+		}
+
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}

--- a/internal/forge/github/auth.go
+++ b/internal/forge/github/auth.go
@@ -23,26 +23,111 @@ const (
 	// (These are not secret.)
 )
 
+// TokenType is the source of the GitHub authentication token.
+type TokenType int
+
+const (
+	// TokenTypeStash indicates that the token is loaded from the stash.
+	// The AccessToken MUST be stored in the stash.
+	TokenTypeStash TokenType = iota
+
+	// TokenTypeGCM indicates that the token is loaded from git-credential-manager.
+	// AccessToken is not used.
+	TokenTypeGCM
+
+	// TokenTypeCLI indicates that the token is loaded from GitHub CLI.
+	// AccessToken is not used.
+	TokenTypeCLI
+)
+
+func (s TokenType) String() string {
+	switch s {
+	case TokenTypeStash:
+		return "stash"
+	case TokenTypeGCM:
+		return "git-credential-manager"
+	case TokenTypeCLI:
+		return "gh"
+	default:
+		return "unknown"
+	}
+}
+
+// MarshalText encodes the token type as a stable string identifier.
+func (s TokenType) MarshalText() ([]byte, error) {
+	return []byte(s.String()), nil
+}
+
+// UnmarshalText decodes a token type from its string identifier.
+func (s *TokenType) UnmarshalText(text []byte) error {
+	switch strings.ToLower(string(text)) {
+	case "stash", "":
+		*s = TokenTypeStash
+	case "git-credential-manager", "gcm":
+		*s = TokenTypeGCM
+	case "gh", "cli":
+		*s = TokenTypeCLI
+	default:
+		return fmt.Errorf("invalid token source: %q", text)
+	}
+
+	return nil
+}
+
 // AuthenticationToken defines the token returned by the GitHub forge.
 type AuthenticationToken struct {
 	forge.AuthenticationToken
 
-	// GitHubCLI is true if we should use GitHub CLI for API requests.
-	//
-	// If true, AccessToken is not used.
-	GitHubCLI bool `json:"github_cli,omitempty"`
+	// Type indicates where the token is loaded from.
+	// This determines whether AccessToken is used.
+	Type TokenType `json:"type"`
 
 	// AccessToken is the GitHub access token.
+	//
+	// Not used if Type is TokenTypeGCM or TokenTypeCLI.
 	AccessToken string `json:"access_token,omitempty"`
 }
 
 var _ forge.AuthenticationToken = (*AuthenticationToken)(nil)
 
-func (t *AuthenticationToken) tokenSource() oauth2.TokenSource {
-	if t.GitHubCLI {
-		return &CLITokenSource{}
+// UnmarshalJSON decodes the current token schema and legacy CLI schema.
+func (t *AuthenticationToken) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Type        TokenType `json:"type"`
+		AccessToken string    `json:"access_token,omitempty"`
+
+		GitHubCLI bool `json:"github_cli,omitempty"` // for backward compatibility
 	}
-	return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: t.AccessToken})
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	t.Type = raw.Type
+	t.AccessToken = raw.AccessToken
+	if raw.GitHubCLI {
+		t.Type = TokenTypeCLI
+	}
+
+	return nil
+}
+
+func (f *Forge) tokenSource(t *AuthenticationToken) (oauth2.TokenSource, error) {
+	switch t.Type {
+	case TokenTypeGCM:
+		tok, err := f.loadGCMToken()
+		if err != nil {
+			return nil, fmt.Errorf("load GCM token: %w", err)
+		}
+		return oauth2.StaticTokenSource(&oauth2.Token{
+			AccessToken: tok.AccessToken,
+		}), nil
+
+	case TokenTypeCLI:
+		return &CLITokenSource{}, nil
+
+	default:
+		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: t.AccessToken}), nil
+	}
 }
 
 func (f *Forge) oauth2Endpoint() (oauth2.Endpoint, error) {
@@ -112,34 +197,11 @@ func (f *Forge) SaveAuthenticationToken(stash secret.Stash, t forge.Authenticati
 // Priority order:
 //  1. Environment variable (GITHUB_TOKEN)
 //  2. Stored token in secret stash
-//  3. git-credential-manager (GCM)
 func (f *Forge) LoadAuthenticationToken(stash secret.Stash) (forge.AuthenticationToken, error) {
 	if f.Options.Token != "" {
 		return &AuthenticationToken{AccessToken: f.Options.Token}, nil
 	}
 
-	var errs []error
-
-	// Try stored token.
-	if tok, err := f.loadStoredToken(stash); err != nil {
-		errs = append(errs, fmt.Errorf("load stored token: %w", err))
-	} else {
-		return tok, nil
-	}
-
-	// Fall back to git-credential-manager.
-	if tok, err := f.loadGCMToken(); err != nil {
-		errs = append(errs, fmt.Errorf("load GCM token: %w", err))
-	} else {
-		f.logger().Debug("Using credentials from git-credential-manager")
-		return tok, nil
-	}
-
-	return nil, fmt.Errorf("no authentication token available:\n%w",
-		errors.Join(errs...))
-}
-
-func (f *Forge) loadStoredToken(stash secret.Stash) (*AuthenticationToken, error) {
 	tokstr, err := stash.LoadSecret(f.URL(), "token")
 	if err != nil {
 		return nil, err
@@ -466,7 +528,7 @@ func (a *CLIAuthenticator) Authenticate(ctx context.Context, _ ui.View) (*Authen
 		return nil, fmt.Errorf("run gh: %w", err)
 	}
 
-	return &AuthenticationToken{GitHubCLI: true}, nil
+	return &AuthenticationToken{Type: TokenTypeCLI}, nil
 }
 
 // GCMAuthenticator loads OAuth credentials
@@ -479,11 +541,8 @@ type GCMAuthenticator struct {
 func (a *GCMAuthenticator) Authenticate(
 	ctx context.Context, _ ui.View,
 ) (*AuthenticationToken, error) {
-	cred, err := forge.LoadGCMCredential(ctx, a.URL)
-	if err != nil {
+	if _, err := forge.LoadGCMCredential(ctx, a.URL); err != nil {
 		return nil, fmt.Errorf("load GCM credentials: %w", err)
 	}
-	return &AuthenticationToken{
-		AccessToken: cred.Password,
-	}, nil
+	return &AuthenticationToken{Type: TokenTypeGCM}, nil
 }

--- a/internal/forge/github/auth_test.go
+++ b/internal/forge/github/auth_test.go
@@ -8,8 +8,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os/exec"
+	"os"
+	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -20,6 +22,7 @@ import (
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/ui"
 	"go.abhg.dev/gs/internal/ui/uitest"
+	"go.abhg.dev/gs/internal/xec"
 	"go.abhg.dev/gs/internal/xec/xectest"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/oauth2"
@@ -27,11 +30,14 @@ import (
 
 func TestAuthenticationToken_tokenSource(t *testing.T) {
 	t.Run("AccessToken", func(t *testing.T) {
+		f := Forge{Log: silog.Nop()}
 		tok := &AuthenticationToken{
 			AccessToken: "token",
 		}
 
-		src := tok.tokenSource()
+		src, err := f.tokenSource(tok)
+		require.NoError(t, err)
+
 		got, err := src.Token()
 		require.NoError(t, err)
 
@@ -39,12 +45,27 @@ func TestAuthenticationToken_tokenSource(t *testing.T) {
 	})
 
 	t.Run("GitHubCLI", func(t *testing.T) {
+		f := Forge{Log: silog.Nop()}
 		token := &AuthenticationToken{
-			GitHubCLI: true,
+			Type: TokenTypeCLI,
 		}
 
-		src := token.tokenSource()
+		src, err := f.tokenSource(token)
+		require.NoError(t, err)
+
 		assert.IsType(t, new(CLITokenSource), src)
+	})
+
+	t.Run("GCM", func(t *testing.T) {
+		f := Forge{Log: silog.Nop()}
+		putFakeGitOnPath(t)
+
+		src, err := f.tokenSource(&AuthenticationToken{Type: TokenTypeGCM})
+		require.NoError(t, err)
+
+		got, err := src.Token()
+		require.NoError(t, err)
+		assert.Equal(t, "test-token", got.AccessToken)
 	})
 }
 
@@ -185,7 +206,7 @@ func TestDeviceFlowAuthenticator(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "my-token", tok.AccessToken)
-	assert.False(t, tok.GitHubCLI)
+	assert.Equal(t, TokenTypeStash, tok.Type)
 }
 
 func TestSelectAuthenticator(t *testing.T) {
@@ -370,7 +391,11 @@ func TestAuthCLI(t *testing.T) {
 			tok, err := f.LoadAuthenticationToken(&stash)
 			require.NoError(t, err)
 
-			assert.True(t, tok.(*AuthenticationToken).GitHubCLI)
+			assert.Equal(
+				t,
+				TokenTypeCLI,
+				tok.(*AuthenticationToken).Type,
+			)
 		})
 	})
 
@@ -378,7 +403,7 @@ func TestAuthCLI(t *testing.T) {
 		execer := xectest.NewMockExecer(gomock.NewController(t))
 		execer.EXPECT().
 			Run(gomock.Any()).
-			Return(&exec.ExitError{
+			Return(&xec.ExitError{
 				Stderr: []byte("great sadness"),
 			})
 
@@ -404,4 +429,108 @@ func TestAuthCLI(t *testing.T) {
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "gh not found")
 	})
+}
+
+func TestLoadAuthenticationToken_noStoredTokenDoesNotFallbackToGCM(
+	t *testing.T,
+) {
+	f := Forge{Log: silog.Nop()}
+	var stash secret.MemoryStash
+
+	putFakeGitOnPath(t)
+
+	_, err := f.LoadAuthenticationToken(&stash)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "secret not found")
+}
+
+func TestLoadAuthenticationToken_storedGCM(t *testing.T) {
+	f := Forge{Log: silog.Nop()}
+	var stash secret.MemoryStash
+
+	putFakeGitOnPath(t)
+
+	err := stash.SaveSecret(f.URL(), "token", `{"type":"gcm"}`)
+	require.NoError(t, err)
+
+	got, err := f.LoadAuthenticationToken(&stash)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		&AuthenticationToken{Type: TokenTypeGCM},
+		got.(*AuthenticationToken),
+	)
+}
+
+func TestLoadAuthenticationToken_oldGitHubCLISchema(t *testing.T) {
+	f := Forge{Log: silog.Nop()}
+	var stash secret.MemoryStash
+
+	err := stash.SaveSecret(f.URL(), "token", `{"github_cli":true}`)
+	require.NoError(t, err)
+
+	got, err := f.LoadAuthenticationToken(&stash)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		&AuthenticationToken{Type: TokenTypeCLI},
+		got,
+	)
+}
+
+func TestLoadAuthenticationToken_savedCLISchema(t *testing.T) {
+	f := Forge{Log: silog.Nop()}
+	var stash secret.MemoryStash
+
+	require.NoError(t, f.SaveAuthenticationToken(&stash, &AuthenticationToken{
+		Type: TokenTypeCLI,
+	}))
+
+	got, err := f.LoadAuthenticationToken(&stash)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		&AuthenticationToken{Type: TokenTypeCLI},
+		got,
+	)
+}
+
+func putFakeGitOnPath(t *testing.T) {
+	t.Helper()
+
+	dir := t.TempDir()
+	gitPath := filepath.Join(dir, "git")
+	if runtime.GOOS == "windows" {
+		gitPath += ".exe"
+	}
+
+	testExe, err := os.Executable()
+	require.NoError(t, err)
+	linkTestBinary(t, testExe, gitPath)
+
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func linkTestBinary(t *testing.T, testExe, gitPath string) {
+	t.Helper()
+
+	if err := os.Symlink(testExe, gitPath); err == nil {
+		return
+	}
+
+	src, err := os.Open(testExe)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, src.Close())
+	}()
+
+	dst, err := os.Create(gitPath)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, dst.Close())
+	}()
+
+	_, err = io.Copy(dst, src)
+	require.NoError(t, err)
+	require.NoError(t, os.Chmod(gitPath, 0o755))
 }

--- a/internal/forge/github/forge.go
+++ b/internal/forge/github/forge.go
@@ -105,7 +105,11 @@ func (f *Forge) ParseRemoteURL(remoteURL string) (forge.RepositoryID, error) {
 func (f *Forge) OpenRepository(ctx context.Context, tok forge.AuthenticationToken, id forge.RepositoryID) (forge.Repository, error) {
 	rid := mustRepositoryID(id)
 
-	tokenSource := tok.(*AuthenticationToken).tokenSource()
+	tokenSource, err := f.tokenSource(tok.(*AuthenticationToken))
+	if err != nil {
+		return nil, err
+	}
+
 	ghc, err := newGitHubv4Client(ctx, f.APIURL(), tokenSource)
 	if err != nil {
 		return nil, fmt.Errorf("create GitHub client: %w", err)

--- a/internal/forge/github/main_test.go
+++ b/internal/forge/github/main_test.go
@@ -1,0 +1,32 @@
+package github
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	name := filepath.Base(os.Args[0])
+	if runtime.GOOS == "windows" {
+		name = strings.TrimSuffix(strings.ToLower(name), ".exe")
+	}
+
+	if name == "git" {
+		if len(os.Args) == 3 && os.Args[1] == "credential" && os.Args[2] == "fill" {
+			fmt.Print(`protocol=https
+host=github.com
+username=test-user
+password=test-token
+`)
+			os.Exit(0)
+		}
+
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
`gs auth login` could hit `git credential fill` before the user
selected Git Credential Manager.
When no helper was configured,
Git prompted for credentials and bypassed the intended auth flow.

Store GCM as an explicit authentication mode instead of an
ambient fallback,
and load credentials on demand only for tokens that were saved
with that mode.
Update the auth docs to match that contract,
and move the regression tests to package-local `TestMain` fake
`git` helpers so they exercise the same path without shell shims.

Resolves #1120