### PR TITLE
submit: Skip unsubmitted branches before restack checks during update-only submissions

### DIFF
--- a/.changes/unreleased/Fixed-20260430-163207.yaml
+++ b/.changes/unreleased/Fixed-20260430-163207.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'submit: Skipped unsubmitted branches before restack checks during update-only stack submissions.'
+time: 2026-04-30T16:32:07.587405012Z

--- a/.changes/unreleased/Fixed-20260430-163207.yaml
+++ b/.changes/unreleased/Fixed-20260430-163207.yaml
@@ -1,3 +1,3 @@
 kind: Fixed
-body: 'submit: Skipped unsubmitted branches before restack checks during update-only stack submissions.'
+body: 'submit: Fix update-only submissions failing instead of skipping unsubmitted branches.'
 time: 2026-04-30T16:32:07.587405012Z

--- a/internal/handler/submit/handler.go
+++ b/internal/handler/submit/handler.go
@@ -473,29 +473,6 @@ func (h *Handler) submitBranch(
 		return status, fmt.Errorf("lookup branch: %w", err)
 	}
 
-	// Refuse to submit if the branch is not restacked.
-	if !opts.Force {
-		if err := svc.VerifyRestacked(ctx, branchToSubmit); err != nil {
-			if shouldSkipRestackCheck(
-				opts.SkipRestackCheck,
-				branch.Base,
-				h.Store.Trunk(),
-			) {
-				log.Warnf("Branch %[1]s is not restacked."+
-					" Run '%[2]s branch restack --branch=%[1]s'"+
-					" to fix this.",
-					branchToSubmit, cli.Name(),
-				)
-			} else {
-				log.Errorf("Branch %s needs to be restacked.", branchToSubmit)
-				log.Errorf("Run the following command to fix this:")
-				log.Errorf("  %s branch restack --branch=%s", cli.Name(), branchToSubmit)
-				log.Errorf("Or, try again with --force to submit anyway.")
-				return status, errors.New("refusing to submit outdated branch")
-			}
-		}
-	}
-
 	// Various code paths down below should call this
 	// if the branch is being published as a CR (new or existing)
 	// so it should get a nav comment.
@@ -713,7 +690,32 @@ func (h *Handler) submitBranch(
 			}
 			return status, nil
 		}
+	}
 
+	// Refuse to submit if the branch is not restacked.
+	if !opts.Force {
+		if err := svc.VerifyRestacked(ctx, branchToSubmit); err != nil {
+			if shouldSkipRestackCheck(
+				opts.SkipRestackCheck,
+				branch.Base,
+				h.Store.Trunk(),
+			) {
+				log.Warnf("Branch %[1]s is not restacked."+
+					" Run '%[2]s branch restack --branch=%[1]s'"+
+					" to fix this.",
+					branchToSubmit, cli.Name(),
+				)
+			} else {
+				log.Errorf("Branch %s needs to be restacked.", branchToSubmit)
+				log.Errorf("Run the following command to fix this:")
+				log.Errorf("  %s branch restack --branch=%s", cli.Name(), branchToSubmit)
+				log.Errorf("Or, try again with --force to submit anyway.")
+				return status, errors.New("refusing to submit outdated branch")
+			}
+		}
+	}
+
+	if existingChange == nil {
 		if opts.DryRun {
 			if opts.Publish {
 				log.Infof("WOULD create a CR for %s", branchToSubmit)

--- a/testdata/script/issue1131_stack_submit_update_only_skips_unsubmitted_needs_restack.txt
+++ b/testdata/script/issue1131_stack_submit_update_only_skips_unsubmitted_needs_restack.txt
@@ -1,0 +1,45 @@
+# stack submit --update-only skips an unsubmitted branch even if it needs restack
+
+as 'Test <test@example.com>'
+at '2024-12-20T21:00:00Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# stack: main -> feat1 -> feat2
+git add feat1.txt
+gs bc -m feat1
+git add feat2.txt
+gs bc -m feat2
+
+# submit only feat1
+gs down
+gs bs --fill
+stderr 'Created #1'
+gs up
+
+# add a new commit to feat1 and leave feat2 behind so feat2 needs restack
+gs bco feat1
+git commit --allow-empty -m 'feat1 update'
+gs bco feat2
+gs ll
+stderr 'feat2 .*needs restack'
+
+# update-only submit should succeed: feat1 updated, feat2 skipped
+gs stack submit --update-only --fill
+stderr 'Updated #1'
+stderr 'feat2: Skipping unsubmitted branch'
+
+-- repo/feat1.txt --
+feature 1
+-- repo/feat2.txt --
+feature 2


### PR DESCRIPTION
Ensure `--update-only` submissions do not fail on branches that have never been submitted even if those branches would otherwise need restacking.

Resolves #1131 