### PR TITLE
lint: use 'golangci-lint fmt'

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -75,38 +75,6 @@ url = "https://dl.google.com/go/go1.26.3.darwin-amd64.tar.gz"
 checksum = "sha256:20d2ceafb4ed41b96b879010927b28bc92a5be57a7c1801ce365a9ca51d3224a"
 url = "https://dl.google.com/go/go1.26.3.windows-amd64.zip"
 
-[[tools.gofumpt]]
-version = "0.10.0"
-backend = "aqua:mvdan/gofumpt"
-
-[tools.gofumpt."platforms.linux-arm64"]
-checksum = "sha256:5d239f93b1ed2dfe74d39b25112bb770a04f6581f986d4b4f5d380521e12ca61"
-url = "https://github.com/mvdan/gofumpt/releases/download/v0.10.0/gofumpt_v0.10.0_linux_arm64"
-
-[tools.gofumpt."platforms.linux-arm64-musl"]
-checksum = "sha256:5d239f93b1ed2dfe74d39b25112bb770a04f6581f986d4b4f5d380521e12ca61"
-url = "https://github.com/mvdan/gofumpt/releases/download/v0.10.0/gofumpt_v0.10.0_linux_arm64"
-
-[tools.gofumpt."platforms.linux-x64"]
-checksum = "sha256:48ee398ec72afdaca6accb70f5ed741349d5dcccb52c5bb4c4469d698980b186"
-url = "https://github.com/mvdan/gofumpt/releases/download/v0.10.0/gofumpt_v0.10.0_linux_amd64"
-
-[tools.gofumpt."platforms.linux-x64-musl"]
-checksum = "sha256:48ee398ec72afdaca6accb70f5ed741349d5dcccb52c5bb4c4469d698980b186"
-url = "https://github.com/mvdan/gofumpt/releases/download/v0.10.0/gofumpt_v0.10.0_linux_amd64"
-
-[tools.gofumpt."platforms.macos-arm64"]
-checksum = "sha256:ba4b348e729cba915d5c7dc515774e2f2c7cc5c5ad011de20d34be10e5a2f906"
-url = "https://github.com/mvdan/gofumpt/releases/download/v0.10.0/gofumpt_v0.10.0_darwin_arm64"
-
-[tools.gofumpt."platforms.macos-x64"]
-checksum = "sha256:30e5b914a824c3b6bd0480e4f493517012167d380de74643879c50f4aa0c834e"
-url = "https://github.com/mvdan/gofumpt/releases/download/v0.10.0/gofumpt_v0.10.0_darwin_amd64"
-
-[tools.gofumpt."platforms.windows-x64"]
-checksum = "sha256:20872b464435512b74678b1155b75bd75220de5737ad8c075b9151c846543697"
-url = "https://github.com/mvdan/gofumpt/releases/download/v0.10.0/gofumpt_v0.10.0_windows_amd64.exe"
-
 [[tools.golangci-lint]]
 version = "2.12.2"
 backend = "aqua:golangci/golangci-lint"

--- a/mise.toml
+++ b/mise.toml
@@ -12,7 +12,6 @@ _.path = ["{{ config_root }}/bin"]
 golangci-lint = "aqua:golangci/golangci-lint"
 changie = "github:miniscruff/changie"
 requiredfield = "github:abhinav/requiredfield"
-gofumpt = "aqua:mvdan/gofumpt"
 
 [tools]
 # Self-explanatory.
@@ -20,9 +19,6 @@ go = "latest"
 
 # Test runner with prettier output.
 gotestsum = "latest"
-
-# Stricter code formatting.
-gofumpt = "latest"
 
 # Collection of linters.
 golangci-lint = "latest"
@@ -110,7 +106,7 @@ run = "go mod tidy"
 description = "Update go.mod and go.sum files"
 
 [tasks.fmt]
-run = "gofumpt -w ."
+run = "golangci-lint fmt"
 description = "Format all go files"
 
 [tasks.lint]


### PR DESCRIPTION
gofumpt + golangci-lint are providing two definitions of formatting.