### PR TITLE
fix(commit-fixup): Preserve dirty edits

### DIFF
--- a/.changes/unreleased/Fixed-20260516-182551.yaml
+++ b/.changes/unreleased/Fixed-20260516-182551.yaml
@@ -1,0 +1,4 @@
+kind: Fixed
+body: >-
+  commit fixup: Fix unstaged worktree changes when staged fixup changes conflict.
+time: 2026-05-16T18:25:51.319248-07:00

--- a/internal/handler/autostash/handler.go
+++ b/internal/handler/autostash/handler.go
@@ -186,6 +186,17 @@ func (h *Handler) BeginAutostash(
 			return
 		}
 
+		var rebaseErr *git.RebaseInterruptError
+		// Only rebase interruptions can safely defer autostash restoration.
+		// Other failures have no continuation path,
+		// so restore the stash before returning the original error.
+		if !errors.As(*errPtr, &rebaseErr) && !spice.IsRebaseRescue(*errPtr) {
+			if err := h.RestoreAutostash(ctx, stashHash.String()); err != nil {
+				*errPtr = errors.Join(*errPtr, err)
+			}
+			return
+		}
+
 		rescueBranch := opts.Branch
 		if cleanupOpts != nil && cleanupOpts.RescueBranch != "" {
 			rescueBranch = cleanupOpts.RescueBranch

--- a/internal/handler/autostash/handler_test.go
+++ b/internal/handler/autostash/handler_test.go
@@ -159,6 +159,35 @@ func TestHandler_AutoStash_reset(t *testing.T) {
 }
 
 func TestHandler_AutoStash_options(t *testing.T) {
+	t.Run("NonRebaseFailureRestoresImmediately", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+
+		mockWorktree := NewMockGitWorktree(mockCtrl)
+		stashHash := git.Hash("stashhash")
+		mockWorktree.EXPECT().
+			StashCreate(gomock.Any(), gomock.Any()).
+			Return(stashHash, nil)
+
+		cleanup, err := (&Handler{
+			Log:      silogtest.New(t),
+			Worktree: mockWorktree,
+			Service:  NewMockService(mockCtrl),
+		}).BeginAutostash(t.Context(), &Options{
+			Branch:    "feature",
+			ResetMode: ResetNone,
+		})
+		require.NoError(t, err)
+
+		wantErr := errors.New("sadness")
+		operationErr := wantErr
+		mockWorktree.EXPECT().
+			StashApply(gomock.Any(), stashHash.String()).
+			Return(nil)
+		cleanup(&operationErr, nil)
+
+		assert.ErrorIs(t, operationErr, wantErr)
+	})
+
 	t.Run("BranchFallback", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 
@@ -179,7 +208,10 @@ func TestHandler_AutoStash_options(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		conflictErr := errors.New("sadness")
+		conflictErr := error(&git.RebaseInterruptError{
+			Kind:  git.RebaseInterruptConflict,
+			State: &git.RebaseState{Branch: "feature"},
+		})
 		mockService.EXPECT().
 			RebaseRescue(gomock.Any(), rebaseRescueMatcher{
 				Err:    conflictErr,
@@ -208,7 +240,10 @@ func TestHandler_AutoStash_options(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		conflictErr := errors.New("sadness")
+		conflictErr := error(&git.RebaseInterruptError{
+			Kind:  git.RebaseInterruptConflict,
+			State: &git.RebaseState{Branch: "feature"},
+		})
 		mockService.EXPECT().
 			RebaseRescue(gomock.Any(), rebaseRescueMatcher{
 				Err:    conflictErr,

--- a/internal/spice/rebase.go
+++ b/internal/spice/rebase.go
@@ -44,6 +44,13 @@ func (r *rescuedRebaseError) Error() string {
 	return r.err.Error()
 }
 
+// IsRebaseRescue reports whether the error has already been handled by
+// RebaseRescue.
+func IsRebaseRescue(err error) bool {
+	var rescuedErr *rescuedRebaseError
+	return errors.As(err, &rescuedErr)
+}
+
 // RebaseRescue helps operations continue from rebase conflicts.
 // To use it, call RebaseRescue with the error that caused the rebase
 // operation to be interrupted.

--- a/testdata/script/commit_fixup_conflict_staged.txt
+++ b/testdata/script/commit_fixup_conflict_staged.txt
@@ -11,8 +11,8 @@ git commit --allow-empty -m 'Initial commit'
 gs repo init
 git config spice.experiment.commitFixup true
 
-# Create initial commit with file
-git add conflict_file.txt
+# Create initial commit with files
+git add conflict_file.txt dirty_file.txt
 gs bc -m 'Add conflict file' feature
 
 # Create second commit that modifies the file differently
@@ -27,6 +27,9 @@ cmp stdout $WORK/golden/log.txt
 cp $WORK/extra/conflict_file_v3.txt conflict_file.txt
 git add conflict_file.txt
 
+# Leave an unrelated unstaged edit in the worktree.
+cp $WORK/extra/dirty_file_modified.txt dirty_file.txt
+
 # Try to fixup the first commit - should fail due to conflict
 ! gs commit fixup HEAD~1
 cmp stderr $WORK/golden/fixup_stderr.txt
@@ -35,6 +38,7 @@ cmp stderr $WORK/golden/fixup_stderr.txt
 # Verify the working directory and staging area are unchanged
 git status --porcelain
 cmp stdout $WORK/golden/status.txt
+cmp dirty_file.txt $WORK/extra/dirty_file_modified.txt
 
 # Verify the original commits are still intact
 git log --oneline
@@ -45,6 +49,10 @@ Original content
 line 2
 line 3
 
+-- repo/dirty_file.txt --
+Original dirty content
+-- extra/dirty_file_modified.txt --
+Unstaged dirty content
 -- extra/conflict_file_v2.txt --
 Modified content in commit 2
 line 2
@@ -56,14 +64,16 @@ line 2
 line 3
 
 -- golden/fixup_stderr.txt --
-ERR Staged changes conflict with commit 257b793:
+ERR Staged changes conflict with commit ccb4cca:
 ERR   Auto-merging conflict_file.txt
 ERR   CONFLICT (content): Merge conflict in conflict_file.txt
 ERR Try unstaging some changes and running the command again.
+INF Applied autostash
 FTL gs: merge conflict in files: conflict_file.txt
 -- golden/status.txt --
 M  conflict_file.txt
+ M dirty_file.txt
 -- golden/log.txt --
-34e36b2 Modify conflict file
-257b793 Add conflict file
+3aa60b8 Modify conflict file
+ccb4cca Add conflict file
 7cd9101 Initial commit


### PR DESCRIPTION
When staged fixup changes conflict with the target commit,
commit fixup reports the merge-tree failure before any rebase starts.
Autostash cleanup must restore dirty worktree edits immediately in that
case because there is no rebase continuation that can pop them later.

Keep deferred autostash restoration only for real rebase interruptions
and already-rescued rebase errors. The regression script covers the
staged-conflict path and verifies both the index and dirty worktree edit
survive the failure.