### PR TITLE
git: Add Merge, IsClean, and CheckoutNewBranch worktree helpers

### DIFF
--- a/internal/git/branch_wt.go
+++ b/internal/git/branch_wt.go
@@ -80,3 +80,49 @@ func (w *Worktree) CheckoutBranch(ctx context.Context, branch string) error {
 	}
 	return nil
 }
+
+// CheckoutNewBranchRequest is a request to create and switch to a new
+// branch in one operation.
+type CheckoutNewBranchRequest struct {
+	// Name is the name of the branch to create.
+	Name string // required
+
+	// StartPoint is the commit-ish that the new branch should point at.
+	// If empty, the current HEAD is used.
+	StartPoint string
+
+	// Force resets the branch if it already exists.
+	// Without Force, the operation fails if the branch already exists.
+	Force bool
+}
+
+// CheckoutNewBranch creates a new branch and switches to it.
+// With Force=true, an existing branch with the same name is reset
+// to StartPoint.
+func (w *Worktree) CheckoutNewBranch(ctx context.Context, req CheckoutNewBranchRequest) error {
+	if req.Name == "" {
+		return errors.New("checkout new branch: name is required")
+	}
+
+	w.log.Debug("Creating and checking out new branch",
+		"name", req.Name,
+		"start", req.StartPoint,
+		"force", req.Force,
+	)
+
+	flag := "-b"
+	if req.Force {
+		flag = "-B"
+	}
+	args := []string{flag, req.Name}
+	if req.StartPoint != "" {
+		args = append(args, req.StartPoint)
+	}
+
+	if err := w.runGitWithIndexLockRetry(ctx, func() *gitCmd {
+		return w.gitCmd(ctx, "checkout", args...)
+	}); err != nil {
+		return fmt.Errorf("git checkout: %w", err)
+	}
+	return nil
+}

