### PR TITLE
sync: retarget upstack PRs on forge after deletion

### DIFF
--- a/.changes/unreleased/Changed-20260523-114425.yaml
+++ b/.changes/unreleased/Changed-20260523-114425.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'repo sync: Upstack PRs are now retargeted after their base branch is merged.'
+time: 2026-05-23T11:44:25.007139-07:00

--- a/internal/handler/delete/handler.go
+++ b/internal/handler/delete/handler.go
@@ -51,7 +51,7 @@ var _ Store = (*state.Store)(nil)
 // Service provides access to spice.Service methods
 type Service interface {
 	LookupBranch(ctx context.Context, name string) (*spice.LookupBranchResponse, error)
-	ListAbove(ctx context.Context, branch string) ([]string, error)
+	BranchGraph(ctx context.Context, opts *spice.BranchGraphOptions) (*spice.BranchGraph, error)
 	BranchOnto(ctx context.Context, req *spice.BranchOntoRequest) error
 	RebaseRescue(ctx context.Context, req spice.RebaseRescueRequest) error
 }
@@ -235,6 +235,11 @@ func (h *Handler) DeleteBranches(ctx context.Context, req *Request) error {
 		deleteOrder[i] = branchesToDelete[name]
 	}
 
+	branchGraph, err := h.Service.BranchGraph(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("get branch graph: %w", err)
+	}
+
 	// For each branch under consideration,
 	// if it's a tracked branch, update the upstacks from it
 	// to point to its base, or the next branch downstack
