### PR TITLE
fix(repo sync): Avoid stale rebase upstream

### DIFF
--- a/.changes/unreleased/Fixed-20260426-134029.yaml
+++ b/.changes/unreleased/Fixed-20260426-134029.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'repo sync: Fixed spurious conflicts after squash-merging branches with upstack work.'
+time: 2026-04-26T13:40:29.475444-07:00

--- a/internal/spice/onto.go
+++ b/internal/spice/onto.go
@@ -58,7 +58,30 @@ func (s *Service) BranchOnto(ctx context.Context, req *BranchOntoRequest) error 
 		ontoHash = onto.Head
 	}
 
-	// We're trying to move commits BaseHash..HEAD onto commit OntoHash.
+	// The recorded base hash may be stale if the old base branch
+	// was advanced outside git-spice,
+	// and the branch being moved was restacked outside git-spice.
+	//
+	// For example:
+	//
+	//     o---A (RecordedBase)
+	//          \
+	//           B---C (ActualBase)
+	//                \
+	//                 D (Current)
+	//
+	// git-spice may still think Current is based on RecordedBase,
+	// but using RecordedBase..Current would replay B and C.
+	// If ActualBase is reachable from Current,
+	// use ActualBase..Current so only Current's own commits are replayed.
+	fromHash := branch.BaseHash
+	if actualBaseHash, err := s.repo.PeelToCommit(ctx, branch.Base); err == nil {
+		if s.repo.IsAncestor(ctx, actualBaseHash, branch.Head) {
+			fromHash = actualBaseHash
+		}
+	}
+
+	// We're trying to move the selected commit range onto OntoHash.
 	//
 	// However, there's a possibility that BaseHash is reachable from OntoHash
 	// because the old base is also the base of onto,
@@ -91,7 +114,6 @@ func (s *Service) BranchOnto(ctx context.Context, req *BranchOntoRequest) error 
 	// To catch this, if OriginalBase is reachable from NewBase,
 	// we'll change the commit range to NewBase..Current.
 	// This will turn the rebase into a no-op, but it'll correctly update state.
-	fromHash := branch.BaseHash
 	if s.repo.IsAncestor(ctx, fromHash, ontoHash) {
 		fromHash = ontoHash
 	}

--- a/testdata/script/issue939_repo_sync_squash_merged_stale_base.txt
+++ b/testdata/script/issue939_repo_sync_squash_merged_stale_base.txt
@@ -1,0 +1,76 @@
+# Regression test for https://github.com/abhinav/git-spice/issues/939
+#
+# When a squash-merged downstack branch is deleted,
+# 'repo sync' must not replay downstack commits already present
+# in the upstack branch because git-spice's stored base hash is stale.
+
+as 'Test <test@example.com>'
+at '2026-04-26T12:00:00Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# Create a stack: main -> base -> stacked.
+git add base.txt
+gs bc base -m 'Add base file'
+
+git add stacked.txt
+gs bc stacked -m 'Add stacked file'
+
+# Add another commit to the downstack branch after the upstack exists.
+gs bco base
+cp $WORK/extra/base-v2.txt base.txt
+git add base.txt
+git commit -m 'Update base file'
+cp $WORK/extra/base-v3.txt base.txt
+git add base.txt
+git commit -m 'Update base file again'
+
+# Restack the upstack branch with plain Git.
+# This makes the new downstack commits reachable from 'stacked',
+# but leaves git-spice's stored BaseHash for 'stacked' pointing
+# at the older downstack commit.
+git checkout stacked
+git rebase base
+
+# Submit only the downstack branch.
+gs bco base
+gs branch submit --fill
+stderr 'Created #1'
+
+shamhub merge -squash -prune alice/example 1
+gs repo sync
+stderr 'base: #1 was merged'
+
+# The downstack branch was deleted,
+# and the upstack branch was moved onto the squash-merged trunk.
+! git rev-parse --verify base
+git rev-parse --verify stacked
+
+gs ll -a
+stderr 'stacked'
+stderr 'main'
+
+git graph --branches
+stdout 'Add stacked file'
+stdout 'Add base file \(\#1\)'
+
+-- repo/base.txt --
+base v1
+-- repo/stacked.txt --
+stacked
+-- extra/base-v2.txt --
+base v2
+-- extra/base-v3.txt --
+base v3


### PR DESCRIPTION
When deleting a merged downstack branch,
upstack branches may have already been restacked outside git-spice.
In that state, the stored base hash
can point behind the old base branch head.

Resolve the current old base before rebasing.
If that head is reachable from the upstack branch,
use it as the rebase upstream so
`repo sync` replays only the upstack commits.

A regression script covers the squash-merge case where replaying the
stale range conflicts on downstack commits.

Verified with:

    mise run test:script --run issue939_repo_sync_squash_merged_stale_base
    mise run test:script --run '(repo_sync_squash_merged|repo_sync_restack|repo_sync_conflict|issue897_repo_sync_with_worktree_branch)$'

Resolves #939