### PR TITLE
Fix crash when MR > 20

### DIFF
--- a/.changes/unreleased/Fixed-20260422-215117.yaml
+++ b/.changes/unreleased/Fixed-20260422-215117.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'gitlab: Fix crash when restacking a stack with more than 20 submitted MRs.'
+time: 2026-04-22T21:51:17.320974-07:00

--- a/internal/forge/gitlab/states.go
+++ b/internal/forge/gitlab/states.go
@@ -8,6 +8,11 @@ import (
 	"go.abhg.dev/gs/internal/gateway/gitlab"
 )
 
+// maxMergeRequestsPerPage is GitLab's documented upper bound on per_page
+// for list endpoints. It also caps the number of iids[] filters per
+// request to keep query strings within reasonable URL length limits.
+const maxMergeRequestsPerPage = 100
+
 // ChangesStates retrieves the states of the given changes in bulk.
 func (r *Repository) ChangesStates(ctx context.Context, ids []forge.ChangeID) ([]forge.ChangeState, error) {
 	mrIDs := make([]int64, len(ids))
@@ -15,23 +20,45 @@ func (r *Repository) ChangesStates(ctx context.Context, ids []forge.ChangeID) ([
 		mrIDs[i] = mustMR(id).Number
 	}
 
-	mergeRequests, _, err := r.client.MergeRequestList(
-		ctx, r.repoID,
-		&gitlab.ListProjectMergeRequestsOptions{IIDs: &mrIDs},
-	)
-	if err != nil {
-		return nil, fmt.Errorf("query failed: %w", err)
-	}
+	mrMap := make(map[int64]*gitlab.BasicMergeRequest, len(mrIDs))
+	for start := 0; start < len(mrIDs); start += maxMergeRequestsPerPage {
+		end := min(start+maxMergeRequestsPerPage, len(mrIDs))
+		batch := mrIDs[start:end]
 
-	// create a map of MR IDs to MRs
-	mrMap := make(map[int64]*gitlab.BasicMergeRequest)
-	for _, mr := range mergeRequests {
-		mrMap[mr.IID] = mr
+		page := int64(0)
+		for {
+			opts := &gitlab.ListProjectMergeRequestsOptions{
+				ListOptions: gitlab.ListOptions{
+					PerPage: maxMergeRequestsPerPage,
+					Page:    page,
+				},
+				IIDs: &batch,
+			}
+			mergeRequests, resp, err := r.client.MergeRequestList(ctx, r.repoID, opts)
+			if err != nil {
+				return nil, fmt.Errorf("query failed: %w", err)
+			}
+
+			for _, mr := range mergeRequests {
+				mrMap[mr.IID] = mr
+			}
+
+			if resp.NextPage == 0 {
+				break
+			}
+			page = int64(resp.NextPage)
+		}
 	}
 
 	states := make([]forge.ChangeState, len(mrIDs))
 	for i, id := range mrIDs {
-		mr := mrMap[id]
+		mr, ok := mrMap[id]
+		if !ok {
+			// Missing from response (deleted or inaccessible);
+			// treat as open so downstream code skips it.
+			states[i] = forge.ChangeOpen
+			continue
+		}
 		switch mr.State {
 		case "opened":
 			states[i] = forge.ChangeOpen
@@ -40,7 +67,7 @@ func (r *Repository) ChangesStates(ctx context.Context, ids []forge.ChangeID) ([
 		case "closed":
 			states[i] = forge.ChangeClosed
 		default:
-			states[i] = forge.ChangeOpen // default to open for unknown states
+			states[i] = forge.ChangeOpen
 		}
 	}
 

--- a/internal/gateway/gitlab/api_test.go
+++ b/internal/gateway/gitlab/api_test.go
@@ -213,6 +213,52 @@ func TestClient_MergeRequestList(t *testing.T) {
 	assert.Equal(t, int64(56), mergeRequests[1].IID)
 }
 
+func TestClient_MergeRequestList_paginated(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		switch r.URL.Query().Get("page") {
+		case "", "1":
+			w.Header().Set("X-Page", "1")
+			w.Header().Set("X-Next-Page", "2")
+			w.Header().Set("X-Total-Pages", "2")
+			writeJSON(t, w, http.StatusOK, []*BasicMergeRequest{
+				{IID: 1, Title: "One"},
+				{IID: 2, Title: "Two"},
+			})
+		case "2":
+			w.Header().Set("X-Page", "2")
+			w.Header().Set("X-Next-Page", "")
+			w.Header().Set("X-Total-Pages", "2")
+			writeJSON(t, w, http.StatusOK, []*BasicMergeRequest{
+				{IID: 3, Title: "Three"},
+			})
+		default:
+			t.Fatalf("unexpected page: %q", r.URL.Query().Get("page"))
+		}
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+
+	var all []*BasicMergeRequest
+	opts := &ListProjectMergeRequestsOptions{
+		ListOptions: ListOptions{PerPage: 2},
+	}
+	for {
+		page, resp, err := client.MergeRequestList(t.Context(), int64(42), opts)
+		require.NoError(t, err)
+		all = append(all, page...)
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = int64(resp.NextPage)
+	}
+
+	require.Len(t, all, 3)
+	assert.Equal(t, int64(1), all[0].IID)
+	assert.Equal(t, int64(3), all[2].IID)
+}
+
 func TestClient_MergeRequestAccept(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method)


### PR DESCRIPTION
Encountered this nil pointer

```
$ gw rs
INF main: already up-to-date
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x2 addr=0x28 pc=0x1045778f4]

goroutine 668 [running]:
sync.(*WaitGroup).Go.func1.1()
        /Users/dieend/.local/share/mise/installs/go/1.26.1/src/sync/waitgroup.go:251 +0x48
panic({0x104b08fa0?, 0x104ca5880?})
        /Users/dieend/.local/share/mise/installs/go/1.26.1/src/runtime/panic.go:860 +0x12c
go.abhg.dev/gs/internal/forge/gitlab.(*Repository).ChangesStates(0x298c00052a20, {0x104bd4048, 0x298c000f42d0}, {0x298c006851e0, 0x1a, 0x0?})
        /Users/dieend/src/git-spice/internal/forge/gitlab/states.go:35 +0x284
go.abhg.dev/gs/internal/handler/sync.(*Handler).findForgeFinishedBranches.func1()
        /Users/dieend/src/git-spice/internal/handler/sync/handler.go:570 +0xbc
sync.(*WaitGroup).Go.func1()
        /Users/dieend/.local/share/mise/installs/go/1.26.1/src/sync/waitgroup.go:258 +0x48
created by sync.(*WaitGroup).Go in goroutine 1
        /Users/dieend/.local/share/mise/installs/go/1.26.1/src/sync/waitgroup.go:238 +0x70
```

Fixed with this MR