### PR TITLE
submodule: auto-commit and gitlink update on parent commits

### DIFF
--- a/.changes/unreleased/Added-20260514-073615.yaml
+++ b/.changes/unreleased/Added-20260514-073615.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'submodule: ''gs cc'', ''gs bc -m'' auto-commit staged changes in tracked submodules (state 1) and update gitlinks in a single parent commit; ''gs ca'' does the same non-interactively, with --module-message=<path>=<msg> overriding the per-sub message.'
+time: 2026-05-14T07:36:15.953873-04:00

--- a/branch_create.go
+++ b/branch_create.go
@@ -8,6 +8,7 @@ import (
 
 	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/handler/submodule"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
@@ -32,8 +33,9 @@ type branchCreateCmd struct {
 	Message     string `short:"m" xor:"commit-message-source" placeholder:"MSG" help:"Commit message"`
 	MessageFile string `short:"F" xor:"commit-message-source" placeholder:"FILE" help:"Read the commit message from the given file."`
 
-	NoVerify bool `help:"Bypass pre-commit and commit-msg hooks."`
-	Signoff  bool `config:"commit.signoff" help:"Add Signed-off-by trailer to the commit message"`
+	NoVerify      bool              `help:"Bypass pre-commit and commit-msg hooks."`
+	Signoff       bool              `config:"commit.signoff" help:"Add Signed-off-by trailer to the commit message"`
+	ModuleMessage map[string]string `name:"module-message" placeholder:"PATH=MSG" help:"Per-submodule commit message override (repeatable)"`
 
 	Commit bool `negatable:"" default:"true" config:"branchCreate.commit" help:"Commit staged changes to the new branch, or create an empty commit"`
 }
@@ -105,6 +107,7 @@ func (cmd *branchCreateCmd) Run(
 	store *state.Store,
 	svc *spice.Service,
 	submoduleTracker SubmoduleTracker,
+	submoduleApplier SubmoduleApplier,
 	restackHandler RestackHandler,
 ) (err error) {
 	// If a message is specified, automatically enable commits
@@ -210,6 +213,20 @@ func (cmd *branchCreateCmd) Run(
 	)
 	branchAt := baseHash
 	if cmd.Commit {
+		// Run submodule-side commit/state checks against the parent
+		// branch (cmd.Target) before detaching HEAD — state 3 errors
+		// should fail loud before we touch the worktree.
+		if _, err := submoduleApplier.PreCommitSubmodules(ctx, cmd.Target, submodule.CommitModeCreate, submodule.CommitMessageSource{
+			Message:       cmd.Message,
+			MessageFile:   cmd.MessageFile,
+			ModuleMessage: cmd.ModuleMessage,
+			Signoff:       cmd.Signoff,
+			NoVerify:      cmd.NoVerify,
+			All:           cmd.All,
+		}); err != nil {
+			return fmt.Errorf("submodule pre-commit: %w", err)
+		}
+
 		commitHash, restore, err := cmd.commit(ctx, wt, baseName, log)
 		if err != nil {
 			return err

--- a/branch_submodule.go
+++ b/branch_submodule.go
@@ -16,9 +16,19 @@ type SubmoduleTracker interface {
 var _ SubmoduleTracker = (*submodule.Tracker)(nil)
 
 // SubmoduleApplier switches tracked submodules to the branches
-// recorded for a parent branch, transactionally.
+// recorded for a parent branch, transactionally, and coordinates
+// submodule-side commits at parent commit time.
 type SubmoduleApplier interface {
 	ApplyAssociations(ctx context.Context, parentBranch string) error
+	PreCommitSubmodules(
+		ctx context.Context,
+		parentBranch string,
+		mode submodule.CommitMode,
+		msg submodule.CommitMessageSource,
+	) (staged []string, err error)
+	PostAmendInteractiveSubmodules(
+		ctx context.Context, parentBranch string,
+	) (staged []string, err error)
 }
 
 var _ SubmoduleApplier = (*submodule.Applier)(nil)

--- a/commit_amend.go
+++ b/commit_amend.go
@@ -8,6 +8,7 @@ import (
 	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/handler/restack"
+	"go.abhg.dev/gs/internal/handler/submodule"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
@@ -23,9 +24,10 @@ type commitAmendCmd struct {
 	Message     string `short:"m" xor:"commit-message-source" placeholder:"MSG" help:"Use the given message as the commit message."`
 	MessageFile string `short:"F" xor:"commit-message-source" placeholder:"FILE" help:"Read the commit message from the given file."`
 
-	NoEdit   bool `help:"Don't edit the commit message"`
-	NoVerify bool `help:"Bypass pre-commit and commit-msg hooks."`
-	Signoff  bool `config:"commit.signoff" help:"Add Signed-off-by trailer to the commit message"`
+	NoEdit        bool              `help:"Don't edit the commit message"`
+	NoVerify      bool              `help:"Bypass pre-commit and commit-msg hooks."`
+	Signoff       bool              `config:"commit.signoff" help:"Add Signed-off-by trailer to the commit message"`
+	ModuleMessage map[string]string `name:"module-message" placeholder:"PATH=MSG" help:"Per-submodule commit message override (repeatable, non-interactive amend only)"`
 }
 
 func (*commitAmendCmd) Help() string {
@@ -62,6 +64,7 @@ func (cmd *commitAmendCmd) Run(
 	store *state.Store,
 	svc *spice.Service,
 	submoduleTracker SubmoduleTracker,
+	submoduleApplier SubmoduleApplier,
 	restackHandler RestackHandler,
 ) error {
 	var detachedHead bool
@@ -129,7 +132,7 @@ func (cmd *commitAmendCmd) Run(
 					MessageFile:        cmd.MessageFile,
 					Signoff:            cmd.Signoff,
 					Commit:             true,
-				}).Run(ctx, log, repo, wt, store, svc, submoduleTracker, restackHandler)
+				}).Run(ctx, log, repo, wt, store, svc, submoduleTracker, submoduleApplier, restackHandler)
 			}
 		}
 	}
@@ -219,6 +222,26 @@ func (cmd *commitAmendCmd) Run(
 		}
 	}
 
+	// Determine whether this is a non-interactive amend.
+	// Non-interactive: message is provided via -m/-F or --no-edit.
+	nonInteractive := cmd.Message != "" || cmd.MessageFile != "" || cmd.NoEdit
+
+	// Non-interactive: pre-commit sub work runs before the parent
+	// amend so the gitlinks land in a single resulting commit.
+	if nonInteractive && currentBranch != "" {
+		if _, err := submoduleApplier.PreCommitSubmodules(ctx, currentBranch, submodule.CommitModeAmend, submodule.CommitMessageSource{
+			Message:       cmd.Message,
+			MessageFile:   cmd.MessageFile,
+			NoEdit:        cmd.NoEdit,
+			ModuleMessage: cmd.ModuleMessage,
+			Signoff:       cmd.Signoff,
+			NoVerify:      cmd.NoVerify,
+			All:           cmd.All,
+		}); err != nil {
+			return fmt.Errorf("submodule pre-commit: %w", err)
+		}
+	}
+
 	if err := wt.Commit(ctx, git.CommitRequest{
 		Message:     cmd.Message,
 		MessageFile: cmd.MessageFile,
@@ -240,6 +263,26 @@ func (cmd *commitAmendCmd) Run(
 	if detachedHead {
 		log.Debug("HEAD is detached, skipping restack")
 		return nil
+	}
+
+	// Interactive amend (editor opened): handle the gitlink-only path
+	// after the user saved the editor. If any gitlinks were staged
+	// during this step, amend a second time with --no-edit to fold
+	// them in.
+	if !nonInteractive {
+		staged, err := submoduleApplier.PostAmendInteractiveSubmodules(ctx, currentBranch)
+		if err != nil {
+			return fmt.Errorf("submodule post-amend: %w", err)
+		}
+		if len(staged) > 0 {
+			if err := wt.Commit(ctx, git.CommitRequest{
+				Amend:    true,
+				NoEdit:   true,
+				NoVerify: cmd.NoVerify,
+			}); err != nil {
+				return fmt.Errorf("amend gitlinks: %w", err)
+			}
+		}
 	}
 
 	if err := submoduleTracker.RecordBranchState(

--- a/commit_create.go
+++ b/commit_create.go
@@ -8,18 +8,20 @@ import (
 	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/handler/restack"
+	"go.abhg.dev/gs/internal/handler/submodule"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/text"
 )
 
 type commitCreateCmd struct {
-	All         bool   `short:"a" help:"Stage all changes before committing."`
-	AllowEmpty  bool   `help:"Create a new commit even if it contains no changes."`
-	Fixup       string `help:"Create a fixup commit. See also 'git-spice commit fixup'." placeholder:"COMMIT"`
-	Message     string `short:"m" xor:"commit-message-source" placeholder:"MSG" help:"Use the given message as the commit message."`
-	MessageFile string `short:"F" xor:"commit-message-source" placeholder:"FILE" help:"Read the commit message from the given file."`
-	NoVerify    bool   `help:"Bypass pre-commit and commit-msg hooks."`
-	Signoff     bool   `config:"commit.signoff" help:"Add Signed-off-by trailer to the commit message"`
+	All           bool              `short:"a" help:"Stage all changes before committing."`
+	AllowEmpty    bool              `help:"Create a new commit even if it contains no changes."`
+	Fixup         string            `help:"Create a fixup commit. See also 'git-spice commit fixup'." placeholder:"COMMIT"`
+	Message       string            `short:"m" xor:"commit-message-source" placeholder:"MSG" help:"Use the given message as the commit message."`
+	MessageFile   string            `short:"F" xor:"commit-message-source" placeholder:"FILE" help:"Read the commit message from the given file."`
+	NoVerify      bool              `help:"Bypass pre-commit and commit-msg hooks."`
+	Signoff       bool              `config:"commit.signoff" help:"Add Signed-off-by trailer to the commit message"`
+	ModuleMessage map[string]string `name:"module-message" placeholder:"PATH=MSG" help:"Per-submodule commit message override (repeatable)"`
 }
 
 func (*commitCreateCmd) Help() string {
@@ -49,8 +51,29 @@ func (cmd *commitCreateCmd) Run(
 	log *silog.Logger,
 	wt *git.Worktree,
 	submoduleTracker SubmoduleTracker,
+	submoduleApplier SubmoduleApplier,
 	restackHandler RestackHandler,
 ) error {
+	// Pre-commit submodule work runs before the parent commit so the
+	// parent commit can include any updated gitlinks in a single commit.
+	// Fixup mode is treated like create (we just commit in subs; the
+	// recursive --fixup propagation is deferred).
+	if cmd.Fixup == "" {
+		currentForState, _ := wt.CurrentBranch(ctx)
+		if currentForState != "" {
+			if _, err := submoduleApplier.PreCommitSubmodules(ctx, currentForState, submodule.CommitModeCreate, submodule.CommitMessageSource{
+				Message:       cmd.Message,
+				MessageFile:   cmd.MessageFile,
+				ModuleMessage: cmd.ModuleMessage,
+				Signoff:       cmd.Signoff,
+				NoVerify:      cmd.NoVerify,
+				All:           cmd.All,
+			}); err != nil {
+				return fmt.Errorf("submodule pre-commit: %w", err)
+			}
+		}
+	}
+
 	if err := wt.Commit(ctx, git.CommitRequest{
 		Message:     cmd.Message,
 		MessageFile: cmd.MessageFile,

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -310,9 +310,11 @@ Before merging, the stack is checked for branches
 whose base PR was already merged on the forge.
 Use --no-branch-check to skip this validation.
 
-Before each merge, waits for CI checks to pass.
-Use --build-timeout to configure the maximum wait
-before failing if checks are not ready.
+Before each merge, waits for merge readiness:
+the forge must observe the pushed head
+and report that the CR is ready to merge.
+Use --ready-timeout to configure the maximum wait
+before failing if merge readiness is not reached.
 
 By default, a branch failure skips that branch's upstack descendants,
 but independent sibling branches continue.
@@ -321,12 +323,12 @@ Use --fail-fast to stop the queue after the first branch failure.
 **Flags**
 
 * `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
-* `--build-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.buildTimeout" }](/cli/config.md#spicemergebuildtimeout)): Max time to wait for CI checks before each merge. 0 means check once.
+* `--ready-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.readyTimeout" }](/cli/config.md#spicemergereadytimeout)): Max time to wait for merge readiness before each merge. 0 means check once.
 * `--no-branch-check`: Skip stale base validation before merging.
 * `--fail-fast`: Stop the merge queue after the first branch failure.
 * `--branch=NAME`: Branch whose stack to merge
 
-**Configuration**: [spice.merge.buildTimeout](/cli/config.md#spicemergebuildtimeout), [spice.merge.method](/cli/config.md#spicemergemethod)
+**Configuration**: [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
 
 ### git-spice stack restack {#gs-stack-restack}
 
@@ -624,7 +626,7 @@ This command acts as a local merge queue:
 it merges one Change Request,
 waits for that merge to finish,
 restacks and updates the next Change Request,
-waits for its CI checks to pass,
+waits for merge readiness on the updated Change Request,
 and then repeats the process.
 
 For a stack like this:
@@ -642,13 +644,15 @@ Before merging, the downstack is checked for branches
 whose base PR was already merged on the forge.
 Use --no-branch-check to skip this validation.
 
-Before each merge, waits for CI checks to pass.
-Use --build-timeout to configure the maximum wait
+Before each merge, waits for merge readiness:
+the forge must observe the pushed head
+and report that the CR is ready to merge.
+Use --ready-timeout to configure the maximum wait
 (default: 30m, 0 means fail immediately if not ready).
 
 Between merges, the command waits for each merge
 to complete, restacks and updates the next PR,
-waits for CI checks on the updated PR,
+waits for merge readiness on the updated PR,
 and syncs merged branch cleanup.
 
 Use --no-wait for single branch merging
@@ -658,12 +662,12 @@ when you don't want to wait for the merge to propagate.
 **Flags**
 
 * `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
-* `--build-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.buildTimeout" }](/cli/config.md#spicemergebuildtimeout)): Max time to wait for CI checks before each merge. 0 means check once.
+* `--ready-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.readyTimeout" }](/cli/config.md#spicemergereadytimeout)): Max time to wait for merge readiness before each merge. 0 means check once.
 * `--no-wait`: Skip polling for a single branch merge to propagate.
 * `--no-branch-check`: Skip stale base validation before merging.
 * `--branch=NAME`: Branch to start merging from
 
-**Configuration**: [spice.merge.buildTimeout](/cli/config.md#spicemergebuildtimeout), [spice.merge.method](/cli/config.md#spicemergemethod)
+**Configuration**: [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
 
 ### git-spice downstack edit {#gs-downstack-edit}
 
@@ -1135,16 +1139,18 @@ Use --branch to merge a different branch.
 The branch must be based directly on trunk.
 To merge a stacked branch, use 'gs downstack merge'.
 
-Before merging, waits for CI checks to pass.
-Use --build-timeout to configure the maximum wait.
+Before merging, waits for merge readiness:
+the forge must observe the pushed head
+and report that the CR is ready to merge.
+Use --ready-timeout to configure the maximum wait.
 
 **Flags**
 
 * `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
-* `--build-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.buildTimeout" }](/cli/config.md#spicemergebuildtimeout)): Max time to wait for CI checks before each merge. 0 means check once.
+* `--ready-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.readyTimeout" }](/cli/config.md#spicemergereadytimeout)): Max time to wait for merge readiness before each merge. 0 means check once.
 * `--branch=NAME`: Branch to merge
 
-**Configuration**: [spice.merge.buildTimeout](/cli/config.md#spicemergebuildtimeout), [spice.merge.method](/cli/config.md#spicemergemethod)
+**Configuration**: [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
 
 ### git-spice branch submit {#gs-branch-submit}
 

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -286,6 +286,48 @@ only if there are multiple CRs in the stack.
 
 **Configuration**: [spice.submit.assignees](/cli/config.md#spicesubmitassignees), [spice.submit.draft](/cli/config.md#spicesubmitdraft), [spice.submit.labels](/cli/config.md#spicesubmitlabels), [spice.submit.labels.addWhen](/cli/config.md#spicesubmitlabelsaddwhen), [spice.submit.listTemplatesTimeout](/cli/config.md#spicesubmitlisttemplatestimeout), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.navigationComment.downstack](/cli/config.md#spicesubmitnavigationcommentdownstack), [spice.submit.navigationCommentStyle.marker](/cli/config.md#spicesubmitnavigationcommentstylemarker), [spice.submit.navigationCommentSync](/cli/config.md#spicesubmitnavigationcommentsync), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.reviewers](/cli/config.md#spicesubmitreviewers), [spice.submit.reviewers.addWhen](/cli/config.md#spicesubmitreviewersaddwhen), [spice.submit.skipRestackCheck](/cli/config.md#spicesubmitskiprestackcheck), [spice.submit.template](/cli/config.md#spicesubmittemplate), [spice.submit.updateOnly](/cli/config.md#spicesubmitupdateonly), [spice.submit.web](/cli/config.md#spicesubmitweb)
 
+### git-spice stack merge {#gs-stack-merge}
+
+```
+gs stack (s) merge (m) [flags]
+```
+
+<span class="mdx-badge mdx-badge--experiment"><span class="mdx-badge__icon">:material-test-tube:{ title="Experimental" }</span><span class="mdx-badge__text">[merge](/cli/experiments.md#merge)</span></span>
+
+Merge a stack
+
+Merges the CRs for the current branch's stack into trunk.
+Use --branch to merge a different branch's stack.
+
+The stack includes the selected branch,
+its downstack branches down to trunk,
+and every upstack branch.
+
+Already-merged branches are skipped automatically.
+Branches must have an open Change Request to be merged.
+
+Before merging, the stack is checked for branches
+whose base PR was already merged on the forge.
+Use --no-branch-check to skip this validation.
+
+Before each merge, waits for CI checks to pass.
+Use --build-timeout to configure the maximum wait
+before failing if checks are not ready.
+
+By default, a branch failure skips that branch's upstack descendants,
+but independent sibling branches continue.
+Use --fail-fast to stop the queue after the first branch failure.
+
+**Flags**
+
+* `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
+* `--build-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.buildTimeout" }](/cli/config.md#spicemergebuildtimeout)): Max time to wait for CI checks before each merge. 0 means check once.
+* `--no-branch-check`: Skip stale base validation before merging.
+* `--fail-fast`: Stop the merge queue after the first branch failure.
+* `--branch=NAME`: Branch whose stack to merge
+
+**Configuration**: [spice.merge.buildTimeout](/cli/config.md#spicemergebuildtimeout), [spice.merge.method](/cli/config.md#spicemergemethod)
+
 ### git-spice stack restack {#gs-stack-restack}
 
 ```
@@ -615,11 +657,11 @@ when you don't want to wait for the merge to propagate.
 
 **Flags**
 
-* `--branch=NAME`: Branch to start merging from
-* `--no-wait`: Skip polling for a single branch merge to propagate.
-* `--no-branch-check`: Skip stale base validation before merging.
 * `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
 * `--build-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.buildTimeout" }](/cli/config.md#spicemergebuildtimeout)): Max time to wait for CI checks before each merge. 0 means check once.
+* `--no-wait`: Skip polling for a single branch merge to propagate.
+* `--no-branch-check`: Skip stale base validation before merging.
+* `--branch=NAME`: Branch to start merging from
 
 **Configuration**: [spice.merge.buildTimeout](/cli/config.md#spicemergebuildtimeout), [spice.merge.method](/cli/config.md#spicemergemethod)
 
@@ -1076,6 +1118,33 @@ Use --branch to target a different branch.
 **Flags**
 
 * `--branch=NAME`: Branch to diff
+
+### git-spice branch merge {#gs-branch-merge}
+
+```
+gs branch (b) merge (m) [flags]
+```
+
+<span class="mdx-badge mdx-badge--experiment"><span class="mdx-badge__icon">:material-test-tube:{ title="Experimental" }</span><span class="mdx-badge__text">[merge](/cli/experiments.md#merge)</span></span>
+
+Merge a branch into trunk
+
+Merges the CR for the current branch into trunk.
+Use --branch to merge a different branch.
+
+The branch must be based directly on trunk.
+To merge a stacked branch, use 'gs downstack merge'.
+
+Before merging, waits for CI checks to pass.
+Use --build-timeout to configure the maximum wait.
+
+**Flags**
+
+* `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
+* `--build-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.buildTimeout" }](/cli/config.md#spicemergebuildtimeout)): Max time to wait for CI checks before each merge. 0 means check once.
+* `--branch=NAME`: Branch to merge
+
+**Configuration**: [spice.merge.buildTimeout](/cli/config.md#spicemergebuildtimeout), [spice.merge.method](/cli/config.md#spicemergemethod)
 
 ### git-spice branch submit {#gs-branch-submit}
 

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -286,48 +286,6 @@ only if there are multiple CRs in the stack.
 
 **Configuration**: [spice.submit.assignees](/cli/config.md#spicesubmitassignees), [spice.submit.draft](/cli/config.md#spicesubmitdraft), [spice.submit.labels](/cli/config.md#spicesubmitlabels), [spice.submit.labels.addWhen](/cli/config.md#spicesubmitlabelsaddwhen), [spice.submit.listTemplatesTimeout](/cli/config.md#spicesubmitlisttemplatestimeout), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.navigationComment.downstack](/cli/config.md#spicesubmitnavigationcommentdownstack), [spice.submit.navigationCommentStyle.marker](/cli/config.md#spicesubmitnavigationcommentstylemarker), [spice.submit.navigationCommentSync](/cli/config.md#spicesubmitnavigationcommentsync), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.reviewers](/cli/config.md#spicesubmitreviewers), [spice.submit.reviewers.addWhen](/cli/config.md#spicesubmitreviewersaddwhen), [spice.submit.skipRestackCheck](/cli/config.md#spicesubmitskiprestackcheck), [spice.submit.template](/cli/config.md#spicesubmittemplate), [spice.submit.updateOnly](/cli/config.md#spicesubmitupdateonly), [spice.submit.web](/cli/config.md#spicesubmitweb)
 
-### git-spice stack merge {#gs-stack-merge}
-
-```
-gs stack (s) merge (m) [flags]
-```
-
-<span class="mdx-badge mdx-badge--experiment"><span class="mdx-badge__icon">:material-test-tube:{ title="Experimental" }</span><span class="mdx-badge__text">[merge](/cli/experiments.md#merge)</span></span>
-
-Merge a stack
-
-Merges the CRs for the current branch's stack into trunk.
-Use --branch to merge a different branch's stack.
-
-The stack includes the selected branch,
-its downstack branches down to trunk,
-and every upstack branch.
-
-Already-merged branches are skipped automatically.
-Branches must have an open Change Request to be merged.
-
-Before merging, the stack is checked for branches
-whose base PR was already merged on the forge.
-Use --no-branch-check to skip this validation.
-
-Before each merge, waits for CI checks to pass.
-Use --build-timeout to configure the maximum wait
-before failing if checks are not ready.
-
-By default, a branch failure skips that branch's upstack descendants,
-but independent sibling branches continue.
-Use --fail-fast to stop the queue after the first branch failure.
-
-**Flags**
-
-* `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
-* `--build-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.buildTimeout" }](/cli/config.md#spicemergebuildtimeout)): Max time to wait for CI checks before each merge. 0 means check once.
-* `--no-branch-check`: Skip stale base validation before merging.
-* `--fail-fast`: Stop the merge queue after the first branch failure.
-* `--branch=NAME`: Branch whose stack to merge
-
-**Configuration**: [spice.merge.buildTimeout](/cli/config.md#spicemergebuildtimeout), [spice.merge.method](/cli/config.md#spicemergemethod)
-
 ### git-spice stack restack {#gs-stack-restack}
 
 ```
@@ -657,11 +615,11 @@ when you don't want to wait for the merge to propagate.
 
 **Flags**
 
-* `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
-* `--build-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.buildTimeout" }](/cli/config.md#spicemergebuildtimeout)): Max time to wait for CI checks before each merge. 0 means check once.
+* `--branch=NAME`: Branch to start merging from
 * `--no-wait`: Skip polling for a single branch merge to propagate.
 * `--no-branch-check`: Skip stale base validation before merging.
-* `--branch=NAME`: Branch to start merging from
+* `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
+* `--build-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.buildTimeout" }](/cli/config.md#spicemergebuildtimeout)): Max time to wait for CI checks before each merge. 0 means check once.
 
 **Configuration**: [spice.merge.buildTimeout](/cli/config.md#spicemergebuildtimeout), [spice.merge.method](/cli/config.md#spicemergemethod)
 
@@ -858,6 +816,7 @@ target (A) to the specified branch:
 * `-F`, `--message-file=FILE`: Read the commit message from the given file.
 * `--no-verify`: Bypass pre-commit and commit-msg hooks.
 * `--signoff` ([:material-wrench:{ .middle title="spice.commit.signoff" }](/cli/config.md#spicecommitsignoff)): Add Signed-off-by trailer to the commit message
+* `--module-message=PATH=MSG`: Per-submodule commit message override (repeatable)
 * `--[no-]commit` ([:material-wrench:{ .middle title="spice.branchCreate.commit" }](/cli/config.md#spicebranchcreatecommit)): Commit staged changes to the new branch, or create an empty commit
 
 **Configuration**: [spice.branchCreate.commit](/cli/config.md#spicebranchcreatecommit), [spice.branchCreate.generatedBranchNameLimit](/cli/config.md#spicebranchcreategeneratedbranchnamelimit), [spice.branchCreate.prefix](/cli/config.md#spicebranchcreateprefix), [spice.commit.signoff](/cli/config.md#spicecommitsignoff)
@@ -1118,33 +1077,6 @@ Use --branch to target a different branch.
 
 * `--branch=NAME`: Branch to diff
 
-### git-spice branch merge {#gs-branch-merge}
-
-```
-gs branch (b) merge (m) [flags]
-```
-
-<span class="mdx-badge mdx-badge--experiment"><span class="mdx-badge__icon">:material-test-tube:{ title="Experimental" }</span><span class="mdx-badge__text">[merge](/cli/experiments.md#merge)</span></span>
-
-Merge a branch into trunk
-
-Merges the CR for the current branch into trunk.
-Use --branch to merge a different branch.
-
-The branch must be based directly on trunk.
-To merge a stacked branch, use 'gs downstack merge'.
-
-Before merging, waits for CI checks to pass.
-Use --build-timeout to configure the maximum wait.
-
-**Flags**
-
-* `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
-* `--build-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.buildTimeout" }](/cli/config.md#spicemergebuildtimeout)): Max time to wait for CI checks before each merge. 0 means check once.
-* `--branch=NAME`: Branch to merge
-
-**Configuration**: [spice.merge.buildTimeout](/cli/config.md#spicemergebuildtimeout), [spice.merge.method](/cli/config.md#spicemergemethod)
-
 ### git-spice branch submit {#gs-branch-submit}
 
 ```
@@ -1275,6 +1207,7 @@ when you want to apply changes to an older commit.
 * `-F`, `--message-file=FILE`: Read the commit message from the given file.
 * `--no-verify`: Bypass pre-commit and commit-msg hooks.
 * `--signoff` ([:material-wrench:{ .middle title="spice.commit.signoff" }](/cli/config.md#spicecommitsignoff)): Add Signed-off-by trailer to the commit message
+* `--module-message=PATH=MSG`: Per-submodule commit message override (repeatable)
 
 **Configuration**: [spice.commit.signoff](/cli/config.md#spicecommitsignoff)
 
@@ -1315,6 +1248,7 @@ The --no-prompt flag can be used to skip this prompt in scripts.
 * `--no-edit`: Don't edit the commit message
 * `--no-verify`: Bypass pre-commit and commit-msg hooks.
 * `--signoff` ([:material-wrench:{ .middle title="spice.commit.signoff" }](/cli/config.md#spicecommitsignoff)): Add Signed-off-by trailer to the commit message
+* `--module-message=PATH=MSG`: Per-submodule commit message override (repeatable, non-interactive amend only)
 
 **Configuration**: [spice.branchCreate.generatedBranchNameLimit](/cli/config.md#spicebranchcreategeneratedbranchnamelimit), [spice.branchCreate.prefix](/cli/config.md#spicebranchcreateprefix), [spice.commit.signoff](/cli/config.md#spicecommitsignoff)
 

--- a/internal/git/submodule.go
+++ b/internal/git/submodule.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+
+	"go.abhg.dev/gs/internal/xec"
 )
 
 // Submodule describes a git submodule
@@ -253,6 +255,34 @@ func (w *Worktree) SubmoduleHasGsStore(
 		return false, nil //nolint:nilerr
 	}
 	return true, nil
+}
+
+// AddUpdate stages updates to all tracked files in the worktree
+// (`git add -u`). Untracked files are not affected.
+func (w *Worktree) AddUpdate(ctx context.Context) error {
+	if err := w.gitCmd(ctx, "add", "-u").Run(); err != nil {
+		return fmt.Errorf("git add -u: %w", err)
+	}
+	return nil
+}
+
+// HasStagedChanges reports whether the worktree's index differs
+// from HEAD (i.e., there is staged content waiting to be committed).
+func (w *Worktree) HasStagedChanges(ctx context.Context) (bool, error) {
+	// `git diff --cached --quiet` exits 0 when there are no staged
+	// changes, 1 when there are, and other non-zero values on error.
+	err := w.gitCmd(ctx,
+		"diff", "--cached", "--quiet",
+	).Run()
+	if err == nil {
+		return false, nil
+	}
+	// Exit code 1 means "differences present" — not an error.
+	var exitErr *xec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return true, nil
+	}
+	return false, fmt.Errorf("git diff --cached: %w", err)
 }
 
 // HeadSnapshot captures the HEAD state of a worktree

--- a/internal/handler/submodule/applier.go
+++ b/internal/handler/submodule/applier.go
@@ -16,7 +16,9 @@ import (
 type ApplierGitWorktree interface {
 	Submodules(ctx context.Context) ([]git.Submodule, error)
 	SubmoduleStatus(ctx context.Context, path string) (*git.SubmoduleStatus, error)
+	SubmoduleHead(ctx context.Context, path string) (git.Hash, error)
 	SubmoduleWorktree(ctx context.Context, path string) (*git.Worktree, error)
+	UpdateSubmodulePointer(ctx context.Context, path string, hash git.Hash) error
 }
 
 var _ ApplierGitWorktree = (*git.Worktree)(nil)

--- a/internal/handler/submodule/commit.go
+++ b/internal/handler/submodule/commit.go
@@ -1,0 +1,286 @@
+package submodule
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/spice/state"
+)
+
+// CommitMode selects which submodule-side commit operation to run
+// for staged content in a tracked sub.
+type CommitMode int
+
+const (
+	// CommitModeCreate makes a new commit in the sub (matches `gs cc`).
+	CommitModeCreate CommitMode = iota
+	// CommitModeAmend amends the sub's HEAD commit (matches non-interactive `gs ca`).
+	CommitModeAmend
+)
+
+// CommitMessageSource bundles the inputs that determine the commit
+// message and behavior for both parent and submodule commits.
+type CommitMessageSource struct {
+	Message       string
+	MessageFile   string
+	NoEdit        bool // amend only
+	ModuleMessage map[string]string
+	Signoff       bool
+	NoVerify      bool
+	All           bool
+}
+
+// PreCommitSubmodules performs submodule-side commit operations and
+// stages gitlink updates in the parent so a subsequent parent commit
+// reflects sub state changes in a single commit.
+//
+// For each tracked submodule on parentBranch, it applies the three-
+// state model documented in the plan:
+//
+//	State 1: sub has staged content + is on the recorded branch
+//	    → auto-commit (or amend) in sub; stage new gitlink in parent.
+//	State 2: sub has no staged content
+//	    → if sub HEAD moved past the gitlink in parent's HEAD,
+//	      stage the new gitlink. Otherwise no-op.
+//	State 3: sub has staged content but is on a different branch
+//	    → return DivergedFromRecordError before any work.
+//
+// Returns the list of sub paths whose gitlink was staged.
+func (a *Applier) PreCommitSubmodules(
+	ctx context.Context,
+	parentBranch string,
+	mode CommitMode,
+	msg CommitMessageSource,
+) (staged []string, err error) {
+	resp, err := a.Store.LookupBranch(ctx, parentBranch)
+	if err != nil {
+		// Not tracked yet — nothing to do.
+		if isErrNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf(
+			"lookup branch %s: %w", parentBranch, err,
+		)
+	}
+	if len(resp.Submodules) == 0 {
+		return nil, nil
+	}
+
+	paths := make([]string, 0, len(resp.Submodules))
+	for p := range resp.Submodules {
+		if a.isExcluded(p) {
+			continue
+		}
+		paths = append(paths, p)
+	}
+	slices.Sort(paths)
+
+	// First pass: state checks; bail before mutating anything on
+	// state-3 errors so the parent commit doesn't run with a
+	// half-applied submodule state.
+	type plan struct {
+		path         string
+		recorded     string
+		status       *git.SubmoduleStatus
+		hasStaged    bool
+		shouldCommit bool
+	}
+	var todo []plan
+	for _, p := range paths {
+		recorded := resp.Submodules[p]
+		subWt, err := a.Worktree.SubmoduleWorktree(ctx, p)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"submodule %s: open worktree: %w", p, err,
+			)
+		}
+
+		// -a flag: stage tracked-and-modified files inside the sub.
+		if msg.All {
+			if err := subWt.AddUpdate(ctx); err != nil {
+				return nil, fmt.Errorf(
+					"submodule %s: git add -u: %w", p, err,
+				)
+			}
+		}
+
+		st, err := a.Worktree.SubmoduleStatus(ctx, p)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"submodule %s: status: %w", p, err,
+			)
+		}
+
+		hasStaged, err := subWt.HasStagedChanges(ctx)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"submodule %s: check staged: %w", p, err,
+			)
+		}
+
+		// State 3: staged content but on a different branch.
+		// Detached + staged is treated as the same class.
+		if hasStaged && (st.Detached || st.Branch != recorded) {
+			cur := st.Branch
+			if st.Detached {
+				cur = "(detached HEAD)"
+			}
+			return nil, &DivergedFromRecordError{
+				Path:           p,
+				RecordedBranch: recorded,
+				CurrentBranch:  cur,
+			}
+		}
+
+		todo = append(todo, plan{
+			path:         p,
+			recorded:     recorded,
+			status:       st,
+			hasStaged:    hasStaged,
+			shouldCommit: hasStaged,
+		})
+	}
+
+	// Second pass: perform sub commits (state 1) and stage gitlinks.
+	for _, t := range todo {
+		subWt, err := a.Worktree.SubmoduleWorktree(ctx, t.path)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"submodule %s: open worktree: %w", t.path, err,
+			)
+		}
+
+		if t.shouldCommit {
+			subMsg := msg.Message
+			if v, ok := msg.ModuleMessage[t.path]; ok {
+				subMsg = v
+			}
+			req := git.CommitRequest{
+				Message:     subMsg,
+				MessageFile: msg.MessageFile,
+				NoEdit:      msg.NoEdit && subMsg == "" && msg.MessageFile == "",
+				NoVerify:    msg.NoVerify,
+				Signoff:     msg.Signoff,
+			}
+			switch mode {
+			case CommitModeAmend:
+				req.Amend = true
+				// In non-interactive amend with no new message, --no-edit.
+				if subMsg == "" && msg.MessageFile == "" {
+					req.NoEdit = true
+				}
+			case CommitModeCreate:
+				// Plain commit; no special flags.
+			}
+			if err := subWt.Commit(ctx, req); err != nil {
+				return nil, fmt.Errorf(
+					"submodule %s: commit: %w", t.path, err,
+				)
+			}
+		}
+
+		// Recompute sub HEAD after potential commit.
+		newHead, err := a.Worktree.SubmoduleHead(ctx, t.path)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"submodule %s: head: %w", t.path, err,
+			)
+		}
+
+		// State 2 / post-commit: stage gitlink if HEAD moved past
+		// the gitlink in parent's HEAD.
+		if newHead != t.status.GitlinkHash {
+			if err := a.parentUpdateGitlink(ctx, t.path, newHead); err != nil {
+				return nil, fmt.Errorf(
+					"submodule %s: stage gitlink: %w", t.path, err,
+				)
+			}
+			staged = append(staged, t.path)
+		}
+	}
+
+	return staged, nil
+}
+
+// PostAmendInteractiveSubmodules is the gitlink-only variant for the
+// interactive `gs ca` editor-aborts-allowed path: state 1 is skipped
+// (we cannot atomically amend subs across an editor abort), but state
+// 2 (sub HEAD moved without our intervention) is honored.
+//
+// State 3 still surfaces as a DivergedFromRecordError so the parent's
+// recorded gitlink does not silently disagree with the sub's branch.
+func (a *Applier) PostAmendInteractiveSubmodules(
+	ctx context.Context, parentBranch string,
+) (staged []string, err error) {
+	resp, err := a.Store.LookupBranch(ctx, parentBranch)
+	if err != nil {
+		if isErrNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf(
+			"lookup branch %s: %w", parentBranch, err,
+		)
+	}
+	if len(resp.Submodules) == 0 {
+		return nil, nil
+	}
+
+	paths := make([]string, 0, len(resp.Submodules))
+	for p := range resp.Submodules {
+		if a.isExcluded(p) {
+			continue
+		}
+		paths = append(paths, p)
+	}
+	slices.Sort(paths)
+
+	for _, p := range paths {
+		recorded := resp.Submodules[p]
+		st, err := a.Worktree.SubmoduleStatus(ctx, p)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"submodule %s: status: %w", p, err,
+			)
+		}
+		if st.HeadHash == st.GitlinkHash {
+			continue
+		}
+		// Sub HEAD moved. Refuse to record a stale gitlink if the sub
+		// is not on the recorded branch.
+		if st.Detached || st.Branch != recorded {
+			cur := st.Branch
+			if st.Detached {
+				cur = "(detached HEAD)"
+			}
+			return nil, &DivergedFromRecordError{
+				Path:           p,
+				RecordedBranch: recorded,
+				CurrentBranch:  cur,
+			}
+		}
+		if err := a.parentUpdateGitlink(ctx, p, st.HeadHash); err != nil {
+			return nil, fmt.Errorf(
+				"submodule %s: stage gitlink: %w", p, err,
+			)
+		}
+		staged = append(staged, p)
+	}
+	return staged, nil
+}
+
+// parentUpdateGitlink stages a new gitlink in the parent worktree's
+// index for the submodule at path.
+func (a *Applier) parentUpdateGitlink(
+	ctx context.Context, path string, head git.Hash,
+) error {
+	return a.Worktree.UpdateSubmodulePointer(ctx, path, head)
+}
+
+// isErrNotExist reports whether err indicates that a branch was not
+// found in the state store.
+func isErrNotExist(err error) bool {
+	return errors.Is(err, state.ErrNotExist)
+}

--- a/testdata/help/branch_create.txt
+++ b/testdata/help/branch_create.txt
@@ -56,19 +56,23 @@ Arguments:
   [<name>]    Name of the new branch
 
 Flags:
-      --insert               Restack the upstack of the target branch onto the
-                             new branch
-      --below                Place the branch below the target branch and
-                             restack its upstack
-  -t, --target=BRANCH        Branch to create the new branch above/below
-  -a, --all                  Automatically stage modified and deleted files
-  -m, --message=MSG          Commit message
-  -F, --message-file=FILE    Read the commit message from the given file.
-      --no-verify            Bypass pre-commit and commit-msg hooks.
-      --signoff              Add Signed-off-by trailer to the commit message (🔧
-                             spice.commit.signoff)
-      --[no-]commit          Commit staged changes to the new branch, or create
-                             an empty commit (🔧 spice.branchCreate.commit)
+      --insert                     Restack the upstack of the target branch onto
+                                   the new branch
+      --below                      Place the branch below the target branch and
+                                   restack its upstack
+  -t, --target=BRANCH              Branch to create the new branch above/below
+  -a, --all                        Automatically stage modified and deleted
+                                   files
+  -m, --message=MSG                Commit message
+  -F, --message-file=FILE          Read the commit message from the given file.
+      --no-verify                  Bypass pre-commit and commit-msg hooks.
+      --signoff                    Add Signed-off-by trailer to the commit
+                                   message (🔧 spice.commit.signoff)
+      --module-message=PATH=MSG    Per-submodule commit message override
+                                   (repeatable)
+      --[no-]commit                Commit staged changes to the new
+                                   branch, or create an empty commit (🔧
+                                   spice.branchCreate.commit)
 
 Global Flags:
   -h, --help           Show help for the command

--- a/testdata/help/commit_amend.txt
+++ b/testdata/help/commit_amend.txt
@@ -19,14 +19,17 @@ confirmation when amending on trunk. The --no-prompt flag can be used to skip
 this prompt in scripts.
 
 Flags:
-  -a, --all                  Stage all changes before committing.
-      --allow-empty          Create a commit even if it contains no changes.
-  -m, --message=MSG          Use the given message as the commit message.
-  -F, --message-file=FILE    Read the commit message from the given file.
-      --no-edit              Don't edit the commit message
-      --no-verify            Bypass pre-commit and commit-msg hooks.
-      --signoff              Add Signed-off-by trailer to the commit message (🔧
-                             spice.commit.signoff)
+  -a, --all                        Stage all changes before committing.
+      --allow-empty                Create a commit even if it contains no
+                                   changes.
+  -m, --message=MSG                Use the given message as the commit message.
+  -F, --message-file=FILE          Read the commit message from the given file.
+      --no-edit                    Don't edit the commit message
+      --no-verify                  Bypass pre-commit and commit-msg hooks.
+      --signoff                    Add Signed-off-by trailer to the commit
+                                   message (🔧 spice.commit.signoff)
+      --module-message=PATH=MSG    Per-submodule commit message override
+                                   (repeatable, non-interactive amend only)
 
 Global Flags:
   -h, --help           Show help for the command

--- a/testdata/help/commit_create.txt
+++ b/testdata/help/commit_create.txt
@@ -17,15 +17,18 @@ commit when run with 'git rebase --autosquash'. See also, the 'gs commit fixup'
 command, which is preferable when you want to apply changes to an older commit.
 
 Flags:
-  -a, --all                  Stage all changes before committing.
-      --allow-empty          Create a new commit even if it contains no changes.
-      --fixup=COMMIT         Create a fixup commit. See also 'git-spice commit
-                             fixup'.
-  -m, --message=MSG          Use the given message as the commit message.
-  -F, --message-file=FILE    Read the commit message from the given file.
-      --no-verify            Bypass pre-commit and commit-msg hooks.
-      --signoff              Add Signed-off-by trailer to the commit message (🔧
-                             spice.commit.signoff)
+  -a, --all                        Stage all changes before committing.
+      --allow-empty                Create a new commit even if it contains no
+                                   changes.
+      --fixup=COMMIT               Create a fixup commit. See also 'git-spice
+                                   commit fixup'.
+  -m, --message=MSG                Use the given message as the commit message.
+  -F, --message-file=FILE          Read the commit message from the given file.
+      --no-verify                  Bypass pre-commit and commit-msg hooks.
+      --signoff                    Add Signed-off-by trailer to the commit
+                                   message (🔧 spice.commit.signoff)
+      --module-message=PATH=MSG    Per-submodule commit message override
+                                   (repeatable)
 
 Global Flags:
   -h, --help           Show help for the command

--- a/testdata/script/commit_create_submodule_autocommit.txt
+++ b/testdata/script/commit_create_submodule_autocommit.txt
@@ -1,0 +1,53 @@
+# 'gs commit create' auto-commits staged content in a tracked
+# submodule that's on the recorded branch (state 1), and updates
+# the gitlink in the parent commit in one go.
+
+as 'Test <test@example.com>'
+at '2026-03-11T15:00:00Z'
+
+# Set up a submodule repo with a 'feat' branch.
+cd sub-repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+git add feat.txt
+gs branch create sub-feat -m 'Add feat'
+
+# Set up the parent repo with a tracked branch on the submodule.
+cd $WORK/repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+git -c protocol.file.allow=always submodule add $WORK/sub-repo libs/core
+git commit -m 'Add submodule'
+
+# Move sub onto sub-feat and create parent branch.
+cd libs/core
+git checkout sub-feat
+cd $WORK/repo
+git add parent-file.txt
+gs branch create feat-x -m 'Add parent file'
+
+# Stage content inside the submodule.
+cp $WORK/extra/new-feat.txt libs/core/new-feat.txt
+cd libs/core
+git add new-feat.txt
+cd $WORK/repo
+
+# Commit on the parent. The submodule should auto-commit and the
+# parent commit should include the gitlink update.
+gs commit create -m 'Update with submodule changes'
+
+# Verify the submodule has a new commit on sub-feat.
+cd libs/core
+git log --oneline sub-feat
+stdout 'Update with submodule changes'
+git rev-parse --abbrev-ref HEAD
+stdout 'sub-feat'
+
+-- sub-repo/feat.txt --
+sub feature
+-- repo/parent-file.txt --
+parent content
+-- extra/new-feat.txt --
+new sub content

--- a/testdata/script/commit_create_submodule_diverged_fails.txt
+++ b/testdata/script/commit_create_submodule_diverged_fails.txt
@@ -1,0 +1,55 @@
+# State 3: 'gs commit create' refuses to commit when a tracked
+# submodule has staged content but is on a different branch than
+# what the parent records.
+
+as 'Test <test@example.com>'
+at '2026-03-11T15:00:00Z'
+
+cd sub-repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+git add feat.txt
+gs branch create sub-feat -m 'Add feat'
+gs trunk
+git add fix.txt
+gs branch create sub-fix -m 'Add fix'
+
+cd $WORK/repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+git -c protocol.file.allow=always submodule add $WORK/sub-repo libs/core
+git commit -m 'Add submodule'
+
+# Move sub to sub-feat; parent records that on feat-x.
+cd libs/core
+git checkout sub-feat
+cd $WORK/repo
+git add parent-file.txt
+gs branch create feat-x -m 'Add parent file'
+
+# Now the user moves the submodule to sub-fix manually and stages
+# content there.
+cd libs/core
+git checkout sub-fix
+cd $WORK/repo
+cp $WORK/extra/new.txt libs/core/new.txt
+cd libs/core
+git add new.txt
+cd $WORK/repo
+
+# Commit should refuse, with a clear message and both remediation hints.
+! gs commit create -m 'Update'
+stderr 'libs/core'
+stderr 'sub-feat'
+stderr 'sub-fix'
+
+-- sub-repo/feat.txt --
+sub feature
+-- sub-repo/fix.txt --
+sub fix
+-- repo/parent-file.txt --
+parent content
+-- extra/new.txt --
+new sub content

--- a/testdata/script/commit_create_submodule_pointer_only.txt
+++ b/testdata/script/commit_create_submodule_pointer_only.txt
@@ -1,0 +1,52 @@
+# State 2: sub HEAD moved (independent of parent's staged content)
+# but no staged content in the sub. The parent commit should still
+# pick up the updated gitlink.
+
+as 'Test <test@example.com>'
+at '2026-03-11T15:00:00Z'
+
+cd sub-repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+git add feat.txt
+gs branch create sub-feat -m 'Add feat'
+
+cd $WORK/repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+git -c protocol.file.allow=always submodule add $WORK/sub-repo libs/core
+git commit -m 'Add submodule'
+
+cd libs/core
+git checkout sub-feat
+cd $WORK/repo
+git add parent-file.txt
+gs branch create feat-x -m 'Add parent file'
+
+# User commits directly in the submodule via plain git.
+cd libs/core
+cp $WORK/extra/independent.txt independent.txt
+git add independent.txt
+git -c user.name=Test -c user.email=test@example.com commit -m 'Independent sub commit'
+cd $WORK/repo
+
+# The parent's gitlink is now behind the sub's HEAD.
+# Running 'gs commit create' should pick up the gitlink update.
+cp $WORK/extra/more-parent.txt more-parent.txt
+git add more-parent.txt
+gs commit create -m 'More parent work'
+
+# The latest parent commit should record the new gitlink.
+git diff HEAD^ HEAD -- libs/core
+stdout 'Subproject commit'
+
+-- sub-repo/feat.txt --
+sub feature
+-- repo/parent-file.txt --
+parent content
+-- extra/independent.txt --
+independent sub work
+-- extra/more-parent.txt --
+more parent work


### PR DESCRIPTION
Teach `gs commit create`, `gs commit amend`, and committing
`gs branch create` to include staged submodule work in the parent
commit.

Each tracked submodule with staged changes is committed first, then its
gitlink is updated in the parent commit. Pointer-only changes are
preserved without creating an unnecessary submodule commit. Diverged
submodule state stops the operation before the parent commit is created.

`--module-message=PATH=MSG` supplies a non-interactive message for an
individual submodule commit.