### PR TITLE
fix(nav): reject invalid branch counts

### DIFF
--- a/.changes/unreleased/Fixed-20260523-093536.yaml
+++ b/.changes/unreleased/Fixed-20260523-093536.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'navigation: Non-positive branch counts for up and down are now rejected instead of causing a panic.'
+time: 2026-05-23T09:35:36.521337-07:00

--- a/down.go
+++ b/down.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"go.abhg.dev/gs/internal/git"
@@ -35,6 +36,10 @@ func (cmd *downCmd) Run(
 	svc *spice.Service,
 	checkoutHandler CheckoutHandler,
 ) error {
+	if cmd.N <= 0 {
+		return errors.New("number of branches must be positive")
+	}
+
 	current, err := wt.CurrentBranch(ctx)
 	if err != nil {
 		// TODO: handle not a branch

--- a/testdata/script/up_down_top_bottom.txt
+++ b/testdata/script/up_down_top_bottom.txt
@@ -69,6 +69,14 @@ gs up 3
 git branch
 cmp stdout $WORK/golden/git_branch_feature3.output
 
+# up [N] rejects zero
+! gs up 0
+stderr 'number of branches must be positive'
+
+# up [N] rejects negative counts
+! gs up -- -1
+stderr 'number of branches must be positive'
+
 # up [N] out of bounds
 gs up 5
 git branch
@@ -78,6 +86,14 @@ cmp stdout $WORK/golden/git_branch_feature5.output
 gs down 2
 git branch
 cmp stdout $WORK/golden/git_branch_feature3.output
+
+# down [N] rejects zero
+! gs down 0
+stderr 'number of branches must be positive'
+
+# down [N] rejects negative counts
+! gs down -- -1
+stderr 'number of branches must be positive'
 
 # down [N] out of bounds
 gs down 5

--- a/up.go
+++ b/up.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 
@@ -37,6 +38,10 @@ func (cmd *upCmd) Run(
 	svc *spice.Service,
 	checkoutHandler CheckoutHandler,
 ) error {
+	if cmd.N <= 0 {
+		return errors.New("number of branches must be positive")
+	}
+
 	current, err := wt.CurrentBranch(ctx)
 	if err != nil {
 		// TODO: handle not a branch


### PR DESCRIPTION

`git-spice up` and `git-spice down` should reject invalid hop counts
with a user-facing error.

When the count is zero or negative, navigation currently falls through
into a blank checkout target and panics.
This change rejects non-positive counts before stack traversal starts,
so both commands fail cleanly instead.

The regression script now covers `0` and `-- -1`,
and the changelog records the new validation contract.
