### PR TITLE
feat: Add Ubuntu PPA publishing

### DIFF
--- a/.changes/unreleased/Added-20260506-214627.yaml
+++ b/.changes/unreleased/Added-20260506-214627.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Set up an official Ubuntu PPA for downloading git-spice.
+time: 2026-05-06T21:46:27.948459-07:00

--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,10 @@
 *.png filter=lfs diff=lfs merge=lfs -text
 *.gif filter=lfs diff=lfs merge=lfs -text
 
+# Don't put these in exported archives.
+.*/ export-ignore
+doc/ export-ignore
+
 # pgregory.net/rapid should be considered generated code to reduce noise.
 **/testdata/rapid/**/*.fail linguist-generated
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -13,8 +13,8 @@ on:
         description: Git ref to release from.
         required: true
         type: string
-      skip_publish:
-        description: Skip the publish step.
+      skip_goreleaser:
+        description: Skip the GoReleaser publish step.
         required: false
         default: false
         type: boolean
@@ -23,6 +23,18 @@ on:
         required: false
         default: false
         type: boolean
+      skip_ppa:
+        description: Skip the Ubuntu PPA upload step.
+        required: false
+        default: false
+        type: boolean
+      ppa_revision:
+        description: >-
+          PPA package revision.
+          Increase this to retry an upload for the same upstream version.
+        required: false
+        default: '1'
+        type: string
 
 permissions:
   contents: write
@@ -31,6 +43,7 @@ jobs:
   release:
     name: Publish Release
     runs-on: ubuntu-latest
+    environment: release
 
     steps:
     - uses: actions/checkout@v6
@@ -79,7 +92,7 @@ jobs:
         echo "::endgroup::"
 
     - name: Tag a release
-      if: inputs.skip_publish == false
+      if: inputs.skip_goreleaser == false
       run: |
         git tag "$TAG"
         git push origin "$TAG"
@@ -87,7 +100,7 @@ jobs:
         TAG: v${{ env.VERSION }}
 
     - name: Release
-      if: inputs.skip_publish == false
+      if: inputs.skip_goreleaser == false
       uses: goreleaser/goreleaser-action@v7
       with:
         distribution: goreleaser
@@ -103,6 +116,7 @@ jobs:
   homebrew:
     name: Bump Homebrew Formula
     runs-on: ubuntu-latest
+    environment: release
     needs: [release]
     steps:
     - name: Check out repository
@@ -142,3 +156,72 @@ jobs:
         user_email: "187913561+abhinav-robot@users.noreply.github.com"
         formula: git-spice
         tag: v${{ env.VERSION }}
