### PR TITLE
log: Suppress missing remote warning

### DIFF
--- a/.changes/unreleased/Fixed-20260523-112429.yaml
+++ b/.changes/unreleased/Fixed-20260523-112429.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'log: Avoid warning about missing remote metadata when listing local-only repositories.'
+time: 2026-05-23T11:24:29.04097-07:00

--- a/internal/handler/list/handler.go
+++ b/internal/handler/list/handler.go
@@ -175,7 +175,11 @@ func (h *Handler) ListBranches(ctx context.Context, req *BranchesRequest) (*Bran
 
 	getRemote := sync.OnceValue(func() state.Remote {
 		remote, err := h.Store.Remote()
+		if errors.Is(err, state.ErrNotExist) {
+			return state.Remote{}
+		}
 		if err != nil {
+			log.Warn("Could not load remote configuration", "error", err)
 			return state.Remote{}
 		}
 		return remote
@@ -189,7 +193,7 @@ func (h *Handler) ListBranches(ctx context.Context, req *BranchesRequest) (*Bran
 		err := func() error {
 			remote := getRemote()
 			if remote == (state.Remote{}) {
-				return state.ErrNotExist
+				return nil
 			}
 
 			remoteURL, err := h.Repository.RemoteURL(ctx, remote.Upstream)

--- a/testdata/script/log_json_trunk_no_remote_no_warning.txt
+++ b/testdata/script/log_json_trunk_no_remote_no_warning.txt
@@ -1,0 +1,17 @@
+# 'gs ls --json' on trunk does not warn about missing remote forge data.
+
+as 'Test <test@example.com>'
+at '2026-05-23T18:28:00Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+gs ls --json
+cmp stdout $WORK/golden/ls.json
+! stderr 'Could not find information about the remote'
+
+-- golden/ls.json --
+{"name":"main","current":true}


### PR DESCRIPTION
Local-only repositories should be able to use `gs log` and `gs ls`
without seeing warnings for optional remote-backed metadata.

Treat a missing configured remote as an expected degraded mode
for log enrichment.
Other remote configuration errors still warn,
and change URLs continue to fall back to change IDs
when forge metadata is unavailable.

A script regression covers `gs ls --json` on the trunk branch
in a repository with no configured remote.

Discovered in #1191