### PR TITLE
downstack: Add restack command

### DIFF
--- a/.changes/unreleased/Added-20260512-201343.yaml
+++ b/.changes/unreleased/Added-20260512-201343.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'downstack: Add restack command for the current branch and branches below it'
+time: 2026-05-12T20:13:43.868687-07:00

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -582,6 +582,24 @@ Branches that are upstack of the current branch will not be modified.
 * `--editor=STRING`: Editor to use for editing the downstack. Defaults to Git's default editor.
 * `--branch=NAME`: Branch to edit from. Defaults to current branch.
 
+### git-spice downstack restack {#gs-downstack-restack}
+
+```
+gs downstack (ds) restack (r) [flags]
+```
+
+Restack a branch and its downstack
+
+The current branch and all branches below it until trunk
+are rebased on top of their respective bases,
+ensuring a linear history.
+
+Use --branch to start at a different branch.
+
+**Flags**
+
+* `--branch=NAME`: Branch to restack the downstack of
+
 ## Branch
 
 ### git-spice branch track {#gs-branch-track}

--- a/doc/includes/cli-shorthands.md
+++ b/doc/includes/cli-shorthands.md
@@ -20,6 +20,7 @@
 | gs cp | [gs commit pick](/cli/reference.md#gs-commit-pick) |
 | gs csp | [gs commit split](/cli/reference.md#gs-commit-split) |
 | gs dse | [gs downstack edit](/cli/reference.md#gs-downstack-edit) |
+| gs dsr | [gs downstack restack](/cli/reference.md#gs-downstack-restack) |
 | gs dss | [gs downstack submit](/cli/reference.md#gs-downstack-submit) |
 | gs dstr | [gs downstack track](/cli/reference.md#gs-downstack-track) |
 | gs ll | [gs log long](/cli/reference.md#gs-log-long) |

--- a/doc/src/guide/branch.md
+++ b/doc/src/guide/branch.md
@@ -297,6 +297,8 @@ text "gs upstack restack" mono with w at last.e
 
     git-spice also offers
     $$gs branch restack$$ to restack just the current branch onto its base,
+    $$gs upstack restack$$ to restack the current branch and branches above it,
+    $$gs downstack restack$$ to restack the current branch and branches below it,
     and $$gs stack restack$$ to restack all branches in the current stack.
 
 ### Automatic restacking

--- a/downstack.go
+++ b/downstack.go
@@ -1,7 +1,8 @@
 package main
 
 type downstackCmd struct {
-	Track  downstackTrackCmd  `cmd:"" aliases:"tr" help:"Track all untracked branches below a branch"`
-	Submit downstackSubmitCmd `cmd:"" aliases:"s" help:"Submit a branch and those below it"`
-	Edit   downstackEditCmd   `cmd:"" aliases:"e" help:"Edit the order of branches below a branch"`
+	Track   downstackTrackCmd   `cmd:"" aliases:"tr" help:"Track all untracked branches below a branch"`
+	Submit  downstackSubmitCmd  `cmd:"" aliases:"s" help:"Submit a branch and those below it"`
+	Edit    downstackEditCmd    `cmd:"" aliases:"e" help:"Edit the order of branches below a branch"`
+	Restack downstackRestackCmd `cmd:"" aliases:"r" help:"Restack a branch and its downstack"`
 }

--- a/downstack_restack.go
+++ b/downstack_restack.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/spice/state"
+	"go.abhg.dev/gs/internal/text"
+)
+
+type downstackRestackCmd struct {
+	Branch string `help:"Branch to restack the downstack of" placeholder:"NAME" predictor:"trackedBranches"`
+}
+
+func (*downstackRestackCmd) Help() string {
+	return text.Dedent(`
+		The current branch and all branches below it until trunk
+		are rebased on top of their respective bases,
+		ensuring a linear history.
+
+		Use --branch to start at a different branch.
+	`)
+}
+
+func (cmd *downstackRestackCmd) AfterApply(ctx context.Context, wt *git.Worktree) error {
+	if cmd.Branch == "" {
+		currentBranch, err := wt.CurrentBranch(ctx)
+		if err != nil {
+			return fmt.Errorf("get current branch: %w", err)
+		}
+		cmd.Branch = currentBranch
+	}
+	return nil
+}
+
+func (cmd *downstackRestackCmd) Run(
+	ctx context.Context,
+	store *state.Store,
+	handler RestackHandler,
+) error {
+	if cmd.Branch == store.Trunk() {
+		return errors.New("nothing to restack below trunk")
+	}
+
+	return handler.RestackDownstack(ctx, cmd.Branch)
+}

--- a/internal/handler/restack/downstack.go
+++ b/internal/handler/restack/downstack.go
@@ -1,0 +1,14 @@
+package restack
+
+import "context"
+
+// RestackDownstack restacks the downstack of the given branch.
+// This includes the branch itself.
+func (h *Handler) RestackDownstack(ctx context.Context, branch string) error {
+	_, err := h.Restack(ctx, &Request{
+		Branch:          branch,
+		Scope:           ScopeDownstack,
+		ContinueCommand: []string{"downstack", "restack"},
+	})
+	return err
+}

--- a/internal/handler/restack/downstack_test.go
+++ b/internal/handler/restack/downstack_test.go
@@ -1,0 +1,104 @@
+package restack
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/silog"
+	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/state/statetest"
+)
+
+func TestHandler_RestackDownstack(t *testing.T) {
+	t.Run("SuccessfulRestack", func(t *testing.T) {
+		var logBuffer bytes.Buffer
+		log := silog.New(&logBuffer, nil)
+		ctrl := gomock.NewController(t)
+
+		mockService := NewMockService(ctrl)
+		mockService.EXPECT().
+			BranchGraph(gomock.Any(), gomock.Any()).
+			Return(newBranchGraphBuilder("main").
+				Branch("feature1", "main").
+				Branch("feature2", "feature1").
+				Branch("feature3", "feature2").
+				Branch("feature4", "feature3").
+				Build(t), nil)
+		mockService.EXPECT().
+			Restack(gomock.Any(), "feature1").
+			Return(&spice.RestackResponse{Base: "main"}, nil)
+		mockService.EXPECT().
+			Restack(gomock.Any(), "feature2").
+			Return(&spice.RestackResponse{Base: "feature1"}, nil)
+		mockService.EXPECT().
+			Restack(gomock.Any(), "feature3").
+			Return(&spice.RestackResponse{Base: "feature2"}, nil)
+
+		mockWorktree := NewMockGitWorktree(ctrl)
+		mockWorktree.EXPECT().
+			RootDir().
+			Return(t.TempDir())
+		mockWorktree.EXPECT().
+			CheckoutBranch(gomock.Any(), "feature3").
+			Return(nil)
+
+		handler := &Handler{
+			Log:      log,
+			Worktree: mockWorktree,
+			Store:    statetest.NewMemoryStore(t, "main", "", log),
+			Service:  mockService,
+		}
+
+		require.NoError(t, handler.RestackDownstack(t.Context(), "feature3"))
+		assert.Contains(t, logBuffer.String(), "feature1: restacked on main")
+		assert.Contains(t, logBuffer.String(), "feature2: restacked on feature1")
+		assert.Contains(t, logBuffer.String(), "feature3: restacked on feature2")
+		assert.NotContains(t, logBuffer.String(), "feature4: restacked")
+	})
+
+	t.Run("RestackInterrupted", func(t *testing.T) {
+		log := silog.Nop()
+		ctrl := gomock.NewController(t)
+
+		rebaseErr := &git.RebaseInterruptError{
+			Kind: git.RebaseInterruptConflict,
+		}
+
+		mockService := NewMockService(ctrl)
+		mockService.EXPECT().
+			BranchGraph(gomock.Any(), gomock.Any()).
+			Return(newBranchGraphBuilder("main").
+				Branch("feature1", "main").
+				Branch("feature2", "feature1").
+				Build(t), nil)
+		mockService.EXPECT().
+			Restack(gomock.Any(), "feature1").
+			Return(nil, rebaseErr)
+		mockService.EXPECT().
+			RebaseRescue(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ any, req spice.RebaseRescueRequest) error {
+				assert.Equal(t, []string{"downstack", "restack"}, req.Command)
+				assert.Equal(t, "feature2", req.Branch)
+				return nil
+			})
+
+		mockWorktree := NewMockGitWorktree(ctrl)
+		mockWorktree.EXPECT().
+			RootDir().
+			Return(t.TempDir())
+
+		handler := &Handler{
+			Log:      log,
+			Worktree: mockWorktree,
+			Store:    statetest.NewMemoryStore(t, "main", "", log),
+			Service:  mockService,
+		}
+
+		require.NoError(t, handler.RestackDownstack(t.Context(), "feature2"))
+	})
+}

--- a/testdata/help/downstack_restack.txt
+++ b/testdata/help/downstack_restack.txt
@@ -1,0 +1,18 @@
+Usage: gs downstack (ds) restack (r) [flags]
+
+Restack a branch and its downstack
+
+The current branch and all branches below it until trunk are rebased on top of
+their respective bases, ensuring a linear history.
+
+Use --branch to start at a different branch.
+
+Flags:
+  --branch=NAME    Branch to restack the downstack of
+
+Global Flags:
+  -h, --help           Show help for the command
+      --version        Print version information and quit
+  -v, --verbose        Enable verbose output ($GIT_SPICE_VERBOSE)
+  -C, --dir=DIR        Change to DIR before doing anything
+      --[no-]prompt    Whether to prompt for missing information

--- a/testdata/help/gs.txt
+++ b/testdata/help/gs.txt
@@ -30,17 +30,18 @@ Log
   log (l) long (l)     List branches and commits
 
 Stack
-  stack (s) submit (s)         Submit a stack
-  stack (s) restack (r)        Restack a stack
-  stack (s) edit (e)           Edit the order of branches in a stack
-  stack (s) delete (d)         Delete all branches in a stack
-  upstack (us) submit (s)      Submit a branch and those above it
-  upstack (us) restack (r)     Restack a branch and its upstack
-  upstack (us) onto (o)        Move a branch onto another branch
-  upstack (us) delete (d)      Delete all branches above the current branch
-  downstack (ds) track (tr)    Track all untracked branches below a branch
-  downstack (ds) submit (s)    Submit a branch and those below it
-  downstack (ds) edit (e)      Edit the order of branches below a branch
+  stack (s) submit (s)          Submit a stack
+  stack (s) restack (r)         Restack a stack
+  stack (s) edit (e)            Edit the order of branches in a stack
+  stack (s) delete (d)          Delete all branches in a stack
+  upstack (us) submit (s)       Submit a branch and those above it
+  upstack (us) restack (r)      Restack a branch and its upstack
+  upstack (us) onto (o)         Move a branch onto another branch
+  upstack (us) delete (d)       Delete all branches above the current branch
+  downstack (ds) track (tr)     Track all untracked branches below a branch
+  downstack (ds) submit (s)     Submit a branch and those below it
+  downstack (ds) edit (e)       Edit the order of branches below a branch
+  downstack (ds) restack (r)    Restack a branch and its downstack
 
 Branch
   branch (b) track (tr)        Track a branch

--- a/testdata/script/downstack_restack_conflict.txt
+++ b/testdata/script/downstack_restack_conflict.txt
@@ -1,0 +1,107 @@
+# A 'downstack restack' can continue through conflicts with 'gs rebase continue'.
+
+as 'Test <test@example.com>'
+at '2026-05-12T18:30:00Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+cp $WORK/extra/feature1.txt feature1.txt
+git add feature1.txt
+gs branch create feature1 -m 'feature1'
+
+cp $WORK/extra/feature2.txt feature2.txt
+git add feature2.txt
+gs branch create feature2 -m 'feature2'
+
+cp $WORK/extra/feature3.txt feature3.txt
+git add feature3.txt
+gs branch create feature3 -m 'feature3'
+
+cp $WORK/extra/feature4.txt feature4.txt
+git add feature4.txt
+gs branch create feature4 -m 'feature4'
+
+# Advance trunk with changes that conflict with downstack branches.
+gs trunk
+cp $WORK/extra/feature1.conflict.txt feature1.txt
+cp $WORK/extra/feature2.conflict.txt feature2.txt
+git add feature1.txt feature2.txt
+git commit -m 'Add feature 1 and 2 on trunk'
+
+# Restack from feature3 down toward trunk.
+gs branch checkout feature3
+! gs downstack restack
+stderr 'There was a conflict'
+
+# Only feature1.txt should be conflicting right now.
+git status --porcelain
+cmp stdout $WORK/golden/conflict-status-feature1.txt
+
+cp $WORK/extra/feature1.resolved.txt feature1.txt
+git add feature1.txt
+! gs rebase continue --no-edit
+stderr 'There was a conflict'
+
+# Only feature2.txt should be conflicting now,
+# proving the original downstack restack operation resumed.
+git status --porcelain
+cmp stdout $WORK/golden/conflict-status-feature2.txt
+
+cp $WORK/extra/feature2.resolved.txt feature2.txt
+git add feature2.txt
+gs rebase continue --no-edit
+
+git graph --branches
+cmp stdout $WORK/golden/graph.txt
+
+gs branch checkout feature3
+cmp feature1.txt $WORK/extra/feature1.resolved.txt
+cmp feature2.txt $WORK/extra/feature2.resolved.txt
+cmp feature3.txt $WORK/extra/feature3.txt
+
+gs branch checkout feature4
+cmp feature1.txt $WORK/extra/feature1.txt
+cmp feature2.txt $WORK/extra/feature2.txt
+cmp feature3.txt $WORK/extra/feature3.txt
+cmp feature4.txt $WORK/extra/feature4.txt
+
+-- extra/feature1.txt --
+foo
+-- extra/feature2.txt --
+bar
+-- extra/feature3.txt --
+baz
+-- extra/feature4.txt --
+qux
+
+-- extra/feature1.conflict.txt --
+not foo
+-- extra/feature2.conflict.txt --
+not bar
+
+-- extra/feature1.resolved.txt --
+foo
+not foo
+-- extra/feature2.resolved.txt --
+bar
+not bar
+
+-- golden/conflict-status-feature1.txt --
+AA feature1.txt
+-- golden/conflict-status-feature2.txt --
+AA feature2.txt
+-- golden/graph.txt --
+* 4f3cac8 (HEAD -> feature3) feature3
+* ef00f7d (feature2) feature2
+* c63096a (feature1) feature1
+* 6934d49 (main) Add feature 1 and 2 on trunk
+| * 43c11d6 (feature4) feature4
+| * 54c2862 feature3
+| * 1163ed0 feature2
+| * a788d4b feature1
+|/  
+* bb84898 Initial commit

--- a/testdata/script/downstack_restack_linear.txt
+++ b/testdata/script/downstack_restack_linear.txt
@@ -1,0 +1,69 @@
+# Restack a branch and its downstack without restacking its upstack.
+
+as 'Test <test@example.com>'
+at '2026-05-12T18:00:00Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# Set up a stack of four branches on top of each other.
+git add feature1.txt
+gs branch create feature1 -m 'Add feature1'
+
+git add feature2.txt
+gs branch create feature2 -m 'Add feature2'
+
+git add feature3.txt
+gs branch create feature3 -m 'Add feature3'
+
+git add feature4.txt
+gs branch create feature4 -m 'Add feature4'
+
+# Advance trunk so every branch in the stack needs restacking.
+gs branch checkout main
+cp $WORK/extra/feature0.txt .
+git add feature0.txt
+git commit -m 'Add feature0'
+
+# Restack from feature3 down toward trunk.
+git checkout feature3
+gs downstack restack
+stderr 'INF feature1: restacked on main'
+stderr 'INF feature2: restacked on feature1'
+stderr 'INF feature3: restacked on feature2'
+! stderr 'feature4: restacked'
+
+# The operation returns to the starting branch.
+git branch --show-current
+stdout '^feature3$'
+
+git graph --branches
+cmp stdout $WORK/golden/branches.txt
+
+! gs downstack restack --branch main
+stderr 'nothing to restack below trunk'
+
+-- repo/feature1.txt --
+foo
+-- repo/feature2.txt --
+bar
+-- repo/feature3.txt --
+baz
+-- repo/feature4.txt --
+qux
+-- extra/feature0.txt --
+quux
+-- golden/branches.txt --
+* 13b3e98 (HEAD -> feature3) Add feature3
+* fe3b184 (feature2) Add feature2
+* ee6da8b (feature1) Add feature1
+* 4e3615c (main) Add feature0
+| * a91fd9c (feature4) Add feature4
+| * 1daffe4 Add feature3
+| * 5a8a43d Add feature2
+| * 3652a5c Add feature1
+|/  
+* 204b656 Initial commit

--- a/upstack_restack.go
+++ b/upstack_restack.go
@@ -34,6 +34,7 @@ func (*upstackRestackCmd) Help() string {
 // RestackHandler implements high level restack operations.
 type RestackHandler interface {
 	RestackUpstack(ctx context.Context, branch string, opts *restack.UpstackOptions) error
+	RestackDownstack(ctx context.Context, branch string) error
 	Restack(context.Context, *restack.Request) (int, error)
 	RestackStack(ctx context.Context, branch string) error
 	RestackBranch(ctx context.Context, branch string) error


### PR DESCRIPTION
Users can now restack the current branch and all tracked branches
below it with `gs downstack restack`.
This fills the gap between `upstack restack` and `stack restack`
for workflows that need to repair the lower part of a stack
without moving branches above the current branch.

The new command is available as `gs downstack restack`,
with `gs dsr` as its shorthand.
Coverage verifies the linear restack path,
the trunk no-op error,
and conflict recovery through `gs rebase continue --no-edit`.

Resolves #1155
