### PR TITLE
ui: Add support for prompt footers

### DIFF
--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -32,6 +32,7 @@ type FormStyle struct {
 
 	Title         Style
 	Description   Style
+	Footer        Style
 	AcceptedTitle Style
 
 	AcceptedField Style
@@ -42,8 +43,15 @@ var DefaultFormStyle = FormStyle{
 	Error:         NewStyle().Foreground(Red),
 	Title:         NewStyle().Foreground(Green).Bold(true),
 	Description:   NewStyle().Foreground(Gray).Faint(true),
+	Footer:        NewStyle().Foreground(Plain),
 	AcceptedTitle: NewStyle().Foreground(Plain),
 	AcceptedField: NewStyle().Faint(true),
+}
+
+// fieldFooter is implemented by fields that render clear,
+// active-field guidance below the ordinary field description.
+type fieldFooter interface {
+	Footer() string
 }
 
 type acceptFieldMsg struct{}
@@ -128,6 +136,7 @@ type Form struct {
 	err     error
 	focused int // index of the focused field
 	theme   Theme
+	width   int
 }
 
 var _ tea.Model = (*Form)(nil)
@@ -253,6 +262,9 @@ func (f *Form) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case skipFieldMsg:
 		f.focused++
 
+	case tea.WindowSizeMsg:
+		f.width = msg.Width
+
 	case tea.KeyMsg:
 		if key.Matches(msg, f.KeyMap.Cancel) {
 			f.err = errors.New("user cancelled")
@@ -309,6 +321,19 @@ func (f *Form) renderField(w Writer, field Field, accepted bool) {
 		fmt.Fprintf(w, "\n%s", style.Error.Render(f.theme, err.Error()))
 	}
 	if desc := field.Description(); !accepted && desc != "" {
-		fmt.Fprintf(w, "\n%s", style.Description.Render(f.theme, desc))
+		descStyle := style.Description.Resolve(f.theme)
+		if f.width > 0 {
+			descStyle = descStyle.Width(f.width)
+		}
+		fmt.Fprintf(w, "\n%s", descStyle.Render(desc))
+	}
+	if footerField, ok := field.(fieldFooter); !accepted && ok {
+		if footer := footerField.Footer(); footer != "" {
+			footerStyle := style.Footer.Resolve(f.theme)
+			if f.width > 0 {
+				footerStyle = footerStyle.Width(f.width)
+			}
+			fmt.Fprintf(w, "\n\n%s", footerStyle.Render(footer))
+		}
 	}
 }

--- a/internal/ui/form_test.go
+++ b/internal/ui/form_test.go
@@ -1,0 +1,75 @@
+package ui_test
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"go.abhg.dev/gs/internal/ui"
+)
+
+func TestForm_Footer(t *testing.T) {
+	field := &footerField{
+		view:   "field value",
+		footer: "clear footer",
+	}
+	form := ui.NewForm(field)
+
+	assert.Contains(t, form.Render(), "clear footer")
+
+	_, _ = form.Update(ui.AcceptField())
+
+	assert.NotContains(t, form.Render(), "clear footer")
+	assert.Contains(t, form.Render(), "field value")
+}
+
+func TestForm_FooterWraps(t *testing.T) {
+	field := &footerField{
+		view: "field value",
+		footer: "Fork mode: local stacks work normally, but submit creates " +
+			"CRs only for trunk-based branches.",
+	}
+	form := ui.NewForm(field)
+	_, _ = form.Update(tea.WindowSizeMsg{Width: 36, Height: 10})
+
+	rendered := form.Render()
+	assert.Contains(t, rendered, "field value\n\nFork mode: local stacks work")
+	assert.Contains(t, rendered, "\nnormally, but submit creates CRs")
+	assert.LessOrEqual(t, maxLineWidth(rendered), 36)
+}
+
+type footerField struct {
+	view   string
+	footer string
+}
+
+var _ ui.Field = (*footerField)(nil)
+
+func (*footerField) Init() tea.Cmd { return nil }
+
+func (*footerField) Update(tea.Msg) tea.Cmd { return nil }
+
+func (f *footerField) Render(w ui.Writer, _ ui.Theme) {
+	_, _ = w.WriteString(f.view)
+}
+
+func (*footerField) UnmarshalValue(func(any) error) error { return nil }
+
+func (*footerField) Err() error { return nil }
+
+func (*footerField) Title() string { return "" }
+
+func (*footerField) Description() string { return "" }
+
+func (f *footerField) Footer() string {
+	return f.footer
+}
+
+func maxLineWidth(s string) int {
+	maxWidth := 0
+	for line := range strings.SplitSeq(s, "\n") {
+		maxWidth = max(maxWidth, len(line))
+	}
+	return maxWidth
+}

