### PR TITLE
commit fixup: Add -e/--edit flag for message editing

### DIFF
--- a/.changes/unreleased/Added-20260516-142124.yaml
+++ b/.changes/unreleased/Added-20260516-142124.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: >-
+  commit fixup: Add --edit flag to allow editing commit messages.
+  This runs appropriate Git message hooks by default.
+  The commit-msg hook may be skipped with the --no-verify flag.
+time: 2026-05-16T14:21:24.899976-07:00

--- a/commit_fixup.go
+++ b/commit_fixup.go
@@ -12,6 +12,7 @@ import (
 	"go.abhg.dev/gs/internal/handler/autostash"
 	"go.abhg.dev/gs/internal/handler/fixup"
 	"go.abhg.dev/gs/internal/must"
+	"go.abhg.dev/gs/internal/sigstack"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/sliceutil"
 	"go.abhg.dev/gs/internal/spice"
@@ -53,12 +54,14 @@ func (cmd *commitFixupCmd) AfterApply(kctx *kong.Context) error {
 		log *silog.Logger,
 		repo *git.Repository,
 		wt *git.Worktree,
+		signals *sigstack.Stack,
 		svc *spice.Service,
 		restackHandler RestackHandler,
 	) (FixupHandler, error) {
 		return &fixup.Handler{
 			Log:        log,
 			Worktree:   wt,
+			Signals:    signals,
 			Repository: repo,
 			Service:    svc,
 			Restack:    restackHandler,

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -1181,6 +1181,11 @@ This command requires at least Git 2.45.
 
 * `commit`: The commit to fixup. Must be reachable from the HEAD commit.
 
+**Flags**
+
+* `-e`, `--edit`: Open an editor to modify the commit message.
+* `--no-verify`: Bypass commit-msg hooks.
+
 ### git-spice commit pick {#gs-commit-pick}
 
 ```

--- a/internal/handler/fixup/handler.go
+++ b/internal/handler/fixup/handler.go
@@ -6,11 +6,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"iter"
+	"os"
 	"slices"
 	"strings"
 
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/git/gitedit"
 	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/spice"
@@ -28,6 +31,7 @@ var _ RestackHandler = (*restack.Handler)(nil)
 // GitWorktree is a subset of the git.Worktree interface.
 type GitWorktree interface {
 	Head(ctx context.Context) (git.Hash, error)
+	IndexFile(ctx context.Context) (string, error)
 	DiffIndex(ctx context.Context, treeish string) ([]git.FileStatus, error)
 	WriteIndexTree(ctx context.Context) (git.Hash, error)
 	Rebase(ctx context.Context, req git.RebaseRequest) (err error)
@@ -44,6 +48,16 @@ type GitRepository interface {
 	PeelToCommit(ctx context.Context, rev string) (git.Hash, error)
 	ReadCommit(ctx context.Context, commitish string) (*git.CommitObject, error)
 	ListCommits(ctx context.Context, commits git.CommitRange) iter.Seq2[git.Hash, error]
+
+	// Methods required by gitedit.Repository.
+	GitDir() string
+	Var(ctx context.Context, name string) (string, error)
+	DiffTreePatch(ctx context.Context, w io.Writer,
+		treeish1, treeish2 string) error
+	Stripspace(ctx context.Context, input io.Reader,
+		output io.Writer, opts *git.StripspaceOptions) error
+	HookRun(ctx context.Context, hook string,
+		opts *git.HookRunOptions) error
 }
 
 var _ GitRepository = (*git.Repository)(nil)
@@ -59,17 +73,36 @@ var _ Service = (*spice.Service)(nil)
 
 // Handler implements commit fixup operations.
 type Handler struct {
-	Log        *silog.Logger  // required
-	Restack    RestackHandler // required
-	Worktree   GitWorktree    // required
-	Repository GitRepository  // required
-	Service    Service        // required
+	Log        *silog.Logger       // required
+	Restack    RestackHandler      // required
+	Signals    gitedit.SignalStack // required
+	Worktree   GitWorktree         // required
+	Repository GitRepository       // required
+	Service    Service             // required
 }
 
 // Options holds options for fixing up a commit.
 type Options struct {
-	// SignCommits indicates whether Git is configured to sign commits.
+	// SignCommits indicates whether Git is configured
+	// to sign commits.
 	SignCommits bool `default:"false" hidden:"" config:"@commit.gpgsign"`
+
+	// Edit opens an editor to modify the commit message.
+	Edit bool `short:"e" help:"Open an editor to modify the commit message."`
+
+	// NoVerify allows a commit
+	// with commit-msg hooks bypassed.
+	NoVerify bool `help:"Bypass commit-msg hooks."`
+
+	// CommentString is the comment prefix for editor messages.
+	CommentString string `hidden:"" config:"@core.commentString" default:"#"`
+
+	// CleanupMode is the commit message cleanup mode.
+	CleanupMode string `hidden:"" config:"@commit.cleanup" default:"strip"`
+
+	// CommitVerbose is the verbosity level
+	// for the editor diff.
+	CommitVerbose bool `hidden:"" config:"@commit.verbose" default:"false"`
 
 	// TODO: -a/--all option to stage all changes?
 }
@@ -156,15 +189,51 @@ func (h *Handler) FixupCommit(ctx context.Context, req *Request) error {
 		return fmt.Errorf("merge conflict in files: %v", strings.Join(files, ", "))
 	}
 
+	// Determine the commit message.
+	// If --edit is specified, open the editor for the user.
+	commitMessage := targetCommit.Message()
+	// TODO: instead of holding message in memory, we could stream it.
+	if req.Options.Edit {
+		// TODO: inject editor
+		editor := &gitedit.Editor{
+			Repository:    h.Repository,
+			Signals:       h.Signals,
+			Log:           h.Log,
+			CommentString: req.Options.CommentString,
+			CleanupMode:   req.Options.CleanupMode,
+			Verbose:       req.Options.CommitVerbose,
+		}
+
+		var parent git.Hash
+		if len(targetCommit.Parents) > 0 {
+			parent = targetCommit.Parents[0]
+		}
+
+		var edited strings.Builder
+		err := editor.EditCommitMessage(
+			ctx,
+			strings.NewReader(commitMessage),
+			&edited,
+			&gitedit.EditCommitMessageOptions{
+				Env:      h.editorEnv(ctx),
+				NoVerify: req.Options.NoVerify,
+				Commit:   req.TargetHash,
+				Parent:   parent,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("edit commit message: %w", err)
+		}
+		commitMessage = strings.TrimRight(edited.String(), "\n")
+	}
+
 	newCommit, err := h.Repository.CommitTree(ctx, git.CommitTreeRequest{
 		Tree:      mergedTree,
 		Parents:   targetCommit.Parents,
-		Message:   targetCommit.Message(),
+		Message:   commitMessage,
 		GPGSign:   req.Options.SignCommits,
 		Author:    &targetCommit.Author,
 		Committer: &targetCommit.Committer,
-		// TODO: support -e/--edit?
-		// TODO: does this run pre-commit hooks?
 	})
 	if err != nil {
 		return fmt.Errorf("commit staged changes to target commit: %w", err)
@@ -186,8 +255,7 @@ func (h *Handler) FixupCommit(ctx context.Context, req *Request) error {
 	}); err != nil {
 		// If the rebase is interrupted by a conflict,
 		// after it's resolved, just restack the upstack.
-		var rebaseErr *git.RebaseInterruptError
-		if errors.As(err, &rebaseErr) {
+		if rebaseErr, ok := errors.AsType[*git.RebaseInterruptError](err); ok {
 			return h.Service.RebaseRescue(ctx, spice.RebaseRescueRequest{
 				Err:     rebaseErr,
 				Command: []string{"upstack", "restack", "--skip-start"},
@@ -243,4 +311,14 @@ func (h *Handler) findCommitBranch(
 	}
 
 	return "", fmt.Errorf("commit not found in any tracked branch: %s", wantCommit)
+}
+
+func (h *Handler) editorEnv(ctx context.Context) []string {
+	indexFile, err := h.Worktree.IndexFile(ctx)
+	if err == nil {
+		if _, err := os.Stat(indexFile); err == nil {
+			return []string{"GIT_INDEX_FILE=" + indexFile}
+		}
+	}
+	return nil
 }

--- a/internal/handler/fixup/handler_test.go
+++ b/internal/handler/fixup/handler_test.go
@@ -3,12 +3,15 @@ package fixup
 import (
 	"bytes"
 	"iter"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/git/gittest"
+	"go.abhg.dev/gs/internal/sigstack"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/silog/silogtest"
 	"go.abhg.dev/gs/internal/spice"
@@ -29,6 +32,7 @@ func TestFixupCommit_errors(t *testing.T) {
 		err := (&Handler{
 			Log:        silogtest.New(t),
 			Restack:    NewMockRestackHandler(mockCtrl),
+			Signals:    &sigstack.Stack{},
 			Worktree:   mockWorktree,
 			Repository: NewMockGitRepository(mockCtrl),
 			Service:    NewMockService(mockCtrl),
@@ -58,6 +62,7 @@ func TestFixupCommit_errors(t *testing.T) {
 		err := (&Handler{
 			Log:        silogtest.New(t),
 			Restack:    NewMockRestackHandler(mockCtrl),
+			Signals:    &sigstack.Stack{},
 			Worktree:   mockWorktree,
 			Repository: mockRepo,
 			Service:    NewMockService(mockCtrl),
@@ -90,6 +95,7 @@ func TestFixupCommit_errors(t *testing.T) {
 		err := (&Handler{
 			Log:        silogtest.New(t),
 			Restack:    NewMockRestackHandler(mockCtrl),
+			Signals:    &sigstack.Stack{},
 			Worktree:   mockWorktree,
 			Repository: mockRepo,
 			Service:    NewMockService(mockCtrl),
@@ -119,6 +125,7 @@ func TestFixupCommit_errors(t *testing.T) {
 		err := (&Handler{
 			Log:        silogtest.New(t),
 			Restack:    NewMockRestackHandler(mockCtrl),
+			Signals:    &sigstack.Stack{},
 			Worktree:   mockWorktree,
 			Repository: NewMockGitRepository(mockCtrl),
 			Service:    mockService,
@@ -148,6 +155,7 @@ func TestFixupCommit_errors(t *testing.T) {
 		err := (&Handler{
 			Log:        silogtest.New(t),
 			Restack:    NewMockRestackHandler(mockCtrl),
+			Signals:    &sigstack.Stack{},
 			Worktree:   mockWorktree,
 			Repository: NewMockGitRepository(mockCtrl),
 			Service:    mockService,
@@ -231,6 +239,7 @@ func TestFixupCommit_success(t *testing.T) {
 	err = (&Handler{
 		Log:        log,
 		Restack:    mockRestack,
+		Signals:    &sigstack.Stack{},
 		Worktree:   wt,
 		Repository: repo,
 		Service:    mockService,
@@ -247,6 +256,121 @@ func TestFixupCommit_success(t *testing.T) {
 
 	var got bytes.Buffer
 	err = repo.ReadObject(t.Context(), git.BlobType, blob, &got)
+	require.NoError(t, err)
+	assert.Equal(t, "staged content\n", got.String())
+}
+
+func TestFixupCommit_edit(t *testing.T) {
+	gittest.SkipUnlessVersionAtLeast(t, gittest.Version{
+		Major: 2, Minor: 45,
+	})
+
+	fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+		# main → feature1 → feature2
+		#         (target)   (head)
+		as 'Test Author <test@example.com>'
+		at '2025-06-20T21:28:29Z'
+
+		git init
+		git add main.txt
+		git commit -m 'Initial commit'
+
+		git checkout -b feature1
+		git add feature1.txt
+		git commit -m 'Add feature1'
+
+		git checkout -b feature2
+		git add feature2.txt
+		git commit -m 'Add feature2'
+
+		# Stage changes for fixup
+		git add staged.txt
+
+		-- main.txt --
+		main content
+
+		-- feature1.txt --
+		feature1 content
+
+		-- feature2.txt --
+		feature2 content
+
+		-- staged.txt --
+		staged content
+	`)))
+	require.NoError(t, err)
+	t.Cleanup(fixture.Cleanup)
+
+	log := silog.Nop()
+	wt, err := git.OpenWorktree(t.Context(),
+		fixture.Dir(), git.OpenOptions{Log: log})
+	require.NoError(t, err)
+	repo := wt.Repository()
+
+	feature1Hash, err := repo.PeelToCommit(
+		t.Context(), "feature1",
+	)
+	require.NoError(t, err)
+
+	// Set GIT_EDITOR to a helper that replaces
+	// the message with "Edited message".
+	newMsgFile := filepath.Join(t.TempDir(), "new-msg")
+	require.NoError(t,
+		os.WriteFile(newMsgFile, []byte("Edited message\n"), 0o644))
+	editorExe, err := os.Executable()
+	require.NoError(t, err)
+	t.Setenv("FIXUP_EDITOR_HELPER", "1")
+	t.Setenv("FIXUP_EDITOR_GIVE", newMsgFile)
+	t.Setenv("GIT_EDITOR", editorExe)
+
+	mockCtrl := gomock.NewController(t)
+
+	mockService := NewMockService(mockCtrl)
+	mockService.EXPECT().
+		Trunk().
+		Return("main").
+		AnyTimes()
+
+	mockRestack := NewMockRestackHandler(mockCtrl)
+	mockRestack.EXPECT().
+		RestackUpstack(gomock.Any(), "feature1", gomock.Any()).
+		Return(nil)
+
+	var signals sigstack.Stack
+	err = (&Handler{
+		Log:        log,
+		Restack:    mockRestack,
+		Signals:    &signals,
+		Worktree:   wt,
+		Repository: repo,
+		Service:    mockService,
+	}).FixupCommit(t.Context(), &Request{
+		TargetHash:   feature1Hash,
+		TargetBranch: "feature1",
+		HeadBranch:   "feature2",
+		Options: &Options{
+			Edit: true,
+		},
+	})
+	require.NoError(t, err)
+
+	// Verify the commit message was changed.
+	commit, err := repo.ReadCommit(
+		t.Context(), "feature1",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "Edited message", commit.Message())
+
+	// Verify the staged file was applied.
+	blob, err := repo.HashAt(
+		t.Context(), "feature1", "staged.txt",
+	)
+	require.NoError(t, err)
+
+	var got bytes.Buffer
+	err = repo.ReadObject(
+		t.Context(), git.BlobType, blob, &got,
+	)
 	require.NoError(t, err)
 	assert.Equal(t, "staged content\n", got.String())
 }
