### PR TITLE
release: Add Linux package distribution

### DIFF
--- a/.changes/unreleased/Added-20260425-180156.yaml
+++ b/.changes/unreleased/Added-20260425-180156.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add Snap, Debian/Ubuntu, Fedora/RHEL, and Alpine installation methods for published releases.
+time: 2026-04-25T18:01:56.343013-07:00

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -86,6 +86,11 @@ jobs:
       env:
         TAG: v${{ env.VERSION }}
 
+    - name: Install packaging tools
+      if: inputs.skip_publish == false
+      run: |
+        sudo snap install snapcraft --classic
+
     - name: Release
       if: inputs.skip_publish == false
       uses: goreleaser/goreleaser-action@v7
@@ -94,9 +99,11 @@ jobs:
         version: latest
         args: release --clean --release-notes ${{ github.workspace }}-CHANGELOG.txt
       env:
+        ENABLE_SNAPCRAFT: "true"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         AUR_KEY: ${{ secrets.AUR_KEY }}
         HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         GORELEASER_CURRENT_TAG: v${{ env.VERSION }}
 
   # Run only if the release was successful.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,15 @@
 version: 2
 project_name: git-spice
 
+release:
+  prerelease: auto
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  version_template: "{{ incminor .Tag }}-dev"
+
 builds:
   - id: git-spice
     env:
@@ -19,8 +28,22 @@ builds:
     flags:
       - -trimpath
 
+  # Keep Linux distro packages on a narrower target matrix than release
+  # archives so package formats do not inherit every Linux ARM variant.
+  - id: git-spice-linux-package
+    env:
+      - CGO_ENABLED=0
+    main: .
+    binary: git-spice
+    goos: [linux]
+    goarch: [amd64, arm64]
+    ldflags: '-s -w -X main._version={{.Version}}'
+    flags:
+      - -trimpath
+
 archives:
-  - formats: tar.gz
+  - ids: [git-spice]
+    formats: tar.gz
     # uname compatible archive name.
     name_template: >-
       {{- .ProjectName }}.
@@ -31,8 +54,45 @@ archives:
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
 
-release:
-  prerelease: auto
+nfpms:
+  - ids: [git-spice-linux-package]
+    package_name: git-spice
+    file_name_template: "{{ .ConventionalFileName }}"
+    homepage: "https://abhinav.github.io/git-spice/"
+    maintainer: "Abhinav Gupta <mail@abhinavg.net>"
+    description: "A tool for stacking Git branches."
+    license: "GPL-3.0-or-later"
+    formats:
+      - deb
+      - rpm
+      - apk
+    bindir: /usr/bin
+    dependencies:
+      - git
+    contents:
+      - src: ./LICENSE
+        dst: /usr/share/licenses/git-spice/LICENSE
+      - src: ./README.md
+        dst: /usr/share/doc/git-spice/README.md
+      - src: ./CHANGELOG.md
+        dst: /usr/share/doc/git-spice/CHANGELOG.md
+
+snapcrafts:
+  - ids: [git-spice-linux-package]
+    name: git-spice
+    title: git-spice
+    summary: A tool for stacking Git branches.
+    description: >-
+      git-spice helps you manage stacked Git branches, restack changes,
+      and submit pull requests or merge requests for a stack.
+    license: "GPL-3.0-or-later"
+    confinement: classic
+    grade: stable
+    publish: true
+    disable: '{{ ne (index .Env "ENABLE_SNAPCRAFT") "true" }}'
+    apps:
+      git-spice:
+        command: git-spice
 
 aurs:
   - name: git-spice-bin
@@ -77,9 +137,3 @@ homebrew_casks:
           if OS.mac?
             system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/git-spice"]
           end
-
-checksum:
-  name_template: 'checksums.txt'
-
-snapshot:
-  version_template: "{{ incminor .Tag }}-dev"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -583,6 +583,8 @@ or test-only changes, include `[skip changelog]: <cause description>` in the PR 
 Markdown documentation resides inside `doc/src`.
 The layout and structure of the documentation
 is described in `doc/mkdocs.yml`.
+This content powers the website,
+so document user-facing changes there when appropriate.
 
 When documenting unreleased features, add the following placeholder:
 
@@ -590,8 +592,10 @@ When documenting unreleased features, add the following placeholder:
 <!-- gs:version unreleased -->
 ```
 
-This will be automatically updated to the correct version
-when the feature is released.
+On the website,
+this renders a badge indicating that the feature is unreleased.
+The placeholder will be automatically updated to the correct version
+on the next release.
 
 ## Documentation style
 

--- a/doc/src/start/install.md
+++ b/doc/src/start/install.md
@@ -81,6 +81,57 @@ makepkg -si
 yay -S git-spice-bin
 ```
 
+### Linux packages
+
+<!-- gs:version unreleased -->
+
+GitHub Releases also provides native Linux packages:
+
+- `.deb` packages for Debian and Ubuntu
+- `.rpm` packages for Fedora, RHEL, Rocky, AlmaLinux, and openSUSE
+- `.apk` packages for Alpine
+
+Download the package for your architecture
+from the [GitHub Releases page](https://github.com/abhinav/git-spice/releases),
+then install it with your system package manager:
+
+=== "Debian / Ubuntu"
+
+    ```bash
+    sudo apt install ./git-spice_<version>_<arch>.deb
+    ```
+
+=== "Fedora / RHEL / Rocky / AlmaLinux"
+
+    ```bash
+    sudo dnf install ./git-spice-<version>-1.<arch>.rpm
+    ```
+
+=== "openSUSE"
+
+    ```bash
+    sudo zypper install ./git-spice-<version>-1.<arch>.rpm
+    ```
+
+=== "Alpine"
+
+    ```bash
+    sudo apk add --allow-untrusted ./git-spice-<version>-r1.<arch>.apk
+    ```
+
+### Snap
+
+<!-- gs:version unreleased -->
+
+If you use Snap, install the published `git-spice` snap with:
+
+```bash
+sudo snap install git-spice --classic
+```
+
+The snap uses `classic` confinement
+so it can work with your existing Git repositories and system Git binary.
+
 ### Manual download
 
 You can manually download the latest release of git-spice from the


### PR DESCRIPTION
Publish Snap and native Linux packages from GoReleaser so users
can install git-spice through Snap, `.deb`, `.rpm`, and `.apk`
distribution channels instead of relying only on archives and taps.

Keep Arch on the existing AUR path while limiting distro
packages to the release artifacts that GoReleaser can ship
cleanly.

## Testing

Built a snapshot release and verified installation.

    goreleaser release --snapshot --clean

For Debian, Fedora, and Alpine packages, used Docker to
validate.

    docker run ... apt-get install /dist/git-spice_...deb
    docker run ... dnf install /dist/git-spice-...rpm
    docker run ... apk add /dist/git-spice_...apk

For Snap, used an Ubuntu VM:

    ENABLE_SNAPCRAFT=true goreleaser release --snapshot --clean
    sudo snap install --classic --dangerous ./git-spice_<version>_<arch>.snap

Resolves #1117