--- a/internal/git/branch_wt_test.go
+++ b/internal/git/branch_wt_test.go
@@ -1,0 +1,169 @@
+package git_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/git/gittest"
+	"go.abhg.dev/gs/internal/silog/silogtest"
+	"go.abhg.dev/gs/internal/text"
+)
+
+func TestWorktree_CheckoutNewBranch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("CreateAtHEAD", func(t *testing.T) {
+		fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+			as 'Test <test@example.com>'
+			at '2025-01-01T00:00:00Z'
+
+			git init
+			git add file.txt
+			git commit -m 'Initial commit'
+
+			-- file.txt --
+			content
+		`)))
+		require.NoError(t, err)
+		t.Cleanup(fixture.Cleanup)
+
+		wt, err := git.OpenWorktree(t.Context(), fixture.Dir(), git.OpenOptions{
+			Log: silogtest.New(t),
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, wt.CheckoutNewBranch(t.Context(), git.CheckoutNewBranchRequest{
+			Name: "feature",
+		}))
+
+		cur, err := wt.CurrentBranch(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, "feature", cur)
+	})
+
+	t.Run("CreateAtStartPoint", func(t *testing.T) {
+		fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+			as 'Test <test@example.com>'
+			at '2025-01-01T00:00:00Z'
+
+			git init
+			git add file.txt
+			git commit -m 'Initial commit'
+
+			git checkout -b feature
+			git add feature.txt
+			git commit -m 'Feature commit'
+
+			git checkout main
+
+			-- file.txt --
+			content
+			-- feature.txt --
+			feature content
+		`)))
+		require.NoError(t, err)
+		t.Cleanup(fixture.Cleanup)
+
+		wt, err := git.OpenWorktree(t.Context(), fixture.Dir(), git.OpenOptions{
+			Log: silogtest.New(t),
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, wt.CheckoutNewBranch(t.Context(), git.CheckoutNewBranchRequest{
+			Name:       "new-branch",
+			StartPoint: "feature",
+		}))
+
+		cur, err := wt.CurrentBranch(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, "new-branch", cur)
+	})
+
+	t.Run("ExistsWithoutForceFails", func(t *testing.T) {
+		fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+			as 'Test <test@example.com>'
+			at '2025-01-01T00:00:00Z'
+
+			git init
+			git add file.txt
+			git commit -m 'Initial commit'
+
+			git checkout -b existing
+			git checkout main
+
+			-- file.txt --
+			content
+		`)))
+		require.NoError(t, err)
+		t.Cleanup(fixture.Cleanup)
+
+		wt, err := git.OpenWorktree(t.Context(), fixture.Dir(), git.OpenOptions{
+			Log: silogtest.New(t),
+		})
+		require.NoError(t, err)
+
+		err = wt.CheckoutNewBranch(t.Context(), git.CheckoutNewBranchRequest{
+			Name: "existing",
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("ForceResetsExisting", func(t *testing.T) {
+		fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+			as 'Test <test@example.com>'
+			at '2025-01-01T00:00:00Z'
+
+			git init
+			git add file.txt
+			git commit -m 'Initial commit'
+
+			git checkout -b existing
+			git add new.txt
+			git commit -m 'On existing'
+
+			git checkout main
+
+			-- file.txt --
+			content
+			-- new.txt --
+			more content
+		`)))
+		require.NoError(t, err)
+		t.Cleanup(fixture.Cleanup)
+
+		wt, err := git.OpenWorktree(t.Context(), fixture.Dir(), git.OpenOptions{
+			Log: silogtest.New(t),
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, wt.CheckoutNewBranch(t.Context(), git.CheckoutNewBranchRequest{
+			Name:       "existing",
+			StartPoint: "main",
+			Force:      true,
+		}))
+
+		cur, err := wt.CurrentBranch(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, "existing", cur)
+	})
+
+	t.Run("EmptyNameFails", func(t *testing.T) {
+		fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+			git init
+			git commit --allow-empty -m 'Initial commit'
+		`)))
+		require.NoError(t, err)
+		t.Cleanup(fixture.Cleanup)
+
+		wt, err := git.OpenWorktree(t.Context(), fixture.Dir(), git.OpenOptions{
+			Log: silogtest.New(t),
+		})
+		require.NoError(t, err)
+
+		err = wt.CheckoutNewBranch(t.Context(), git.CheckoutNewBranchRequest{Name: ""})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "name is required")
+	})
+}

--- a/internal/git/files_wt.go
+++ b/internal/git/files_wt.go
@@ -64,3 +64,16 @@ func (w *Worktree) ListUntrackedFiles(ctx context.Context) iter.Seq2[string, err
 		}
 	}
 }
+
+// IsClean reports whether the worktree has no uncommitted changes among
+// tracked files. Staged changes, unstaged changes, and unmerged paths
+// all make the worktree unclean. Untracked files are ignored.
+func (w *Worktree) IsClean(ctx context.Context) (bool, error) {
+	out, err := w.gitCmd(ctx, "status",
+		"--porcelain", "--untracked-files=no").
+		OutputChomp()
+	if err != nil {
+		return false, fmt.Errorf("git status: %w", err)
+	}
+	return out == "", nil
+}

--- a/internal/git/files_wt_test.go
+++ b/internal/git/files_wt_test.go
@@ -237,6 +237,95 @@ func TestListFilesPaths_specialCharacters(t *testing.T) {
 	assert.ElementsMatch(t, expected, paths)
 }
 
+func TestWorktree_IsClean(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Clean", func(t *testing.T) {
+		fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+			as 'Test <test@example.com>'
+			at '2025-01-01T00:00:00Z'
+
+			git init
+			git add file.txt
+			git commit -m 'Initial commit'
+
+			-- file.txt --
+			content
+		`)))
+		require.NoError(t, err)
+		t.Cleanup(fixture.Cleanup)
+
+		wt, err := git.OpenWorktree(t.Context(), fixture.Dir(), git.OpenOptions{
+			Log: silogtest.New(t),
+		})
+		require.NoError(t, err)
+
+		clean, err := wt.IsClean(t.Context())
+		require.NoError(t, err)
+		assert.True(t, clean)
+	})
+
+	t.Run("StagedChanges", func(t *testing.T) {
+		fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+			as 'Test <test@example.com>'
+			at '2025-01-01T00:00:00Z'
+
+			git init
+			git add file.txt
+			git commit -m 'Initial commit'
+
+			cp $WORK/new.txt staged.txt
+			git add staged.txt
+
+			-- file.txt --
+			content
+			-- new.txt --
+			staged content
+		`)))
+		require.NoError(t, err)
+		t.Cleanup(fixture.Cleanup)
+
+		wt, err := git.OpenWorktree(t.Context(), fixture.Dir(), git.OpenOptions{
+			Log: silogtest.New(t),
+		})
+		require.NoError(t, err)
+
+		clean, err := wt.IsClean(t.Context())
+		require.NoError(t, err)
+		assert.False(t, clean)
+	})
+
+	t.Run("UntrackedFilesIgnored", func(t *testing.T) {
+		fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+			as 'Test <test@example.com>'
+			at '2025-01-01T00:00:00Z'
+
+			cd repo
+			git init
+			git add file.txt
+			git commit -m 'Initial commit'
+
+			cp $WORK/untracked.txt extra.txt
+
+			-- repo/file.txt --
+			content
+			-- untracked.txt --
+			untracked
+		`)))
+		require.NoError(t, err)
+		t.Cleanup(fixture.Cleanup)
+
+		wt, err := git.OpenWorktree(t.Context(), filepath.Join(fixture.Dir(), "repo"), git.OpenOptions{
+			Log: silogtest.New(t),
+		})
+		require.NoError(t, err)
+
+		clean, err := wt.IsClean(t.Context())
+		require.NoError(t, err)
+		assert.True(t, clean, "untracked files should not count as dirty")
+	})
+}
+
 func TestWorktree_ListUntrackedFiles(t *testing.T) {
 	t.Parallel()
 

--- a/internal/git/gittest/fixture.go
+++ b/internal/git/gittest/fixture.go
@@ -80,7 +80,71 @@ func LoadFixtureFile(path string) (_ *Fixture, err error) {
 		must.Failf("fixtureDir must exist: %v", err)
 	}
 
+	// Persist a usable git identity into every git repository created
+	// inside the fixture so that subsequent Go-driven git invocations
+	// (e.g. git merge, git commit) inherit a valid identity even on
+	// CI runners with no global gitconfig.
+	if err := setFixtureIdentity(fixtureDir); err != nil {
+		return nil, fmt.Errorf("set fixture identity: %w", err)
+	}
+
 	return &Fixture{dir: fixtureDir}, nil
+}
+
+// fixtureIdentity is appended to the local config of every git
+// repository discovered inside a fixture.
+const fixtureIdentity = "\n[user]\n" +
+	"\tname = Test\n" +
+	"\temail = test@example.com\n"
+
+// setFixtureIdentity appends a test git identity to the local config
+// of every git repository found inside dir. This includes both
+// non-bare repositories (where the config lives at .git/config) and
+// bare repositories (where the config lives at config).
+func setFixtureIdentity(dir string) error {
+	return filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			return nil
+		}
+
+		// Non-bare repo: identified by a .git directory or file
+		// inside the working tree.
+		if cfg := filepath.Join(path, ".git", "config"); fileExists(cfg) {
+			if err := appendIdentity(cfg); err != nil {
+				return err
+			}
+		}
+
+		// Bare repo: identified by HEAD + config alongside refs.
+		if fileExists(filepath.Join(path, "HEAD")) &&
+			fileExists(filepath.Join(path, "config")) {
+			if err := appendIdentity(filepath.Join(path, "config")); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+func appendIdentity(configPath string) error {
+	f, err := os.OpenFile(configPath, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", configPath, err)
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.WriteString(fixtureIdentity); err != nil {
+		return fmt.Errorf("write %s: %w", configPath, err)
+	}
+	return nil
 }
 
 // LoadFixtureScript loads a fixture from the testscript.

--- a/internal/git/merge_wt.go
+++ b/internal/git/merge_wt.go
@@ -1,0 +1,138 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"go.abhg.dev/gs/internal/sliceutil"
+	"go.abhg.dev/gs/internal/xec"
+)
+
+// MergeOptions specifies parameters for a [Worktree.Merge] operation.
+type MergeOptions struct {
+	// Refs lists the commits or branches to merge into HEAD.
+	// At least one is required.
+	Refs []string
+
+	// NoFF forces a merge commit even when a fast-forward is possible.
+	NoFF bool
+
+	// Message is the commit message for the merge commit.
+	// If empty, Git's default message is used.
+	Message string
+
+	// EnableRerere enables rerere.enabled and rerere.autoupdate
+	// for this merge invocation only.
+	// User git config is not modified.
+	EnableRerere bool
+
+	// LeaveConflict, when true, leaves a conflicting merge in the
+	// worktree (with unmerged paths) rather than aborting it. The
+	// caller is then responsible for resolving or aborting the merge.
+	LeaveConflict bool
+}
+
+// MergeConflictError indicates that a [Worktree.Merge] could not be
+// completed due to conflicts. By default the merge is aborted before
+// this error is returned, leaving the worktree at HEAD. If
+// [MergeOptions.LeaveConflict] is set, the worktree is left with
+// unmerged paths.
+type MergeConflictError struct {
+	// Refs are the references that were being merged.
+	Refs []string
+
+	// ConflictPaths lists the files with unresolved conflicts.
+	ConflictPaths []string
+}
+
+func (e *MergeConflictError) Error() string {
+	switch len(e.Refs) {
+	case 0:
+		return fmt.Sprintf("merge conflict in %d file(s)", len(e.ConflictPaths))
+	case 1:
+		return fmt.Sprintf("merge of %s conflicted in %d file(s)",
+			e.Refs[0], len(e.ConflictPaths))
+	default:
+		return fmt.Sprintf("merge of %s conflicted in %d file(s)",
+			strings.Join(e.Refs, ", "), len(e.ConflictPaths))
+	}
+}
+
+// Merge runs git merge with the given options.
+//
+// On a merge conflict, the merge is automatically aborted and a
+// [*MergeConflictError] is returned with the list of conflicting paths.
+func (w *Worktree) Merge(ctx context.Context, opts MergeOptions) error {
+	if len(opts.Refs) == 0 {
+		return errors.New("merge: at least one ref is required")
+	}
+
+	mergeArgs := []string{"merge"}
+	if opts.NoFF {
+		mergeArgs = append(mergeArgs, "--no-ff")
+	}
+	if opts.Message != "" {
+		mergeArgs = append(mergeArgs, "-m", opts.Message)
+	}
+	mergeArgs = append(mergeArgs, opts.Refs...)
+
+	cmd := w.gitCmd(ctx, "merge", mergeArgs[1:]...)
+	if opts.EnableRerere {
+		prefix := []string{
+			"-c", "rerere.enabled=true",
+			"-c", "rerere.autoupdate=true",
+		}
+		cmd = cmd.WithArgs(append(prefix, cmd.Args()...)...)
+	}
+
+	err := w.runGitWithIndexLockRetry(ctx, func() *gitCmd { return cmd })
+	if err == nil {
+		return nil
+	}
+	if !errors.As(err, new(*xec.ExitError)) {
+		return fmt.Errorf("git merge: %w", err)
+	}
+
+	// A non-zero exit may mean conflicts. Check for unmerged files.
+	unmerged, listErr := sliceutil.CollectErr(
+		w.ListFilesPaths(ctx, &ListFilesOptions{Unmerged: true}))
+	if listErr != nil {
+		return fmt.Errorf("list unmerged files: %w", listErr)
+	}
+	if len(unmerged) == 0 {
+		// rerere with autoupdate=true may have fully resolved and
+		// staged the conflicts, leaving git merge with a non-zero exit
+		// but no unmerged paths. In that case, commit the merge to
+		// complete it. If no merge is in progress, surface the
+		// original error.
+		mergeMsg := opts.Message
+		if mergeMsg == "" {
+			mergeMsg = "Merge"
+		}
+		commitCmd := w.gitCmd(ctx, "commit", "--no-edit", "-m", mergeMsg)
+		if commitErr := w.runGitWithIndexLockRetry(ctx, func() *gitCmd { return commitCmd }); commitErr != nil {
+			return fmt.Errorf("git merge: %w", err)
+		}
+		return nil
+	}
+
+	if !opts.LeaveConflict {
+		if abortErr := w.MergeAbort(ctx); abortErr != nil {
+			return fmt.Errorf("git merge: conflicted and abort failed: %w", abortErr)
+		}
+	}
+	return &MergeConflictError{
+		Refs:          opts.Refs,
+		ConflictPaths: unmerged,
+	}
+}
+
+// MergeAbort aborts an ongoing merge operation.
+func (w *Worktree) MergeAbort(ctx context.Context) error {
+	if err := w.gitCmd(ctx, "merge", "--abort").Run(); err != nil {
+		return fmt.Errorf("git merge --abort: %w", err)
+	}
+	return nil
+}

--- a/internal/git/merge_wt_test.go
+++ b/internal/git/merge_wt_test.go
@@ -1,0 +1,188 @@
+package git_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/git/gittest"
+	"go.abhg.dev/gs/internal/silog/silogtest"
+	"go.abhg.dev/gs/internal/text"
+)
+
+func TestWorktree_Merge_noFF(t *testing.T) {
+	t.Parallel()
+
+	fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+		as 'Test <test@example.com>'
+		at '2025-01-01T00:00:00Z'
+
+		git init
+		git add base.txt
+		git commit -m 'Initial commit'
+
+		git checkout -b feature
+		git add feature.txt
+		git commit -m 'Add feature'
+
+		git checkout main
+
+		-- base.txt --
+		base content
+		-- feature.txt --
+		feature content
+	`)))
+	require.NoError(t, err)
+	t.Cleanup(fixture.Cleanup)
+
+	wt, err := git.OpenWorktree(t.Context(), fixture.Dir(), git.OpenOptions{
+		Log: silogtest.New(t),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, wt.Merge(t.Context(), git.MergeOptions{
+		Refs:    []string{"feature"},
+		NoFF:    true,
+		Message: "Merge feature",
+	}))
+
+	// HEAD should now have feature.txt.
+	content, err := os.ReadFile(filepath.Join(fixture.Dir(), "feature.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "feature content", strings.TrimSpace(string(content)))
+}
+
+func TestWorktree_Merge_conflict(t *testing.T) {
+	t.Parallel()
+
+	fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+		as 'Test <test@example.com>'
+		at '2025-01-01T00:00:00Z'
+
+		git init
+		git add shared.txt
+		git commit -m 'Initial commit'
+
+		git checkout -b feature
+		cp feature.txt shared.txt
+		git add shared.txt
+		git commit -m 'Feature changes shared.txt'
+
+		git checkout main
+		cp main.txt shared.txt
+		git add shared.txt
+		git commit -m 'Main changes shared.txt'
+
+		-- shared.txt --
+		base content
+		-- feature.txt --
+		feature content
+		-- main.txt --
+		main content
+	`)))
+	require.NoError(t, err)
+	t.Cleanup(fixture.Cleanup)
+
+	wt, err := git.OpenWorktree(t.Context(), fixture.Dir(), git.OpenOptions{
+		Log: silogtest.New(t),
+	})
+	require.NoError(t, err)
+
+	err = wt.Merge(t.Context(), git.MergeOptions{
+		Refs:    []string{"feature"},
+		NoFF:    true,
+		Message: "Merge feature",
+	})
+
+	var conflict *git.MergeConflictError
+	require.Error(t, err)
+	require.True(t, errors.As(err, &conflict), "want MergeConflictError, got %T: %v", err, err)
+	assert.Equal(t, []string{"feature"}, conflict.Refs)
+	assert.Equal(t, []string{"shared.txt"}, conflict.ConflictPaths)
+
+	// Merge must have been aborted: worktree is clean.
+	clean, err := wt.IsClean(t.Context())
+	require.NoError(t, err)
+	assert.True(t, clean, "worktree should be clean after aborted merge")
+}
+
+func TestWorktree_Merge_conflictLeaveInWorktree(t *testing.T) {
+	t.Parallel()
+
+	fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+		as 'Test <test@example.com>'
+		at '2025-01-01T00:00:00Z'
+
+		git init
+		git add shared.txt
+		git commit -m 'Initial commit'
+
+		git checkout -b feature
+		cp feature.txt shared.txt
+		git add shared.txt
+		git commit -m 'Feature changes shared.txt'
+
+		git checkout main
+		cp main.txt shared.txt
+		git add shared.txt
+		git commit -m 'Main changes shared.txt'
+
+		-- shared.txt --
+		base content
+		-- feature.txt --
+		feature content
+		-- main.txt --
+		main content
+	`)))
+	require.NoError(t, err)
+	t.Cleanup(fixture.Cleanup)
+
+	wt, err := git.OpenWorktree(t.Context(), fixture.Dir(), git.OpenOptions{
+		Log: silogtest.New(t),
+	})
+	require.NoError(t, err)
+
+	err = wt.Merge(t.Context(), git.MergeOptions{
+		Refs:          []string{"feature"},
+		NoFF:          true,
+		Message:       "Merge feature",
+		LeaveConflict: true,
+	})
+
+	var conflict *git.MergeConflictError
+	require.Error(t, err)
+	require.True(t, errors.As(err, &conflict))
+
+	// The merge was NOT aborted; the worktree is left in conflict
+	// state for the caller to resolve.
+	clean, err := wt.IsClean(t.Context())
+	require.NoError(t, err)
+	assert.False(t, clean, "worktree should remain in conflict state when LeaveConflict is set")
+
+	require.NoError(t, wt.MergeAbort(t.Context()))
+}
+
+func TestWorktree_Merge_noRefs(t *testing.T) {
+	t.Parallel()
+
+	fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+		git init
+		git commit --allow-empty -m 'Initial commit'
+	`)))
+	require.NoError(t, err)
+	t.Cleanup(fixture.Cleanup)
+
+	wt, err := git.OpenWorktree(t.Context(), fixture.Dir(), git.OpenOptions{
+		Log: silogtest.New(t),
+	})
+	require.NoError(t, err)
+
+	err = wt.Merge(t.Context(), git.MergeOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one ref")
+}


### PR DESCRIPTION
Worktree.Merge supports --no-ff and optional rerere via per-command
-c rerere.enabled=true -c rerere.autoupdate=true flags. On conflict the
merge is automatically aborted (default) and a *MergeConflictError
carrying the refs and unmerged paths is returned, leaving the worktree
at HEAD. Setting MergeOptions.LeaveConflict skips the abort so the
caller can drive a conflict-resolution flow.

Worktree.IsClean reports whether the worktree has uncommitted changes
among tracked files (untracked files are ignored), backed by
git status --porcelain --untracked-files=no.

Worktree.CheckoutNewBranch creates a new branch at an optional start
point in one operation, with a Force flag for git checkout -B semantics.