@@ -278,6 +402,49 @@ func (m mapGraph) Downstack(branch string) iter.Seq[string] {
 			current = item.Base
 		}
 	}
+}
+
+func TestHandler_editorEnv(t *testing.T) {
+	t.Run("IndexExists", func(t *testing.T) {
+		indexFile := filepath.Join(t.TempDir(), "index")
+		require.NoError(t, os.WriteFile(indexFile, nil, 0o644))
+
+		mockCtrl := gomock.NewController(t)
+		mockWorktree := NewMockGitWorktree(mockCtrl)
+		mockWorktree.EXPECT().
+			IndexFile(gomock.Any()).
+			Return(indexFile, nil)
+
+		assert.Equal(
+			t,
+			[]string{"GIT_INDEX_FILE=" + indexFile},
+			(&Handler{
+				Log:        silogtest.New(t),
+				Restack:    NewMockRestackHandler(mockCtrl),
+				Signals:    &sigstack.Stack{},
+				Worktree:   mockWorktree,
+				Repository: NewMockGitRepository(mockCtrl),
+				Service:    NewMockService(mockCtrl),
+			}).editorEnv(t.Context()),
+		)
+	})
+
+	t.Run("IndexMissing", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		mockWorktree := NewMockGitWorktree(mockCtrl)
+		mockWorktree.EXPECT().
+			IndexFile(gomock.Any()).
+			Return(filepath.Join(t.TempDir(), "index"), nil)
+
+		assert.Nil(t, (&Handler{
+			Log:        silogtest.New(t),
+			Restack:    NewMockRestackHandler(mockCtrl),
+			Signals:    &sigstack.Stack{},
+			Worktree:   mockWorktree,
+			Repository: NewMockGitRepository(mockCtrl),
+			Service:    NewMockService(mockCtrl),
+		}).editorEnv(t.Context()))
+	})
 }
 
 func TestFindCommitBranch(t *testing.T) {
@@ -528,6 +695,7 @@ func TestFindCommitBranch(t *testing.T) {
 			handler := &Handler{
 				Log:        log,
 				Restack:    NewMockRestackHandler(mockCtrl),
+				Signals:    &sigstack.Stack{},
 				Repository: repo,
 				Worktree:   wt,
 				Service:    NewMockService(mockCtrl),

--- a/internal/handler/fixup/main_test.go
+++ b/internal/handler/fixup/main_test.go
@@ -1,0 +1,31 @@
+package fixup
+
+import (
+	"log"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("FIXUP_EDITOR_HELPER") == "1" {
+		fixupEditorHelper()
+		return
+	}
+
+	os.Exit(m.Run())
+}
+
+func fixupEditorHelper() {
+	log.SetFlags(0)
+	if len(os.Args) != 2 {
+		log.Fatal("usage: fixup-editor-helper file")
+	}
+
+	content, err := os.ReadFile(os.Getenv("FIXUP_EDITOR_GIVE"))
+	if err != nil {
+		log.Fatalf("read content: %v", err)
+	}
+	if err := os.WriteFile(os.Args[1], content, 0o644); err != nil {
+		log.Fatalf("write target file: %v", err)
+	}
+}

--- a/internal/handler/fixup/mocks_test.go
+++ b/internal/handler/fixup/mocks_test.go
@@ -11,6 +11,7 @@ package fixup
 
 import (
 	context "context"
+	io "io"
 	iter "iter"
 	reflect "reflect"
 
@@ -180,6 +181,45 @@ func (c *MockGitWorktreeHeadCall) Do(f func(context.Context) (git.Hash, error)) 
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockGitWorktreeHeadCall) DoAndReturn(f func(context.Context) (git.Hash, error)) *MockGitWorktreeHeadCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// IndexFile mocks base method.
+func (m *MockGitWorktree) IndexFile(ctx context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IndexFile", ctx)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IndexFile indicates an expected call of IndexFile.
+func (mr *MockGitWorktreeMockRecorder) IndexFile(ctx any) *MockGitWorktreeIndexFileCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndexFile", reflect.TypeOf((*MockGitWorktree)(nil).IndexFile), ctx)
+	return &MockGitWorktreeIndexFileCall{Call: call}
+}
+
+// MockGitWorktreeIndexFileCall wrap *gomock.Call
+type MockGitWorktreeIndexFileCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockGitWorktreeIndexFileCall) Return(arg0 string, arg1 error) *MockGitWorktreeIndexFileCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockGitWorktreeIndexFileCall) Do(f func(context.Context) (string, error)) *MockGitWorktreeIndexFileCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockGitWorktreeIndexFileCall) DoAndReturn(f func(context.Context) (string, error)) *MockGitWorktreeIndexFileCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -358,6 +398,120 @@ func (c *MockGitRepositoryCommitTreeCall) Do(f func(context.Context, git.CommitT
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockGitRepositoryCommitTreeCall) DoAndReturn(f func(context.Context, git.CommitTreeRequest) (git.Hash, error)) *MockGitRepositoryCommitTreeCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// DiffTreePatch mocks base method.
+func (m *MockGitRepository) DiffTreePatch(ctx context.Context, w io.Writer, treeish1, treeish2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DiffTreePatch", ctx, w, treeish1, treeish2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DiffTreePatch indicates an expected call of DiffTreePatch.
+func (mr *MockGitRepositoryMockRecorder) DiffTreePatch(ctx, w, treeish1, treeish2 any) *MockGitRepositoryDiffTreePatchCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiffTreePatch", reflect.TypeOf((*MockGitRepository)(nil).DiffTreePatch), ctx, w, treeish1, treeish2)
+	return &MockGitRepositoryDiffTreePatchCall{Call: call}
+}
+
+// MockGitRepositoryDiffTreePatchCall wrap *gomock.Call
+type MockGitRepositoryDiffTreePatchCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockGitRepositoryDiffTreePatchCall) Return(arg0 error) *MockGitRepositoryDiffTreePatchCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockGitRepositoryDiffTreePatchCall) Do(f func(context.Context, io.Writer, string, string) error) *MockGitRepositoryDiffTreePatchCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockGitRepositoryDiffTreePatchCall) DoAndReturn(f func(context.Context, io.Writer, string, string) error) *MockGitRepositoryDiffTreePatchCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GitDir mocks base method.
+func (m *MockGitRepository) GitDir() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GitDir")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GitDir indicates an expected call of GitDir.
+func (mr *MockGitRepositoryMockRecorder) GitDir() *MockGitRepositoryGitDirCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GitDir", reflect.TypeOf((*MockGitRepository)(nil).GitDir))
+	return &MockGitRepositoryGitDirCall{Call: call}
+}
+
+// MockGitRepositoryGitDirCall wrap *gomock.Call
+type MockGitRepositoryGitDirCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockGitRepositoryGitDirCall) Return(arg0 string) *MockGitRepositoryGitDirCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockGitRepositoryGitDirCall) Do(f func() string) *MockGitRepositoryGitDirCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockGitRepositoryGitDirCall) DoAndReturn(f func() string) *MockGitRepositoryGitDirCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// HookRun mocks base method.
+func (m *MockGitRepository) HookRun(ctx context.Context, hook string, opts *git.HookRunOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HookRun", ctx, hook, opts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// HookRun indicates an expected call of HookRun.
+func (mr *MockGitRepositoryMockRecorder) HookRun(ctx, hook, opts any) *MockGitRepositoryHookRunCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HookRun", reflect.TypeOf((*MockGitRepository)(nil).HookRun), ctx, hook, opts)
+	return &MockGitRepositoryHookRunCall{Call: call}
+}
+
+// MockGitRepositoryHookRunCall wrap *gomock.Call
+type MockGitRepositoryHookRunCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockGitRepositoryHookRunCall) Return(arg0 error) *MockGitRepositoryHookRunCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockGitRepositoryHookRunCall) Do(f func(context.Context, string, *git.HookRunOptions) error) *MockGitRepositoryHookRunCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockGitRepositoryHookRunCall) DoAndReturn(f func(context.Context, string, *git.HookRunOptions) error) *MockGitRepositoryHookRunCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -551,6 +705,83 @@ func (c *MockGitRepositoryReadCommitCall) Do(f func(context.Context, string) (*g
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockGitRepositoryReadCommitCall) DoAndReturn(f func(context.Context, string) (*git.CommitObject, error)) *MockGitRepositoryReadCommitCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// Stripspace mocks base method.
+func (m *MockGitRepository) Stripspace(ctx context.Context, input io.Reader, output io.Writer, opts *git.StripspaceOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Stripspace", ctx, input, output, opts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Stripspace indicates an expected call of Stripspace.
+func (mr *MockGitRepositoryMockRecorder) Stripspace(ctx, input, output, opts any) *MockGitRepositoryStripspaceCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stripspace", reflect.TypeOf((*MockGitRepository)(nil).Stripspace), ctx, input, output, opts)
+	return &MockGitRepositoryStripspaceCall{Call: call}
+}
+
+// MockGitRepositoryStripspaceCall wrap *gomock.Call
+type MockGitRepositoryStripspaceCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockGitRepositoryStripspaceCall) Return(arg0 error) *MockGitRepositoryStripspaceCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockGitRepositoryStripspaceCall) Do(f func(context.Context, io.Reader, io.Writer, *git.StripspaceOptions) error) *MockGitRepositoryStripspaceCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockGitRepositoryStripspaceCall) DoAndReturn(f func(context.Context, io.Reader, io.Writer, *git.StripspaceOptions) error) *MockGitRepositoryStripspaceCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// Var mocks base method.
+func (m *MockGitRepository) Var(ctx context.Context, name string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Var", ctx, name)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Var indicates an expected call of Var.
+func (mr *MockGitRepositoryMockRecorder) Var(ctx, name any) *MockGitRepositoryVarCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Var", reflect.TypeOf((*MockGitRepository)(nil).Var), ctx, name)
+	return &MockGitRepositoryVarCall{Call: call}
+}
+
+// MockGitRepositoryVarCall wrap *gomock.Call
+type MockGitRepositoryVarCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockGitRepositoryVarCall) Return(arg0 string, arg1 error) *MockGitRepositoryVarCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockGitRepositoryVarCall) Do(f func(context.Context, string) (string, error)) *MockGitRepositoryVarCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockGitRepositoryVarCall) DoAndReturn(f func(context.Context, string) (string, error)) *MockGitRepositoryVarCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/testdata/help/commit_fixup.txt
+++ b/testdata/help/commit_fixup.txt
@@ -17,6 +17,10 @@ This command requires at least Git 2.45.
 Arguments:
   [<commit>]    The commit to fixup. Must be reachable from the HEAD commit.
 
