### PR TITLE
fix TestGitEditor sensitivity to GIT_EDITOR/VISUAL env vars

### DIFF
--- a/internal/handler/submit/form_test.go
+++ b/internal/handler/submit/form_test.go
@@ -17,6 +17,18 @@ func TestGitEditor(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	// git var GIT_EDITOR checks GIT_EDITOR and VISUAL before core.editor,
+	// and t.Setenv("KEY", "") is not good enough, we need to unset.
+	// Use t.Setenv first to register the restore cleanup,
+	// then os.Unsetenv to actually unset for the duration of the test.
+	if prev, ok := os.LookupEnv("GIT_EDITOR"); ok {
+		t.Setenv("GIT_EDITOR", prev)
+		require.NoError(t, os.Unsetenv("GIT_EDITOR"))
+	}
+	if prev, ok := os.LookupEnv("VISUAL"); ok {
+		t.Setenv("VISUAL", prev)
+		require.NoError(t, os.Unsetenv("VISUAL"))
+	}
 
 	runGit := func(t *testing.T, dir string, args ...string) {
 		t.Helper()


### PR DESCRIPTION
## Summary

- `git var GIT_EDITOR` checks `GIT_EDITOR` and `VISUAL` environment variables before `core.editor` config, so tests fail if either is set in the parent shell environment. This fails the test in local envs that have those set (mine, e.g.), which is annoying when one wants to submit a PR.
- Fix: unset both vars with `os.Unsetenv` and restore the original value via `t.Cleanup` (`t.Setenv("FOO", "")` is insufficient: it sets to empty string rather than unsetting, and git still reads it.)

## Test plan

- [x] Run `GIT_EDITOR=true VISUAL=vim go test ./internal/handler/submit/... -run TestGitEditor` before the fix: tests fail.
- [x] Run `GIT_EDITOR=true VISUAL=vim go test ./internal/handler/submit/... -run TestGitEditor` with the fix: all pass.