--- a/internal/ui/select.go
+++ b/internal/ui/select.go
@@ -61,9 +61,10 @@ type Select[T any] struct {
 	KeyMap SelectKeyMap
 	Style  SelectStyle
 
-	title string
-	desc  string
-	value *T
+	title      string
+	desc       string
+	footerFunc func(T) string
+	value      *T
 
 	options  []selectOption[T] // list of options
 	filter   []rune            // filter to match options
@@ -250,6 +251,39 @@ func (s *Select[T]) Description() string {
 func (s *Select[T]) WithDescription(desc string) *Select[T] {
 	s.desc = desc
 	return s
+}
+
+// Footer returns the footer for the currently selected option.
+func (s *Select[T]) Footer() string {
+	if s.footerFunc == nil {
+		return ""
+	}
+
+	value, ok := s.selectedValue()
+	if !ok {
+		return ""
+	}
+
+	return s.footerFunc(value)
+}
+
+// WithFooterFunc sets a function that produces footer text
+// for the currently selected option.
+//
+// The footer is rendered as active-field guidance by [Form],
+// separate from the field description.
+func (s *Select[T]) WithFooterFunc(f func(T) string) *Select[T] {
+	s.footerFunc = f
+	return s
+}
+
+func (s *Select[T]) selectedValue() (T, bool) {
+	if s.selected < 0 || s.selected >= len(s.matched) {
+		var zero T
+		return zero, false
+	}
+
+	return s.options[s.matched[s.selected]].Value, true
 }
 
 // WithVisible sets the number of visible options in the select field.

--- a/internal/ui/select_test.go
+++ b/internal/ui/select_test.go
@@ -68,3 +68,23 @@ func TestSelect(t *testing.T) {
 		"testdata/script/select",
 	)
 }
+
+func TestSelect_Footer(t *testing.T) {
+	selectField := ui.NewSelect[string]().
+		WithOptions(
+			ui.SelectOption[string]{Label: "origin", Value: "origin"},
+			ui.SelectOption[string]{Label: "upstream", Value: "upstream"},
+		).
+		WithFooterFunc(func(value string) string {
+			if value == "upstream" {
+				return "fork mode"
+			}
+			return ""
+		})
+
+	assert.Empty(t, selectField.Footer())
+
+	selectField.WithSelected(1)
+
+	assert.Equal(t, "fork mode", selectField.Footer())
+}

--- a/internal/ui/uitest/robot.go
+++ b/internal/ui/uitest/robot.go
@@ -241,6 +241,12 @@ fieldLoop:
 			_, _ = fieldViewWriter.WriteString("\n")
 			_, _ = fieldViewWriter.WriteString(desc)
 		}
+		if footerField, ok := field.(interface{ Footer() string }); ok {
+			if footer := footerField.Footer(); footer != "" {
+				_, _ = fieldViewWriter.WriteString("\n")
+				_, _ = fieldViewWriter.WriteString(footer)
+			}
+		}
 		if err := field.Err(); err != nil {
 			return fmt.Errorf("field [%d]: %w", fieldIdx, err)
 		}

--- a/internal/ui/uitest/robot_test.go
+++ b/internal/ui/uitest/robot_test.go
@@ -156,9 +156,40 @@ func TestRobotView_noTTYStripsANSI(t *testing.T) {
 	`), string(got))
 }
 
+func TestRobotView_rendersFooter(t *testing.T) {
+	dir := t.TempDir()
+	inputFile := filepath.Join(dir, "input")
+	outputFile := filepath.Join(dir, "output")
+
+	require.NoError(t, os.WriteFile(inputFile, []byte(`"foo"`+"\n"), 0o644))
+
+	view, err := NewRobotView(inputFile, &RobotViewOptions{
+		OutputFile: outputFile,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, view.Prompt(&fakeField{
+		View:       "Warp factor?",
+		FooterText: "Engineering advisory",
+	}))
+	require.NoError(t, view.Close())
+
+	got, err := os.ReadFile(outputFile)
+	require.NoError(t, err)
+
+	assert.Equal(t, text.Dedent(`
+		===
+		> Warp factor?
+		> Engineering advisory
+		"foo"
+
+	`), string(got))
+}
+
 type fakeField struct {
-	GotValue any
-	View     string
+	GotValue   any
+	View       string
+	FooterText string
 }
 
 var _ ui.Field = (*fakeField)(nil)
@@ -168,6 +199,7 @@ func (f *fakeField) Err() error    { return nil }
 
 func (f *fakeField) Description() string { return "" }
 func (f *fakeField) Title() string       { return "" }
+func (f *fakeField) Footer() string      { return f.FooterText }
 
 func (f *fakeField) Update(tea.Msg) tea.Cmd { return nil }
 


### PR DESCRIPTION
Some prompts need active guidance that is more prominent
than the faint description text.
For example, repo init needs to print a clear message
in fork mode (#413) about the degraded experience.

Add a means of extending prompts with a footer.
The footer, if present, renders after the description
and before the error message, separated by a blank line.

Select fields can now provide a footer via a callback
which is able to inspect the currently selected option.

[skip changelog]: no user facing changes