@@ -247,19 +252,12 @@ func (h *Handler) DeleteBranches(ctx context.Context, req *Request) error {
 
 		// Search through the bases to find one
 		// that isn't being deleted.
-		base := info.Base
-		baseInfo, deletingBase := branchesToDelete[base]
-		for base != h.Store.Trunk() && deletingBase {
-			base = baseInfo.Base
-			baseInfo, deletingBase = branchesToDelete[base]
-		}
+		base := branchGraph.NextBase(branch, func(branch string) bool {
+			_, ok := branchesToDelete[branch]
+			return ok
+		})
 
-		aboves, err := h.Service.ListAbove(ctx, branch)
-		if err != nil {
-			return fmt.Errorf("list above %v: %w", branch, err)
-		}
-
-		for _, above := range aboves {
+		for above := range branchGraph.Aboves(branch) {
 			if _, ok := branchesToDelete[above]; ok {
 				// This upstack is also being deleted. Skip.
 				continue

--- a/internal/handler/sync/handler.go
+++ b/internal/handler/sync/handler.go
@@ -436,6 +436,15 @@ func (h *Handler) SyncTrunk(ctx context.Context, opts *TrunkOptions) (retErr err
 		}
 	}
 
+	// Retarget surviving upstack PRs on the forge
+	// so their base matches the updated local state.
+	if h.RemoteRepository != nil {
+		h.retargetUpstackChanges(ctx,
+			collectRetargetCandidates(
+				branchesToDelete, candidates, trunk,
+			))
+	}
+
 	if opts.Restack {
 		if err := beginAutostash(); err != nil {
 			return err
@@ -955,4 +964,103 @@ func (h *Handler) deleteBranches(ctx context.Context, branchesToDelete []branchD
 	}
 
 	return nil
+}
+
+// retargetCandidate is a branch whose forge change
+// needs retargeting after a sync deletion.
+type retargetCandidate struct {
+	branch   string
+	changeID forge.ChangeID
+	newBase  string
+}
+
+// collectRetargetCandidates identifies branches
+// that need forge retargeting after sync deletion.
+//
+// It examines pre-deletion branch state to find branches
+// that survive deletion but have a base being deleted.
+// For each, it resolves the nearest surviving ancestor
+// as the new base.
+func collectRetargetCandidates(
+	deletions []branchDeletion,
+	candidates []spice.LoadBranchItem,
+	trunk string,
+) []retargetCandidate {
+	deletedNames := make(map[string]struct{}, len(deletions))
+	for _, d := range deletions {
+		deletedNames[d.BranchName] = struct{}{}
+	}
+
+	baseOf := make(map[string]string, len(candidates))
+	for _, c := range candidates {
+		baseOf[c.Name] = c.Base
+	}
+
+	var result []retargetCandidate
+	for _, c := range candidates {
+		if _, deleted := deletedNames[c.Name]; deleted {
+			continue
+		}
+		if c.Change == nil {
+			continue
+		}
+		if _, baseDeleted := deletedNames[c.Base]; !baseDeleted {
+			continue
+		}
+
+		result = append(result, retargetCandidate{
+			branch:   c.Name,
+			changeID: c.Change.ChangeID(),
+			newBase: survivingAncestor(
+				c.Base, baseOf, deletedNames, trunk,
+			),
+		})
+	}
+	return result
+}
+
+// survivingAncestor walks up the base chain
+// to find the nearest ancestor not being deleted.
+func survivingAncestor(
+	base string,
+	baseOf map[string]string,
+	deletedNames map[string]struct{},
+	trunk string,
+) string {
+	visited := make(map[string]struct{})
+	for {
+		if _, cycle := visited[base]; cycle {
+			return trunk
+		}
+		visited[base] = struct{}{}
+
+		parent, ok := baseOf[base]
+		if !ok {
+			return trunk
+		}
+		if _, deleted := deletedNames[parent]; !deleted {
+			return parent
+		}
+		base = parent
+	}
+}
+
+// retargetUpstackChanges retargets forge changes
+// for upstack branches surviving deletion.
+func (h *Handler) retargetUpstackChanges(
+	ctx context.Context,
+	candidates []retargetCandidate,
+) {
+	for _, c := range candidates {
+		h.Log.Infof("Retargeting %s to %s...",
+			c.branch, c.newBase)
+		err := h.RemoteRepository.EditChange(
+			ctx, c.changeID,
+			forge.EditChangeOptions{Base: c.newBase},
+		)
+		if err != nil {
+			h.Log.Warn("Retarget failed",
+				"branch", c.branch, "error", err)
+		}
+	}
 }

--- a/internal/handler/sync/handler.go
+++ b/internal/handler/sync/handler.go
@@ -63,7 +63,7 @@ var _ Store = (*state.Store)(nil)
 
 // Service is a subset of the spice.Service interface.
 type Service interface {
-	LoadBranches(ctx context.Context) ([]spice.LoadBranchItem, error)
+	BranchGraph(ctx context.Context, opts *spice.BranchGraphOptions) (*spice.BranchGraph, error)
 	ListAbove(ctx context.Context, name string) ([]string, error)
 }
 
@@ -366,10 +366,11 @@ func (h *Handler) SyncTrunk(ctx context.Context, opts *TrunkOptions) (retErr err
 		}
 	}
 
-	candidates, err := h.Service.LoadBranches(ctx)
+	branchGraph, err := h.Service.BranchGraph(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("list tracked branches: %w", err)
+		return fmt.Errorf("get branch graph: %w", err)
 	}
+	candidates := slices.Collect(branchGraph.All())
 
 	var branchesToDelete []branchDeletion
 	if h.RemoteRepository == nil {
@@ -437,11 +438,11 @@ func (h *Handler) SyncTrunk(ctx context.Context, opts *TrunkOptions) (retErr err
 	}
 
 	// Retarget surviving upstack PRs on the forge
-	// so their base matches the updated local state.
+	// around branches that are finished there.
 	if h.RemoteRepository != nil {
 		h.retargetUpstackChanges(ctx,
 			collectRetargetCandidates(
-				branchesToDelete, candidates, trunk,
+				branchesToDelete, branchGraph,
 			))
 	}
 
@@ -983,21 +984,15 @@ type retargetCandidate struct {
 // as the new base.
 func collectRetargetCandidates(
 	deletions []branchDeletion,
-	candidates []spice.LoadBranchItem,
-	trunk string,
+	branchGraph *spice.BranchGraph,
 ) []retargetCandidate {
 	deletedNames := make(map[string]struct{}, len(deletions))
 	for _, d := range deletions {
 		deletedNames[d.BranchName] = struct{}{}
 	}
 
-	baseOf := make(map[string]string, len(candidates))
-	for _, c := range candidates {
-		baseOf[c.Name] = c.Base
-	}
-
 	var result []retargetCandidate
-	for _, c := range candidates {
+	for c := range branchGraph.All() {
 		if _, deleted := deletedNames[c.Name]; deleted {
 			continue
 		}
@@ -1011,38 +1006,13 @@ func collectRetargetCandidates(
 		result = append(result, retargetCandidate{
 			branch:   c.Name,
 			changeID: c.Change.ChangeID(),
-			newBase: survivingAncestor(
-				c.Base, baseOf, deletedNames, trunk,
-			),
+			newBase: branchGraph.NextBase(c.Name, func(branch string) bool {
+				_, deleted := deletedNames[branch]
+				return deleted
+			}),
 		})
 	}
 	return result
-}
-
-// survivingAncestor walks up the base chain
-// to find the nearest ancestor not being deleted.
-func survivingAncestor(
-	base string,
-	baseOf map[string]string,
-	deletedNames map[string]struct{},
-	trunk string,
-) string {
-	visited := make(map[string]struct{})
-	for {
-		if _, cycle := visited[base]; cycle {
-			return trunk
-		}
-		visited[base] = struct{}{}
-
-		parent, ok := baseOf[base]
-		if !ok {
-			return trunk
-		}
-		if _, deleted := deletedNames[parent]; !deleted {
-			return parent
-		}
-		base = parent
-	}
 }
 
 // retargetUpstackChanges retargets forge changes

--- a/internal/handler/sync/handler_test.go
+++ b/internal/handler/sync/handler_test.go
@@ -14,6 +14,7 @@ import (
 	branchdel "go.abhg.dev/gs/internal/handler/delete"
 	"go.abhg.dev/gs/internal/silog/silogtest"
 	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/spicetest"
 	"go.abhg.dev/gs/internal/ui"
 )
 
@@ -107,8 +108,10 @@ func TestHandler_SyncTrunk_autostashLazy(t *testing.T) {
 		mockRepo := newFetchOnlyRepoMocks(ctrl)
 		mockService := NewMockService(ctrl)
 		mockService.EXPECT().
-			LoadBranches(gomock.Any()).
-			Return(nil, nil)
+			BranchGraph(gomock.Any(), (*spice.BranchGraphOptions)(nil)).
+			Return(spicetest.NewBranchGraph(t, spicetest.BranchGraphConfig{
+				Trunk: "main",
+			}), nil)
 
 		handler := &Handler{
 			Log:        silogtest.New(t),
@@ -170,12 +173,15 @@ func TestHandler_SyncTrunk_autostashLazy(t *testing.T) {
 
 		mockService := NewMockService(ctrl)
 		mockService.EXPECT().
-			LoadBranches(gomock.Any()).
-			Return([]spice.LoadBranchItem{{
-				Name: "feature",
-				Head: git.Hash("trunk"),
-				Base: "main",
-			}}, nil)
+			BranchGraph(gomock.Any(), (*spice.BranchGraphOptions)(nil)).
+			Return(spicetest.NewBranchGraph(t, spicetest.BranchGraphConfig{
+				Trunk: "main",
+				Branches: []spice.LoadBranchItem{{
+					Name: "feature",
+					Head: git.Hash("trunk"),
+					Base: "main",
+				}},
+			}), nil)
 
 		mockDelete := NewMockDeleteHandler(ctrl)
 		mockDelete.EXPECT().
@@ -242,8 +248,10 @@ func TestHandler_SyncTrunk_autostashLazy(t *testing.T) {
 		mockRepo := newFetchOnlyRepoMocks(ctrl)
 		mockService := NewMockService(ctrl)
 		mockService.EXPECT().
-			LoadBranches(gomock.Any()).
-			Return(nil, nil)
+			BranchGraph(gomock.Any(), (*spice.BranchGraphOptions)(nil)).
+			Return(spicetest.NewBranchGraph(t, spicetest.BranchGraphConfig{
+				Trunk: "main",
+			}), nil)
 
 		mockRestack := NewMockRestackHandler(ctrl)
 		mockRestack.EXPECT().

--- a/internal/handler/sync/mocks_test.go
+++ b/internal/handler/sync/mocks_test.go
@@ -655,6 +655,45 @@ func (m *MockService) EXPECT() *MockServiceMockRecorder {
 	return m.recorder
 }
 
+// BranchGraph mocks base method.
+func (m *MockService) BranchGraph(ctx context.Context, opts *spice.BranchGraphOptions) (*spice.BranchGraph, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BranchGraph", ctx, opts)
+	ret0, _ := ret[0].(*spice.BranchGraph)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BranchGraph indicates an expected call of BranchGraph.
+func (mr *MockServiceMockRecorder) BranchGraph(ctx, opts any) *MockServiceBranchGraphCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BranchGraph", reflect.TypeOf((*MockService)(nil).BranchGraph), ctx, opts)
+	return &MockServiceBranchGraphCall{Call: call}
+}
+
+// MockServiceBranchGraphCall wrap *gomock.Call
+type MockServiceBranchGraphCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockServiceBranchGraphCall) Return(arg0 *spice.BranchGraph, arg1 error) *MockServiceBranchGraphCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockServiceBranchGraphCall) Do(f func(context.Context, *spice.BranchGraphOptions) (*spice.BranchGraph, error)) *MockServiceBranchGraphCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockServiceBranchGraphCall) DoAndReturn(f func(context.Context, *spice.BranchGraphOptions) (*spice.BranchGraph, error)) *MockServiceBranchGraphCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ListAbove mocks base method.
 func (m *MockService) ListAbove(ctx context.Context, name string) ([]string, error) {
 	m.ctrl.T.Helper()
@@ -690,45 +729,6 @@ func (c *MockServiceListAboveCall) Do(f func(context.Context, string) ([]string,
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockServiceListAboveCall) DoAndReturn(f func(context.Context, string) ([]string, error)) *MockServiceListAboveCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// LoadBranches mocks base method.
-func (m *MockService) LoadBranches(ctx context.Context) ([]spice.LoadBranchItem, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoadBranches", ctx)
-	ret0, _ := ret[0].([]spice.LoadBranchItem)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// LoadBranches indicates an expected call of LoadBranches.
-func (mr *MockServiceMockRecorder) LoadBranches(ctx any) *MockServiceLoadBranchesCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadBranches", reflect.TypeOf((*MockService)(nil).LoadBranches), ctx)
-	return &MockServiceLoadBranchesCall{Call: call}
-}
-
-// MockServiceLoadBranchesCall wrap *gomock.Call
-type MockServiceLoadBranchesCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockServiceLoadBranchesCall) Return(arg0 []spice.LoadBranchItem, arg1 error) *MockServiceLoadBranchesCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockServiceLoadBranchesCall) Do(f func(context.Context) ([]spice.LoadBranchItem, error)) *MockServiceLoadBranchesCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockServiceLoadBranchesCall) DoAndReturn(f func(context.Context) ([]spice.LoadBranchItem, error)) *MockServiceLoadBranchesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/handler/sync/retarget_test.go
+++ b/internal/handler/sync/retarget_test.go
@@ -1,0 +1,175 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/spice"
+)
+
+// fakeChangeID is a string-based ChangeID for testing.
+type fakeChangeID string
+
+func (f fakeChangeID) String() string { return string(f) }
+
+// fakeChangeMetadata implements forge.ChangeMetadata for testing.
+type fakeChangeMetadata struct {
+	id forge.ChangeID
+}
+
+func (m *fakeChangeMetadata) ForgeID() string          { return "fake" }
+func (m *fakeChangeMetadata) ChangeID() forge.ChangeID { return m.id }
+
+func (m *fakeChangeMetadata) NavigationCommentID() forge.ChangeCommentID {
+	return nil
+}
+
+func (m *fakeChangeMetadata) SetNavigationCommentID(forge.ChangeCommentID) {}
+
+func TestCollectRetargetCandidates(t *testing.T) {
+	t.Run("SingleDeletion", func(t *testing.T) {
+		// main -> A -> B; A deleted, B survives with change.
+		got := collectRetargetCandidates(
+			[]branchDeletion{{BranchName: "A"}},
+			[]spice.LoadBranchItem{
+				{Name: "A", Base: "main"},
+				{
+					Name:   "B",
+					Base:   "A",
+					Change: &fakeChangeMetadata{id: fakeChangeID("pr-2")},
+				},
+			},
+			"main",
+		)
+
+		assert.Equal(t, []retargetCandidate{
+			{branch: "B", changeID: fakeChangeID("pr-2"), newBase: "main"},
+		}, got)
+	})
+
+	t.Run("MultiLevel", func(t *testing.T) {
+		// main -> A -> B -> C; A and B deleted, C survives.
+		got := collectRetargetCandidates(
+			[]branchDeletion{
+				{BranchName: "A"},
+				{BranchName: "B"},
+			},
+			[]spice.LoadBranchItem{
+				{Name: "A", Base: "main"},
+				{Name: "B", Base: "A"},
+				{
+					Name:   "C",
+					Base:   "B",
+					Change: &fakeChangeMetadata{id: fakeChangeID("pr-3")},
+				},
+			},
+			"main",
+		)
+
+		assert.Equal(t, []retargetCandidate{
+			{branch: "C", changeID: fakeChangeID("pr-3"), newBase: "main"},
+		}, got)
+	})
+
+	t.Run("NoChange", func(t *testing.T) {
+		// A deleted, B survives but has no published change.
+		got := collectRetargetCandidates(
+			[]branchDeletion{{BranchName: "A"}},
+			[]spice.LoadBranchItem{
+				{Name: "A", Base: "main"},
+				{Name: "B", Base: "A"},
+			},
+			"main",
+		)
+
+		assert.Empty(t, got)
+	})
+
+	t.Run("UpstackAlsoDeleted", func(t *testing.T) {
+		// A and B both deleted — no retarget candidates.
+		got := collectRetargetCandidates(
+			[]branchDeletion{
+				{BranchName: "A"},
+				{BranchName: "B"},
+			},
+			[]spice.LoadBranchItem{
+				{Name: "A", Base: "main"},
+				{
+					Name:   "B",
+					Base:   "A",
+					Change: &fakeChangeMetadata{id: fakeChangeID("pr-2")},
+				},
+			},
+			"main",
+		)
+
+		assert.Empty(t, got)
+	})
+
+	t.Run("BaseNotDeleted", func(t *testing.T) {
+		// A is not deleted; B's base is not in the deletion set.
+		got := collectRetargetCandidates(
+			[]branchDeletion{{BranchName: "X"}},
+			[]spice.LoadBranchItem{
+				{Name: "A", Base: "main"},
+				{
+					Name:   "B",
+					Base:   "A",
+					Change: &fakeChangeMetadata{id: fakeChangeID("pr-2")},
+				},
+			},
+			"main",
+		)
+
+		assert.Empty(t, got)
+	})
+
+	t.Run("CyclicBases", func(t *testing.T) {
+		// A -> B -> A (cycle), both deleted, C survives.
+		// Should fall back to trunk instead of looping.
+		got := collectRetargetCandidates(
+			[]branchDeletion{
+				{BranchName: "A"},
+				{BranchName: "B"},
+			},
+			[]spice.LoadBranchItem{
+				{Name: "A", Base: "B"},
+				{Name: "B", Base: "A"},
+				{
+					Name:   "C",
+					Base:   "A",
+					Change: &fakeChangeMetadata{id: fakeChangeID("pr-3")},
+				},
+			},
+			"main",
+		)
+
+		assert.Equal(t, []retargetCandidate{
+			{branch: "C", changeID: fakeChangeID("pr-3"), newBase: "main"},
+		}, got)
+	})
+
+	t.Run("SurvivingNonTrunkAncestor", func(t *testing.T) {
+		// main -> A -> B -> C; B deleted, A survives.
+		// C should retarget to A, not main.
+		got := collectRetargetCandidates(
+			[]branchDeletion{{BranchName: "B"}},
+			[]spice.LoadBranchItem{
+				{Name: "A", Base: "main"},
+				{Name: "B", Base: "A"},
+				{
+					Name:   "C",
+					Base:   "B",
+					Change: &fakeChangeMetadata{id: fakeChangeID("pr-3")},
+				},
+			},
+			"main",
+		)
+
+		assert.Equal(t, []retargetCandidate{
+			{branch: "C", changeID: fakeChangeID("pr-3"), newBase: "A"},
+		}, got)
+	})
+}

--- a/internal/handler/sync/retarget_test.go
+++ b/internal/handler/sync/retarget_test.go
@@ -7,6 +7,7 @@ import (
 
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/spicetest"
 )
 
 // fakeChangeID is a string-based ChangeID for testing.
@@ -29,19 +30,25 @@ func (m *fakeChangeMetadata) NavigationCommentID() forge.ChangeCommentID {
 func (m *fakeChangeMetadata) SetNavigationCommentID(forge.ChangeCommentID) {}
 
 func TestCollectRetargetCandidates(t *testing.T) {
+	branchGraph := func(branches []spice.LoadBranchItem) *spice.BranchGraph {
+		return spicetest.NewBranchGraph(t, spicetest.BranchGraphConfig{
+			Trunk:    "main",
+			Branches: branches,
+		})
+	}
+
 	t.Run("SingleDeletion", func(t *testing.T) {
 		// main -> A -> B; A deleted, B survives with change.
 		got := collectRetargetCandidates(
 			[]branchDeletion{{BranchName: "A"}},
-			[]spice.LoadBranchItem{
+			branchGraph([]spice.LoadBranchItem{
 				{Name: "A", Base: "main"},
 				{
 					Name:   "B",
 					Base:   "A",
 					Change: &fakeChangeMetadata{id: fakeChangeID("pr-2")},
 				},
-			},
-			"main",
+			}),
 		)
 
 		assert.Equal(t, []retargetCandidate{
@@ -56,7 +63,7 @@ func TestCollectRetargetCandidates(t *testing.T) {
 				{BranchName: "A"},
 				{BranchName: "B"},
 			},
-			[]spice.LoadBranchItem{
+			branchGraph([]spice.LoadBranchItem{
 				{Name: "A", Base: "main"},
 				{Name: "B", Base: "A"},
 				{
@@ -64,8 +71,7 @@ func TestCollectRetargetCandidates(t *testing.T) {
 					Base:   "B",
 					Change: &fakeChangeMetadata{id: fakeChangeID("pr-3")},
 				},
-			},
-			"main",
+			}),
 		)
 
 		assert.Equal(t, []retargetCandidate{
@@ -77,11 +83,10 @@ func TestCollectRetargetCandidates(t *testing.T) {
 		// A deleted, B survives but has no published change.
 		got := collectRetargetCandidates(
 			[]branchDeletion{{BranchName: "A"}},
-			[]spice.LoadBranchItem{
+			branchGraph([]spice.LoadBranchItem{
 				{Name: "A", Base: "main"},
 				{Name: "B", Base: "A"},
-			},
-			"main",
+			}),
 		)
 
 		assert.Empty(t, got)
@@ -94,15 +99,14 @@ func TestCollectRetargetCandidates(t *testing.T) {
 				{BranchName: "A"},
 				{BranchName: "B"},
 			},
-			[]spice.LoadBranchItem{
+			branchGraph([]spice.LoadBranchItem{
 				{Name: "A", Base: "main"},
 				{
 					Name:   "B",
 					Base:   "A",
 					Change: &fakeChangeMetadata{id: fakeChangeID("pr-2")},
 				},
-			},
-			"main",
+			}),
 		)
 
 		assert.Empty(t, got)
@@ -112,15 +116,14 @@ func TestCollectRetargetCandidates(t *testing.T) {
 		// A is not deleted; B's base is not in the deletion set.
 		got := collectRetargetCandidates(
 			[]branchDeletion{{BranchName: "X"}},
-			[]spice.LoadBranchItem{
+			branchGraph([]spice.LoadBranchItem{
 				{Name: "A", Base: "main"},
 				{
 					Name:   "B",
 					Base:   "A",
 					Change: &fakeChangeMetadata{id: fakeChangeID("pr-2")},
 				},
-			},
-			"main",
+			}),
 		)
 
 		assert.Empty(t, got)
@@ -134,7 +137,7 @@ func TestCollectRetargetCandidates(t *testing.T) {
 				{BranchName: "A"},
 				{BranchName: "B"},
 			},
-			[]spice.LoadBranchItem{
+			branchGraph([]spice.LoadBranchItem{
 				{Name: "A", Base: "B"},
 				{Name: "B", Base: "A"},
 				{
@@ -142,8 +145,7 @@ func TestCollectRetargetCandidates(t *testing.T) {
 					Base:   "A",
 					Change: &fakeChangeMetadata{id: fakeChangeID("pr-3")},
 				},
-			},
-			"main",
+			}),
 		)
 
 		assert.Equal(t, []retargetCandidate{
@@ -156,7 +158,7 @@ func TestCollectRetargetCandidates(t *testing.T) {
 		// C should retarget to A, not main.
 		got := collectRetargetCandidates(
 			[]branchDeletion{{BranchName: "B"}},
-			[]spice.LoadBranchItem{
+			branchGraph([]spice.LoadBranchItem{
 				{Name: "A", Base: "main"},
 				{Name: "B", Base: "A"},
 				{
@@ -164,8 +166,7 @@ func TestCollectRetargetCandidates(t *testing.T) {
 					Base:   "B",
 					Change: &fakeChangeMetadata{id: fakeChangeID("pr-3")},
 				},
-			},
-			"main",
+			}),
 		)
 
 		assert.Equal(t, []retargetCandidate{

--- a/internal/spice/branch_graph.go
+++ b/internal/spice/branch_graph.go
@@ -262,6 +262,67 @@ func (g *BranchGraph) Bottom(branch string) string {
 	return ""
 }
 
+// NextBase resolves the base branch to use
+// when one or more downstack branches should be ignored.
+//
+// This is a graph operation,
+// but not a policy decision:
+// callers decide what "except" means.
+// For branch deletion,
+// the predicate usually means "this branch is being deleted locally."
+// For repository sync,
+// it may mean "this branch is already finished on the forge."
+//
+// The search starts from branch's current base,
+// not from branch itself.
+// If that base is excepted,
+// NextBase walks downstack until it finds a base
+// that the predicate allows.
+//
+// A base that is not excepted is returned as-is,
+// even if the graph does not track that base branch.
+// This lets callers build a graph from only the branches
+// relevant to the operation:
+// the graph must know how to walk through excepted branches,
+// but it does not need to know every possible surviving base.
+//
+// If branch is unknown,
+// or an excepted base is not in the graph,
+// NextBase returns trunk.
+// These fallbacks keep callers from preserving an invalid base edge
+// when the branch graph is already inconsistent.
+func (g *BranchGraph) NextBase(
+	branch string,
+	except func(string) bool,
+) string {
+	idx, ok := g.byName[branch]
+	if !ok {
+		return g.trunk
+	}
+
+	if except == nil {
+		except = func(string) bool { return false }
+	}
+
+	visited := make(map[string]struct{})
+	visited[branch] = struct{}{}
+	base := g.branches[idx].Base
+	for except(base) {
+		if _, ok := visited[base]; ok {
+			return g.trunk
+		}
+		visited[base] = struct{}{}
+
+		idx, ok := g.byName[base]
+		if !ok {
+			return g.trunk
+		}
+		base = g.branches[idx].Base
+	}
+
+	return base
+}
+
 // Stack returns the full stack of branches that the given branch is in.
 //
 // This includes all downstack branches and all upstack branches,

--- a/internal/spice/branch_graph_test.go
+++ b/internal/spice/branch_graph_test.go
@@ -1,13 +1,14 @@
-package spice
+package spice_test
 
 import (
-	"context"
 	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/spicetest"
 	"pgregory.net/rapid"
 )
 
@@ -18,21 +19,20 @@ func TestBranchGraph(t *testing.T) {
 	//	      '-> feature3 --> feature5
 	feature1WT := t.TempDir()
 	feature5WT := t.TempDir()
-	graph, err := NewBranchGraph(t.Context(), &branchLoaderStub{
-		trunk: "main",
-		branches: []LoadBranchItem{
+	graph := spicetest.NewBranchGraph(t, spicetest.BranchGraphConfig{
+		Trunk: "main",
+		Branches: []spice.LoadBranchItem{
 			{Name: "feature1", Base: "main"},
 			{Name: "feature2", Base: "feature1"},
 			{Name: "feature4", Base: "feature1"},
 			{Name: "feature3", Base: "main"},
 			{Name: "feature5", Base: "feature3"},
 		},
-		worktrees: map[string]string{
+		Worktrees: map[string]string{
 			"feature1": feature1WT,
 			"feature5": feature5WT,
 		},
-	}, &BranchGraphOptions{IncludeWorktrees: true})
-	require.NoError(t, err)
+	})
 
 	assert.Equal(t, "main", graph.Trunk())
 
@@ -175,6 +175,30 @@ func TestBranchGraph(t *testing.T) {
 		}
 	})
 
+	t.Run("NextBase", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			except []string
+			want   string
+		}{
+			{name: "main", except: []string{"feature1"}, want: "main"},
+			{name: "unknown", except: []string{"feature1"}, want: "main"},
+			{name: "feature1", except: []string{"feature1"}, want: "main"},
+			{name: "feature2", except: []string{"feature1"}, want: "main"},
+			{name: "feature4", except: []string{"feature1"}, want: "main"},
+			{name: "feature5", except: []string{"feature3"}, want: "main"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				got := graph.NextBase(tt.name, func(branch string) bool {
+					return slices.Contains(tt.except, branch)
+				})
+				assert.Equal(t, tt.want, got)
+			})
+		}
+	})
+
 	t.Run("Stack", func(t *testing.T) {
 		tests := []struct {
 			name string
@@ -236,6 +260,34 @@ func TestBranchGraph(t *testing.T) {
 	})
 }
 
+func TestBranchGraph_NextBase_cycle(t *testing.T) {
+	graph := spicetest.NewBranchGraph(t, spicetest.BranchGraphConfig{
+		Trunk: "main",
+		Branches: []spice.LoadBranchItem{
+			{Name: "feature1", Base: "feature2"},
+			{Name: "feature2", Base: "feature1"},
+		},
+	})
+
+	got := graph.NextBase("feature1", func(string) bool { return true })
+	assert.Equal(t, "main", got)
+}
+
+func TestBranchGraph_NextBase_partialGraph(t *testing.T) {
+	graph := spicetest.NewBranchGraph(t, spicetest.BranchGraphConfig{
+		Trunk: "main",
+		Branches: []spice.LoadBranchItem{
+			{Name: "feature1", Base: "feature2"},
+			{Name: "feature2", Base: "survivor"},
+		},
+	})
+
+	got := graph.NextBase("feature1", func(branch string) bool {
+		return branch == "feature2"
+	})
+	assert.Equal(t, "survivor", got)
+}
+
 func TestBranchGraphRapid(t *testing.T) {
 	rapid.Check(t, testBranchGraphRapid)
 }
@@ -249,7 +301,7 @@ func testBranchGraphRapid(t *rapid.T) {
 
 	// To guarantee no cycles in generated graph,
 	// we'll only use previously generated branches as bases.
-	var branchItems []LoadBranchItem
+	var branchItems []spice.LoadBranchItem
 	for range rapid.IntRange(0, 100).Draw(t, "numBranches") {
 		name := branchNameGen.Filter(func(name string) bool {
 			// Requested name must be unused.
@@ -257,7 +309,7 @@ func testBranchGraphRapid(t *rapid.T) {
 		}).Draw(t, "branchName")
 		base := rapid.SampledFrom(allBranches).Draw(t, "baseBranch")
 		allBranches = append(allBranches, name)
-		branchItems = append(branchItems, LoadBranchItem{
+		branchItems = append(branchItems, spice.LoadBranchItem{
 			Name:           name,
 			Base:           base,
 			Head:           git.Hash(gitHashGen.Draw(t, "headHash")),
@@ -266,11 +318,10 @@ func testBranchGraphRapid(t *rapid.T) {
 		})
 	}
 
-	graph, err := NewBranchGraph(t.Context(), &branchLoaderStub{
-		trunk:    trunk,
-		branches: branchItems,
-	}, nil)
-	require.NoError(t, err)
+	graph := spicetest.NewBranchGraph(t, spicetest.BranchGraphConfig{
+		Trunk:    trunk,
+		Branches: branchItems,
+	})
 
 	t.Repeat(map[string]func(*rapid.T){
 		"All": func(t *rapid.T) {
@@ -336,8 +387,9 @@ func testBranchGraphRapid(t *rapid.T) {
 				assert.NotEmpty(t, bottom, "bottom should not be empty for tracked branches")
 				assert.NotEqual(t, trunk, bottom, "bottom should not be trunk for tracked branches")
 
-				// TODO: don't look at internals
-				assert.Equal(t, trunk, graph.branches[graph.byName[bottom]].Base,
+				bottomBranch, ok := graph.Lookup(bottom)
+				require.True(t, ok, "bottom branch should be tracked")
+				assert.Equal(t, trunk, bottomBranch.Base,
 					"base of bottom branch should be trunk")
 			}
 		},
@@ -361,31 +413,4 @@ func testBranchGraphRapid(t *rapid.T) {
 			}
 		},
 	})
-}
-
-type branchLoaderStub struct {
-	trunk     string
-	branches  []LoadBranchItem
-	worktrees map[string]string
-}
-
-var _ BranchLoader = (*branchLoaderStub)(nil)
-
-func (s *branchLoaderStub) Trunk() string {
-	return s.trunk
-}
-
-func (s *branchLoaderStub) LoadBranches(_ context.Context) ([]LoadBranchItem, error) {
-	return slices.Clone(s.branches), nil
-}
-
-func (s *branchLoaderStub) LookupWorktrees(_ context.Context, branches []string) (map[string]string, error) {
-	wts := make(map[string]string)
-	for _, b := range branches {
-		wt := s.worktrees[b]
-		if wt != "" {
-			wts[b] = wt
-		}
-	}
-	return wts, nil
 }

--- a/internal/spice/spicetest/branch_graph.go
+++ b/internal/spice/spicetest/branch_graph.go
@@ -1,0 +1,91 @@
+// Package spicetest provides test fixtures for spice package concepts.
+package spicetest
+
+import (
+	"context"
+	"slices"
+
+	"github.com/stretchr/testify/require"
+
+	"go.abhg.dev/gs/internal/spice"
+)
+
+// T is the subset of test APIs needed to build fixtures.
+type T interface {
+	Context() context.Context
+	Helper()
+	Errorf(string, ...any)
+	FailNow()
+}
+
+// BranchGraphConfig specifies the branch graph fixture
+// that a test wants to build.
+//
+// It keeps test setup close to the graph's domain model:
+// Branches are the tracked branch records,
+// Trunk is the repository trunk,
+// and Worktrees records optional branch checkout locations.
+type BranchGraphConfig struct {
+	// Trunk is the repository trunk branch.
+	Trunk string
+
+	// Branches are the tracked branches in the graph.
+	Branches []spice.LoadBranchItem
+
+	// Worktrees maps branch names to checkout directories.
+	//
+	// When this map is non-empty,
+	// NewBranchGraph asks the graph builder to load worktree information.
+	Worktrees map[string]string
+}
+
+// NewBranchGraph builds a branch graph fixture for tests.
+func NewBranchGraph(t T, cfg BranchGraphConfig) *spice.BranchGraph {
+	t.Helper()
+
+	graph, err := spice.NewBranchGraph(
+		t.Context(),
+		&branchLoader{
+			trunk:     cfg.Trunk,
+			branches:  cfg.Branches,
+			worktrees: cfg.Worktrees,
+		},
+		&spice.BranchGraphOptions{
+			IncludeWorktrees: len(cfg.Worktrees) > 0,
+		},
+	)
+	require.NoError(t, err)
+	return graph
+}
+
+type branchLoader struct {
+	trunk     string
+	branches  []spice.LoadBranchItem
+	worktrees map[string]string
+}
+
+var _ spice.BranchLoader = (*branchLoader)(nil)
+
+func (l *branchLoader) Trunk() string {
+	return l.trunk
+}
+
+func (l *branchLoader) LoadBranches(
+	context.Context,
+) ([]spice.LoadBranchItem, error) {
+	return slices.Clone(l.branches), nil
+}
+
+func (l *branchLoader) LookupWorktrees(
+	_ context.Context,
+	branches []string,
+) (map[string]string, error) {
+	worktrees := make(map[string]string)
+	for _, branch := range branches {
+		worktree := l.worktrees[branch]
+		if worktree != "" {
+			worktrees[branch] = worktree
+		}
+	}
+	return worktrees, nil
+}

--- a/testdata/script/repo_sync_retarget_deep_stack.txt
+++ b/testdata/script/repo_sync_retarget_deep_stack.txt
@@ -1,0 +1,59 @@
+# 'repo sync' retargets upstack PRs correctly
+# when multiple stacked branches are merged.
+
+as 'Test <test@example.com>'
+at '2026-03-04T18:00:00Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# create a stack: main -> A -> B -> C
+git add a.txt
+gs bc feature-a -m 'Add feature A'
+git add b.txt
+gs bc feature-b -m 'Add feature B'
+git add c.txt
+gs bc feature-c -m 'Add feature C'
+
+# submit the full stack
+gs downstack submit --fill
+stderr 'Created #1'
+stderr 'Created #2'
+stderr 'Created #3'
+
+# verify feature-c targets feature-b initially
+shamhub dump change 3
+stdout '"ref": "feature-b"'
+
+# merge A and B externally
+shamhub merge alice/example 1
+shamhub merge alice/example 2
+
+# sync should detect both merges
+# and retarget feature-c's PR to main.
+gs repo sync
+stderr 'feature-a: #1 was merged'
+stderr 'feature-b: #2 was merged'
+stderr 'Retargeting feature-c to main'
+
+# verify feature-c's PR now targets main
+shamhub dump change 3
+stdout '"ref": "main"'
+
+-- repo/a.txt --
+Feature A
+-- repo/b.txt --
+Feature B
+-- repo/c.txt --
+Feature C

--- a/testdata/script/repo_sync_retarget_skipped_local_delete.txt
+++ b/testdata/script/repo_sync_retarget_skipped_local_delete.txt
@@ -1,0 +1,85 @@
+# 'repo sync' retargets upstack PRs on the forge
+# even when local branch deletion is skipped.
+
+as 'Test <test@example.com>'
+at '2026-05-23T20:00:00Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# create a stack: main -> feature1 -> feature2
+git add feature1.txt
+gs bc feature1 -m 'Add feature 1'
+git add feature2.txt
+gs bc feature2 -m 'Add feature 2'
+
+# submit the stack
+gs downstack submit --fill
+stderr 'Created #1'
+stderr 'Created #2'
+
+# verify the local stack shape
+gs ls
+cmp stderr $WORK/golden/ls-before.txt
+
+# feature1 is checked out elsewhere,
+# so sync cannot delete it locally even after the forge merges it.
+git checkout main
+git worktree add ../wt-feature1 feature1
+shamhub merge alice/example 1
+
+# The local branch remains,
+# but the forge stack should no longer target a finished branch.
+gs repo sync
+stderr 'feature1: #1 was merged'
+stderr 'feature1: checked out in another worktree.*skipping deletion'
+stderr 'Retargeting feature2 to main'
+
+git rev-parse --verify feature1
+
+shamhub dump change 2
+cmpenvJSON stdout $WORK/golden/change-2.json
+
+-- repo/feature1.txt --
+This is feature 1
+-- repo/feature2.txt --
+This is feature 2
+-- golden/ls-before.txt --
+  ┏━■ feature2 (#2) ◀
+┏━┻□ feature1 (#1)
+main
+-- golden/change-2.json --
+{
+  "number": 2,
+  "html_url": "$SHAMHUB_URL/alice/example/change/2",
+  "state": "open",
+  "title": "Add feature 2",
+  "body": "",
+  "base": {
+    "repository": {
+      "owner": "alice",
+      "name": "example"
+    },
+    "ref": "main",
+    "sha": "c6e2fe6a9663ac4b978e5504aa4114d42eb2c608"
+  },
+  "head": {
+    "repository": {
+      "owner": "alice",
+      "name": "example"
+    },
+    "ref": "feature2",
+    "sha": "ecb61364f24700c531d9bfaa30007864fbc295e8"
+  }
+}

--- a/testdata/script/repo_sync_retarget_upstack.txt
+++ b/testdata/script/repo_sync_retarget_upstack.txt
@@ -1,0 +1,52 @@
+# 'repo sync' retargets upstack PRs on the forge
+# after deleting merged branches.
+
+as 'Test <test@example.com>'
+at '2026-03-04T18:00:00Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# create a stack: main -> feature1 -> feature2
+git add feature1.txt
+gs bc feature1 -m 'Add feature 1'
+git add feature2.txt
+gs bc feature2 -m 'Add feature 2'
+
+# submit the stack
+gs downstack submit --fill
+stderr 'Created #1'
+stderr 'Created #2'
+
+# verify feature2 targets feature1 initially
+shamhub dump change 2
+stdout '"ref": "feature1"'
+
+# merge feature1 externally
+shamhub merge alice/example 1
+
+# sync should detect the merge, delete feature1,
+# and retarget feature2's PR to main.
+gs repo sync
+stderr 'feature1: #1 was merged'
+stderr 'Retargeting feature2 to main'
+
+# verify feature2's PR now targets main
+shamhub dump change 2
+stdout '"ref": "main"'
+
+-- repo/feature1.txt --
+This is feature 1
+-- repo/feature2.txt --
+This is feature 2


### PR DESCRIPTION
When `gs repo sync` deletes branches whose PRs were merged,
upstack PRs on the forge are left targeting deleted branches.
This causes confusion on platforms like GitHub, where the PR
base no longer matches the local stack state.

This change retargets surviving upstack PRs on the forge to
their nearest surviving ancestor (or trunk if none exists)
after sync deletes merged branches. Cyclic base chains fall
back to trunk to avoid infinite loops.

Covered by unit tests for candidate collection and ancestor
resolution, plus test scripts exercising single-merge and
deep-stack scenarios end-to-end.

Regarding this question on #1073:
> So just to clarify/confirm the behavior:
> git-spice already retargets upstack branches when their bases are deleted, but it does so entirely locally.
> The focus of this change is to specifically also update the forge?
> The next submit for those branches would also update the base branch in the forge.
> I would appreciate some more context on what issue we're running into here.
> (Context on my hesitance: repo sync is currently read-only for the forge. This would add a write, so I want to make sure we have a good reason to.)

The issue encountered is branch corruption when adding the `gs bm` command - which I will post later today on this stack. Prior to the merge command, the forge itself drove merge events and the sync/submit cycle pulled merge changes and drove repointing based on merges that happened elsewhere. When I added the `gs bm` command the flow was flipped, and the stack would become corrupted if you merged anything besides the bottom branch. I'll post a ref to that PR when I post it. It took me a minute to remember what had been happening and I needed claude to help me figure it out again 😂 . It provided this somewhat more verbose explanation:

> Before gs branch merge, gs read forge merge state and reconciled local — that's the read-only pattern you're describing, and repo sync was fine being one-way (forge → local). The next submit falling back to fix the forge base was fine because nothing else gs did was authoritative over forge merges.
> 
> gs branch merge (in a separate PR in this stack) breaks that assumption. It writes merges to the forge and then reacts to those merges by mutating local state (deletes branches, reparents upstack). That makes the forge↔local invariant load-bearing inside gs bm, not just at "next submit" time. Concretely, a stack of A → B → C where A was squash-merged externally and you then run gs bm C will silently bring A's pre-squash commits back into main via B's merge, because B's remote branch still contains them and gs has no way to know B should be rebased first.
>
> PR #1073 is the other half of that contract: when repo sync rebases B locally, also retarget B's forge PR base so the forge and local agree on what B's parent is. Without it, gs is making local decisions (rebases, reparents) that the forge isn't told about, and the next forge-driven operation (review, or another gs bm) sees an inconsistent world.

[skip changelog]: bug fix only