### PR TITLE
integration: Wire gs integration command tree

### DIFF
--- a/.changes/unreleased/Added-20260514-113901.yaml
+++ b/.changes/unreleased/Added-20260514-113901.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'integration: Add ''gs integration'' command for managing a combined integration branch that merges multiple stack tips onto trunk.'
+time: 2026-05-14T11:39:01.837856-04:00

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -12,7 +12,7 @@ git-spice is a command line tool for stacking Git branches.
 * `-C`, `--dir=DIR`: Change to DIR before doing anything
 * `--[no-]prompt`: Whether to prompt for missing information
 
-**Configuration**: [spice.forge.bitbucket.apiURL](/cli/config.md#spiceforgebitbucketapiurl), [spice.forge.bitbucket.url](/cli/config.md#spiceforgebitbucketurl), [spice.forge.github.apiUrl](/cli/config.md#spiceforgegithubapiurl), [spice.forge.github.url](/cli/config.md#spiceforgegithuburl), [spice.forge.gitlab.apiURL](/cli/config.md#spiceforgegitlabapiurl), [spice.forge.gitlab.oauth.clientID](/cli/config.md#spiceforgegitlaboauthclientid), [spice.forge.gitlab.removeSourceBranch](/cli/config.md#spiceforgegitlabremovesourcebranch), [spice.forge.gitlab.url](/cli/config.md#spiceforgegitlaburl), [spice.forge.kind](/cli/config.md#spiceforgekind), [spice.git.indexLockTimeout](/cli/config.md#spicegitindexlocktimeout), [spice.secret.backend](/cli/config.md#spicesecretbackend)
+**Configuration**: [spice.forge.bitbucket.apiURL](/cli/config.md#spiceforgebitbucketapiurl), [spice.forge.bitbucket.url](/cli/config.md#spiceforgebitbucketurl), [spice.forge.github.apiUrl](/cli/config.md#spiceforgegithubapiurl), [spice.forge.github.url](/cli/config.md#spiceforgegithuburl), [spice.forge.gitlab.apiURL](/cli/config.md#spiceforgegitlabapiurl), [spice.forge.gitlab.oauth.clientID](/cli/config.md#spiceforgegitlaboauthclientid), [spice.forge.gitlab.removeSourceBranch](/cli/config.md#spiceforgegitlabremovesourcebranch), [spice.forge.gitlab.url](/cli/config.md#spiceforgegitlaburl), [spice.git.indexLockTimeout](/cli/config.md#spicegitindexlocktimeout), [spice.secret.backend](/cli/config.md#spicesecretbackend)
 
 ## Shell
 
@@ -156,17 +156,11 @@ The repository must have a remote associated for syncing.
 A prompt will ask for one if the repository
 was not initialized with a remote.
 
-Branches above merged and deleted branches
-are retargeted to the trunk branch.
-Run with --restack to also restack them and their upstacks.
-Run with --restack=aboves to only restack direct upstacks
-of deleted branches, leaving higher branches in place.
-
 **Flags**
 
-* `--restack` ([:material-wrench:{ .middle title="spice.repoSync.restack" }](/cli/config.md#spicereposyncrestack)): How to restack branches above deleted branches. One of 'none', 'aboves', and 'upstack'.
+* `--restack`: Restack the current stack after syncing
 
-**Configuration**: [spice.repoSync.closedChanges](/cli/config.md#spicereposyncclosedchanges), [spice.repoSync.restack](/cli/config.md#spicereposyncrestack)
+**Configuration**: [spice.repoSync.closedChanges](/cli/config.md#spicereposyncclosedchanges)
 
 ### git-spice repo restack {#gs-repo-restack}
 
@@ -284,51 +278,7 @@ only if there are multiple CRs in the stack.
 * `-a`, `--assign=ASSIGNEE,...`: Assign the change request to these users. Pass multiple times or separate with commas. <span class="mdx-badge"><span class="mdx-badge__icon">:material-tag:{ title="Released in version" }</span><span class="mdx-badge__text">[v0.21.0](/changelog.md#v0.21.0)</span>
 * `--no-web`: Alias for --web=false.
 
-**Configuration**: [spice.submit.assignees](/cli/config.md#spicesubmitassignees), [spice.submit.draft](/cli/config.md#spicesubmitdraft), [spice.submit.labels](/cli/config.md#spicesubmitlabels), [spice.submit.labels.addWhen](/cli/config.md#spicesubmitlabelsaddwhen), [spice.submit.listTemplatesTimeout](/cli/config.md#spicesubmitlisttemplatestimeout), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.navigationComment.downstack](/cli/config.md#spicesubmitnavigationcommentdownstack), [spice.submit.navigationCommentStyle.marker](/cli/config.md#spicesubmitnavigationcommentstylemarker), [spice.submit.navigationCommentSync](/cli/config.md#spicesubmitnavigationcommentsync), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.reviewers](/cli/config.md#spicesubmitreviewers), [spice.submit.reviewers.addWhen](/cli/config.md#spicesubmitreviewersaddwhen), [spice.submit.skipRestackCheck](/cli/config.md#spicesubmitskiprestackcheck), [spice.submit.template](/cli/config.md#spicesubmittemplate), [spice.submit.updateOnly](/cli/config.md#spicesubmitupdateonly), [spice.submit.web](/cli/config.md#spicesubmitweb)
-
-### git-spice stack merge {#gs-stack-merge}
-
-```
-gs stack (s) merge (m) [flags]
-```
-
-<span class="mdx-badge mdx-badge--experiment"><span class="mdx-badge__icon">:material-test-tube:{ title="Experimental" }</span><span class="mdx-badge__text">[merge](/cli/experiments.md#merge)</span></span>
-
-Merge a stack
-
-Merges the CRs for the current branch's stack into trunk.
-Use --branch to merge a different branch's stack.
-
-The stack includes the selected branch,
-its downstack branches down to trunk,
-and every upstack branch.
-
-Already-merged branches are skipped automatically.
-Branches must have an open Change Request to be merged.
-
-Before merging, the stack is checked for branches
-whose base PR was already merged on the forge.
-Use --no-branch-check to skip this validation.
-
-Before each merge, waits for merge readiness:
-the forge must observe the pushed head
-and report that the CR is ready to merge.
-Use --ready-timeout to configure the maximum wait
-before failing if merge readiness is not reached.
-
-By default, a branch failure skips that branch's upstack descendants,
-but independent sibling branches continue.
-Use --fail-fast to stop the queue after the first branch failure.
-
-**Flags**
-
-* `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
-* `--ready-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.readyTimeout" }](/cli/config.md#spicemergereadytimeout)): Max time to wait for merge readiness before each merge. 0 means check once.
-* `--no-branch-check`: Skip stale base validation before merging.
-* `--fail-fast`: Stop the merge queue after the first branch failure.
-* `--branch=NAME`: Branch whose stack to merge
-
-**Configuration**: [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
+**Configuration**: [spice.submit.assignees](/cli/config.md#spicesubmitassignees), [spice.submit.draft](/cli/config.md#spicesubmitdraft), [spice.submit.label](/cli/config.md#spicesubmitlabel), [spice.submit.label.addWhen](/cli/config.md#spicesubmitlabeladdwhen), [spice.submit.listTemplatesTimeout](/cli/config.md#spicesubmitlisttemplatestimeout), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.navigationComment.downstack](/cli/config.md#spicesubmitnavigationcommentdownstack), [spice.submit.navigationCommentStyle.marker](/cli/config.md#spicesubmitnavigationcommentstylemarker), [spice.submit.navigationCommentSync](/cli/config.md#spicesubmitnavigationcommentsync), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.reviewers](/cli/config.md#spicesubmitreviewers), [spice.submit.reviewers.addWhen](/cli/config.md#spicesubmitreviewersaddwhen), [spice.submit.skipRestackCheck](/cli/config.md#spicesubmitskiprestackcheck), [spice.submit.template](/cli/config.md#spicesubmittemplate), [spice.submit.updateOnly](/cli/config.md#spicesubmitupdateonly), [spice.submit.web](/cli/config.md#spicesubmitweb)
 
 ### git-spice stack restack {#gs-stack-restack}
 
@@ -451,7 +401,7 @@ only if there are multiple CRs in the stack.
 * `--no-web`: Alias for --web=false.
 * `--branch=NAME`: Branch to start at
 
-**Configuration**: [spice.submit.assignees](/cli/config.md#spicesubmitassignees), [spice.submit.draft](/cli/config.md#spicesubmitdraft), [spice.submit.labels](/cli/config.md#spicesubmitlabels), [spice.submit.labels.addWhen](/cli/config.md#spicesubmitlabelsaddwhen), [spice.submit.listTemplatesTimeout](/cli/config.md#spicesubmitlisttemplatestimeout), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.navigationComment.downstack](/cli/config.md#spicesubmitnavigationcommentdownstack), [spice.submit.navigationCommentStyle.marker](/cli/config.md#spicesubmitnavigationcommentstylemarker), [spice.submit.navigationCommentSync](/cli/config.md#spicesubmitnavigationcommentsync), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.reviewers](/cli/config.md#spicesubmitreviewers), [spice.submit.reviewers.addWhen](/cli/config.md#spicesubmitreviewersaddwhen), [spice.submit.skipRestackCheck](/cli/config.md#spicesubmitskiprestackcheck), [spice.submit.template](/cli/config.md#spicesubmittemplate), [spice.submit.updateOnly](/cli/config.md#spicesubmitupdateonly), [spice.submit.web](/cli/config.md#spicesubmitweb)
+**Configuration**: [spice.submit.assignees](/cli/config.md#spicesubmitassignees), [spice.submit.draft](/cli/config.md#spicesubmitdraft), [spice.submit.label](/cli/config.md#spicesubmitlabel), [spice.submit.label.addWhen](/cli/config.md#spicesubmitlabeladdwhen), [spice.submit.listTemplatesTimeout](/cli/config.md#spicesubmitlisttemplatestimeout), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.navigationComment.downstack](/cli/config.md#spicesubmitnavigationcommentdownstack), [spice.submit.navigationCommentStyle.marker](/cli/config.md#spicesubmitnavigationcommentstylemarker), [spice.submit.navigationCommentSync](/cli/config.md#spicesubmitnavigationcommentsync), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.reviewers](/cli/config.md#spicesubmitreviewers), [spice.submit.reviewers.addWhen](/cli/config.md#spicesubmitreviewersaddwhen), [spice.submit.skipRestackCheck](/cli/config.md#spicesubmitskiprestackcheck), [spice.submit.template](/cli/config.md#spicesubmittemplate), [spice.submit.updateOnly](/cli/config.md#spicesubmitupdateonly), [spice.submit.web](/cli/config.md#spicesubmitweb)
 
 ### git-spice upstack restack {#gs-upstack-restack}
 
@@ -606,68 +556,7 @@ only if there are multiple CRs in the stack.
 * `--no-web`: Alias for --web=false.
 * `--branch=NAME`: Branch to start at
 
-**Configuration**: [spice.submit.assignees](/cli/config.md#spicesubmitassignees), [spice.submit.draft](/cli/config.md#spicesubmitdraft), [spice.submit.labels](/cli/config.md#spicesubmitlabels), [spice.submit.labels.addWhen](/cli/config.md#spicesubmitlabelsaddwhen), [spice.submit.listTemplatesTimeout](/cli/config.md#spicesubmitlisttemplatestimeout), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.navigationComment.downstack](/cli/config.md#spicesubmitnavigationcommentdownstack), [spice.submit.navigationCommentStyle.marker](/cli/config.md#spicesubmitnavigationcommentstylemarker), [spice.submit.navigationCommentSync](/cli/config.md#spicesubmitnavigationcommentsync), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.reviewers](/cli/config.md#spicesubmitreviewers), [spice.submit.reviewers.addWhen](/cli/config.md#spicesubmitreviewersaddwhen), [spice.submit.skipRestackCheck](/cli/config.md#spicesubmitskiprestackcheck), [spice.submit.template](/cli/config.md#spicesubmittemplate), [spice.submit.updateOnly](/cli/config.md#spicesubmitupdateonly), [spice.submit.web](/cli/config.md#spicesubmitweb)
-
-### git-spice downstack merge {#gs-downstack-merge}
-
-```
-gs downstack (ds) merge (m) [flags]
-```
-
-<span class="mdx-badge mdx-badge--experiment"><span class="mdx-badge__icon">:material-test-tube:{ title="Experimental" }</span><span class="mdx-badge__text">[merge](/cli/experiments.md#merge)</span></span>
-
-Merge a branch and those below it
-
-Merges the current branch and all branches below it
-into trunk via the forge API, bottom-up.
-Use --branch to start at a different branch.
-
-This command acts as a local merge queue:
-it merges one Change Request,
-waits for that merge to finish,
-restacks and updates the next Change Request,
-waits for merge readiness on the updated Change Request,
-and then repeats the process.
-
-For a stack like this:
-
-    main <- feature1 <- feature2 <- feature3
-
-Running from feature3 merges in this order:
-
-    feature1, feature2, feature3
-
-Already-merged branches are skipped automatically.
-Branches must have an open Change Request to be merged.
-
-Before merging, the downstack is checked for branches
-whose base PR was already merged on the forge.
-Use --no-branch-check to skip this validation.
-
-Before each merge, waits for merge readiness:
-the forge must observe the pushed head
-and report that the CR is ready to merge.
-Use --ready-timeout to configure the maximum wait
-(default: 30m, 0 means fail immediately if not ready).
-
-Between merges, the command waits for each merge
-to complete, restacks and updates the next PR,
-waits for merge readiness on the updated PR,
-and syncs merged branch cleanup.
-
-Use --no-wait for single branch merging
-when you don't want to wait for the merge to propagate.
---no-wait is rejected for multi-branch merges.
-
-**Flags**
-
-* `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
-* `--ready-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.readyTimeout" }](/cli/config.md#spicemergereadytimeout)): Max time to wait for merge readiness before each merge. 0 means check once.
-* `--no-wait`: Skip polling for a single branch merge to propagate.
-* `--no-branch-check`: Skip stale base validation before merging.
-* `--branch=NAME`: Branch to start merging from
-
-**Configuration**: [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
+**Configuration**: [spice.submit.assignees](/cli/config.md#spicesubmitassignees), [spice.submit.draft](/cli/config.md#spicesubmitdraft), [spice.submit.label](/cli/config.md#spicesubmitlabel), [spice.submit.label.addWhen](/cli/config.md#spicesubmitlabeladdwhen), [spice.submit.listTemplatesTimeout](/cli/config.md#spicesubmitlisttemplatestimeout), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.navigationComment.downstack](/cli/config.md#spicesubmitnavigationcommentdownstack), [spice.submit.navigationCommentStyle.marker](/cli/config.md#spicesubmitnavigationcommentstylemarker), [spice.submit.navigationCommentSync](/cli/config.md#spicesubmitnavigationcommentsync), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.reviewers](/cli/config.md#spicesubmitreviewers), [spice.submit.reviewers.addWhen](/cli/config.md#spicesubmitreviewersaddwhen), [spice.submit.skipRestackCheck](/cli/config.md#spicesubmitskiprestackcheck), [spice.submit.template](/cli/config.md#spicesubmittemplate), [spice.submit.updateOnly](/cli/config.md#spicesubmitupdateonly), [spice.submit.web](/cli/config.md#spicesubmitweb)
 
 ### git-spice downstack edit {#gs-downstack-edit}
 
@@ -875,12 +764,9 @@ gs branch (b) delete (d,rm) [<branches> ...] [flags]
 Delete branches
 
 The deleted branches and their commits are removed from the stack.
-Branches above the deleted branches are retargeted onto
+Branches above the deleted branches are first rebased onto
 the next branches available downstack,
 or onto trunk if there are no branches available below.
-
-Use --restack to rebase those branches and their upstacks
-immediately after retargeting.
 
 Without any arguments,
 a prompt will allow selecting the branch to delete.
@@ -896,9 +782,8 @@ Use --force to delete the branch regardless of unmerged changes.
 **Flags**
 
 * `--force`: Force deletion of the branch
-* `--restack` ([:material-wrench:{ .middle title="spice.branchDelete.restack" }](/cli/config.md#spicebranchdeleterestack)): How to restack branches above deleted branches. One of 'none', 'aboves', and 'upstack'.
 
-**Configuration**: [spice.branchDelete.restack](/cli/config.md#spicebranchdeleterestack), [spice.branchPrompt.sort](/cli/config.md#spicebranchpromptsort)
+**Configuration**: [spice.branchPrompt.sort](/cli/config.md#spicebranchpromptsort)
 
 ### git-spice branch fold {#gs-branch-fold}
 
@@ -1068,11 +953,8 @@ Commits of the current branch
 are transplanted onto another branch
 while leaving the rest of the stack intact.
 That is, branches above the current branch
-are retargeted onto its original base,
+are first rebased onto its original base,
 and then the current branch is moved onto the new base.
-
-Use --restack to rebase those branches and their upstacks
-immediately after retargeting.
 
 A prompt will allow selecting the new base for the branch.
 Provide an argument to skip the prompt.
@@ -1098,9 +980,8 @@ Use 'gs upstack onto' to also move the upstack branches.
 **Flags**
 
 * `--branch=NAME`: Branch to move
-* `--restack` ([:material-wrench:{ .middle title="spice.branchOnto.restack" }](/cli/config.md#spicebranchontorestack)): How to restack branches above the moved branch. One of 'none', 'aboves', and 'upstack'.
 
-**Configuration**: [spice.branchOnto.restack](/cli/config.md#spicebranchontorestack), [spice.branchPrompt.sort](/cli/config.md#spicebranchpromptsort)
+**Configuration**: [spice.branchPrompt.sort](/cli/config.md#spicebranchpromptsort)
 
 ### git-spice branch diff {#gs-branch-diff}
 
@@ -1120,35 +1001,6 @@ Use --branch to target a different branch.
 **Flags**
 
 * `--branch=NAME`: Branch to diff
-
-### git-spice branch merge {#gs-branch-merge}
-
-```
-gs branch (b) merge (m) [flags]
-```
-
-<span class="mdx-badge mdx-badge--experiment"><span class="mdx-badge__icon">:material-test-tube:{ title="Experimental" }</span><span class="mdx-badge__text">[merge](/cli/experiments.md#merge)</span></span>
-
-Merge a branch into trunk
-
-Merges the CR for the current branch into trunk.
-Use --branch to merge a different branch.
-
-The branch must be based directly on trunk.
-To merge a stacked branch, use 'gs downstack merge'.
-
-Before merging, waits for merge readiness:
-the forge must observe the pushed head
-and report that the CR is ready to merge.
-Use --ready-timeout to configure the maximum wait.
-
-**Flags**
-
-* `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
-* `--ready-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.readyTimeout" }](/cli/config.md#spicemergereadytimeout)): Max time to wait for merge readiness before each merge. 0 means check once.
-* `--branch=NAME`: Branch to merge
-
-**Configuration**: [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
 
 ### git-spice branch submit {#gs-branch-submit}
 
@@ -1203,7 +1055,7 @@ only if there are multiple CRs in the stack.
 * `--body=BODY`: Body of the change request
 * `--branch=NAME`: Branch to submit
 
-**Configuration**: [spice.submit.assignees](/cli/config.md#spicesubmitassignees), [spice.submit.draft](/cli/config.md#spicesubmitdraft), [spice.submit.labels](/cli/config.md#spicesubmitlabels), [spice.submit.labels.addWhen](/cli/config.md#spicesubmitlabelsaddwhen), [spice.submit.listTemplatesTimeout](/cli/config.md#spicesubmitlisttemplatestimeout), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.navigationComment.downstack](/cli/config.md#spicesubmitnavigationcommentdownstack), [spice.submit.navigationCommentStyle.marker](/cli/config.md#spicesubmitnavigationcommentstylemarker), [spice.submit.navigationCommentSync](/cli/config.md#spicesubmitnavigationcommentsync), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.reviewers](/cli/config.md#spicesubmitreviewers), [spice.submit.reviewers.addWhen](/cli/config.md#spicesubmitreviewersaddwhen), [spice.submit.skipRestackCheck](/cli/config.md#spicesubmitskiprestackcheck), [spice.submit.template](/cli/config.md#spicesubmittemplate), [spice.submit.web](/cli/config.md#spicesubmitweb)
+**Configuration**: [spice.submit.assignees](/cli/config.md#spicesubmitassignees), [spice.submit.draft](/cli/config.md#spicesubmitdraft), [spice.submit.label](/cli/config.md#spicesubmitlabel), [spice.submit.label.addWhen](/cli/config.md#spicesubmitlabeladdwhen), [spice.submit.listTemplatesTimeout](/cli/config.md#spicesubmitlisttemplatestimeout), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.navigationComment.downstack](/cli/config.md#spicesubmitnavigationcommentdownstack), [spice.submit.navigationCommentStyle.marker](/cli/config.md#spicesubmitnavigationcommentstylemarker), [spice.submit.navigationCommentSync](/cli/config.md#spicesubmitnavigationcommentsync), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.reviewers](/cli/config.md#spicesubmitreviewers), [spice.submit.reviewers.addWhen](/cli/config.md#spicesubmitreviewersaddwhen), [spice.submit.skipRestackCheck](/cli/config.md#spicesubmitskiprestackcheck), [spice.submit.template](/cli/config.md#spicesubmittemplate), [spice.submit.web](/cli/config.md#spicesubmitweb)
 
 ## Commit
 
@@ -1366,6 +1218,177 @@ This command requires at least Git 2.45.
 **Flags**
 
 * `--from=NAME`: Branch whose upstack commits will be considered.
+
+## Integration
+
+### git-spice integration show {#gs-integration-show}
+
+```
+gs integration (int) show
+```
+
+Show the configured integration branch
+
+Displays the configured integration branch and the tip branches
+that compose it. For each tip, shows whether its hash has drifted
+from the hash recorded at the last successful rebuild.
+
+### git-spice integration create {#gs-integration-create}
+
+```
+gs integration (int) create (c) <name> [flags]
+```
+
+Configure the integration branch
+
+Configures the singleton integration branch for this repo.
+The branch is materialized by sequentially merging each
+tip onto trunk; it is never given a PR and is invisible to
+'gs branch' commands.
+
+Use 'gs integration tip add <branch>' to add tips later,
+or pass --tip multiple times here.
+
+**Arguments**
+
+* `name`: Local name of the integration branch
+
+**Flags**
+
+* `--upstream=BRANCH`: Upstream branch name (defaults to local name)
+* `--tip=BRANCH,...`: Tip branches to include (repeat to add more)
+
+### git-spice integration delete {#gs-integration-delete}
+
+```
+gs integration (int) delete (d,rm)
+```
+
+Remove the integration branch configuration
+
+Removes the integration branch configuration. The underlying
+Git branch (if any) is not deleted; only the git-spice config
+that drives auto-rebuild and submit is removed.
+
+### git-spice integration checkout {#gs-integration-checkout}
+
+```
+gs integration (int) checkout (co)
+```
+
+Switch to the integration branch
+
+Switches the worktree to the configured integration branch.
+Fails if no integration is configured, or if the integration
+branch has not yet been materialized (run 'gs integration
+rebuild' first).
+
+### git-spice integration rebuild {#gs-integration-rebuild}
+
+```
+gs integration (int) rebuild (rb) [flags]
+```
+
+Rebuild the integration branch
+
+Regenerates the integration branch by resetting it to trunk
+and sequentially merging each configured tip with --no-ff.
+Rerere is enabled for the duration of these merges so any
+recorded conflict resolutions are replayed automatically.
+
+On conflict, the merge is left in the worktree. Resolve the
+conflicting files, commit with 'git merge --continue', then
+re-run 'gs integration rebuild' (or 'gs intrb') to resume.
+
+**Flags**
+
+* `--push`: Also push the integration branch after rebuilding
+
+### git-spice integration submit {#gs-integration-submit}
+
+```
+gs integration (int) submit (s)
+```
+
+Push the integration branch to the remote
+
+Pushes the integration branch to the configured remote with
+--force-with-lease against the hash recorded at the previous
+successful push.
+
+No change request (PR) is opened: this command only pushes the
+branch. Once a manual submit succeeds, 'gs stack submit' and
+'gs upstack submit' will keep the published branch in sync with
+local rebuilds.
+
+### git-spice integration mark-pushed {#gs-integration-mark-pushed}
+
+```
+gs integration (int) mark-pushed [<hash>]
+```
+
+Record a hash as the integration branch's last-pushed value
+
+Records the given commit hash as the integration branch's
+last-pushed value in gs's local state. Does not push.
+
+Used to reconcile state after a manual git push of the
+integration branch, or after a "push rejected" error caused by
+a multi-checkout collision or a state reset.
+
+With no argument, the hash is discovered from the configured
+push remote. With an explicit hash, that hash is recorded
+verbatim.
+
+After 'gs integration mark-pushed', the next
+'gs integration submit' uses --force-with-lease against the
+recorded hash. If multiple checkouts are publishing this
+branch, this command will not save you from a collision; it
+just confirms which remote state you accept as your baseline
+before overwriting.
+
+**Arguments**
+
+* `hash`: Commit hash to record as last-pushed. If empty, fetches the configured push remote and uses its current tip.
+
+### git-spice integration tip add {#gs-integration-tip-add}
+
+```
+gs integration (int) tip add (a) <branches> ...
+```
+
+Add a branch to the integration tip list
+
+Adds one or more tracked branches to the integration tip list.
+Each branch must already be tracked by git-spice; this command
+does not track new branches.
+
+Branches are added in order. If one fails to add, the previous
+ones remain in the tip list.
+
+**Arguments**
+
+* `branches`: Branches to add as tips
+
+### git-spice integration tip remove {#gs-integration-tip-remove}
+
+```
+gs integration (int) tip remove (r,rm) <branches> ...
+```
+
+Remove a branch from the integration tip list
+
+**Arguments**
+
+* `branches`: Branches to remove from the tip list
+
+### git-spice integration tip list {#gs-integration-tip-list}
+
+```
+gs integration (int) tip list (l,ls)
+```
+
+List the configured integration tips
 
 ## Rebase
 

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -310,9 +310,11 @@ Before merging, the stack is checked for branches
 whose base PR was already merged on the forge.
 Use --no-branch-check to skip this validation.
 
-Before each merge, waits for CI checks to pass.
-Use --build-timeout to configure the maximum wait
-before failing if checks are not ready.
+Before each merge, waits for merge readiness:
+the forge must observe the pushed head
+and report that the CR is ready to merge.
+Use --ready-timeout to configure the maximum wait
+before failing if merge readiness is not reached.
 
 By default, a branch failure skips that branch's upstack descendants,
 but independent sibling branches continue.
@@ -321,12 +323,12 @@ Use --fail-fast to stop the queue after the first branch failure.
 **Flags**
 
 * `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
-* `--build-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.buildTimeout" }](/cli/config.md#spicemergebuildtimeout)): Max time to wait for CI checks before each merge. 0 means check once.
+* `--ready-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.readyTimeout" }](/cli/config.md#spicemergereadytimeout)): Max time to wait for merge readiness before each merge. 0 means check once.
 * `--no-branch-check`: Skip stale base validation before merging.
 * `--fail-fast`: Stop the merge queue after the first branch failure.
 * `--branch=NAME`: Branch whose stack to merge
 
-**Configuration**: [spice.merge.buildTimeout](/cli/config.md#spicemergebuildtimeout), [spice.merge.method](/cli/config.md#spicemergemethod)
+**Configuration**: [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
 
 ### git-spice stack restack {#gs-stack-restack}
 
@@ -624,7 +626,7 @@ This command acts as a local merge queue:
 it merges one Change Request,
 waits for that merge to finish,
 restacks and updates the next Change Request,
-waits for its CI checks to pass,
+waits for merge readiness on the updated Change Request,
 and then repeats the process.
 
 For a stack like this:
@@ -642,13 +644,15 @@ Before merging, the downstack is checked for branches
 whose base PR was already merged on the forge.
 Use --no-branch-check to skip this validation.
 
-Before each merge, waits for CI checks to pass.
-Use --build-timeout to configure the maximum wait
+Before each merge, waits for merge readiness:
+the forge must observe the pushed head
+and report that the CR is ready to merge.
+Use --ready-timeout to configure the maximum wait
 (default: 30m, 0 means fail immediately if not ready).
 
 Between merges, the command waits for each merge
 to complete, restacks and updates the next PR,
-waits for CI checks on the updated PR,
+waits for merge readiness on the updated PR,
 and syncs merged branch cleanup.
 
 Use --no-wait for single branch merging
@@ -658,12 +662,12 @@ when you don't want to wait for the merge to propagate.
 **Flags**
 
 * `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
-* `--build-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.buildTimeout" }](/cli/config.md#spicemergebuildtimeout)): Max time to wait for CI checks before each merge. 0 means check once.
+* `--ready-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.readyTimeout" }](/cli/config.md#spicemergereadytimeout)): Max time to wait for merge readiness before each merge. 0 means check once.
 * `--no-wait`: Skip polling for a single branch merge to propagate.
 * `--no-branch-check`: Skip stale base validation before merging.
 * `--branch=NAME`: Branch to start merging from
 
-**Configuration**: [spice.merge.buildTimeout](/cli/config.md#spicemergebuildtimeout), [spice.merge.method](/cli/config.md#spicemergemethod)
+**Configuration**: [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
 
 ### git-spice downstack edit {#gs-downstack-edit}
 
@@ -1133,16 +1137,18 @@ Use --branch to merge a different branch.
 The branch must be based directly on trunk.
 To merge a stacked branch, use 'gs downstack merge'.
 
-Before merging, waits for CI checks to pass.
-Use --build-timeout to configure the maximum wait.
+Before merging, waits for merge readiness:
+the forge must observe the pushed head
+and report that the CR is ready to merge.
+Use --ready-timeout to configure the maximum wait.
 
 **Flags**
 
 * `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
-* `--build-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.buildTimeout" }](/cli/config.md#spicemergebuildtimeout)): Max time to wait for CI checks before each merge. 0 means check once.
+* `--ready-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.readyTimeout" }](/cli/config.md#spicemergereadytimeout)): Max time to wait for merge readiness before each merge. 0 means check once.
 * `--branch=NAME`: Branch to merge
 
-**Configuration**: [spice.merge.buildTimeout](/cli/config.md#spicemergebuildtimeout), [spice.merge.method](/cli/config.md#spicemergemethod)
+**Configuration**: [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
 
 ### git-spice branch submit {#gs-branch-submit}
 

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -12,7 +12,7 @@ git-spice is a command line tool for stacking Git branches.
 * `-C`, `--dir=DIR`: Change to DIR before doing anything
 * `--[no-]prompt`: Whether to prompt for missing information
 
-**Configuration**: [spice.forge.bitbucket.apiURL](/cli/config.md#spiceforgebitbucketapiurl), [spice.forge.bitbucket.url](/cli/config.md#spiceforgebitbucketurl), [spice.forge.github.apiUrl](/cli/config.md#spiceforgegithubapiurl), [spice.forge.github.url](/cli/config.md#spiceforgegithuburl), [spice.forge.gitlab.apiURL](/cli/config.md#spiceforgegitlabapiurl), [spice.forge.gitlab.oauth.clientID](/cli/config.md#spiceforgegitlaboauthclientid), [spice.forge.gitlab.removeSourceBranch](/cli/config.md#spiceforgegitlabremovesourcebranch), [spice.forge.gitlab.url](/cli/config.md#spiceforgegitlaburl), [spice.git.indexLockTimeout](/cli/config.md#spicegitindexlocktimeout), [spice.secret.backend](/cli/config.md#spicesecretbackend)
+**Configuration**: [spice.forge.bitbucket.apiURL](/cli/config.md#spiceforgebitbucketapiurl), [spice.forge.bitbucket.url](/cli/config.md#spiceforgebitbucketurl), [spice.forge.github.apiUrl](/cli/config.md#spiceforgegithubapiurl), [spice.forge.github.url](/cli/config.md#spiceforgegithuburl), [spice.forge.gitlab.apiURL](/cli/config.md#spiceforgegitlabapiurl), [spice.forge.gitlab.oauth.clientID](/cli/config.md#spiceforgegitlaboauthclientid), [spice.forge.gitlab.removeSourceBranch](/cli/config.md#spiceforgegitlabremovesourcebranch), [spice.forge.gitlab.url](/cli/config.md#spiceforgegitlaburl), [spice.forge.kind](/cli/config.md#spiceforgekind), [spice.git.indexLockTimeout](/cli/config.md#spicegitindexlocktimeout), [spice.secret.backend](/cli/config.md#spicesecretbackend)
 
 ## Shell
 
@@ -156,11 +156,17 @@ The repository must have a remote associated for syncing.
 A prompt will ask for one if the repository
 was not initialized with a remote.
 
+Branches above merged and deleted branches
+are retargeted to the trunk branch.
+Run with --restack to also restack them and their upstacks.
+Run with --restack=aboves to only restack direct upstacks
+of deleted branches, leaving higher branches in place.
+
 **Flags**
 
-* `--restack`: Restack the current stack after syncing
+* `--restack` ([:material-wrench:{ .middle title="spice.repoSync.restack" }](/cli/config.md#spicereposyncrestack)): How to restack branches above deleted branches. One of 'none', 'aboves', and 'upstack'.
 
-**Configuration**: [spice.repoSync.closedChanges](/cli/config.md#spicereposyncclosedchanges)
+**Configuration**: [spice.repoSync.closedChanges](/cli/config.md#spicereposyncclosedchanges), [spice.repoSync.restack](/cli/config.md#spicereposyncrestack)
 
 ### git-spice repo restack {#gs-repo-restack}
 
@@ -278,7 +284,7 @@ only if there are multiple CRs in the stack.
 * `-a`, `--assign=ASSIGNEE,...`: Assign the change request to these users. Pass multiple times or separate with commas. <span class="mdx-badge"><span class="mdx-badge__icon">:material-tag:{ title="Released in version" }</span><span class="mdx-badge__text">[v0.21.0](/changelog.md#v0.21.0)</span>
 * `--no-web`: Alias for --web=false.
 
-**Configuration**: [spice.submit.assignees](/cli/config.md#spicesubmitassignees), [spice.submit.draft](/cli/config.md#spicesubmitdraft), [spice.submit.label](/cli/config.md#spicesubmitlabel), [spice.submit.label.addWhen](/cli/config.md#spicesubmitlabeladdwhen), [spice.submit.listTemplatesTimeout](/cli/config.md#spicesubmitlisttemplatestimeout), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.navigationComment.downstack](/cli/config.md#spicesubmitnavigationcommentdownstack), [spice.submit.navigationCommentStyle.marker](/cli/config.md#spicesubmitnavigationcommentstylemarker), [spice.submit.navigationCommentSync](/cli/config.md#spicesubmitnavigationcommentsync), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.reviewers](/cli/config.md#spicesubmitreviewers), [spice.submit.reviewers.addWhen](/cli/config.md#spicesubmitreviewersaddwhen), [spice.submit.skipRestackCheck](/cli/config.md#spicesubmitskiprestackcheck), [spice.submit.template](/cli/config.md#spicesubmittemplate), [spice.submit.updateOnly](/cli/config.md#spicesubmitupdateonly), [spice.submit.web](/cli/config.md#spicesubmitweb)
+**Configuration**: [spice.submit.assignees](/cli/config.md#spicesubmitassignees), [spice.submit.draft](/cli/config.md#spicesubmitdraft), [spice.submit.labels](/cli/config.md#spicesubmitlabels), [spice.submit.labels.addWhen](/cli/config.md#spicesubmitlabelsaddwhen), [spice.submit.listTemplatesTimeout](/cli/config.md#spicesubmitlisttemplatestimeout), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.navigationComment.downstack](/cli/config.md#spicesubmitnavigationcommentdownstack), [spice.submit.navigationCommentStyle.marker](/cli/config.md#spicesubmitnavigationcommentstylemarker), [spice.submit.navigationCommentSync](/cli/config.md#spicesubmitnavigationcommentsync), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.reviewers](/cli/config.md#spicesubmitreviewers), [spice.submit.reviewers.addWhen](/cli/config.md#spicesubmitreviewersaddwhen), [spice.submit.skipRestackCheck](/cli/config.md#spicesubmitskiprestackcheck), [spice.submit.template](/cli/config.md#spicesubmittemplate), [spice.submit.updateOnly](/cli/config.md#spicesubmitupdateonly), [spice.submit.web](/cli/config.md#spicesubmitweb)
 
 ### git-spice stack restack {#gs-stack-restack}
 
@@ -401,7 +407,7 @@ only if there are multiple CRs in the stack.
 * `--no-web`: Alias for --web=false.
 * `--branch=NAME`: Branch to start at
 
-**Configuration**: [spice.submit.assignees](/cli/config.md#spicesubmitassignees), [spice.submit.draft](/cli/config.md#spicesubmitdraft), [spice.submit.label](/cli/config.md#spicesubmitlabel), [spice.submit.label.addWhen](/cli/config.md#spicesubmitlabeladdwhen), [spice.submit.listTemplatesTimeout](/cli/config.md#spicesubmitlisttemplatestimeout), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.navigationComment.downstack](/cli/config.md#spicesubmitnavigationcommentdownstack), [spice.submit.navigationCommentStyle.marker](/cli/config.md#spicesubmitnavigationcommentstylemarker), [spice.submit.navigationCommentSync](/cli/config.md#spicesubmitnavigationcommentsync), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.reviewers](/cli/config.md#spicesubmitreviewers), [spice.submit.reviewers.addWhen](/cli/config.md#spicesubmitreviewersaddwhen), [spice.submit.skipRestackCheck](/cli/config.md#spicesubmitskiprestackcheck), [spice.submit.template](/cli/config.md#spicesubmittemplate), [spice.submit.updateOnly](/cli/config.md#spicesubmitupdateonly), [spice.submit.web](/cli/config.md#spicesubmitweb)
+**Configuration**: [spice.submit.assignees](/cli/config.md#spicesubmitassignees), [spice.submit.draft](/cli/config.md#spicesubmitdraft), [spice.submit.labels](/cli/config.md#spicesubmitlabels), [spice.submit.labels.addWhen](/cli/config.md#spicesubmitlabelsaddwhen), [spice.submit.listTemplatesTimeout](/cli/config.md#spicesubmitlisttemplatestimeout), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.navigationComment.downstack](/cli/config.md#spicesubmitnavigationcommentdownstack), [spice.submit.navigationCommentStyle.marker](/cli/config.md#spicesubmitnavigationcommentstylemarker), [spice.submit.navigationCommentSync](/cli/config.md#spicesubmitnavigationcommentsync), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.reviewers](/cli/config.md#spicesubmitreviewers), [spice.submit.reviewers.addWhen](/cli/config.md#spicesubmitreviewersaddwhen), [spice.submit.skipRestackCheck](/cli/config.md#spicesubmitskiprestackcheck), [spice.submit.template](/cli/config.md#spicesubmittemplate), [spice.submit.updateOnly](/cli/config.md#spicesubmitupdateonly), [spice.submit.web](/cli/config.md#spicesubmitweb)
 
 ### git-spice upstack restack {#gs-upstack-restack}
 
@@ -556,7 +562,66 @@ only if there are multiple CRs in the stack.
 * `--no-web`: Alias for --web=false.
 * `--branch=NAME`: Branch to start at
 
-**Configuration**: [spice.submit.assignees](/cli/config.md#spicesubmitassignees), [spice.submit.draft](/cli/config.md#spicesubmitdraft), [spice.submit.label](/cli/config.md#spicesubmitlabel), [spice.submit.label.addWhen](/cli/config.md#spicesubmitlabeladdwhen), [spice.submit.listTemplatesTimeout](/cli/config.md#spicesubmitlisttemplatestimeout), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.navigationComment.downstack](/cli/config.md#spicesubmitnavigationcommentdownstack), [spice.submit.navigationCommentStyle.marker](/cli/config.md#spicesubmitnavigationcommentstylemarker), [spice.submit.navigationCommentSync](/cli/config.md#spicesubmitnavigationcommentsync), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.reviewers](/cli/config.md#spicesubmitreviewers), [spice.submit.reviewers.addWhen](/cli/config.md#spicesubmitreviewersaddwhen), [spice.submit.skipRestackCheck](/cli/config.md#spicesubmitskiprestackcheck), [spice.submit.template](/cli/config.md#spicesubmittemplate), [spice.submit.updateOnly](/cli/config.md#spicesubmitupdateonly), [spice.submit.web](/cli/config.md#spicesubmitweb)
+**Configuration**: [spice.submit.assignees](/cli/config.md#spicesubmitassignees), [spice.submit.draft](/cli/config.md#spicesubmitdraft), [spice.submit.labels](/cli/config.md#spicesubmitlabels), [spice.submit.labels.addWhen](/cli/config.md#spicesubmitlabelsaddwhen), [spice.submit.listTemplatesTimeout](/cli/config.md#spicesubmitlisttemplatestimeout), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.navigationComment.downstack](/cli/config.md#spicesubmitnavigationcommentdownstack), [spice.submit.navigationCommentStyle.marker](/cli/config.md#spicesubmitnavigationcommentstylemarker), [spice.submit.navigationCommentSync](/cli/config.md#spicesubmitnavigationcommentsync), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.reviewers](/cli/config.md#spicesubmitreviewers), [spice.submit.reviewers.addWhen](/cli/config.md#spicesubmitreviewersaddwhen), [spice.submit.skipRestackCheck](/cli/config.md#spicesubmitskiprestackcheck), [spice.submit.template](/cli/config.md#spicesubmittemplate), [spice.submit.updateOnly](/cli/config.md#spicesubmitupdateonly), [spice.submit.web](/cli/config.md#spicesubmitweb)
+
+### git-spice downstack merge {#gs-downstack-merge}
+
+```
+gs downstack (ds) merge (m) [flags]
+```
+
+<span class="mdx-badge mdx-badge--experiment"><span class="mdx-badge__icon">:material-test-tube:{ title="Experimental" }</span><span class="mdx-badge__text">[merge](/cli/experiments.md#merge)</span></span>
+
+Merge a branch and those below it
+
+Merges the current branch and all branches below it
+into trunk via the forge API, bottom-up.
+Use --branch to start at a different branch.
+
+This command acts as a local merge queue:
+it merges one Change Request,
+waits for that merge to finish,
+restacks and updates the next Change Request,
+waits for its CI checks to pass,
+and then repeats the process.
+
+For a stack like this:
+
+    main <- feature1 <- feature2 <- feature3
+
+Running from feature3 merges in this order:
+
+    feature1, feature2, feature3
+
+Already-merged branches are skipped automatically.
+Branches must have an open Change Request to be merged.
+
+Before merging, the downstack is checked for branches
+whose base PR was already merged on the forge.
+Use --no-branch-check to skip this validation.
+
+Before each merge, waits for CI checks to pass.
+Use --build-timeout to configure the maximum wait
+(default: 30m, 0 means fail immediately if not ready).
+
+Between merges, the command waits for each merge
+to complete, restacks and updates the next PR,
+waits for CI checks on the updated PR,
+and syncs merged branch cleanup.
+
+Use --no-wait for single branch merging
+when you don't want to wait for the merge to propagate.
+--no-wait is rejected for multi-branch merges.
+
+**Flags**
+
+* `--branch=NAME`: Branch to start merging from
+* `--no-wait`: Skip polling for a single branch merge to propagate.
+* `--no-branch-check`: Skip stale base validation before merging.
+* `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
+* `--build-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.buildTimeout" }](/cli/config.md#spicemergebuildtimeout)): Max time to wait for CI checks before each merge. 0 means check once.
+
+**Configuration**: [spice.merge.buildTimeout](/cli/config.md#spicemergebuildtimeout), [spice.merge.method](/cli/config.md#spicemergemethod)
 
 ### git-spice downstack edit {#gs-downstack-edit}
 
@@ -764,9 +829,12 @@ gs branch (b) delete (d,rm) [<branches> ...] [flags]
 Delete branches
 
 The deleted branches and their commits are removed from the stack.
-Branches above the deleted branches are first rebased onto
+Branches above the deleted branches are retargeted onto
 the next branches available downstack,
 or onto trunk if there are no branches available below.
+
+Use --restack to rebase those branches and their upstacks
+immediately after retargeting.
 
 Without any arguments,
 a prompt will allow selecting the branch to delete.
@@ -782,8 +850,9 @@ Use --force to delete the branch regardless of unmerged changes.
 **Flags**
 
 * `--force`: Force deletion of the branch
+* `--restack` ([:material-wrench:{ .middle title="spice.branchDelete.restack" }](/cli/config.md#spicebranchdeleterestack)): How to restack branches above deleted branches. One of 'none', 'aboves', and 'upstack'.
 
-**Configuration**: [spice.branchPrompt.sort](/cli/config.md#spicebranchpromptsort)
+**Configuration**: [spice.branchDelete.restack](/cli/config.md#spicebranchdeleterestack), [spice.branchPrompt.sort](/cli/config.md#spicebranchpromptsort)
 
 ### git-spice branch fold {#gs-branch-fold}
 
@@ -953,8 +1022,11 @@ Commits of the current branch
 are transplanted onto another branch
 while leaving the rest of the stack intact.
 That is, branches above the current branch
-are first rebased onto its original base,
+are retargeted onto its original base,
 and then the current branch is moved onto the new base.
+
+Use --restack to rebase those branches and their upstacks
+immediately after retargeting.
 
 A prompt will allow selecting the new base for the branch.
 Provide an argument to skip the prompt.
@@ -980,8 +1052,9 @@ Use 'gs upstack onto' to also move the upstack branches.
 **Flags**
 
 * `--branch=NAME`: Branch to move
+* `--restack` ([:material-wrench:{ .middle title="spice.branchOnto.restack" }](/cli/config.md#spicebranchontorestack)): How to restack branches above the moved branch. One of 'none', 'aboves', and 'upstack'.
 
-**Configuration**: [spice.branchPrompt.sort](/cli/config.md#spicebranchpromptsort)
+**Configuration**: [spice.branchOnto.restack](/cli/config.md#spicebranchontorestack), [spice.branchPrompt.sort](/cli/config.md#spicebranchpromptsort)
 
 ### git-spice branch diff {#gs-branch-diff}
 
@@ -1055,7 +1128,7 @@ only if there are multiple CRs in the stack.
 * `--body=BODY`: Body of the change request
 * `--branch=NAME`: Branch to submit
 
-**Configuration**: [spice.submit.assignees](/cli/config.md#spicesubmitassignees), [spice.submit.draft](/cli/config.md#spicesubmitdraft), [spice.submit.label](/cli/config.md#spicesubmitlabel), [spice.submit.label.addWhen](/cli/config.md#spicesubmitlabeladdwhen), [spice.submit.listTemplatesTimeout](/cli/config.md#spicesubmitlisttemplatestimeout), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.navigationComment.downstack](/cli/config.md#spicesubmitnavigationcommentdownstack), [spice.submit.navigationCommentStyle.marker](/cli/config.md#spicesubmitnavigationcommentstylemarker), [spice.submit.navigationCommentSync](/cli/config.md#spicesubmitnavigationcommentsync), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.reviewers](/cli/config.md#spicesubmitreviewers), [spice.submit.reviewers.addWhen](/cli/config.md#spicesubmitreviewersaddwhen), [spice.submit.skipRestackCheck](/cli/config.md#spicesubmitskiprestackcheck), [spice.submit.template](/cli/config.md#spicesubmittemplate), [spice.submit.web](/cli/config.md#spicesubmitweb)
+**Configuration**: [spice.submit.assignees](/cli/config.md#spicesubmitassignees), [spice.submit.draft](/cli/config.md#spicesubmitdraft), [spice.submit.labels](/cli/config.md#spicesubmitlabels), [spice.submit.labels.addWhen](/cli/config.md#spicesubmitlabelsaddwhen), [spice.submit.listTemplatesTimeout](/cli/config.md#spicesubmitlisttemplatestimeout), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.navigationComment.downstack](/cli/config.md#spicesubmitnavigationcommentdownstack), [spice.submit.navigationCommentStyle.marker](/cli/config.md#spicesubmitnavigationcommentstylemarker), [spice.submit.navigationCommentSync](/cli/config.md#spicesubmitnavigationcommentsync), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.reviewers](/cli/config.md#spicesubmitreviewers), [spice.submit.reviewers.addWhen](/cli/config.md#spicesubmitreviewersaddwhen), [spice.submit.skipRestackCheck](/cli/config.md#spicesubmitskiprestackcheck), [spice.submit.template](/cli/config.md#spicesubmittemplate), [spice.submit.web](/cli/config.md#spicesubmitweb)
 
 ## Commit
 

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -286,6 +286,48 @@ only if there are multiple CRs in the stack.
 
 **Configuration**: [spice.submit.assignees](/cli/config.md#spicesubmitassignees), [spice.submit.draft](/cli/config.md#spicesubmitdraft), [spice.submit.labels](/cli/config.md#spicesubmitlabels), [spice.submit.labels.addWhen](/cli/config.md#spicesubmitlabelsaddwhen), [spice.submit.listTemplatesTimeout](/cli/config.md#spicesubmitlisttemplatestimeout), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.navigationComment.downstack](/cli/config.md#spicesubmitnavigationcommentdownstack), [spice.submit.navigationCommentStyle.marker](/cli/config.md#spicesubmitnavigationcommentstylemarker), [spice.submit.navigationCommentSync](/cli/config.md#spicesubmitnavigationcommentsync), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.reviewers](/cli/config.md#spicesubmitreviewers), [spice.submit.reviewers.addWhen](/cli/config.md#spicesubmitreviewersaddwhen), [spice.submit.skipRestackCheck](/cli/config.md#spicesubmitskiprestackcheck), [spice.submit.template](/cli/config.md#spicesubmittemplate), [spice.submit.updateOnly](/cli/config.md#spicesubmitupdateonly), [spice.submit.web](/cli/config.md#spicesubmitweb)
 
+### git-spice stack merge {#gs-stack-merge}
+
+```
+gs stack (s) merge (m) [flags]
+```
+
+<span class="mdx-badge mdx-badge--experiment"><span class="mdx-badge__icon">:material-test-tube:{ title="Experimental" }</span><span class="mdx-badge__text">[merge](/cli/experiments.md#merge)</span></span>
+
+Merge a stack
+
+Merges the CRs for the current branch's stack into trunk.
+Use --branch to merge a different branch's stack.
+
+The stack includes the selected branch,
+its downstack branches down to trunk,
+and every upstack branch.
+
+Already-merged branches are skipped automatically.
+Branches must have an open Change Request to be merged.
+
+Before merging, the stack is checked for branches
+whose base PR was already merged on the forge.
+Use --no-branch-check to skip this validation.
+
+Before each merge, waits for CI checks to pass.
+Use --build-timeout to configure the maximum wait
+before failing if checks are not ready.
+
+By default, a branch failure skips that branch's upstack descendants,
+but independent sibling branches continue.
+Use --fail-fast to stop the queue after the first branch failure.
+
+**Flags**
+
+* `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
+* `--build-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.buildTimeout" }](/cli/config.md#spicemergebuildtimeout)): Max time to wait for CI checks before each merge. 0 means check once.
+* `--no-branch-check`: Skip stale base validation before merging.
+* `--fail-fast`: Stop the merge queue after the first branch failure.
+* `--branch=NAME`: Branch whose stack to merge
+
+**Configuration**: [spice.merge.buildTimeout](/cli/config.md#spicemergebuildtimeout), [spice.merge.method](/cli/config.md#spicemergemethod)
+
 ### git-spice stack restack {#gs-stack-restack}
 
 ```
@@ -615,11 +657,11 @@ when you don't want to wait for the merge to propagate.
 
 **Flags**
 
-* `--branch=NAME`: Branch to start merging from
-* `--no-wait`: Skip polling for a single branch merge to propagate.
-* `--no-branch-check`: Skip stale base validation before merging.
 * `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
 * `--build-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.buildTimeout" }](/cli/config.md#spicemergebuildtimeout)): Max time to wait for CI checks before each merge. 0 means check once.
+* `--no-wait`: Skip polling for a single branch merge to propagate.
+* `--no-branch-check`: Skip stale base validation before merging.
+* `--branch=NAME`: Branch to start merging from
 
 **Configuration**: [spice.merge.buildTimeout](/cli/config.md#spicemergebuildtimeout), [spice.merge.method](/cli/config.md#spicemergemethod)
 
@@ -1074,6 +1116,33 @@ Use --branch to target a different branch.
 **Flags**
 
 * `--branch=NAME`: Branch to diff
+
+### git-spice branch merge {#gs-branch-merge}
+
+```
+gs branch (b) merge (m) [flags]
+```
+
+<span class="mdx-badge mdx-badge--experiment"><span class="mdx-badge__icon">:material-test-tube:{ title="Experimental" }</span><span class="mdx-badge__text">[merge](/cli/experiments.md#merge)</span></span>
+
+Merge a branch into trunk
+
+Merges the CR for the current branch into trunk.
+Use --branch to merge a different branch.
+
+The branch must be based directly on trunk.
+To merge a stacked branch, use 'gs downstack merge'.
+
+Before merging, waits for CI checks to pass.
+Use --build-timeout to configure the maximum wait.
+
+**Flags**
+
+* `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
+* `--build-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.buildTimeout" }](/cli/config.md#spicemergebuildtimeout)): Max time to wait for CI checks before each merge. 0 means check once.
+* `--branch=NAME`: Branch to merge
+
+**Configuration**: [spice.merge.buildTimeout](/cli/config.md#spicemergebuildtimeout), [spice.merge.method](/cli/config.md#spicemergemethod)
 
 ### git-spice branch submit {#gs-branch-submit}
 

--- a/doc/includes/cli-shorthands.md
+++ b/doc/includes/cli-shorthands.md
@@ -6,7 +6,6 @@
 | gs bdi | [gs branch diff](/cli/reference.md#gs-branch-diff) |
 | gs be | [gs branch edit](/cli/reference.md#gs-branch-edit) |
 | gs bfo | [gs branch fold](/cli/reference.md#gs-branch-fold) |
-| gs bm | [gs branch merge](/cli/reference.md#gs-branch-merge) |
 | gs bon | [gs branch onto](/cli/reference.md#gs-branch-onto) |
 | gs br | [gs branch restack](/cli/reference.md#gs-branch-restack) |
 | gs brn | [gs branch rename](/cli/reference.md#gs-branch-rename) |
@@ -21,10 +20,14 @@
 | gs cp | [gs commit pick](/cli/reference.md#gs-commit-pick) |
 | gs csp | [gs commit split](/cli/reference.md#gs-commit-split) |
 | gs dse | [gs downstack edit](/cli/reference.md#gs-downstack-edit) |
-| gs dsm | [gs downstack merge](/cli/reference.md#gs-downstack-merge) |
 | gs dsr | [gs downstack restack](/cli/reference.md#gs-downstack-restack) |
 | gs dss | [gs downstack submit](/cli/reference.md#gs-downstack-submit) |
 | gs dstr | [gs downstack track](/cli/reference.md#gs-downstack-track) |
+| gs intc | [gs integration create](/cli/reference.md#gs-integration-create) |
+| gs intco | [gs integration checkout](/cli/reference.md#gs-integration-checkout) |
+| gs intd | [gs integration delete](/cli/reference.md#gs-integration-delete) |
+| gs intrb | [gs integration rebuild](/cli/reference.md#gs-integration-rebuild) |
+| gs ints | [gs integration submit](/cli/reference.md#gs-integration-submit) |
 | gs ll | [gs log long](/cli/reference.md#gs-log-long) |
 | gs ls | [gs log short](/cli/reference.md#gs-log-short) |
 | gs rba | [gs rebase abort](/cli/reference.md#gs-rebase-abort) |
@@ -34,7 +37,6 @@
 | gs rs | [gs repo sync](/cli/reference.md#gs-repo-sync) |
 | gs sd | [gs stack delete](/cli/reference.md#gs-stack-delete) |
 | gs se | [gs stack edit](/cli/reference.md#gs-stack-edit) |
-| gs sm | [gs stack merge](/cli/reference.md#gs-stack-merge) |
 | gs sr | [gs stack restack](/cli/reference.md#gs-stack-restack) |
 | gs ss | [gs stack submit](/cli/reference.md#gs-stack-submit) |
 | gs usd | [gs upstack delete](/cli/reference.md#gs-upstack-delete) |

--- a/doc/includes/cli-shorthands.md
+++ b/doc/includes/cli-shorthands.md
@@ -6,6 +6,7 @@
 | gs bdi | [gs branch diff](/cli/reference.md#gs-branch-diff) |
 | gs be | [gs branch edit](/cli/reference.md#gs-branch-edit) |
 | gs bfo | [gs branch fold](/cli/reference.md#gs-branch-fold) |
+| gs bm | [gs branch merge](/cli/reference.md#gs-branch-merge) |
 | gs bon | [gs branch onto](/cli/reference.md#gs-branch-onto) |
 | gs br | [gs branch restack](/cli/reference.md#gs-branch-restack) |
 | gs brn | [gs branch rename](/cli/reference.md#gs-branch-rename) |
@@ -38,6 +39,7 @@
 | gs rs | [gs repo sync](/cli/reference.md#gs-repo-sync) |
 | gs sd | [gs stack delete](/cli/reference.md#gs-stack-delete) |
 | gs se | [gs stack edit](/cli/reference.md#gs-stack-edit) |
+| gs sm | [gs stack merge](/cli/reference.md#gs-stack-merge) |
 | gs sr | [gs stack restack](/cli/reference.md#gs-stack-restack) |
 | gs ss | [gs stack submit](/cli/reference.md#gs-stack-submit) |
 | gs usd | [gs upstack delete](/cli/reference.md#gs-upstack-delete) |

--- a/doc/includes/cli-shorthands.md
+++ b/doc/includes/cli-shorthands.md
@@ -20,6 +20,7 @@
 | gs cp | [gs commit pick](/cli/reference.md#gs-commit-pick) |
 | gs csp | [gs commit split](/cli/reference.md#gs-commit-split) |
 | gs dse | [gs downstack edit](/cli/reference.md#gs-downstack-edit) |
+| gs dsm | [gs downstack merge](/cli/reference.md#gs-downstack-merge) |
 | gs dsr | [gs downstack restack](/cli/reference.md#gs-downstack-restack) |
 | gs dss | [gs downstack submit](/cli/reference.md#gs-downstack-submit) |
 | gs dstr | [gs downstack track](/cli/reference.md#gs-downstack-track) |

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
     - guide/branch.md
     - guide/cr.md
     - guide/scripts.md
+    - guide/integration.md
     - guide/limits.md
     - guide/troubleshooting.md
     - guide/internals.md

--- a/doc/src/guide/integration.md
+++ b/doc/src/guide/integration.md
@@ -1,0 +1,110 @@
+---
+title: Integration branches
+icon: octicons/git-merge-16
+description: >-
+  Build a single branch that combines multiple stack tips
+  for testing or preview deploys.
+---
+
+# Integration branches
+
+<!-- gs:version unreleased -->
+
+An **integration branch** is a repo-scoped singleton that is rebuilt by
+sequentially merging the tips of multiple tracked branches onto trunk.
+It is intended for testing or preview builds that need to combine
+several otherwise-independent stacks.
+
+Integration branches are deliberately separate from regular stack
+branches:
+
+- They are never given a PR / change request.
+- They are invisible to `gs branch` commands.
+- They are regenerated, not edited: every rebuild force-overwrites the
+  branch.
+
+## Configuration
+
+Configure the singleton with $$gs integration create$$:
+
+```freeze language="terminal"
+{green}${reset} gs integration create preview --tip feat-a --tip feat-b
+```
+
+The branch name (`preview` above) must not equal trunk. Tips must be
+tracked branches; an untracked branch is rejected.
+
+Add or remove tips later with $$gs integration tip add$$ and
+$$gs integration tip remove$$.
+
+## Rebuilding
+
+Materialize or refresh the branch with $$gs integration rebuild$$:
+
+```freeze language="terminal"
+{green}${reset} gs integration rebuild
+```
+
+The worktree must be clean. Each tip is merged with `--no-ff`; `rerere`
+is enabled for these merges so any recorded conflict resolutions are
+replayed automatically. Rebuild can be invoked while the integration
+branch itself is checked out; when finished, the worktree remains on
+the integration branch.
+
+If a tip conflicts, the merge is left in the worktree for you to
+resolve. The conflicting paths are reported. To proceed:
+
+1. Resolve the conflicts.
+2. Stage the resolved files with `git add` and commit the merge with
+   `git merge --continue`.
+3. Re-run `gs integration rebuild` (or `gs intrb`). The rebuild
+   resumes from the next tip after the one you just merged. The
+   conflict resolution is also recorded by `rerere` so future
+   rebuilds skip it automatically.
+
+To bail out of the rebuild instead, run `git merge --abort`. The
+pending-rebuild state remains; clear it by re-configuring the
+integration with `gs integration delete` followed by `gs integration
+create`.
+
+## Switching to the integration branch
+
+Use $$gs integration checkout$$ (shorthand: `gs intco`) to switch the
+worktree to the integration branch:
+
+```freeze language="terminal"
+{green}${reset} gs intco
+```
+
+This fails if the branch has not yet been materialized; run
+$$gs integration rebuild$$ first.
+
+### Auto-rebuild
+
+After any `gs branch restack`, `gs upstack restack`, `gs stack restack`,
+or `gs repo restack`, the integration branch is automatically
+regenerated when at least one of its tips has moved. The auto-rebuild
+is silent when no tip has drifted.
+
+## Submitting
+
+Push the branch to the remote with $$gs integration submit$$:
+
+```freeze language="terminal"
+{green}${reset} gs integration submit
+```
+
+This pushes with `--force-with-lease` against the hash recorded at the
+last successful push. **No change request is created.**
+
+### Auto-submit
+
+Once the integration branch has been pushed manually at least once,
+subsequent `gs stack submit`, `gs upstack submit`, and
+`gs downstack submit` invocations will keep the published branch in
+sync by pushing the latest rebuild.
+
+## Removing the configuration
+
+Use $$gs integration delete$$ to remove the configuration. The
+underlying Git branch is not deleted.

--- a/integration.go
+++ b/integration.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"context"
+
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/handler/integration"
+)
+
+type integrationCmd struct {
+	Show       integrationShowCmd       `cmd:"" help:"Show the configured integration branch" default:"withargs"`
+	Create     integrationCreateCmd     `cmd:"" aliases:"c" help:"Configure the integration branch"`
+	Delete     integrationDeleteCmd     `cmd:"" aliases:"d,rm" help:"Remove the integration branch configuration"`
+	Checkout   integrationCheckoutCmd   `cmd:"" aliases:"co" help:"Switch to the integration branch"`
+	Rebuild    integrationRebuildCmd    `cmd:"" aliases:"rb" help:"Rebuild the integration branch"`
+	Submit     integrationSubmitCmd     `cmd:"" aliases:"s" help:"Push the integration branch to the remote"`
+	MarkPushed integrationMarkPushedCmd `cmd:"" name:"mark-pushed" help:"Record a hash as the integration branch's last-pushed value"`
+	Tip        integrationTipCmd        `cmd:"" help:"Manage the tips composing the integration branch"`
+}
+
+// IntegrationHandler implements integration branch operations.
+type IntegrationHandler interface {
+	Create(ctx context.Context, req *integration.CreateRequest) error
+	Delete(ctx context.Context) error
+	AddTip(ctx context.Context, branch string) error
+	RemoveTip(ctx context.Context, branch string) error
+	Show(ctx context.Context) (*integration.Status, error)
+	Checkout(ctx context.Context) error
+	Rebuild(ctx context.Context) (*integration.RebuildResult, error)
+	Submit(ctx context.Context) error
+	MarkPushed(ctx context.Context, hash git.Hash) error
+	MaybeRebuild(ctx context.Context) error
+	MaybeRebuildAndSubmit(ctx context.Context) error
+}
+
+var _ IntegrationHandler = (*integration.Handler)(nil)

--- a/integration_checkout.go
+++ b/integration_checkout.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+
+	"go.abhg.dev/gs/internal/silog"
+	"go.abhg.dev/gs/internal/text"
+)
+
+type integrationCheckoutCmd struct{}
+
+func (*integrationCheckoutCmd) Help() string {
+	return text.Dedent(`
+		Switches the worktree to the configured integration branch.
+		Fails if no integration is configured, or if the integration
+		branch has not yet been materialized (run 'gs integration
+		rebuild' first).
+	`)
+}
+
+func (cmd *integrationCheckoutCmd) Run(
+	ctx context.Context,
+	log *silog.Logger,
+	handler IntegrationHandler,
+) error {
+	if err := handler.Checkout(ctx); err != nil {
+		return err
+	}
+	log.Info("Switched to integration branch.")
+	return nil
+}

--- a/integration_create.go
+++ b/integration_create.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+
+	"go.abhg.dev/gs/internal/handler/integration"
+	"go.abhg.dev/gs/internal/silog"
+	"go.abhg.dev/gs/internal/text"
+)
+
+type integrationCreateCmd struct {
+	Upstream string   `name:"upstream" placeholder:"BRANCH" help:"Upstream branch name (defaults to local name)"`
+	Tips     []string `name:"tip" placeholder:"BRANCH" predictor:"trackedBranches" help:"Tip branches to include (repeat to add more)"`
+
+	Name string `arg:"" help:"Local name of the integration branch"`
+}
+
+func (*integrationCreateCmd) Help() string {
+	return text.Dedent(`
+		Configures the singleton integration branch for this repo.
+		The branch is materialized by sequentially merging each
+		tip onto trunk; it is never given a PR and is invisible to
+		'gs branch' commands.
+
+		Use 'gs integration tip add <branch>' to add tips later,
+		or pass --tip multiple times here.
+	`)
+}
+
+func (cmd *integrationCreateCmd) Run(
+	ctx context.Context,
+	log *silog.Logger,
+	handler IntegrationHandler,
+) error {
+	if err := handler.Create(ctx, &integration.CreateRequest{
+		Name:           cmd.Name,
+		UpstreamBranch: cmd.Upstream,
+		Tips:           cmd.Tips,
+	}); err != nil {
+		return err
+	}
+
+	log.Infof("Integration branch %q configured.", cmd.Name)
+	if len(cmd.Tips) == 0 {
+		log.Info("Add tips with 'gs integration tip add <branch>'.")
+	} else {
+		log.Info("Run 'gs integration rebuild' to materialize the branch.")
+	}
+	return nil
+}

--- a/integration_delete.go
+++ b/integration_delete.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+
+	"go.abhg.dev/gs/internal/silog"
+	"go.abhg.dev/gs/internal/text"
+)
+
+type integrationDeleteCmd struct{}
+
+func (*integrationDeleteCmd) Help() string {
+	return text.Dedent(`
+		Removes the integration branch configuration. The underlying
+		Git branch (if any) is not deleted; only the git-spice config
+		that drives auto-rebuild and submit is removed.
+	`)
+}
+
+func (cmd *integrationDeleteCmd) Run(
+	ctx context.Context,
+	log *silog.Logger,
+	handler IntegrationHandler,
+) error {
+	if err := handler.Delete(ctx); err != nil {
+		return err
+	}
+	log.Info("Integration branch configuration removed.")
+	return nil
+}

--- a/integration_mark_pushed.go
+++ b/integration_mark_pushed.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/silog"
+	"go.abhg.dev/gs/internal/text"
+)
+
+type integrationMarkPushedCmd struct {
+	Hash string `arg:"" optional:"" help:"Commit hash to record as last-pushed. If empty, fetches the configured push remote and uses its current tip."`
+}
+
+func (*integrationMarkPushedCmd) Help() string {
+	return text.Dedent(`
+		Records the given commit hash as the integration branch's
+		last-pushed value in gs's local state. Does not push.
+
+		Used to reconcile state after a manual git push of the
+		integration branch, or after a "push rejected" error caused by
+		a multi-checkout collision or a state reset.
+
+		With no argument, the hash is discovered from the configured
+		push remote. With an explicit hash, that hash is recorded
+		verbatim.
+
+		After 'gs integration mark-pushed', the next
+		'gs integration submit' uses --force-with-lease against the
+		recorded hash. If multiple checkouts are publishing this
+		branch, this command will not save you from a collision; it
+		just confirms which remote state you accept as your baseline
+		before overwriting.
+	`)
+}
+
+func (cmd *integrationMarkPushedCmd) Run(
+	ctx context.Context,
+	log *silog.Logger,
+	handler IntegrationHandler,
+) error {
+	if err := handler.MarkPushed(ctx, git.Hash(cmd.Hash)); err != nil {
+		return err
+	}
+	log.Info("Recorded integration branch last-pushed hash.")
+	return nil
+}

--- a/integration_rebuild.go
+++ b/integration_rebuild.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"go.abhg.dev/gs/internal/cli"
+	"go.abhg.dev/gs/internal/handler/integration"
+	"go.abhg.dev/gs/internal/silog"
+	"go.abhg.dev/gs/internal/text"
+)
+
+type integrationRebuildCmd struct {
+	Push bool `name:"push" help:"Also push the integration branch after rebuilding"`
+}
+
+func (*integrationRebuildCmd) Help() string {
+	return text.Dedent(`
+		Regenerates the integration branch by resetting it to trunk
+		and sequentially merging each configured tip with --no-ff.
+		Rerere is enabled for the duration of these merges so any
+		recorded conflict resolutions are replayed automatically.
+
+		On conflict, the merge is left in the worktree. Resolve the
+		conflicting files, commit with 'git merge --continue', then
+		re-run 'gs integration rebuild' (or 'gs intrb') to resume.
+	`)
+}
+
+func (cmd *integrationRebuildCmd) Run(
+	ctx context.Context,
+	log *silog.Logger,
+	handler IntegrationHandler,
+) error {
+	res, err := handler.Rebuild(ctx)
+	if err != nil {
+		conflict := new(integration.ConflictError)
+		if errors.As(err, &conflict) {
+			var b strings.Builder
+			b.WriteString("Merge conflict in tip ")
+			b.WriteString(conflict.Tip)
+			b.WriteString(":\n")
+			for _, p := range conflict.Paths {
+				b.WriteString("  - ")
+				b.WriteString(p)
+				b.WriteString("\n")
+			}
+			b.WriteString("Resolve the conflicts, then run:\n")
+			b.WriteString("  git merge --continue\n")
+			b.WriteString("Then resume the rebuild with:\n")
+			b.WriteString("  " + cli.Name() + " integration rebuild")
+			log.Error(b.String())
+			return err
+		}
+		return err
+	}
+	log.Infof("Integration branch %q rebuilt with %d tip(s).",
+		res.Name, len(res.TipHashes))
+
+	if cmd.Push {
+		if err := handler.Submit(ctx); err != nil {
+			return err
+		}
+		log.Infof("Integration branch %q pushed.", res.Name)
+	}
+	return nil
+}

--- a/integration_show.go
+++ b/integration_show.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/alecthomas/kong"
+	"go.abhg.dev/gs/internal/handler/integration"
+	"go.abhg.dev/gs/internal/silog"
+	"go.abhg.dev/gs/internal/text"
+)
+
+type integrationShowCmd struct{}
+
+func (*integrationShowCmd) Help() string {
+	return text.Dedent(`
+		Displays the configured integration branch and the tip branches
+		that compose it. For each tip, shows whether its hash has drifted
+		from the hash recorded at the last successful rebuild.
+	`)
+}
+
+func (cmd *integrationShowCmd) Run(
+	ctx context.Context,
+	kctx *kong.Context,
+	log *silog.Logger,
+	handler IntegrationHandler,
+) error {
+	stdout := kctx.Stdout
+	status, err := handler.Show(ctx)
+	if err != nil {
+		if errors.Is(err, integration.ErrNotConfigured) {
+			log.Info("No integration branch configured.")
+			log.Info("Run 'gs integration create <name>' to configure one.")
+			return nil
+		}
+		return err
+	}
+
+	fmt.Fprintf(stdout, "Integration branch: %s\n", status.Name)
+	if status.UpstreamBranch != "" && status.UpstreamBranch != status.Name {
+		fmt.Fprintf(stdout, "Upstream branch: %s\n", status.UpstreamBranch)
+	}
+	if status.LastPushedHash != "" {
+		fmt.Fprintf(stdout, "Last pushed: %s\n", status.LastPushedHash.Short())
+	}
+
+	if len(status.Tips) == 0 {
+		fmt.Fprintln(stdout, "No tips configured.")
+		return nil
+	}
+
+	fmt.Fprintln(stdout, "Tips:")
+	for _, tip := range status.Tips {
+		switch {
+		case tip.Missing:
+			fmt.Fprintf(stdout, "  - %s (missing)\n", tip.Name)
+		case tip.StoredHash == "":
+			fmt.Fprintf(stdout, "  - %s (pending rebuild)\n", tip.Name)
+		case tip.Drifted():
+			fmt.Fprintf(stdout, "  - %s (drifted: stored=%s current=%s)\n",
+				tip.Name, tip.StoredHash.Short(), tip.CurrentHash.Short())
+		default:
+			fmt.Fprintf(stdout, "  - %s (%s)\n", tip.Name, tip.StoredHash.Short())
+		}
+	}
+
+	return nil
+}

--- a/integration_submit.go
+++ b/integration_submit.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"go.abhg.dev/gs/internal/cli"
+	"go.abhg.dev/gs/internal/handler/integration"
+	"go.abhg.dev/gs/internal/silog"
+	"go.abhg.dev/gs/internal/text"
+)
+
+type integrationSubmitCmd struct{}
+
+func (*integrationSubmitCmd) Help() string {
+	return text.Dedent(`
+		Pushes the integration branch to the configured remote with
+		--force-with-lease against the hash recorded at the previous
+		successful push.
+
+		No change request (PR) is opened: this command only pushes the
+		branch. Once a manual submit succeeds, 'gs stack submit' and
+		'gs upstack submit' will keep the published branch in sync with
+		local rebuilds.
+	`)
+}
+
+func (cmd *integrationSubmitCmd) Run(
+	ctx context.Context,
+	log *silog.Logger,
+	handler IntegrationHandler,
+) error {
+	err := handler.Submit(ctx)
+	if err == nil {
+		log.Info("Integration branch pushed.")
+		return nil
+	}
+
+	var rejected *integration.PushRejectedError
+	if errors.As(err, &rejected) {
+		log.Error(formatPushRejected(rejected))
+		return err
+	}
+	return err
+}
+
+// formatPushRejected renders a multi-line explanation of a
+// [*integration.PushRejectedError] tailored for the user.
+func formatPushRejected(e *integration.PushRejectedError) string {
+	var b strings.Builder
+	b.WriteString("Cannot push integration branch:\n")
+	b.WriteString("  remote ")
+	b.WriteString(e.Remote)
+	b.WriteString("/")
+	b.WriteString(e.UpstreamBranch)
+	b.WriteString(" is at ")
+	b.WriteString(e.RemoteHash.Short())
+	b.WriteString("\n  local ")
+	b.WriteString(e.Branch)
+	b.WriteString(" would push ")
+	b.WriteString(e.LocalHash.Short())
+	b.WriteString("\n  no previously-pushed hash is recorded for this checkout\n\n")
+	b.WriteString("The integration branch is a local throwaway artifact; ")
+	b.WriteString("'git pull' is NOT the right move.\n\n")
+	b.WriteString("Likely causes:\n")
+	b.WriteString("  - You ran 'git push' directly, bypassing gs's tracking.\n")
+	b.WriteString("  - The same integration branch is being pushed from another checkout.\n")
+	b.WriteString("  - The spice state was reset (fresh clone, manual ref edit, rebuild).\n\n")
+	b.WriteString("To resolve, either accept the remote and overwrite on the next push:\n")
+	b.WriteString("  ")
+	b.WriteString(cli.Name())
+	b.WriteString(" integration mark-pushed\n")
+	b.WriteString("  ")
+	b.WriteString(cli.Name())
+	b.WriteString(" integration submit\n")
+	b.WriteString("Or start over locally:\n")
+	b.WriteString("  ")
+	b.WriteString(cli.Name())
+	b.WriteString(" integration delete\n")
+	b.WriteString("  ")
+	b.WriteString(cli.Name())
+	b.WriteString(" integration create ...\n\n")
+	b.WriteString("If multiple checkouts are publishing this branch, stop. ")
+	b.WriteString("It is inherently lossy.")
+	return b.String()
+}

--- a/integration_tip.go
+++ b/integration_tip.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/alecthomas/kong"
+	"go.abhg.dev/gs/internal/silog"
+	"go.abhg.dev/gs/internal/text"
+)
+
+type integrationTipCmd struct {
+	Add    integrationTipAddCmd    `cmd:"" aliases:"a" help:"Add a branch to the integration tip list"`
+	Remove integrationTipRemoveCmd `cmd:"" aliases:"r,rm" help:"Remove a branch from the integration tip list"`
+	List   integrationTipListCmd   `cmd:"" aliases:"l,ls" help:"List the configured integration tips"`
+}
+
+type integrationTipAddCmd struct {
+	Branches []string `arg:"" predictor:"trackedBranches" help:"Branches to add as tips"`
+}
+
+func (*integrationTipAddCmd) Help() string {
+	return text.Dedent(`
+		Adds one or more tracked branches to the integration tip list.
+		Each branch must already be tracked by git-spice; this command
+		does not track new branches.
+
+		Branches are added in order. If one fails to add, the previous
+		ones remain in the tip list.
+	`)
+}
+
+func (cmd *integrationTipAddCmd) Run(
+	ctx context.Context,
+	log *silog.Logger,
+	handler IntegrationHandler,
+) error {
+	for _, branch := range cmd.Branches {
+		if err := handler.AddTip(ctx, branch); err != nil {
+			return err
+		}
+		log.Infof("Added %q to integration tips.", branch)
+	}
+	return nil
+}
+
+type integrationTipRemoveCmd struct {
+	Branches []string `arg:"" predictor:"integrationTips" help:"Branches to remove from the tip list"`
+}
+
+func (cmd *integrationTipRemoveCmd) Run(
+	ctx context.Context,
+	log *silog.Logger,
+	handler IntegrationHandler,
+) error {
+	for _, branch := range cmd.Branches {
+		if err := handler.RemoveTip(ctx, branch); err != nil {
+			return err
+		}
+		log.Infof("Removed %q from integration tips.", branch)
+	}
+	return nil
+}
+
+type integrationTipListCmd struct{}
+
+func (cmd *integrationTipListCmd) Run(
+	ctx context.Context,
+	kctx *kong.Context,
+	handler IntegrationHandler,
+) error {
+	status, err := handler.Show(ctx)
+	if err != nil {
+		return err
+	}
+	for _, tip := range status.Tips {
+		fmt.Fprintln(kctx.Stdout, tip.Name)
+	}
+	return nil
+}

--- a/internal/handler/track/branch.go
+++ b/internal/handler/track/branch.go
@@ -35,6 +35,12 @@ func (h *Handler) TrackBranch(ctx context.Context, req *BranchRequest) error {
 		return fmt.Errorf("branch %q does not exist", req.Branch)
 	}
 
+	if info, err := store.Integration(ctx); err == nil && info.Name == req.Branch {
+		return fmt.Errorf("cannot track integration branch %q", req.Branch)
+	} else if err != nil && !errors.Is(err, state.ErrNotExist) {
+		return fmt.Errorf("check integration: %w", err)
+	}
+
 	if req.Base == "" {
 		log.Debugf("%v: looking for base branch", req.Branch)
 

--- a/internal/handler/track/branch_test.go
+++ b/internal/handler/track/branch_test.go
@@ -41,6 +41,29 @@ func TestHandler_TrackBranch(t *testing.T) {
 		assert.Contains(t, err.Error(), "cannot track trunk branch")
 	})
 
+	t.Run("CannotTrackIntegration", func(t *testing.T) {
+		log := silog.Nop()
+		store := statetest.NewMemoryStore(t, "main", "", log)
+		require.NoError(t, store.SetIntegration(t.Context(), &state.IntegrationInfo{
+			Name: "preview",
+		}))
+
+		ctrl := gomock.NewController(t)
+		handler := &Handler{
+			Log:        log,
+			Repository: NewMockGitRepository(ctrl),
+			Store:      store,
+			Service:    NewMockService(ctrl),
+			View:       ui.NewFileView(t.Output()),
+		}
+
+		err := handler.TrackBranch(t.Context(), &BranchRequest{
+			Branch: "preview",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "integration branch")
+	})
+
 	t.Run("BaseSpecified", func(t *testing.T) {
 		log := silog.Nop()
 		store := statetest.NewMemoryStore(t, "main", "", log)

--- a/internal/handler/track/handler.go
+++ b/internal/handler/track/handler.go
@@ -34,6 +34,10 @@ type Store interface {
 
 	// BeginBranchTx begins a transaction for modifying branch state.
 	BeginBranchTx() *state.BranchTx
+
+	// Integration returns the configured integration branch, or
+	// [state.ErrNotExist] if none is configured.
+	Integration(ctx context.Context) (*state.IntegrationInfo, error)
 }
 
 var _ Store = (*state.Store)(nil)

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	"go.abhg.dev/gs/internal/handler/checkout"
 	"go.abhg.dev/gs/internal/handler/cherrypick"
 	"go.abhg.dev/gs/internal/handler/delete"
+	"go.abhg.dev/gs/internal/handler/integration"
 	"go.abhg.dev/gs/internal/handler/merge"
 	"go.abhg.dev/gs/internal/handler/onto"
 	"go.abhg.dev/gs/internal/handler/restack"
@@ -201,6 +202,7 @@ func main() {
 		}),
 		komplete.WithPredictor("branches", komplete.PredictFunc(predictBranches)),
 		komplete.WithPredictor("trackedBranches", komplete.PredictFunc(predictTrackedBranches)),
+		komplete.WithPredictor("integrationTips", komplete.PredictFunc(predictIntegrationTips)),
 		komplete.WithPredictor("remotes", komplete.PredictFunc(predictRemotes)),
 		komplete.WithPredictor("dirs", komplete.PredictFunc(predictDirs)),
 		komplete.WithPredictor("forges", komplete.PredictFunc(predictForges(&forges))),
@@ -311,6 +313,8 @@ type mainCmd struct {
 
 	Branch branchCmd `cmd:"" aliases:"b" group:"Branch"`
 	Commit commitCmd `cmd:"" aliases:"c" group:"Commit"`
+
+	Integration integrationCmd `cmd:"" aliases:"int" group:"Integration"`
 
 	Rebase rebaseCmd `cmd:"" aliases:"rb" group:"Rebase"`
 
@@ -692,6 +696,21 @@ func (cmd *mainCmd) AfterApply(
 			view ui.View,
 		) (state.Remote, error) {
 			return ensureRemote(ctx, repo, store, log, view)
+		}),
+		kctx.BindSingletonProvider(func(
+			log *silog.Logger,
+			repo *git.Repository,
+			wt *git.Worktree,
+			store *state.Store,
+			svc *spice.Service,
+		) (IntegrationHandler, error) {
+			return &integration.Handler{
+				Log:        log,
+				Repository: repo,
+				Worktree:   wt,
+				Store:      store,
+				Service:    svc,
+			}, nil
 		}),
 	)
 }

--- a/shell_completion.go
+++ b/shell_completion.go
@@ -88,6 +88,32 @@ func predictTrackedBranches(_ komplete.Args) (predictions []string) {
 	return branches
 }
 
+func predictIntegrationTips(_ komplete.Args) (predictions []string) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	repo, err := git.Open(ctx, ".", git.OpenOptions{})
+	if err != nil {
+		return nil
+	}
+
+	db := newRepoStorage(repo, nil /* log */)
+	store, err := state.OpenStore(ctx, db, nil /* log */)
+	if err != nil {
+		return nil
+	}
+
+	info, err := store.Integration(ctx)
+	if err != nil {
+		return nil
+	}
+	for _, tip := range info.Tips {
+		predictions = append(predictions, tip.Name)
+	}
+	sort.Strings(predictions)
+	return predictions
+}
+
 func predictRemotes(_ komplete.Args) (predictions []string) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()

--- a/testdata/help/gs.txt
+++ b/testdata/help/gs.txt
@@ -40,6 +40,7 @@ Stack
   upstack (us) delete (d)       Delete all branches above the current branch
   downstack (ds) track (tr)     Track all untracked branches below a branch
   downstack (ds) submit (s)     Submit a branch and those below it
+  downstack (ds) merge (m)      Merge a branch and those below it
   downstack (ds) edit (e)       Edit the order of branches below a branch
   downstack (ds) restack (r)    Restack a branch and its downstack
 

--- a/testdata/help/gs.txt
+++ b/testdata/help/gs.txt
@@ -31,6 +31,7 @@ Log
 
 Stack
   stack (s) submit (s)          Submit a stack
+  stack (s) merge (m)           Merge a stack
   stack (s) restack (r)         Restack a stack
   stack (s) edit (e)            Edit the order of branches in a stack
   stack (s) delete (d)          Delete all branches in a stack
@@ -58,6 +59,7 @@ Branch
   branch (b) restack (r)       Restack a branch
   branch (b) onto (on)         Move a branch onto another branch
   branch (b) diff (di)         Show diff between a branch and its base
+  branch (b) merge (m)         Merge a branch into trunk
   branch (b) submit (s)        Submit a branch
 
 Commit

--- a/testdata/help/gs.txt
+++ b/testdata/help/gs.txt
@@ -31,7 +31,6 @@ Log
 
 Stack
   stack (s) submit (s)          Submit a stack
-  stack (s) merge (m)           Merge a stack
   stack (s) restack (r)         Restack a stack
   stack (s) edit (e)            Edit the order of branches in a stack
   stack (s) delete (d)          Delete all branches in a stack
@@ -41,7 +40,6 @@ Stack
   upstack (us) delete (d)       Delete all branches above the current branch
   downstack (ds) track (tr)     Track all untracked branches below a branch
   downstack (ds) submit (s)     Submit a branch and those below it
-  downstack (ds) merge (m)      Merge a branch and those below it
   downstack (ds) edit (e)       Edit the order of branches below a branch
   downstack (ds) restack (r)    Restack a branch and its downstack
 
@@ -59,7 +57,6 @@ Branch
   branch (b) restack (r)       Restack a branch
   branch (b) onto (on)         Move a branch onto another branch
   branch (b) diff (di)         Show diff between a branch and its base
-  branch (b) merge (m)         Merge a branch into trunk
   branch (b) submit (s)        Submit a branch
 
 Commit
@@ -68,6 +65,24 @@ Commit
   commit (c) split (sp)    Split the current commit
   commit (c) fixup (f)     Fixup a commit below the current commit
   commit (c) pick (p)      Cherry-pick a commit
+
+Integration
+  integration (int) show           Show the configured integration branch
+  integration (int) create (c)     Configure the integration branch
+  integration (int) delete (d,rm)
+                                   Remove the integration branch configuration
+  integration (int) checkout (co)
+                                   Switch to the integration branch
+  integration (int) rebuild (rb)
+                                   Rebuild the integration branch
+  integration (int) submit (s)     Push the integration branch to the remote
+  integration (int) mark-pushed    Record a hash as the integration branch's
+                                   last-pushed value
+  integration (int) tip add (a)    Add a branch to the integration tip list
+  integration (int) tip remove (r,rm)
+                                   Remove a branch from the integration tip list
+  integration (int) tip list (l,ls)
+                                   List the configured integration tips
 
 Rebase
   rebase (rb) continue (c)    Continue an interrupted operation

--- a/testdata/help/integration_checkout.txt
+++ b/testdata/help/integration_checkout.txt
@@ -1,0 +1,14 @@
+Usage: gs integration (int) checkout (co)
+
+Switch to the integration branch
+
+Switches the worktree to the configured integration branch. Fails if no
+integration is configured, or if the integration branch has not yet been
+materialized (run 'gs integration rebuild' first).
+
+Global Flags:
+  -h, --help           Show help for the command
+      --version        Print version information and quit
+  -v, --verbose        Enable verbose output ($GIT_SPICE_VERBOSE)
+  -C, --dir=DIR        Change to DIR before doing anything
+      --[no-]prompt    Whether to prompt for missing information

--- a/testdata/help/integration_create.txt
+++ b/testdata/help/integration_create.txt
@@ -1,0 +1,24 @@
+Usage: gs integration (int) create (c) <name> [flags]
+
+Configure the integration branch
+
+Configures the singleton integration branch for this repo. The branch is
+materialized by sequentially merging each tip onto trunk; it is never given a PR
+and is invisible to 'gs branch' commands.
+
+Use 'gs integration tip add <branch>' to add tips later, or pass --tip multiple
+times here.
+
+Arguments:
+  <name>    Local name of the integration branch
+
+Flags:
+  --upstream=BRANCH    Upstream branch name (defaults to local name)
+  --tip=BRANCH,...     Tip branches to include (repeat to add more)
+
+Global Flags:
+  -h, --help           Show help for the command
+      --version        Print version information and quit
+  -v, --verbose        Enable verbose output ($GIT_SPICE_VERBOSE)
+  -C, --dir=DIR        Change to DIR before doing anything
+      --[no-]prompt    Whether to prompt for missing information

--- a/testdata/help/integration_delete.txt
+++ b/testdata/help/integration_delete.txt
@@ -1,0 +1,14 @@
+Usage: gs integration (int) delete (d,rm)
+
+Remove the integration branch configuration
+
+Removes the integration branch configuration. The underlying Git branch (if any)
+is not deleted; only the git-spice config that drives auto-rebuild and submit is
+removed.
+
+Global Flags:
+  -h, --help           Show help for the command
+      --version        Print version information and quit
+  -v, --verbose        Enable verbose output ($GIT_SPICE_VERBOSE)
+  -C, --dir=DIR        Change to DIR before doing anything
+      --[no-]prompt    Whether to prompt for missing information

--- a/testdata/help/integration_mark-pushed.txt
+++ b/testdata/help/integration_mark-pushed.txt
@@ -1,0 +1,29 @@
+Usage: gs integration (int) mark-pushed [<hash>]
+
+Record a hash as the integration branch's last-pushed value
+
+Records the given commit hash as the integration branch's last-pushed value in
+gs's local state. Does not push.
+
+Used to reconcile state after a manual git push of the integration branch,
+or after a "push rejected" error caused by a multi-checkout collision or a state
+reset.
+
+With no argument, the hash is discovered from the configured push remote.
+With an explicit hash, that hash is recorded verbatim.
+
+After 'gs integration mark-pushed', the next 'gs integration submit' uses
+--force-with-lease against the recorded hash. If multiple checkouts are
+publishing this branch, this command will not save you from a collision; it just
+confirms which remote state you accept as your baseline before overwriting.
+
+Arguments:
+  [<hash>]    Commit hash to record as last-pushed. If empty, fetches the
+              configured push remote and uses its current tip.
+
+Global Flags:
+  -h, --help           Show help for the command
+      --version        Print version information and quit
+  -v, --verbose        Enable verbose output ($GIT_SPICE_VERBOSE)
+  -C, --dir=DIR        Change to DIR before doing anything
+      --[no-]prompt    Whether to prompt for missing information

--- a/testdata/help/integration_rebuild.txt
+++ b/testdata/help/integration_rebuild.txt
@@ -1,0 +1,21 @@
+Usage: gs integration (int) rebuild (rb) [flags]
+
+Rebuild the integration branch
+
+Regenerates the integration branch by resetting it to trunk and sequentially
+merging each configured tip with --no-ff. Rerere is enabled for the duration of
+these merges so any recorded conflict resolutions are replayed automatically.
+
+On conflict, the merge is left in the worktree. Resolve the conflicting files,
+commit with 'git merge --continue', then re-run 'gs integration rebuild' (or 'gs
+intrb') to resume.
+
+Flags:
+  --push    Also push the integration branch after rebuilding
+
+Global Flags:
+  -h, --help           Show help for the command
+      --version        Print version information and quit
+  -v, --verbose        Enable verbose output ($GIT_SPICE_VERBOSE)
+  -C, --dir=DIR        Change to DIR before doing anything
+      --[no-]prompt    Whether to prompt for missing information

--- a/testdata/help/integration_show.txt
+++ b/testdata/help/integration_show.txt
@@ -1,0 +1,14 @@
+Usage: gs integration (int) show
+
+Show the configured integration branch
+
+Displays the configured integration branch and the tip branches that compose it.
+For each tip, shows whether its hash has drifted from the hash recorded at the
+last successful rebuild.
+
+Global Flags:
+  -h, --help           Show help for the command
+      --version        Print version information and quit
+  -v, --verbose        Enable verbose output ($GIT_SPICE_VERBOSE)
+  -C, --dir=DIR        Change to DIR before doing anything
+      --[no-]prompt    Whether to prompt for missing information

--- a/testdata/help/integration_submit.txt
+++ b/testdata/help/integration_submit.txt
@@ -1,0 +1,17 @@
+Usage: gs integration (int) submit (s)
+
+Push the integration branch to the remote
+
+Pushes the integration branch to the configured remote with --force-with-lease
+against the hash recorded at the previous successful push.
+
+No change request (PR) is opened: this command only pushes the branch. Once a
+manual submit succeeds, 'gs stack submit' and 'gs upstack submit' will keep the
+published branch in sync with local rebuilds.
+
+Global Flags:
+  -h, --help           Show help for the command
+      --version        Print version information and quit
+  -v, --verbose        Enable verbose output ($GIT_SPICE_VERBOSE)
+  -C, --dir=DIR        Change to DIR before doing anything
+      --[no-]prompt    Whether to prompt for missing information

--- a/testdata/help/integration_tip_add.txt
+++ b/testdata/help/integration_tip_add.txt
@@ -1,0 +1,19 @@
+Usage: gs integration (int) tip add (a) <branches> ...
+
+Add a branch to the integration tip list
+
+Adds one or more tracked branches to the integration tip list. Each branch must
+already be tracked by git-spice; this command does not track new branches.
+
+Branches are added in order. If one fails to add, the previous ones remain in
+the tip list.
+
+Arguments:
+  <branches> ...    Branches to add as tips
+
+Global Flags:
+  -h, --help           Show help for the command
+      --version        Print version information and quit
+  -v, --verbose        Enable verbose output ($GIT_SPICE_VERBOSE)
+  -C, --dir=DIR        Change to DIR before doing anything
+      --[no-]prompt    Whether to prompt for missing information

--- a/testdata/help/integration_tip_list.txt
+++ b/testdata/help/integration_tip_list.txt
@@ -1,0 +1,10 @@
+Usage: gs integration (int) tip list (l,ls)
+
+List the configured integration tips
+
+Global Flags:
+  -h, --help           Show help for the command
+      --version        Print version information and quit
+  -v, --verbose        Enable verbose output ($GIT_SPICE_VERBOSE)
+  -C, --dir=DIR        Change to DIR before doing anything
+      --[no-]prompt    Whether to prompt for missing information

--- a/testdata/help/integration_tip_remove.txt
+++ b/testdata/help/integration_tip_remove.txt
@@ -1,0 +1,13 @@
+Usage: gs integration (int) tip remove (r,rm) <branches> ...
+
+Remove a branch from the integration tip list
+
+Arguments:
+  <branches> ...    Branches to remove from the tip list
+
+Global Flags:
+  -h, --help           Show help for the command
+      --version        Print version information and quit
+  -v, --verbose        Enable verbose output ($GIT_SPICE_VERBOSE)
+  -C, --dir=DIR        Change to DIR before doing anything
+      --[no-]prompt    Whether to prompt for missing information

--- a/testdata/script/integration_branch_cmds_excluded.txt
+++ b/testdata/script/integration_branch_cmds_excluded.txt
@@ -1,0 +1,32 @@
+# Verifies that the integration branch is invisible to 'gs branch'
+# commands: it is not tracked, and an attempt to track it is rejected.
+
+as 'Test <test@example.com>'
+at '2025-01-01T00:00:00Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git add feat-a.txt
+gs bc feat-a -m 'Add feat-a'
+
+git checkout main
+gs integration create preview --tip feat-a
+gs integration rebuild
+
+# 'gs ll' does not include preview.
+gs ls
+cmp stderr $WORK/golden/ls.txt
+
+# 'gs branch track preview' is rejected.
+git checkout preview
+! gs branch track preview
+stderr 'cannot track integration branch'
+
+-- repo/feat-a.txt --
+feature a
+-- golden/ls.txt --
+┏━□ feat-a
+main ◀

--- a/testdata/script/integration_checkout.txt
+++ b/testdata/script/integration_checkout.txt
@@ -1,0 +1,45 @@
+# Verifies 'gs integration checkout' (alias 'gs intco') switches to
+# the integration branch when configured and rebuilt.
+
+as 'Test <test@example.com>'
+at '2025-01-01T00:00:00Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git add feat-a.txt
+gs bc feat-a -m 'Add feat-a'
+
+git checkout main
+gs integration create preview --tip feat-a
+
+# Before rebuild: checkout fails because the branch doesn't exist yet.
+! gs integration checkout
+stderr 'does not exist'
+
+# Materialize the branch.
+gs integration rebuild
+
+# Now checkout succeeds.
+gs integration checkout
+stderr 'Switched to integration branch.'
+git symbolic-ref HEAD
+cmp stdout $WORK/golden/head.txt
+
+# The shorthand 'gs intco' also works.
+gs trunk
+gs intco
+git symbolic-ref HEAD
+cmp stdout $WORK/golden/head.txt
+
+# Checkout fails when no integration is configured.
+gs integration delete
+! gs integration checkout
+stderr 'no integration branch configured'
+
+-- repo/feat-a.txt --
+feature a
+-- golden/head.txt --
+refs/heads/preview

--- a/testdata/script/integration_conflict_sequential.txt
+++ b/testdata/script/integration_conflict_sequential.txt
@@ -1,0 +1,64 @@
+# Verifies the conflict-resolution workflow during integration rebuild:
+# the conflict is left in the worktree, pending state is saved, the
+# user resolves and commits via 'git merge --continue', and a follow-up
+# 'gs integration rebuild' picks up where it left off.
+
+as 'Test <test@example.com>'
+at '2025-01-01T00:00:00Z'
+
+cd repo
+git init
+git add shared.txt
+git commit -m 'Initial commit'
+gs repo init
+
+cp feat-a-version.txt shared.txt
+git add shared.txt
+gs bc feat-a -m 'feat-a changes shared.txt'
+
+git checkout main
+cp feat-b-version.txt shared.txt
+git add shared.txt
+gs bc feat-b -m 'feat-b changes shared.txt'
+
+# feat-c does not touch shared.txt so it cannot conflict.
+git checkout main
+git add feat-c.txt
+gs bc feat-c -m 'feat-c adds an unrelated file'
+
+git checkout main
+gs integration create preview --tip feat-a --tip feat-b --tip feat-c
+
+# First rebuild merges feat-a, then conflicts on feat-b.
+! gs integration rebuild
+stderr 'Merge conflict in tip feat-b'
+stderr 'git merge --continue'
+
+# The conflict is still in the worktree (not aborted).
+git status
+stdout 'You have unmerged paths'
+
+# Resolve the conflict and commit the merge.
+cp feat-b-version.txt shared.txt
+git add shared.txt
+git -c core.editor=true merge --continue
+
+# Now resume the rebuild — it should pick up feat-c.
+gs integration rebuild
+stderr 'Resuming integration rebuild'
+stderr 'rebuilt with 3 tip\(s\)'
+
+# preview branch now contains feat-c.txt
+git show preview:feat-c.txt
+cmp stdout $WORK/golden/feat-c.txt
+
+-- repo/shared.txt --
+base content
+-- repo/feat-a-version.txt --
+feat-a content
+-- repo/feat-b-version.txt --
+feat-b content
+-- repo/feat-c.txt --
+feat-c content
+-- golden/feat-c.txt --
+feat-c content

--- a/testdata/script/integration_create.txt
+++ b/testdata/script/integration_create.txt
@@ -1,0 +1,49 @@
+# Verifies basic 'gs integration create' wiring:
+# - Creates an integration branch configuration with two tips.
+# - 'gs integration show' reports the configuration.
+# - 'gs branch track' refuses the integration name.
+
+as 'Test <test@example.com>'
+at '2025-01-01T00:00:00Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git add feat-a.txt
+gs bc feat-a -m 'Add feat-a'
+
+git checkout main
+git add feat-b.txt
+gs bc feat-b -m 'Add feat-b'
+
+git checkout main
+gs integration create preview --tip feat-a --tip feat-b
+
+# Configuration is persisted.
+gs integration show
+cmp stdout $WORK/golden/show.txt
+
+# The integration branch is not tracked by 'gs branch checkout' / 'gs ll'.
+gs ls
+cmp stderr $WORK/golden/ls.txt
+
+# Trying to track the integration name as a branch is rejected.
+git checkout -b preview main
+! gs branch track preview
+stderr 'cannot track integration branch'
+
+-- repo/feat-a.txt --
+feature a
+-- repo/feat-b.txt --
+feature b
+-- golden/show.txt --
+Integration branch: preview
+Tips:
+  - feat-a (pending rebuild)
+  - feat-b (pending rebuild)
+-- golden/ls.txt --
+┏━□ feat-a
+┣━□ feat-b
+main ◀

--- a/testdata/script/integration_delete.txt
+++ b/testdata/script/integration_delete.txt
@@ -1,0 +1,37 @@
+# Verifies 'gs integration delete' removes the configuration without
+# affecting the underlying Git branch.
+
+as 'Test <test@example.com>'
+at '2025-01-01T00:00:00Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git add feat-a.txt
+gs bc feat-a -m 'Add feat-a'
+
+git checkout main
+gs integration create preview --tip feat-a
+gs integration rebuild
+
+# preview branch exists.
+git show-ref --verify refs/heads/preview
+
+gs integration delete
+stderr 'Integration branch configuration removed.'
+
+# 'gs integration show' now reports no configuration.
+gs integration show
+stderr 'No integration branch configured.'
+
+# The git branch itself is untouched.
+git show-ref --verify refs/heads/preview
+
+# Deleting when already not configured is rejected.
+! gs integration delete
+stderr 'no integration branch configured'
+
+-- repo/feat-a.txt --
+feature a

--- a/testdata/script/integration_rebuild.txt
+++ b/testdata/script/integration_rebuild.txt
@@ -1,0 +1,62 @@
+# Verifies that 'gs integration rebuild' materializes the integration
+# branch by sequentially merging tips onto trunk.
+
+as 'Test <test@example.com>'
+at '2025-01-01T00:00:00Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git add feat-a.txt
+gs bc feat-a -m 'Add feat-a'
+
+git checkout main
+git add feat-b.txt
+gs bc feat-b -m 'Add feat-b'
+
+git checkout main
+gs integration create preview --tip feat-a --tip feat-b
+gs integration rebuild
+
+# The preview branch now exists with both tips merged.
+git show-ref --verify refs/heads/preview
+
+git log --oneline preview
+cmp stdout $WORK/golden/log.txt
+
+# After rebuild, both tips are present.
+git show preview:feat-a.txt
+cmp stdout $WORK/golden/feat-a.txt
+git show preview:feat-b.txt
+cmp stdout $WORK/golden/feat-b.txt
+
+# Rebuild is idempotent: a second rebuild with no drift still succeeds.
+gs integration rebuild
+stderr 'Integration branch "preview" rebuilt with 2 tip\(s\).'
+
+# Rebuild also works when already checked out on the integration
+# branch. We stay on the integration branch when finished.
+gs integration checkout
+gs integration rebuild
+stderr 'Integration branch "preview" rebuilt with 2 tip\(s\).'
+git symbolic-ref HEAD
+cmp stdout $WORK/golden/head-preview.txt
+
+-- repo/feat-a.txt --
+feature a
+-- repo/feat-b.txt --
+feature b
+-- golden/feat-a.txt --
+feature a
+-- golden/feat-b.txt --
+feature b
+-- golden/log.txt --
+12332ca Merge feat-b into preview
+132effa Merge feat-a into preview
+6fc243e Add feat-b
+a044690 Initial commit
+b049cb7 Add feat-a
+-- golden/head-preview.txt --
+refs/heads/preview

--- a/testdata/script/integration_submit.txt
+++ b/testdata/script/integration_submit.txt
@@ -1,0 +1,48 @@
+# Verifies 'gs integration submit' pushes the branch without creating a
+# change request (PR).
+
+as 'Test <test@example.com>'
+at '2025-01-01T00:00:00Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+gs repo init
+
+git add feat-a.txt
+gs bc feat-a -m 'Add feat-a'
+
+git checkout main
+gs integration create preview --tip feat-a
+gs integration rebuild
+
+gs integration submit
+stderr 'Integration branch pushed.'
+
+# No CR (PR) was created.
+shamhub dump changes
+cmp stdout $WORK/golden/no-pulls.txt
+
+# Verify the branch appeared on the remote.
+cd ../
+git clone $SHAMHUB_URL/alice/example.git clone
+cd clone
+git branch -r
+cmp stdout $WORK/golden/remote-branches.txt
+
+-- repo/feat-a.txt --
+feature a
+-- golden/no-pulls.txt --
+[]
+-- golden/remote-branches.txt --
+  origin/HEAD -> origin/main
+  origin/main
+  origin/preview

--- a/testdata/script/integration_tip_add.txt
+++ b/testdata/script/integration_tip_add.txt
@@ -1,0 +1,63 @@
+# Verifies 'gs integration tip add/remove/list' behavior.
+
+as 'Test <test@example.com>'
+at '2025-01-01T00:00:00Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git add feat-a.txt
+gs bc feat-a -m 'Add feat-a'
+
+git checkout main
+git add feat-b.txt
+gs bc feat-b -m 'Add feat-b'
+
+git checkout main
+gs integration create preview
+
+# Initially: no tips.
+gs integration tip list
+cmp stdout $WORK/golden/empty.txt
+
+gs integration tip add feat-a feat-b
+gs integration tip list
+cmp stdout $WORK/golden/two-tips.txt
+
+# Adding the same tip twice is rejected.
+! gs integration tip add feat-a
+stderr 'already configured'
+
+# Adding trunk is rejected.
+! gs integration tip add main
+stderr 'must not equal trunk'
+
+# Adding the integration branch name is rejected.
+! gs integration tip add preview
+stderr 'must not equal integration'
+
+# Adding an untracked branch is rejected.
+! gs integration tip add nonexistent
+stderr 'not tracked'
+
+# Remove a tip.
+gs integration tip remove feat-a
+gs integration tip list
+cmp stdout $WORK/golden/one-tip.txt
+
+# Removing a tip that isn't configured is rejected.
+! gs integration tip remove feat-a
+stderr 'is not configured'
+
+-- repo/feat-a.txt --
+feature a
+-- repo/feat-b.txt --
+feature b
+-- golden/empty.txt --
+-- golden/two-tips.txt --
+feat-a
+feat-b
+-- golden/one-tip.txt --
+feat-b

--- a/testdata/script/integration_tip_rename.txt
+++ b/testdata/script/integration_tip_rename.txt
@@ -1,0 +1,29 @@
+# Verifies that renaming a tracked branch via 'gs branch rename' also
+# updates any integration tip that referenced the old name.
+
+as 'Test <test@example.com>'
+at '2025-01-01T00:00:00Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git add feat-a.txt
+gs bc feat-a -m 'Add feat-a'
+
+git checkout main
+gs integration create preview --tip feat-a
+
+# Rename the tip branch.
+gs branch checkout feat-a
+gs branch rename feat-a feat-a-renamed
+
+# Integration tip should now refer to the new name.
+gs integration tip list
+cmp stdout $WORK/golden/tips.txt
+
+-- repo/feat-a.txt --
+feature a
+-- golden/tips.txt --
+feat-a-renamed


### PR DESCRIPTION
Adds the gs integration command tree (alias gs int) backed by the
integration.Handler:

  - show: print configuration and per-tip drift (default subcommand)
  - create: configure the singleton integration branch
  - delete: clear the configuration (leaves the git branch alone)
  - checkout (alias gs intco): switch to the integration branch
  - rebuild: regenerate the branch; --push also submits
  - submit (alias gs ints): force-with-lease push, no PR created
  - tip add/remove/list: manage the tip set
    (add and remove accept multiple branches in one invocation)

A new IntegrationHandler interface in the root package exposes the
handler operations to subcommands and to forthcoming auto-rebuild
hooks. The Kong wiring includes a singleton provider and an
integrationTips completion predictor.

gs branch track now refuses the integration branch name. The
track.Store interface gains Integration(ctx) to support this; the real
state.Store already satisfies it.

End-to-end test scripts cover each command and the cross-cutting
behaviors:

  - integration_create
  - integration_checkout
  - integration_delete
  - integration_rebuild
  - integration_submit
  - integration_tip_add (with variadic args and error cases)
  - integration_tip_rename (gs branch rename rewrites integration tips)
  - integration_branch_cmds_excluded (gs ls hides, gs branch track refuses)
  - integration_conflict_sequential (conflict + git merge --continue +
    gs intrb resume)

Ships the user guide at doc/src/guide/integration.md (wired into
mkdocs nav), regenerated CLI reference, help fixtures, an Added
changelog entry, and the shorthand index.