### PR TITLE
fix: resolve BranchOnto target from git ref, not stored state

### DIFF
--- a/internal/spice/onto.go
+++ b/internal/spice/onto.go
@@ -43,19 +43,22 @@ func (s *Service) BranchOnto(ctx context.Context, req *BranchOntoRequest) error 
 		return fmt.Errorf("lookup branch: %w", err)
 	}
 
-	var ontoHash git.Hash
-	if req.Onto == s.store.Trunk() {
-		ontoHash, err = s.repo.PeelToCommit(ctx, req.Onto)
-		if err != nil {
-			return fmt.Errorf("resolve trunk: %w", err)
-		}
-	} else {
-		// Non-trunk branches must be tracked.
-		onto, err := s.LookupBranch(ctx, req.Onto)
-		if err != nil {
+	// Verify non-trunk target is tracked.
+	if req.Onto != s.store.Trunk() {
+		if _, err := s.LookupBranch(ctx, req.Onto); err != nil {
 			return fmt.Errorf("lookup onto: %w", err)
 		}
-		ontoHash = onto.Head
+	}
+
+	// Always resolve the target from the git ref
+	// rather than the stored state.
+	// The stored head may be stale
+	// if a prior operation in the same transaction
+	// (e.g. branch onto moving upstack branches)
+	// modified the target branch's git ref.
+	ontoHash, err := s.repo.PeelToCommit(ctx, req.Onto)
+	if err != nil {
+		return fmt.Errorf("resolve %v: %w", req.Onto, err)
 	}
 
 	// The recorded base hash may be stale if the old base branch


### PR DESCRIPTION
When `BranchOnto` moved a non-trunk target, it used the target branch's
stored `Head` hash to rebase the moved branch. This stored value could
be stale within a single transaction — for example, when `branch onto`
restacks upstack branches after moving the target, each subsequent
rebase saw the pre-move hash rather than the branch's actual ref.

Resolve the target by peeling its git ref instead, which always
reflects the current state. The tracked-branch check is preserved for
non-trunk targets, but the hash itself now comes from the ref.

This issue is similar to #1150 - the `gs bm` command will introduce the possibility of iterative changes to the stack structure during command execution, so there's a need to re-read refs during command execution.

I also had some issues remembering why exactly we needed this. Claude had this somewhat more verbose explanation:

>  This is a defensive consistency fix in BranchOnto. Before: the target hash was resolved from the git ref when the target was trunk, but from LookupBranch(...).Head when non-trunk. Even though both paths ultimately route through PeelToCommit, the two-source pattern made BranchOnto's behavior sensitive to small state/ref desynchronization windows that show up in chained BranchOnto calls (stack edit, delete-with-upstack-reparent, gs bm's cleanup loop).
> 
> The fix collapses both to PeelToCommit and uses LookupBranch only as a tracking-check for non-trunk targets. The intent is that BranchOnto's rebase target is always exactly what git currently says — no transient stored-state path can produce a stale hash.
> 
> This surfaced while developing gs branch merge, which calls BranchOnto indirectly through gs branch delete for upstack reparenting after each merge in the plan. The corruption symptom there was hard to reproduce in isolation because it requires a partial-stack merge whose surviving base isn't trunk.

[skip changelog]: bug fix only