+
+  # Run only if the release was successful.
+  ppa:
+    name: Publish Ubuntu PPA
+    runs-on: ubuntu-latest
+    environment: release
+    needs: [release]
+    if: inputs.skip_ppa == false
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ inputs.ref }}
+
+    - uses: jdx/mise-action@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set version (changie)
+      if: inputs.version == ''
+      run: |
+        CHANGIE_VERSION=$(changie latest)
+        echo "VERSION=${CHANGIE_VERSION#v}" >> "$GITHUB_ENV"
+    - name: Set version (input)
+      if: inputs.version != ''
+      run:
+        echo "VERSION=${INPUT_VERSION#v}" >> "$GITHUB_ENV"
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+
+    - name: Verify version
+      run: |
+        if [[ -z "$VERSION" ]]; then
+          echo "No version set"
+          exit 1
+        fi
+
+    - name: Install Debian upload tools
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y devscripts dput
+
+    - name: Import Launchpad signing key
+      run: |
+        export GNUPGHOME="${RUNNER_TEMP}/gnupg"
+        mkdir -p "$GNUPGHOME"
+        chmod 700 "$GNUPGHOME"
+
+        printf '%s' "$LAUNCHPAD_GPG_PRIVATE_KEY" \
+          | gpg --batch --import
+
+        echo "GNUPGHOME=$GNUPGHOME" >> "$GITHUB_ENV"
+      env:
+        LAUNCHPAD_GPG_PRIVATE_KEY: ${{ secrets.LAUNCHPAD_GPG_PRIVATE_KEY }}
+
+    - name: Publish source packages
+      run: |
+        go run ./tools/ci/launchpad-ppa \
+          -version "v${VERSION}" \
+          -ref "${REF}" \
+          -series noble,plucky,questing,resolute \
+          -ppa-revision "${PPA_REVISION}" \
+          -sign \
+          -dput
+      env:
+        LAUNCHPAD_GPG_KEY_ID: ${{ secrets.LAUNCHPAD_GPG_KEY_ID }}
+        LAUNCHPAD_GPG_PASSPHRASE: ${{ secrets.LAUNCHPAD_GPG_PASSPHRASE }}
+        PPA_REVISION: ${{ inputs.ppa_revision }}
+        REF: ${{ inputs.ref }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,6 +190,76 @@ To release a new version, take the following steps:
 3. Once the pull request has merged, trigger the
    [Publishh release workflow](https://github.com/abhinav/git-spice/actions/workflows/publish-release.yml).
 
+### Ubuntu PPA packages
+
+The PPA publisher is implemented by `tools/ci/launchpad-ppa`.
+It builds Ubuntu source packages for Launchpad from a Git archive,
+adds the embedded Debian packaging recipe,
+vendors Go modules in the temporary source tree,
+and writes the result to `dist/debian/<series>`.
+
+To build unsigned source packages without uploading them,
+run:
+
+```bash
+go run ./tools/ci/launchpad-ppa \
+  -version vX.Y.Z \
+  -series noble,plucky,questing,resolute
+```
+
+The `-series` flag may be repeated
+or may receive a comma-separated list.
+If `-ref` is omitted,
+the publisher exports the Git ref matching `-version`;
+for example,
+`-version v0.28.0` defaults to `-ref v0.28.0`.
+
+The current package recipe targets Ubuntu Noble and newer series.
+It requires a Go 1.26 toolchain package
+from the configured Launchpad build dependencies
+for each target series.
+
+For GitHub Actions publishing,
+configure these secrets in the release environment:
+
+- `LAUNCHPAD_GPG_PRIVATE_KEY`
+- `LAUNCHPAD_GPG_KEY_ID`
+- `LAUNCHPAD_GPG_PASSPHRASE`
+
+The private key is consumed by the GitHub workflow
+before invoking the publisher.
+Local signing only needs the key already imported into GPG,
+with `LAUNCHPAD_GPG_KEY_ID` and `LAUNCHPAD_GPG_PASSPHRASE`
+set in the environment.
+
+To sign and upload the source packages,
+run:
+
+```bash
+go run ./tools/ci/launchpad-ppa \
+  -version vX.Y.Z \
+  -series noble,plucky,questing,resolute \
+  -sign \
+  -dput
+```
+
+Without `-dput`,
+the publisher prints the `dput` commands it would run.
+With `-dput`,
+it uploads the signed source packages to `ppa:abhg/git-spice`
+unless another `-dput-target` is provided.
+
+The release workflow publishes these source packages
+after the GitHub release succeeds.
+It uses the same publisher command,
+passes `-sign` and `-dput`,
+and requires the GitHub Actions secrets listed above.
+
+If a PPA upload must be retried for the same upstream version,
+rerun the release workflow with a higher `ppa_revision` value.
+For example,
+`ppa_revision=2` publishes `X.Y.Z-1~ppa2`.
+
 ## Backporting changes
 
 (For maintainers only.)

--- a/doc/src/start/install.md
+++ b/doc/src/start/install.md
@@ -81,6 +81,19 @@ makepkg -si
 yay -S git-spice-bin
 ```
 
+### Ubuntu PPA
+
+<!-- gs:version unreleased -->
+
+If you're using Ubuntu,
+install git-spice from the official PPA:
+
+```bash
+sudo add-apt-repository ppa:abhg/git-spice
+sudo apt update
+sudo apt install git-spice
+```
+
 ### Linux packages
 
 <!-- gs:version v0.27.0 -->

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	go.abhg.dev/log/silog v0.3.0
 	go.abhg.dev/testing/stub v0.2.0
 	go.uber.org/mock v0.6.0
+	golang.org/x/mod v0.33.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.20.0
 	gopkg.in/dnaeon/go-vcr.v4 v4.0.6
@@ -69,7 +70,6 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.3 // indirect
 	golang.org/x/exp v0.0.0-20250813145105-42675adae3e6 // indirect
-	golang.org/x/mod v0.33.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/tools v0.41.0 // indirect
 	mvdan.cc/gofumpt v0.9.2 // indirect

--- a/tools/ci/launchpad-ppa/debian.txtar
+++ b/tools/ci/launchpad-ppa/debian.txtar
@@ -1,0 +1,81 @@
+-- debian/changelog --
+git-spice (0.0.0-1~ppa1) noble; urgency=medium
+
+  * Placeholder changelog for local packaging.
+
+ -- Abhinav Gupta <mail@abhinavg.net>  Thu, 01 Jan 1970 00:00:00 +0000
+-- debian/control --
+Source: git-spice
+Section: vcs
+Priority: optional
+Maintainer: Abhinav Gupta <mail@abhinavg.net>
+Build-Depends:
+ debhelper-compat (= 13),
+ golang-go (>= 2:1.26~),
+Standards-Version: 4.7.0
+Rules-Requires-Root: no
+Homepage: https://abhinav.github.io/git-spice/
+
+Package: git-spice
+Architecture: any
+Depends:
+ git (>= 2.38),
+ ${misc:Depends},
+Description: tool for stacking Git branches
+ git-spice helps manage stacked Git branches for workflows that build
+ pull requests or merge requests as a series of dependent changes.
+-- debian/copyright --
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: git-spice
+Source: https://github.com/abhinav/git-spice
+
+Files: *
+Copyright: 2024-2026 Abhinav Gupta
+License: GPL-3+
+
+License: GPL-3+
+ This package is free software:
+ you can redistribute it and/or modify it
+ under the terms of the GNU General Public License
+ as published by the Free Software Foundation,
+ either version 3 of the License,
+ or (at your option) any later version.
+ .
+ This package is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY
+ or FITNESS FOR A PARTICULAR PURPOSE.
+ See the GNU General Public License for more details.
+ .
+ On Debian systems,
+ the full text of the GNU General Public License version 3
+ can be found in `/usr/share/common-licenses/GPL-3`.
+-- debian/docs --
+README.md
+-- debian/install --
+_build/git-spice usr/bin
+-- debian/rules --
+#!/usr/bin/make -f
+
+export GO111MODULE := on
+export GOFLAGS := -mod=vendor -trimpath
+export GOTOOLCHAIN := local
+
+VERSION := $(shell dpkg-parsechangelog -S Version | sed 's/-.*//')
+
+%:
+	dh $@
+
+override_dh_auto_build:
+	CGO_ENABLED=0 go build \
+		-o _build/git-spice \
+		-ldflags "-s -w -X main._version=$(VERSION)" \
+		go.abhg.dev/gs
+
+override_dh_auto_test:
+	@echo "Skipping upstream tests during package build."
+
+override_dh_installchangelogs:
+	dh_installchangelogs CHANGELOG.md
+-- debian/source/format --
+3.0 (quilt)

--- a/tools/ci/launchpad-ppa/main.go
+++ b/tools/ci/launchpad-ppa/main.go
@@ -1,0 +1,633 @@
+// launchpad-ppa builds and optionally uploads Ubuntu PPA source packages.
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	_ "embed"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/rogpeppe/go-internal/txtar"
+	"go.abhg.dev/gs/internal/silog"
+	"go.abhg.dev/gs/internal/xec"
+	"golang.org/x/mod/semver"
+)
+
+const (
+	_defaultSeries     = "noble"
+	_defaultDputTarget = "ppa:abhg/git-spice"
+	_packageName       = "git-spice"
+
+	_launchpadGPGKeyIDEnv      = "LAUNCHPAD_GPG_KEY_ID"
+	_launchpadGPGPassphraseEnv = "LAUNCHPAD_GPG_PASSPHRASE"
+)
+
+//go:embed debian.txtar
+var _debianPackagingTxtar []byte
+
+// publishRequest is the normalized command-line request.
+type publishRequest struct {
+	// Version is the git-spice release version to publish.
+	Version string
+
+	// Ref is the Git object exported as upstream source.
+	Ref string
+
+	// Series lists the Ubuntu series that should receive source uploads.
+	Series seriesFlag
+
+	// PPARevision is the Debian package revision suffix for Launchpad retries.
+	PPARevision int
+
+	// Sign controls whether source packages are signed before upload.
+	Sign bool
+
+	// Dput controls whether packages are uploaded after signing.
+	Dput bool
+
+	// DputTarget is the destination passed to dput.
+	DputTarget string
+}
+
+// seriesFlag accepts repeated and comma-separated -series values.
+type seriesFlag []string
+
+func (f *seriesFlag) String() string {
+	return strings.Join(*f, ",")
+}
+
+func (f *seriesFlag) Set(value string) error {
+	for series := range strings.SplitSeq(value, ",") {
+		series = strings.TrimSpace(series)
+		if series == "" {
+			continue
+		}
+		*f = append(*f, series)
+	}
+	return nil
+}
+
+func main() {
+	log := silog.New(os.Stderr, &silog.Options{
+		Level: silog.LevelDebug,
+	})
+
+	var req publishRequest
+	flag.StringVar(&req.Version, "version", "", "Version to package")
+	flag.StringVar(&req.Ref, "ref", "", "Git ref to export")
+	flag.Var(&req.Series, "series", "Ubuntu series to target")
+	flag.IntVar(&req.PPARevision, "ppa-revision", 1, "PPA revision number")
+	flag.BoolVar(&req.Sign, "sign", false, "Sign packages with Launchpad GPG environment variables")
+	flag.BoolVar(&req.Dput, "dput", false, "Upload signed packages with dput")
+	flag.StringVar(&req.DputTarget, "dput-target", _defaultDputTarget, "dput upload target")
+	flag.Parse()
+
+	if flag.NArg() > 0 {
+		log.Fatalf("launchpad-ppa: unexpected arguments: %v", flag.Args())
+	}
+
+	if err := run(log, req); err != nil {
+		log.Fatalf("launchpad-ppa: %v", err)
+	}
+}
+
+func run(log *silog.Logger, req publishRequest) error {
+	plan, err := newPackagePlan(req)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	log.Info("Resolved package request",
+		"version", plan.Version,
+		"ref", plan.Ref,
+		"series", strings.Join(plan.Series, ","),
+		"ppaRevision", plan.PPARevision,
+		"dput", plan.Dput,
+		"dputTarget", plan.DputTarget)
+
+	root, err := xec.Command(ctx, log, "git", "rev-parse", "--show-toplevel").
+		OutputChomp()
+	if err != nil {
+		return fmt.Errorf("resolve repository root: %w", err)
+	}
+	log.Info("Resolved repository root", "path", root)
+
+	workDir, err := os.MkdirTemp("", "git-spice-ppa.*")
+	if err != nil {
+		return fmt.Errorf("create temporary directory: %w", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(workDir); err != nil {
+			log.Warn("Remove temporary directory", "path", workDir, "error", err)
+		}
+	}()
+	log.Info("Created temporary workspace", "path", workDir)
+
+	sourceDir := filepath.Join(workDir, _packageName+"-"+plan.UpstreamVersion)
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		return fmt.Errorf("create source directory: %w", err)
+	}
+
+	if err := exportSource(ctx, log, root, plan.Ref, sourceDir); err != nil {
+		return fmt.Errorf("export source: %w", err)
+	}
+	if err := writeDebianPackaging(log, sourceDir); err != nil {
+		return fmt.Errorf("write Debian packaging: %w", err)
+	}
+
+	log.Info("Vendoring Go modules")
+	if err := xec.Command(ctx, log, "go", "mod", "vendor").
+		WithDir(sourceDir).
+		Run(); err != nil {
+		return fmt.Errorf("vendor Go modules: %w", err)
+	}
+
+	origTar := filepath.Join(
+		workDir,
+		fmt.Sprintf("%s_%s.orig.tar.gz", _packageName, plan.UpstreamVersion),
+	)
+	if err := writeOrigTar(log, sourceDir, origTar); err != nil {
+		return fmt.Errorf("write orig tarball: %w", err)
+	}
+
+	if plan.Sign != nil {
+		if err := plan.Sign.WritePassphraseFile(workDir); err != nil {
+			return fmt.Errorf("write signing passphrase: %w", err)
+		}
+	}
+
+	var dputCommands []string
+	for _, series := range plan.Series {
+		changes, err := buildSeries(ctx, log, root, sourceDir, workDir, origTar, plan, series)
+		if err != nil {
+			return fmt.Errorf("build %s: %w", series, err)
+		}
+
+		if plan.Sign != nil {
+			if err := signChanges(ctx, log, changes, *plan.Sign); err != nil {
+				return fmt.Errorf("sign %s: %w", series, err)
+			}
+		}
+
+		if plan.Dput {
+			log.Info("Uploading source package", "series", series, "changes", changes)
+			if err := xec.Command(ctx, log, "dput", plan.DputTarget, changes).
+				Run(); err != nil {
+				return fmt.Errorf("dput %s: %w", series, err)
+			}
+		} else {
+			dputCommands = append(dputCommands, renderDputCommand(plan.DputTarget, changes))
+		}
+	}
+
+	if !plan.Dput {
+		log.Info("Dry run complete; dput was not requested")
+		for _, command := range dputCommands {
+			log.Info("WOULD run " + command)
+		}
+	}
+
+	return nil
+}
+
+func writeDebianPackaging(log *silog.Logger, sourceDir string) error {
+	log.Info("Writing embedded Debian packaging")
+
+	if err := os.RemoveAll(filepath.Join(sourceDir, "debian")); err != nil {
+		return fmt.Errorf("remove debian directory: %w", err)
+	}
+	if err := txtar.Write(txtar.Parse(_debianPackagingTxtar), sourceDir); err != nil {
+		return fmt.Errorf("write txtar: %w", err)
+	}
+	if err := os.Chmod(filepath.Join(sourceDir, "debian", "rules"), 0o755); err != nil {
+		return fmt.Errorf("make debian/rules executable: %w", err)
+	}
+	return nil
+}
+
+// signConfig identifies the Launchpad signing material for debsign.
+type signConfig struct {
+	// KeyID is the GPG key ID passed to debsign.
+	KeyID string
+
+	// Passphrase is written to PassphraseFile before signing.
+	Passphrase string
+
+	// PassphraseFile is read by gpg when debsign invokes it.
+	PassphraseFile string
+}
+
+func signConfigFromEnv(enabled bool) (*signConfig, error) {
+	if !enabled {
+		return nil, nil
+	}
+
+	keyID := os.Getenv(_launchpadGPGKeyIDEnv)
+	if keyID == "" {
+		return nil, fmt.Errorf("%s is required with -sign", _launchpadGPGKeyIDEnv)
+	}
+
+	passphrase := os.Getenv(_launchpadGPGPassphraseEnv)
+	if passphrase == "" {
+		return nil, fmt.Errorf("%s is required with -sign", _launchpadGPGPassphraseEnv)
+	}
+
+	return &signConfig{
+		KeyID:      keyID,
+		Passphrase: passphrase,
+	}, nil
+}
+
+func (c *signConfig) WritePassphraseFile(dir string) error {
+	c.PassphraseFile = filepath.Join(dir, "launchpad-gpg-passphrase")
+	return os.WriteFile(c.PassphraseFile, []byte(c.Passphrase), 0o600)
+}
+
+// packagePlan is the derived packaging plan shared by all series builds.
+type packagePlan struct {
+	// Version is the user-facing release version, including its leading "v".
+	Version string
+
+	// UpstreamVersion is the Debian upstream version without a leading "v".
+	UpstreamVersion string
+
+	// DebianVersion is the full Debian source package version.
+	DebianVersion string
+
+	// PPARevision is the Launchpad PPA source package revision.
+	PPARevision int
+
+	// Ref is the Git object exported as upstream source.
+	Ref string
+
+	// Series lists the Ubuntu series to publish.
+	Series []string
+
+	// Sign is nil when source packages should remain unsigned.
+	Sign *signConfig
+
+	// Dput controls whether packages are uploaded after signing.
+	Dput bool
+
+	// DputTarget is the destination passed to dput.
+	DputTarget string
+}
+
+func newPackagePlan(req publishRequest) (packagePlan, error) {
+	var err error
+
+	if req.Version == "" {
+		err = errors.Join(err, errors.New("-version is required"))
+	}
+
+	if req.Version != "" && !semver.IsValid(req.Version) {
+		err = errors.Join(err, fmt.Errorf("version must be a valid semantic version: %q", req.Version))
+	}
+	upstreamVersion := strings.TrimPrefix(req.Version, "v")
+
+	if req.Ref == "" {
+		req.Ref = req.Version
+	}
+
+	series := slices.Clone(req.Series)
+	if len(series) == 0 {
+		series = []string{_defaultSeries}
+	}
+
+	if req.PPARevision <= 0 {
+		err = errors.Join(err, fmt.Errorf("PPA revision must be positive: %d", req.PPARevision))
+	}
+
+	sign, signErr := signConfigFromEnv(req.Sign)
+	err = errors.Join(err, signErr)
+
+	if req.DputTarget == "" {
+		err = errors.Join(err, errors.New("-dput-target is required"))
+	}
+
+	return packagePlan{
+		Version:         req.Version,
+		UpstreamVersion: upstreamVersion,
+		DebianVersion: fmt.Sprintf(
+			"%s-1~ppa%d",
+			upstreamVersion,
+			req.PPARevision,
+		),
+		PPARevision: req.PPARevision,
+		Ref:         req.Ref,
+		Series:      series,
+		Sign:        sign,
+		Dput:        req.Dput,
+		DputTarget:  req.DputTarget,
+	}, err
+}
+
+func exportSource(
+	ctx context.Context,
+	log *silog.Logger,
+	root string,
+	ref string,
+	sourceDir string,
+) error {
+	log.Info("Exporting source", "ref", ref, "path", sourceDir)
+
+	// The source package does not need LFS media content,
+	// and CI runners may not have git-lfs installed.
+	git := xec.Command(ctx, log, "git",
+		"-C", root,
+		"-c", "filter.lfs.required=false",
+		"-c", "filter.lfs.process=",
+		"-c", "filter.lfs.smudge=cat",
+		"archive",
+		"--format=tar",
+		"--worktree-attributes",
+		ref,
+	)
+	out, err := git.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("pipe git archive: %w", err)
+	}
+
+	tarCmd := xec.Command(ctx, log, "tar", "-C", sourceDir, "-xf", "-").
+		WithStdin(out)
+
+	if err := git.Start(); err != nil {
+		return fmt.Errorf("start git archive: %w", err)
+	}
+	if err := tarCmd.Run(); err != nil {
+		_ = git.Kill()
+		return fmt.Errorf("extract source: %w", err)
+	}
+	if err := git.Wait(); err != nil {
+		return fmt.Errorf("wait for git archive: %w", err)
+	}
+
+	return nil
+}
+
+func writeOrigTar(log *silog.Logger, sourceDir string, dest string) error {
+	log.Info("Writing deterministic orig tarball", "path", dest)
+
+	f, err := os.Create(dest)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", dest, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	gz, err := gzip.NewWriterLevel(f, gzip.BestCompression)
+	if err != nil {
+		return fmt.Errorf("create gzip writer: %w", err)
+	}
+	gz.Name = ""
+	gz.ModTime = time.Unix(0, 0).UTC()
+
+	tw := tar.NewWriter(gz)
+	if err := writeTarTree(tw, sourceDir); err != nil {
+		_ = tw.Close()
+		_ = gz.Close()
+		return err
+	}
+	if err := tw.Close(); err != nil {
+		_ = gz.Close()
+		return fmt.Errorf("close tar writer: %w", err)
+	}
+	if err := gz.Close(); err != nil {
+		return fmt.Errorf("close gzip writer: %w", err)
+	}
+
+	return nil
+}
+
+func writeTarTree(tw *tar.Writer, sourceDir string) error {
+	return filepath.WalkDir(sourceDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(sourceDir, path)
+		if err != nil {
+			return fmt.Errorf("relativize %s: %w", path, err)
+		}
+		if rel == "." {
+			return nil
+		}
+
+		name := "./" + filepath.ToSlash(rel)
+		if name == "./debian" || strings.HasPrefix(name, "./debian/") {
+			if d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return fmt.Errorf("stat %s: %w", path, err)
+		}
+
+		var link string
+		if info.Mode()&os.ModeSymlink != 0 {
+			link, err = os.Readlink(path)
+			if err != nil {
+				return fmt.Errorf("read link %s: %w", path, err)
+			}
+		}
+
+		header, err := tar.FileInfoHeader(info, link)
+		if err != nil {
+			return fmt.Errorf("create tar header for %s: %w", path, err)
+		}
+		header.Name = name
+		header.ModTime = time.Unix(0, 0).UTC()
+		header.AccessTime = time.Unix(0, 0).UTC()
+		header.ChangeTime = time.Unix(0, 0).UTC()
+		header.Uid = 0
+		header.Gid = 0
+		header.Uname = ""
+		header.Gname = ""
+		header.Format = tar.FormatPAX
+
+		if err := tw.WriteHeader(header); err != nil {
+			return fmt.Errorf("write tar header for %s: %w", path, err)
+		}
+
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+
+		f, err := os.Open(path)
+		if err != nil {
+			return fmt.Errorf("open %s: %w", path, err)
+		}
+
+		if _, err := io.Copy(tw, f); err != nil {
+			_ = f.Close()
+			return fmt.Errorf("write %s: %w", path, err)
+		}
+		if err := f.Close(); err != nil {
+			return fmt.Errorf("close %s: %w", path, err)
+		}
+
+		return nil
+	})
+}
+
+func buildSeries(
+	ctx context.Context,
+	log *silog.Logger,
+	root string,
+	sourceDir string,
+	workDir string,
+	origTar string,
+	plan packagePlan,
+	series string,
+) (string, error) {
+	log.Info("Building source package", "series", series)
+
+	if err := writeDebianChangelog(sourceDir, plan, series); err != nil {
+		return "", err
+	}
+
+	if err := cleanupBuildProducts(workDir, plan); err != nil {
+		return "", fmt.Errorf("clean previous build products: %w", err)
+	}
+
+	if err := xec.Command(ctx, log, "dpkg-buildpackage", "-S", "-us", "-uc", "-d").
+		WithDir(sourceDir).
+		Run(); err != nil {
+		return "", fmt.Errorf("dpkg-buildpackage: %w", err)
+	}
+
+	outDir := filepath.Join(root, "dist", "debian", series)
+	if err := os.RemoveAll(outDir); err != nil {
+		return "", fmt.Errorf("remove output directory: %w", err)
+	}
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return "", fmt.Errorf("create output directory: %w", err)
+	}
+	if err := copyFile(origTar, filepath.Join(outDir, filepath.Base(origTar))); err != nil {
+		return "", fmt.Errorf("copy orig tarball: %w", err)
+	}
+
+	pattern := filepath.Join(workDir, _packageName+"_"+plan.DebianVersion+"*")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return "", fmt.Errorf("glob build products: %w", err)
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf("no build products matched %s", pattern)
+	}
+
+	var changes string
+	for _, path := range matches {
+		dest := filepath.Join(outDir, filepath.Base(path))
+		if err := copyFile(path, dest); err != nil {
+			return "", fmt.Errorf("copy %s: %w", path, err)
+		}
+		if strings.HasSuffix(dest, "_source.changes") {
+			changes = dest
+		}
+	}
+	if changes == "" {
+		return "", errors.New("source changes file not produced")
+	}
+
+	log.Info("Wrote source package", "series", series, "changes", changes)
+	return changes, nil
+}
+
+func writeDebianChangelog(sourceDir string, plan packagePlan, series string) error {
+	changelog := fmt.Sprintf(`%s (%s) %s; urgency=medium
+
+  * Release git-spice %s.
+
+ -- Abhinav Gupta <mail@abhinavg.net>  %s
+`, _packageName, plan.DebianVersion, series, plan.UpstreamVersion, time.Now().UTC().Format(time.RFC1123Z))
+
+	if err := os.WriteFile(filepath.Join(sourceDir, "debian", "changelog"), []byte(changelog), 0o644); err != nil {
+		return fmt.Errorf("write debian/changelog: %w", err)
+	}
+	return nil
+}
+
+func cleanupBuildProducts(workDir string, plan packagePlan) error {
+	matches, err := filepath.Glob(filepath.Join(workDir, _packageName+"_"+plan.DebianVersion+"*"))
+	if err != nil {
+		return err
+	}
+	for _, path := range matches {
+		if err := os.Remove(path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func signChanges(
+	ctx context.Context,
+	log *silog.Logger,
+	changes string,
+	sign signConfig,
+) error {
+	log.Info("Signing source package", "changes", changes, "key", sign.KeyID)
+
+	gpgCommand := "gpg --batch --pinentry-mode loopback --passphrase-file " + sign.PassphraseFile
+	if err := xec.Command(ctx, log,
+		"debsign",
+		"-k"+sign.KeyID,
+		"-p"+gpgCommand,
+		changes,
+	).Run(); err != nil {
+		return fmt.Errorf("debsign: %w", err)
+	}
+
+	return nil
+}
+
+func copyFile(src string, dest string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = srcFile.Close() }()
+
+	info, err := srcFile.Stat()
+	if err != nil {
+		return err
+	}
+
+	destFile, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	defer func() { _ = destFile.Close() }()
+
+	if _, err := io.Copy(destFile, srcFile); err != nil {
+		return err
+	}
+
+	return destFile.Close()
+}
+
+func renderDputCommand(target string, changes string) string {
+	var buf bytes.Buffer
+	buf.WriteString("dput ")
+	buf.WriteString(target)
+	buf.WriteByte(' ')
+	buf.WriteString(changes)
+	return buf.String()
+}

--- a/tools/ci/launchpad-ppa/main_test.go
+++ b/tools/ci/launchpad-ppa/main_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSeriesFlag_Set(t *testing.T) {
+	var series seriesFlag
+
+	require.NoError(t, series.Set("noble,plucky"))
+	require.NoError(t, series.Set("questing"))
+	require.NoError(t, series.Set(" resolute, "))
+
+	assert.Equal(t,
+		seriesFlag{"noble", "plucky", "questing", "resolute"},
+		series)
+}
+
+func TestNewPackagePlan_defaults(t *testing.T) {
+	plan, err := newPackagePlan(publishRequest{
+		Version:     "v0.28.0",
+		PPARevision: 1,
+		DputTarget:  _defaultDputTarget,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "v0.28.0", plan.Version)
+	assert.Equal(t, "0.28.0", plan.UpstreamVersion)
+	assert.Equal(t, "0.28.0-1~ppa1", plan.DebianVersion)
+	assert.Equal(t, "v0.28.0", plan.Ref)
+	assert.Equal(t, []string{"noble"}, plan.Series)
+	assert.Nil(t, plan.Sign)
+	assert.False(t, plan.Dput)
+	assert.Equal(t, _defaultDputTarget, plan.DputTarget)
+}
+
+func TestNewPackagePlan_customValues(t *testing.T) {
+	plan, err := newPackagePlan(publishRequest{
+		Version:     "v0.28.0",
+		Ref:         "release-branch",
+		Series:      seriesFlag{"noble", "plucky"},
+		PPARevision: 2,
+		Dput:        true,
+		DputTarget:  "ppa:test/git-spice",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "release-branch", plan.Ref)
+	assert.Equal(t, []string{"noble", "plucky"}, plan.Series)
+	assert.Equal(t, "0.28.0-1~ppa2", plan.DebianVersion)
+	assert.Nil(t, plan.Sign)
+	assert.True(t, plan.Dput)
+	assert.Equal(t, "ppa:test/git-spice", plan.DputTarget)
+}
+
+func TestNewPackagePlan_invalid(t *testing.T) {
+	_, err := newPackagePlan(publishRequest{
+		Version:     "not-a-version",
+		PPARevision: 0,
+	})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "version must be a valid semantic version")
+	assert.ErrorContains(t, err, "PPA revision must be positive")
+	assert.ErrorContains(t, err, "-dput-target is required")
+}
+
+func TestSignConfigFromEnv(t *testing.T) {
+	t.Run("Disabled", func(t *testing.T) {
+		sign, err := signConfigFromEnv(false)
+		require.NoError(t, err)
+		assert.Nil(t, sign)
+	})
+
+	t.Run("Valid", func(t *testing.T) {
+		t.Setenv(_launchpadGPGKeyIDEnv, "ABC123")
+		t.Setenv(_launchpadGPGPassphraseEnv, "secret")
+
+		sign, err := signConfigFromEnv(true)
+		require.NoError(t, err)
+		require.NotNil(t, sign)
+		assert.Equal(t, "ABC123", sign.KeyID)
+		assert.Equal(t, "secret", sign.Passphrase)
+	})
+
+	t.Run("MissingKey", func(t *testing.T) {
+		t.Setenv(_launchpadGPGPassphraseEnv, "secret")
+
+		_, err := signConfigFromEnv(true)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, _launchpadGPGKeyIDEnv)
+	})
+
+	t.Run("MissingPassphrase", func(t *testing.T) {
+		t.Setenv(_launchpadGPGKeyIDEnv, "ABC123")
+
+		_, err := signConfigFromEnv(true)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, _launchpadGPGPassphraseEnv)
+	})
+}
+
+func TestRenderDputCommand(t *testing.T) {
+	assert.Equal(t,
+		"dput ppa:abhg/git-spice dist/debian/noble/git-spice_0.28.0-1~ppa1_source.changes",
+		renderDputCommand(
+			"ppa:abhg/git-spice",
+			"dist/debian/noble/git-spice_0.28.0-1~ppa1_source.changes",
+		))
+}


### PR DESCRIPTION
Ubuntu PPA uploads need Debian source packages,
not the binary `.deb` artifacts produced by GoReleaser.
Add a Launchpad publisher that exports a Git archive,
injects the Debian packaging recipe,
vendors Go modules in the temporary source tree,
and builds source artifacts for configured Ubuntu series.

Wire the release workflow to sign and upload the source packages
to `ppa:abhg/git-spice` after the GitHub release succeeds.
The Homebrew and PPA jobs continue to depend on the release job,
but can still run when GoReleaser is intentionally skipped.