### PR TITLE
fix(sync): Protect unsubmitted merged branches

### DIFF
--- a/.changes/unreleased/Fixed-20260426-131752.yaml
+++ b/.changes/unreleased/Fixed-20260426-131752.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'repo sync: Prevent branches with unsubmitted local commits from being deleted after their change request is merged.'
+time: 2026-04-26T13:17:52.841836-07:00

--- a/internal/forge/bitbucket/operations_test.go
+++ b/internal/forge/bitbucket/operations_test.go
@@ -214,7 +214,7 @@ func TestFindChangeByID(t *testing.T) {
 	assert.Equal(t, forge.ChangeOpen, item.State)
 }
 
-func TestChangesStates(t *testing.T) {
+func TestChangeStatuses(t *testing.T) {
 	tests := []struct {
 		name       string
 		prStates   map[int64]string
@@ -260,7 +260,13 @@ func TestChangesStates(t *testing.T) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				// Return first PR state for simple single-PR tests.
 				for id := range tt.prStates {
-					resp := bitbucket.PullRequest{ID: id, State: tt.prStates[id]}
+					resp := bitbucket.PullRequest{
+						ID:    id,
+						State: tt.prStates[id],
+						Source: bitbucket.BranchRef{
+							Commit: &bitbucket.Commit{Hash: "abcdef123456"},
+						},
+					}
 					_ = json.NewEncoder(w).Encode(resp)
 					break
 				}
@@ -270,9 +276,11 @@ func TestChangesStates(t *testing.T) {
 			// Need a more sophisticated mock for multiple PRs.
 			if len(tt.ids) == 1 {
 				repo := newTestRepository(srv.URL)
-				states, err := repo.ChangesStates(t.Context(), tt.ids)
+				statuses, err := repo.ChangeStatuses(t.Context(), tt.ids)
 				require.NoError(t, err)
-				assert.Equal(t, tt.wantStates, states)
+				require.Len(t, statuses, 1)
+				assert.Equal(t, tt.wantStates[0], statuses[0].State)
+				assert.Equal(t, "abcdef123456", statuses[0].HeadHash.String())
 			}
 		})
 	}

--- a/internal/forge/bitbucket/states.go
+++ b/internal/forge/bitbucket/states.go
@@ -15,28 +15,31 @@ const (
 	stateSuperseded = "SUPERSEDED"
 )
 
-// ChangesStates retrieves the states of multiple pull requests.
-func (r *Repository) ChangesStates(
+// ChangeStatuses retrieves compact statuses for multiple pull requests.
+func (r *Repository) ChangeStatuses(
 	ctx context.Context,
 	ids []forge.ChangeID,
-) ([]forge.ChangeState, error) {
-	states := make([]forge.ChangeState, len(ids))
+) ([]forge.ChangeStatus, error) {
+	statuses := make([]forge.ChangeStatus, len(ids))
 	for i, id := range ids {
-		state, err := r.getChangeState(ctx, mustPR(id).Number)
+		status, err := r.getChangeStatus(ctx, mustPR(id).Number)
 		if err != nil {
 			return nil, fmt.Errorf("get state for PR #%d: %w", mustPR(id).Number, err)
 		}
-		states[i] = state
+		statuses[i] = status
 	}
-	return states, nil
+	return statuses, nil
 }
 
-func (r *Repository) getChangeState(ctx context.Context, prID int64) (forge.ChangeState, error) {
+func (r *Repository) getChangeStatus(ctx context.Context, prID int64) (forge.ChangeStatus, error) {
 	pr, err := r.getPullRequest(ctx, prID)
 	if err != nil {
-		return 0, err
+		return forge.ChangeStatus{}, err
 	}
-	return stateFromAPI(pr.State), nil
+	return forge.ChangeStatus{
+		State:    stateFromAPI(pr.State),
+		HeadHash: extractHeadHash(pr),
+	}, nil
 }
 
 func stateFromAPI(state string) forge.ChangeState {

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -236,7 +236,7 @@ type Repository interface {
 	EditChange(ctx context.Context, id ChangeID, opts EditChangeOptions) error
 	FindChangesByBranch(ctx context.Context, branch string, opts FindChangesOptions) ([]*FindChangeItem, error)
 	FindChangeByID(ctx context.Context, id ChangeID) (*FindChangeItem, error)
-	ChangesStates(ctx context.Context, ids []ChangeID) ([]ChangeState, error)
+	ChangeStatuses(ctx context.Context, ids []ChangeID) ([]ChangeStatus, error)
 	CommentCountsByChange(ctx context.Context, ids []ChangeID) ([]*CommentCounts, error)
 
 	// Post, update, and delete comments on changes.
@@ -456,6 +456,15 @@ type FindChangeItem struct {
 	// Assignees are the usernames of users
 	// who are assigned to the change.
 	Assignees []string
+}
+
+// ChangeStatus is a compact status summary for a change.
+type ChangeStatus struct {
+	// State is the current state of the change.
+	State ChangeState
+
+	// HeadHash is the hash of the commit at the top of the change.
+	HeadHash git.Hash
 }
 
 // ChangeTemplate is a template for a new change proposal.

--- a/internal/forge/forgetest/integration.go
+++ b/internal/forge/forgetest/integration.go
@@ -281,7 +281,7 @@ type IntegrationConfig struct {
 	// Set to true for forges where user lookup by username doesn't work.
 	SkipReviewers bool // optional
 
-	// SkipMerge skips merge-related tests in ChangesStates.
+	// SkipMerge skips merge-related tests in ChangeStatuses.
 	// Set to true for forges that require approvals before merge.
 	SkipMerge bool // optional
 
@@ -753,18 +753,19 @@ func (s *integrationSuite) TestChangeStates(t *testing.T) {
 	s.MergeChange(t, repo, mergedChange.ID)
 	s.CloseChange(t, repo, closedChange.ID)
 
-	// Verify states.
-	states, err := repo.ChangesStates(t.Context(), []forge.ChangeID{
+	// Verify statuses.
+	statuses, err := repo.ChangeStatuses(t.Context(), []forge.ChangeID{
 		openChange.ID,
 		mergedChange.ID,
 		closedChange.ID,
 	})
 	require.NoError(t, err, "error fetching change states")
-	assert.Equal(t, []forge.ChangeState{
-		forge.ChangeOpen,
-		forge.ChangeMerged,
-		forge.ChangeClosed,
-	}, states, "change states should match expected")
+	assert.Equal(t, forge.ChangeOpen, statuses[0].State)
+	assert.Equal(t, forge.ChangeMerged, statuses[1].State)
+	assert.Equal(t, forge.ChangeClosed, statuses[2].State)
+	assert.NotEmpty(t, statuses[0].HeadHash)
+	assert.NotEmpty(t, statuses[1].HeadHash)
+	assert.NotEmpty(t, statuses[2].HeadHash)
 }
 
 // FindChangesByBranch returns no error, and an empty slice

--- a/internal/forge/forgetest/mocks.go
+++ b/internal/forge/forgetest/mocks.go
@@ -671,41 +671,41 @@ func (m *MockRepository) EXPECT() *MockRepositoryMockRecorder {
 	return m.recorder
 }
 
-// ChangesStates mocks base method.
-func (m *MockRepository) ChangesStates(ctx context.Context, ids []forge.ChangeID) ([]forge.ChangeState, error) {
+// ChangeStatuses mocks base method.
+func (m *MockRepository) ChangeStatuses(ctx context.Context, ids []forge.ChangeID) ([]forge.ChangeStatus, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ChangesStates", ctx, ids)
-	ret0, _ := ret[0].([]forge.ChangeState)
+	ret := m.ctrl.Call(m, "ChangeStatuses", ctx, ids)
+	ret0, _ := ret[0].([]forge.ChangeStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ChangesStates indicates an expected call of ChangesStates.
-func (mr *MockRepositoryMockRecorder) ChangesStates(ctx, ids any) *MockRepositoryChangesStatesCall {
+// ChangeStatuses indicates an expected call of ChangeStatuses.
+func (mr *MockRepositoryMockRecorder) ChangeStatuses(ctx, ids any) *MockRepositoryChangeStatusesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangesStates", reflect.TypeOf((*MockRepository)(nil).ChangesStates), ctx, ids)
-	return &MockRepositoryChangesStatesCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeStatuses", reflect.TypeOf((*MockRepository)(nil).ChangeStatuses), ctx, ids)
+	return &MockRepositoryChangeStatusesCall{Call: call}
 }
 
-// MockRepositoryChangesStatesCall wrap *gomock.Call
-type MockRepositoryChangesStatesCall struct {
+// MockRepositoryChangeStatusesCall wrap *gomock.Call
+type MockRepositoryChangeStatusesCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockRepositoryChangesStatesCall) Return(arg0 []forge.ChangeState, arg1 error) *MockRepositoryChangesStatesCall {
+func (c *MockRepositoryChangeStatusesCall) Return(arg0 []forge.ChangeStatus, arg1 error) *MockRepositoryChangeStatusesCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRepositoryChangesStatesCall) Do(f func(context.Context, []forge.ChangeID) ([]forge.ChangeState, error)) *MockRepositoryChangesStatesCall {
+func (c *MockRepositoryChangeStatusesCall) Do(f func(context.Context, []forge.ChangeID) ([]forge.ChangeStatus, error)) *MockRepositoryChangeStatusesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRepositoryChangesStatesCall) DoAndReturn(f func(context.Context, []forge.ChangeID) ([]forge.ChangeState, error)) *MockRepositoryChangesStatesCall {
+func (c *MockRepositoryChangeStatusesCall) DoAndReturn(f func(context.Context, []forge.ChangeID) ([]forge.ChangeStatus, error)) *MockRepositoryChangeStatusesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/forge/forgetest/testconfig.yaml
+++ b/internal/forge/forgetest/testconfig.yaml
@@ -13,13 +13,13 @@
 
 github:
   # Repository owner (your GitHub username or organization)
-  owner: "ed-irl"
+  owner: "abhinav"
   # Test repository name (should be a repo you have write access to)
-  repo: "git-spice-test"
+  repo: "test-repo"
   # A GitHub user who can be added as a reviewer (can be a bot account)
-  reviewer: "ekohlwey"
+  reviewer: "abhinav-robot"
   # A GitHub user who can be assigned to PRs (can be the same as reviewer)
-  assignee: "ekohlwey"
+  assignee: "abhinav"
 
 gitlab:
   # Project namespace (your GitLab username or group)

--- a/internal/forge/github/states.go
+++ b/internal/forge/github/states.go
@@ -6,14 +6,16 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/git"
 )
 
-// ChangesStates retrieves the states of the given changes in bulk.
-func (r *Repository) ChangesStates(ctx context.Context, ids []forge.ChangeID) ([]forge.ChangeState, error) {
+// ChangeStatuses retrieves compact statuses for the given changes in bulk.
+func (r *Repository) ChangeStatuses(ctx context.Context, ids []forge.ChangeID) ([]forge.ChangeStatus, error) {
 	var q struct {
 		Nodes []struct {
 			PullRequest struct {
-				State githubv4.PullRequestState `graphql:"state"`
+				State      githubv4.PullRequestState `graphql:"state"`
+				HeadRefOid githubv4.GitObjectID      `graphql:"headRefOid"`
 			} `graphql:"... on PullRequest"`
 		} `graphql:"nodes(ids: $ids)"`
 	}
@@ -32,10 +34,13 @@ func (r *Repository) ChangesStates(ctx context.Context, ids []forge.ChangeID) ([
 		return nil, fmt.Errorf("retrieve change states: %w", err)
 	}
 
-	states := make([]forge.ChangeState, len(ids))
+	statuses := make([]forge.ChangeStatus, len(ids))
 	for i, pr := range q.Nodes {
-		states[i] = forgeChangeState(pr.PullRequest.State)
+		statuses[i] = forge.ChangeStatus{
+			State:    forgeChangeState(pr.PullRequest.State),
+			HeadHash: git.Hash(pr.PullRequest.HeadRefOid),
+		}
 	}
 
-	return states, nil
+	return statuses, nil
 }

--- a/internal/forge/github/testdata/TestIntegration/ChangesStates/closedBranch
+++ b/internal/forge/github/testdata/TestIntegration/ChangesStates/closedBranch
@@ -1,1 +1,1 @@
-"b5PnGZXf"
+"LHSD69GY"

--- a/internal/forge/github/testdata/TestIntegration/ChangesStates/mergedBranch
+++ b/internal/forge/github/testdata/TestIntegration/ChangesStates/mergedBranch
@@ -1,1 +1,1 @@
-"WR7mLr5c"
+"oR1r89qa"

--- a/internal/forge/github/testdata/TestIntegration/ChangesStates/openBranch
+++ b/internal/forge/github/testdata/TestIntegration/ChangesStates/openBranch
@@ -1,1 +1,1 @@
-"GaNySRNV"
+"Lgwei5Q0"

--- a/internal/forge/github/testdata/fixtures/TestIntegration/ChangesStates.yaml
+++ b/internal/forge/github/testdata/fixtures/TestIntegration/ChangesStates.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 146
+        content_length: 142
         host: api.github.com
         body: |
             {"query":"query($owner:String!$repo:String!){repository(owner: $owner, name: $repo){id}}","variables":{"owner":"test-owner","repo":"test-repo"}}
@@ -21,13 +21,13 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"data":{"repository":{"id":"R_kgDORFeuHw"}}}'
+        body: '{"data":{"repository":{"id":"R_kgDOMVd0xg"}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 164.45975ms
+        duration: 286.532125ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -36,7 +36,7 @@ interactions:
         content_length: 260
         host: api.github.com
         body: |
-            {"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDORFeuHw","baseRefName":"main","headRefName":"GaNySRNV","title":"Open GaNySRNV","body":"Open change"}}}
+            {"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"main","headRefName":"Lgwei5Q0","title":"Open Lgwei5Q0","body":"Open change"}}}
         headers:
             Content-Type:
                 - application/json
@@ -48,13 +48,13 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDORFeuH87AtaAm","number":60,"url":"https://github.com/test-owner/test-repo/pull/60"}}}}'
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs7VxHvb","number":68,"url":"https://github.com/test-owner/test-repo/pull/68"}}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.045985708s
+        duration: 915.464625ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -63,7 +63,7 @@ interactions:
         content_length: 264
         host: api.github.com
         body: |
-            {"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDORFeuHw","baseRefName":"main","headRefName":"WR7mLr5c","title":"Merged WR7mLr5c","body":"Merged change"}}}
+            {"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"main","headRefName":"oR1r89qa","title":"Merged oR1r89qa","body":"Merged change"}}}
         headers:
             Content-Type:
                 - application/json
@@ -75,13 +75,13 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDORFeuH87AtaA0","number":62,"url":"https://github.com/test-owner/test-repo/pull/62"}}}}'
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs7VxHvy","number":69,"url":"https://github.com/test-owner/test-repo/pull/69"}}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 713.979667ms
+        duration: 996.899875ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -90,7 +90,7 @@ interactions:
         content_length: 264
         host: api.github.com
         body: |
-            {"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDORFeuHw","baseRefName":"main","headRefName":"b5PnGZXf","title":"Closed b5PnGZXf","body":"Closed change"}}}
+            {"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"main","headRefName":"LHSD69GY","title":"Closed LHSD69GY","body":"Closed change"}}}
         headers:
             Content-Type:
                 - application/json
@@ -102,13 +102,13 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDORFeuH87AtaBC","number":63,"url":"https://github.com/test-owner/test-repo/pull/63"}}}}'
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs7VxHwb","number":70,"url":"https://github.com/test-owner/test-repo/pull/70"}}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 715.496458ms
+        duration: 1.544673917s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -117,7 +117,7 @@ interactions:
         content_length: 164
         host: api.github.com
         body: |
-            {"query":"mutation($input:MergePullRequestInput!){mergePullRequest(input: $input){pullRequest{id}}}","variables":{"input":{"pullRequestId":"PR_kwDORFeuH87AtaA0"}}}
+            {"query":"mutation($input:MergePullRequestInput!){mergePullRequest(input: $input){pullRequest{id}}}","variables":{"input":{"pullRequestId":"PR_kwDOMVd0xs7VxHvy"}}}
         headers:
             Content-Type:
                 - application/json
@@ -129,13 +129,13 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"data":{"mergePullRequest":{"pullRequest":{"id":"PR_kwDORFeuH87AtaA0"}}}}'
+        body: '{"data":{"mergePullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs7VxHvy"}}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.39461725s
+        duration: 1.840947959s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -144,7 +144,7 @@ interactions:
         content_length: 183
         host: api.github.com
         body: |
-            {"query":"mutation($input:UpdatePullRequestInput!){updatePullRequest(input: $input){pullRequest{id}}}","variables":{"input":{"pullRequestId":"PR_kwDORFeuH87AtaBC","state":"CLOSED"}}}
+            {"query":"mutation($input:UpdatePullRequestInput!){updatePullRequest(input: $input){pullRequest{id}}}","variables":{"input":{"pullRequestId":"PR_kwDOMVd0xs7VxHwb","state":"CLOSED"}}}
         headers:
             Content-Type:
                 - application/json
@@ -156,22 +156,22 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"data":{"updatePullRequest":{"pullRequest":{"id":"PR_kwDORFeuH87AtaBC"}}}}'
+        body: '{"data":{"updatePullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs7VxHwb"}}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 720.737167ms
+        duration: 818.099583ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 164
+        content_length: 175
         host: api.github.com
         body: |
-            {"query":"query($ids:[ID!]!){nodes(ids: $ids){... on PullRequest{state}}}","variables":{"ids":["PR_kwDORFeuH87AtaAm","PR_kwDORFeuH87AtaA0","PR_kwDORFeuH87AtaBC"]}}
+            {"query":"query($ids:[ID!]!){nodes(ids: $ids){... on PullRequest{state,headRefOid}}}","variables":{"ids":["PR_kwDOMVd0xs7VxHvb","PR_kwDOMVd0xs7VxHvy","PR_kwDOMVd0xs7VxHwb"]}}
         headers:
             Content-Type:
                 - application/json
@@ -183,10 +183,10 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"data":{"nodes":[{"state":"OPEN"},{"state":"MERGED"},{"state":"CLOSED"}]}}'
+        body: '{"data":{"nodes":[{"state":"OPEN","headRefOid":"3a0df6baa6afa3ba213d544ed1f10d3650e9497d"},{"state":"MERGED","headRefOid":"2fbdfe75f33a6b4b71e8995e13e366b7e96979d2"},{"state":"CLOSED","headRefOid":"01b3391a453432ea5483ae10f67b88d9c1d2e5ba"}]}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 176.806167ms
+        duration: 216.685916ms

--- a/internal/forge/gitlab/states.go
+++ b/internal/forge/gitlab/states.go
@@ -6,6 +6,7 @@ import (
 
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/gateway/gitlab"
+	"go.abhg.dev/gs/internal/git"
 )
 
 // maxMergeRequestsPerPage is GitLab's documented upper bound on per_page
@@ -13,8 +14,8 @@ import (
 // request to keep query strings within reasonable URL length limits.
 const maxMergeRequestsPerPage = 100
 
-// ChangesStates retrieves the states of the given changes in bulk.
-func (r *Repository) ChangesStates(ctx context.Context, ids []forge.ChangeID) ([]forge.ChangeState, error) {
+// ChangeStatuses retrieves compact statuses for the given changes in bulk.
+func (r *Repository) ChangeStatuses(ctx context.Context, ids []forge.ChangeID) ([]forge.ChangeStatus, error) {
 	mrIDs := make([]int64, len(ids))
 	for i, id := range ids {
 		mrIDs[i] = mustMR(id).Number
@@ -50,26 +51,27 @@ func (r *Repository) ChangesStates(ctx context.Context, ids []forge.ChangeID) ([
 		}
 	}
 
-	states := make([]forge.ChangeState, len(mrIDs))
+	statuses := make([]forge.ChangeStatus, len(mrIDs))
 	for i, id := range mrIDs {
 		mr, ok := mrMap[id]
 		if !ok {
 			// Missing from response (deleted or inaccessible);
 			// treat as open so downstream code skips it.
-			states[i] = forge.ChangeOpen
+			statuses[i].State = forge.ChangeOpen
 			continue
 		}
 		switch mr.State {
 		case "opened":
-			states[i] = forge.ChangeOpen
+			statuses[i].State = forge.ChangeOpen
 		case "merged":
-			states[i] = forge.ChangeMerged
+			statuses[i].State = forge.ChangeMerged
 		case "closed":
-			states[i] = forge.ChangeClosed
+			statuses[i].State = forge.ChangeClosed
 		default:
-			states[i] = forge.ChangeOpen
+			statuses[i].State = forge.ChangeOpen
 		}
+		statuses[i].HeadHash = git.Hash(mr.SHA)
 	}
 
-	return states, nil
+	return statuses, nil
 }

--- a/internal/forge/shamhub/change.go
+++ b/internal/forge/shamhub/change.go
@@ -92,6 +92,12 @@ type shamChange struct {
 	// Head will merge into Base.
 	Base, Head *shamBranch
 
+	// HeadHash is the last known hash of Head.
+	// This is populated when the change is merged,
+	// so status queries can keep reporting the merged head
+	// even if the source branch was deleted.
+	HeadHash string
+
 	// Labels are the labels associated with the change.
 	Labels []string
 

--- a/internal/forge/shamhub/states.go
+++ b/internal/forge/shamhub/states.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/xec"
 )
 
@@ -19,10 +20,15 @@ type statesRequest struct {
 }
 
 type statesResponse struct {
-	States []string `json:"states"`
+	Statuses []changeStatus `json:"statuses"`
 }
 
 var _ = shamhubRESTHandler("POST /{owner}/{repo}/change/states", (*ShamHub).handleStates)
+
+type changeStatus struct {
+	State    string `json:"state"`
+	HeadHash string `json:"headHash"`
+}
 
 func (sh *ShamHub) handleStates(_ context.Context, req *statesRequest) (*statesResponse, error) {
 	owner, repo := req.Owner, req.Repo
@@ -33,7 +39,9 @@ func (sh *ShamHub) handleStates(_ context.Context, req *statesRequest) (*statesR
 	}
 
 	sh.mu.RLock()
-	states := make([]string, len(changeNumToIdx))
+	defer sh.mu.RUnlock()
+
+	statuses := make([]changeStatus, len(changeNumToIdx))
 	for _, c := range sh.changes {
 		if c.Base.Owner == owner && c.Base.Repo == repo {
 			idx, ok := changeNumToIdx[c.Number]
@@ -42,11 +50,20 @@ func (sh *ShamHub) handleStates(_ context.Context, req *statesRequest) (*statesR
 			}
 			switch c.State {
 			case shamChangeOpen:
-				states[idx] = "open"
+				statuses[idx].State = "open"
 			case shamChangeClosed:
-				states[idx] = "closed"
+				statuses[idx].State = "closed"
 			case shamChangeMerged:
-				states[idx] = "merged"
+				statuses[idx].State = "merged"
+			}
+			if c.HeadHash != "" {
+				statuses[idx].HeadHash = c.HeadHash
+			} else {
+				head, err := sh.toChangeBranch(c.Head)
+				if err != nil {
+					return nil, fmt.Errorf("head branch: %w", err)
+				}
+				statuses[idx].HeadHash = head.Hash
 			}
 			delete(changeNumToIdx, c.Number)
 
@@ -55,16 +72,14 @@ func (sh *ShamHub) handleStates(_ context.Context, req *statesRequest) (*statesR
 			}
 		}
 	}
-	sh.mu.RUnlock()
-
 	if len(changeNumToIdx) > 0 {
 		return nil, notFoundErrorf("changes not found: %v", changeNumToIdx)
 	}
 
-	return &statesResponse{States: states}, nil
+	return &statesResponse{Statuses: statuses}, nil
 }
 
-func (r *forgeRepository) ChangesStates(ctx context.Context, fids []forge.ChangeID) ([]forge.ChangeState, error) {
+func (r *forgeRepository) ChangeStatuses(ctx context.Context, fids []forge.ChangeID) ([]forge.ChangeStatus, error) {
 	ids := make([]ChangeID, len(fids))
 	for i, fid := range fids {
 		ids[i] = fid.(ChangeID)
@@ -78,21 +93,22 @@ func (r *forgeRepository) ChangesStates(ctx context.Context, fids []forge.Change
 		return nil, fmt.Errorf("get states: %w", err)
 	}
 
-	states := make([]forge.ChangeState, len(res.States))
-	for i, state := range res.States {
-		switch state {
+	statuses := make([]forge.ChangeStatus, len(res.Statuses))
+	for i, status := range res.Statuses {
+		switch status.State {
 		case "open":
-			states[i] = forge.ChangeOpen
+			statuses[i].State = forge.ChangeOpen
 		case "closed":
-			states[i] = forge.ChangeClosed
+			statuses[i].State = forge.ChangeClosed
 		case "merged":
-			states[i] = forge.ChangeMerged
+			statuses[i].State = forge.ChangeMerged
 		default:
-			states[i] = forge.ChangeOpen // default to open for unknown states
+			statuses[i].State = forge.ChangeOpen // default to open for unknown states
 		}
+		statuses[i].HeadHash = git.Hash(status.HeadHash)
 	}
 
-	return states, nil
+	return statuses, nil
 }
 
 // MergeChangeRequest is a request to merge an open change
@@ -237,6 +253,20 @@ func (sh *ShamHub) MergeChange(req MergeChangeRequest) error {
 		return err
 	}
 
+	headHash, err := func() (string, error) {
+		out, err := xec.Command(ctx, sh.log, sh.gitExe, "rev-parse", headRef.Name).
+			WithDir(sh.repoDir(headRef.Owner, headRef.Repo)).
+			Output()
+		if err != nil {
+			return "", fmt.Errorf("rev-parse head: %w", err)
+		}
+
+		return strings.TrimSpace(string(out)), nil
+	}()
+	if err != nil {
+		return err
+	}
+
 	// Update the ref to point to the new commit.
 	err = func() error {
 		ref := "refs/heads/" + sh.changes[changeIdx].Base.Name
@@ -268,5 +298,6 @@ func (sh *ShamHub) MergeChange(req MergeChangeRequest) error {
 	}
 
 	sh.changes[changeIdx].State = shamChangeMerged
+	sh.changes[changeIdx].HeadHash = headHash
 	return nil
 }

--- a/internal/forge/shamhub/testdata/fixtures/TestIntegration/ChangesStates.yaml
+++ b/internal/forge/shamhub/testdata/fixtures/TestIntegration/ChangesStates.yaml
@@ -99,18 +99,27 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 61
+        content_length: 254
         body: |
             {
-              "states": [
-                "open",
-                "merged",
-                "closed"
+              "statuses": [
+                {
+                  "state": "open",
+                  "headHash": "1111111111111111111111111111111111111111"
+                },
+                {
+                  "state": "merged",
+                  "headHash": "2222222222222222222222222222222222222222"
+                },
+                {
+                  "state": "closed",
+                  "headHash": "3333333333333333333333333333333333333333"
+                }
               ]
             }
         headers:
             Content-Length:
-                - "61"
+                - "254"
             Content-Type:
                 - application/json
         status: 200 OK

--- a/internal/handler/list/handler.go
+++ b/internal/handler/list/handler.go
@@ -403,16 +403,16 @@ func (h *Handler) loadRemoteChangeData(
 	wg, ctx := errgroup.WithContext(ctx)
 
 	if include&IncludeChangeState != 0 {
-		var states []forge.ChangeState
+		var statuses []forge.ChangeStatus
 		updates = append(updates, func() {
 			for j, idx := range branchesIdx {
-				branches[idx].ChangeState = states[j]
+				branches[idx].ChangeState = statuses[j].State
 			}
 		})
 
 		wg.Go(func() error {
 			var err error
-			states, err = remoteRepo.ChangesStates(ctx, changeIDs)
+			statuses, err = remoteRepo.ChangeStatuses(ctx, changeIDs)
 			if err != nil {
 				return fmt.Errorf("retrieve change states: %w", err)
 			}

--- a/internal/handler/sync/handler.go
+++ b/internal/handler/sync/handler.go
@@ -493,6 +493,9 @@ func (h *Handler) findForgeFinishedBranches(
 
 		Change forge.ChangeID
 		State  forge.ChangeState
+		// Head SHA reported by the forge for the change.
+		RemoteHeadSHA git.Hash
+		LocalHeadSHA  git.Hash
 
 		// Branch name pushed to the remote.
 		UpstreamBranch string
@@ -540,6 +543,7 @@ func (h *Handler) findForgeFinishedBranches(
 				Name:            b.Name,
 				Base:            b.Base,
 				Change:          b.Change.ChangeID(),
+				LocalHeadSHA:    b.Head,
 				UpstreamBranch:  upstreamBranch,
 				MergedDownstack: b.MergedDownstack,
 			}
@@ -567,14 +571,15 @@ func (h *Handler) findForgeFinishedBranches(
 				changeIDs[i] = b.Change
 			}
 
-			states, err := h.RemoteRepository.ChangesStates(ctx, changeIDs)
+			statuses, err := h.RemoteRepository.ChangeStatuses(ctx, changeIDs)
 			if err != nil {
 				h.Log.Error("Failed to query CR status", "error", err)
 				return
 			}
 
-			for i, state := range states {
-				submittedBranches[i].State = state
+			for i, status := range statuses {
+				submittedBranches[i].State = status.State
+				submittedBranches[i].RemoteHeadSHA = status.HeadHash
 			}
 		})
 	}
@@ -673,7 +678,12 @@ func (h *Handler) findForgeFinishedBranches(
 			}
 
 		case forge.ChangeMerged:
-			h.Log.Infof("%v: %v was merged", branch.Name, branch.Change)
+			if !h.shouldDeleteMergedChange(ctx,
+				branch.Name, branch.Change,
+				branch.LocalHeadSHA, branch.RemoteHeadSHA) {
+				continue
+			}
+
 			finishedBranches[branch.Name] = finishedBranch{
 				Name:           branch.Name,
 				Base:           branch.Base,
@@ -700,34 +710,9 @@ func (h *Handler) findForgeFinishedBranches(
 		}
 		mergedDownstacks[branch.Name] = branch.MergedDownstack
 
-		if branch.RemoteHeadSHA == branch.LocalHeadSHA {
-			h.Log.Infof("%v: %v was merged", branch.Name, branch.Change)
-			finishedBranches[branch.Name] = finished
-			continue
-		}
-
-		mismatchMsg := fmt.Sprintf("%v was merged but local SHA (%v) does not match remote SHA (%v)",
-			branch.Change, branch.LocalHeadSHA.Short(), branch.RemoteHeadSHA.Short())
-
-		// If the remote head SHA doesn't match the local head SHA,
-		// there may be local commits that haven't been pushed yet.
-		// Prompt for deletion if we have the option of prompting.
-		if !ui.Interactive(h.View) {
-			h.Log.Warnf("%v: %v. Skipping...", branch.Name, mismatchMsg)
-			continue
-		}
-
-		var shouldDelete bool
-		prompt := ui.NewConfirm().
-			WithTitle(fmt.Sprintf("Delete %v?", branch.Name)).
-			WithDescription(mismatchMsg).
-			WithValue(&shouldDelete)
-		if err := ui.Run(h.View, prompt); err != nil {
-			h.Log.Warn("Skipping branch", "branch", branch.Name, "error", err)
-			continue
-		}
-
-		if shouldDelete {
+		if h.shouldDeleteMergedChange(ctx,
+			branch.Name, branch.Change,
+			branch.LocalHeadSHA, branch.RemoteHeadSHA) {
 			finishedBranches[branch.Name] = finished
 		}
 	}
@@ -823,6 +808,85 @@ func (h *Handler) findForgeFinishedBranches(
 	}
 
 	return branchesToDelete, nil
+}
+
+func (h *Handler) shouldDeleteMergedChange(
+	ctx context.Context,
+	branchName string,
+	changeID forge.ChangeID,
+	localHead, remoteHead git.Hash,
+) bool {
+	switch mergedChangeHeadCheck(ctx, h.Repository, localHead, remoteHead) {
+	case mergedChangeHeadExact:
+		h.Log.Infof("%v: %v was merged", branchName, changeID)
+		return true
+
+	case mergedChangeHeadRemoteContainsLocal:
+		h.Log.Infof("%v: %v was merged; local SHA %v is included in remote SHA %v",
+			branchName, changeID, localHead.Short(), remoteHead.Short())
+		return true
+
+	case mergedChangeHeadMismatch:
+		mismatchMsg := fmt.Sprintf("%v was merged but local SHA (%v) does not match remote SHA (%v)",
+			changeID, localHead.Short(), remoteHead.Short())
+
+		// If the remote head SHA doesn't contain the local head SHA,
+		// there may be local commits that haven't been pushed yet.
+		// Prompt for deletion if we have the option of prompting.
+		if !ui.Interactive(h.View) {
+			h.Log.Warnf("%v: %v. Skipping...", branchName, mismatchMsg)
+			return false
+		}
+
+		var shouldDelete bool
+		prompt := ui.NewConfirm().
+			WithTitle(fmt.Sprintf("Delete %v?", branchName)).
+			WithDescription(mismatchMsg).
+			WithValue(&shouldDelete)
+		if err := ui.Run(h.View, prompt); err != nil {
+			h.Log.Warn("Skipping branch", "branch", branchName, "error", err)
+			return false
+		}
+
+		return shouldDelete
+
+	default:
+		must.Bef(false, "unknown merged change head status")
+		return false
+	}
+}
+
+type mergedChangeHeadStatus int
+
+const (
+	// The local branch head is the same commit as the forge-reported head.
+	mergedChangeHeadExact mergedChangeHeadStatus = iota + 1
+
+	// The forge-reported head contains the local branch head.
+	mergedChangeHeadRemoteContainsLocal
+
+	// The forge-reported head does not prove that local commits are safe.
+	mergedChangeHeadMismatch
+)
+
+func mergedChangeHeadCheck(
+	ctx context.Context,
+	repo GitRepository,
+	localHead, remoteHead git.Hash,
+) mergedChangeHeadStatus {
+	if localHead == "" || remoteHead == "" {
+		return mergedChangeHeadMismatch
+	}
+
+	if localHead == remoteHead {
+		return mergedChangeHeadExact
+	}
+
+	if repo.IsAncestor(ctx, localHead, remoteHead) {
+		return mergedChangeHeadRemoteContainsLocal
+	}
+
+	return mergedChangeHeadMismatch
 }
 
 type branchDeletion struct {

--- a/internal/handler/sync/handler_test.go
+++ b/internal/handler/sync/handler_test.go
@@ -17,6 +17,77 @@ import (
 	"go.abhg.dev/gs/internal/ui"
 )
 
+func TestMergedChangeHeadCheck(t *testing.T) {
+	// ancestorCheck describes one expected ancestry query.
+	type ancestorCheck struct {
+		ancestor   git.Hash
+		descendant git.Hash
+		isAncestor bool
+	}
+
+	tests := []struct {
+		name   string
+		local  git.Hash
+		remote git.Hash
+		// Ancestry queries expected for non-equal local and remote heads.
+		ancestorChecks []ancestorCheck
+		want           mergedChangeHeadStatus
+	}{
+		{
+			name:   "Exact",
+			local:  git.Hash("aaa"),
+			remote: git.Hash("aaa"),
+			want:   mergedChangeHeadExact,
+		},
+		{
+			name:   "RemoteContainsLocal",
+			local:  git.Hash("aaa"),
+			remote: git.Hash("bbb"),
+			ancestorChecks: []ancestorCheck{
+				{
+					ancestor:   git.Hash("aaa"),
+					descendant: git.Hash("bbb"),
+					isAncestor: true,
+				},
+			},
+			want: mergedChangeHeadRemoteContainsLocal,
+		},
+		{
+			name:   "LocalContainsRemote",
+			local:  git.Hash("bbb"),
+			remote: git.Hash("aaa"),
+			want:   mergedChangeHeadMismatch,
+		},
+		{
+			name:   "Unknown",
+			local:  git.Hash("aaa"),
+			remote: git.Hash("bbb"),
+			want:   mergedChangeHeadMismatch,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			mockRepo := NewMockGitRepository(ctrl)
+			for _, check := range tt.ancestorChecks {
+				mockRepo.EXPECT().
+					IsAncestor(gomock.Any(), check.ancestor, check.descendant).
+					Return(check.isAncestor)
+			}
+			if tt.local != tt.remote && len(tt.ancestorChecks) == 0 {
+				mockRepo.EXPECT().
+					IsAncestor(gomock.Any(), tt.local, tt.remote).
+					Return(false)
+			}
+
+			assert.Equal(t, tt.want,
+				mergedChangeHeadCheck(t.Context(), mockRepo, tt.local, tt.remote))
+		})
+	}
+}
+
 func TestHandler_SyncTrunk_autostashLazy(t *testing.T) {
 	t.Run("FetchOnlyDoesNotStart", func(t *testing.T) {
 		ctrl := gomock.NewController(t)

--- a/testdata/script/issue1107_repo_sync_submitted_branch_local_commits.txt
+++ b/testdata/script/issue1107_repo_sync_submitted_branch_local_commits.txt
@@ -1,0 +1,47 @@
+# Regression test for https://github.com/abhinav/git-spice/issues/1107.
+# 'repo sync' must not delete a submitted branch
+# if it has local commits that were not part of the merged CR.
+
+as 'Test <test@example.com>'
+at '2026-04-26T12:00:00Z'
+
+# Setup.
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# Set up a fake GitHub remote.
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# Submit the branch.
+git add feature.txt
+gs bc -m 'Add feature' feature
+gs branch submit --fill
+stderr 'Created #'
+
+# Add a local commit without updating the CR.
+mv $WORK/extra/modified-feature.txt feature.txt
+git add feature.txt
+gs cc -m 'Modify feature locally'
+
+# Merge the old CR head server-side and sync.
+shamhub merge alice/example 1
+gs repo sync
+stderr 'feature: #1 was merged but local SHA \(80ba8db\) does not match remote SHA \(2c79bb6\). Skipping'
+
+git branch --show-current
+stdout 'feature'
+
+git log -1 --pretty=%s
+stdout 'Modify feature locally'
+
+-- repo/feature.txt --
+Contents of feature
+-- extra/modified-feature.txt --
+New contents of feature

--- a/testdata/script/repo_sync_after_merging_renamed_branch.txt
+++ b/testdata/script/repo_sync_after_merging_renamed_branch.txt
@@ -28,7 +28,8 @@ stderr 'Created #'
 gs branch rename feat1
 cp $WORK/extra/feature1-update.txt feature1.txt
 git add feature1.txt
-git commit -m 'update feature1'
+gs cc -m 'update feature1'
+gs branch submit
 
 # merge the PR
 shamhub merge alice/example 1
@@ -44,4 +45,3 @@ Contents of feature1
 
 -- extra/feature1-update.txt --
 New contents of feature1
-

--- a/testdata/script/repo_sync_external_pr_remote_head_ahead.txt
+++ b/testdata/script/repo_sync_external_pr_remote_head_ahead.txt
@@ -1,0 +1,50 @@
+# 'repo sync' deletes a branch for an externally-created merged CR
+# if the forge-reported CR head includes the local branch head.
+
+as 'Test <test@example.com>'
+at '2026-04-26T12:30:00Z'
+
+# Setup.
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# Set up a fake GitHub remote.
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# Create and submit a branch.
+git add feature.txt
+gs bc -m 'Add feature' feature
+gs branch submit --fill
+stderr 'Created #'
+
+# Push a server-side-style commit to the CR branch,
+# then rewind the local branch to simulate the remote head being ahead.
+mv $WORK/extra/updated-feature.txt feature.txt
+git add feature.txt
+gs cc -m 'Update feature on remote'
+git push origin feature
+git reset --hard HEAD^
+
+# Forget the CR metadata so this exercises the untracked/external path.
+gs repo init --reset --trunk=main --remote=origin
+gs branch track --base=main feature
+
+shamhub merge alice/example 1
+gs repo sync
+stderr 'feature: #1 was merged; local SHA c8a3a1e is included in remote SHA e88f0fc'
+
+git branch --list feature
+cmp stdout $WORK/golden/no-branches.txt
+
+-- repo/feature.txt --
+Contents of feature
+-- extra/updated-feature.txt --
+Updated contents of feature
+-- golden/no-branches.txt --


### PR DESCRIPTION
`repo sync` should not delete a branch just because its CR is merged.
If the local branch has commits that were never part of the merged CR,
removing it can discard work that has not reached the forge.
This protects the case where the forge merged an older CR head,
while the local branch moved on afterward.

Use the forge-reported CR head as the deletion interlock.
Merged branches are deleted automatically only when the local head is the
same commit,
or when local Git can prove that the forge head contains the local head.
Otherwise sync keeps the branch in non-interactive mode
and prompts before deletion when interaction is available.

The compact forge status query now returns both state and head SHA,
so the safety check reuses the existing status request without adding
another network call.

Test note:

The renamed-branch sync script now re-submits the branch after rename.
That keeps its original coverage focused on issue #401: deleting the
old tracking ref, `origin/feature1`, when the local branch has been
renamed to `feat1`. Without re-submitting, the local branch contains an
unsubmitted commit and correctly exercises the new #1107 skip path
instead of the renamed-tracking-ref deletion path.

Resolves #1107