+Flags:
+  -e, --edit         Open an editor to modify the commit message.
+      --no-verify    Bypass commit-msg hooks.
+
 Global Flags:
   -h, --help           Show help for the command
       --version        Print version information and quit

--- a/testdata/script/commit_fixup_edit.txt
+++ b/testdata/script/commit_fixup_edit.txt
@@ -1,0 +1,101 @@
+# Verify that 'commit fixup -e' opens an editor
+# to modify the commit message,
+# and that the editor is NOT invoked without -e.
+
+[!git:2.45.0] skip
+
+as 'Test <test@example.com>'
+at '2025-09-05T21:28:29Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+git config spice.experiment.commitFixup true
+
+# Create a branch with a commit.
+git add file1.txt
+gs bc -m 'Add file1' feature
+
+# Stage a change for fixup.
+cp $WORK/extra/file1_updated.txt file1.txt
+git add file1.txt
+
+# Without -e, the editor should NOT be invoked.
+# Use 'false' as the editor so the test fails
+# if the editor is invoked.
+env EDITOR=false
+gs commit fixup HEAD
+
+# Verify message is unchanged.
+git log -1 --format=%B
+cmp stdout $WORK/golden/original_msg.txt
+
+# Stage another change for a second fixup with --edit.
+cp $WORK/extra/file1_final.txt file1.txt
+git add file1.txt
+
+mkdir $WORK/output
+env EDITOR=mockedit
+env MOCKEDIT_GIVE=$WORK/input/new_msg.txt
+env MOCKEDIT_RECORD=$WORK/output/editmsg.txt
+gs commit fixup -e HEAD
+
+# Verify the commit message was changed.
+git log -1 --format=%B
+cmp stdout $WORK/golden/new_msg.txt
+
+# Stage another change for a fixup with --edit and --no-verify.
+cp $WORK/extra/file1_noverify.txt file1.txt
+git add file1.txt
+
+cp $WORK/hooks/prepare-commit-msg .git/hooks/prepare-commit-msg
+cp $WORK/hooks/commit-msg .git/hooks/commit-msg
+exec chmod +x .git/hooks/prepare-commit-msg
+exec chmod +x .git/hooks/commit-msg
+
+env EDITOR=mockedit
+env MOCKEDIT_GIVE=$WORK/input/noverify_msg.txt
+env MOCKEDIT_RECORD=$WORK/output/noverify_editmsg.txt
+gs commit fixup -e --no-verify HEAD
+
+# --no-verify should skip commit-msg,
+# but it must not skip prepare-commit-msg.
+exists $WORK/output/prepare-ran
+! exists $WORK/output/commit-ran
+
+git log -1 --format=%B
+cmp stdout $WORK/golden/noverify_msg.txt
+
+-- repo/file1.txt --
+Original file1 content
+
+-- extra/file1_updated.txt --
+Updated file1 content
+
+-- extra/file1_final.txt --
+Final file1 content
+
+-- extra/file1_noverify.txt --
+No verify file1 content
+
+-- input/new_msg.txt --
+Edited commit message
+
+-- input/noverify_msg.txt --
+Edited message with no verify
+
+-- golden/original_msg.txt --
+Add file1
+-- golden/new_msg.txt --
+Edited commit message
+-- golden/noverify_msg.txt --
+Edited message with no verify
+-- hooks/prepare-commit-msg --
+#!/bin/sh
+echo prepare >"$WORK/output/prepare-ran"
+
+-- hooks/commit-msg --
+#!/bin/sh
+echo commit >"$WORK/output/commit-ran"
+exit 1


### PR DESCRIPTION
Integrate the gitedit.Editor into the fixup handler
so users can modify the commit message when fixing up.

The fixup handler uses plumbing-level CommitTree
rather than git commit, so the editor is invoked
directly via gitedit.Editor.CommitMessage
before passing the result to CommitTree.

The GitRepository interface is extended
with the methods needed by gitedit.Repository
(GitDir, Var, DiffTreePatch, Stripspace, HookRun)
so the handler's repository can be passed through directly.

The Verbose field is named CommitVerbose
with name:"commit-verbose" to avoid conflicting
with the global --verbose flag.