### PR TITLE
chore: Migrate mise task args

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -18,7 +18,6 @@ url_api = "https://api.github.com/repos/miniscruff/changie/releases/assets/31954
 checksum = "sha256:706937c1874eb7c270d15f644d8a84a74dfa7f27778cbc8ca9cb045a0d68d9df"
 url = "https://github.com/miniscruff/changie/releases/download/v1.24.0/changie_1.24.0_linux_amd64.tar.gz"
 url_api = "https://api.github.com/repos/miniscruff/changie/releases/assets/319542133"
-github_attestations = "unavailable"
 
 [tools.changie."platforms.linux-x64-changie"]
 checksum = "blake3:8b63ce3ca2871dba4d3a50cea6b4fc8c8aad789a18fdb8c88fc8e6b3b26977cc"
@@ -164,7 +163,6 @@ url_api = "https://api.github.com/repos/abhinav/requiredfield/releases/assets/35
 checksum = "sha256:46f82f7a552c0fd61dbe3ca7ffa165de85b6d5ed1e97a833fe7d154dfb331bcf"
 url = "https://github.com/abhinav/requiredfield/releases/download/v0.9.0/requiredfield.Linux-x86_64.tar.gz"
 url_api = "https://api.github.com/repos/abhinav/requiredfield/releases/assets/357740554"
-github_attestations = "unavailable"
 
 [tools.requiredfield."platforms.linux-x64-musl"]
 checksum = "sha256:46f82f7a552c0fd61dbe3ca7ffa165de85b6d5ed1e97a833fe7d154dfb331bcf"

--- a/mise.toml
+++ b/mise.toml
@@ -41,7 +41,10 @@ depends = ["test:*"]
 [tasks."test:default"]
 wait_for = ["generate"]
 description = "Run default tests"
-run = "gotestsum -- ./... -race={{flag(name='race')}}"
+usage = '''
+flag "--race" default="false" help="Enable data race detection"
+'''
+run = "gotestsum -- ./... -race={{usage.race}}"
 
 [tasks."test:script"]
 wait_for = ["generate"]
@@ -55,20 +58,20 @@ flag "--count <count>" default="1" help="Number of times to run tests"
 flag "--shard-index <shard_index>" default="0" help="Shard index to run"
 flag "--shard-count <shard_count>" default="1" help="Total number of shards"
 
-flag "--run <script>" help="Regex to select which script tests to run"
+flag "--run <script>" default="" help="Regex to select which script tests to run"
 complete "script" run="ls testdata/script/*.txt | cut -d/ -f3 | sed 's/.txt$//'"
 '''
 run = """
 gotestsum
-  {%- if flag(name='verbose') == 'true' %} --format=standard-verbose
+  {%- if usage.verbose %} --format=standard-verbose
   {%- endif %} -- {# -#}
   -tags=script {# enable script tests -#}
-  -run TestScript/{{option(name='run')}} {# run only script tests -#}
-  -count {{option(name='count')}} {# number of times to run tests -#}
-  -race={{flag(name='race')}} {# race detection -#}
-  -shard-index={{option(name='shard-index')}} {# shard index -#}
-  -shard-count={{option(name='shard-count')}} {# shard count -#}
-  -update={{flag(name='update')}} {# update expected results -#}
+  -run TestScript/{{usage.run}} {# run only script tests -#}
+  -count {{usage.count}} {# number of times to run tests -#}
+  -race={{usage.race}} {# race detection -#}
+  -shard-index={{usage.shard_index}} {# shard index -#}
+  -shard-count={{usage.shard_count}} {# shard count -#}
+  -update={{usage.update}} {# update expected results -#}
 """
 
 [tasks."_cover_report"]
@@ -78,10 +81,13 @@ run = "go tool cover -html=cover.out -o cover.html"
 wait_for = ["generate"]
 depends_post = ["_cover_report"]
 description = "Run default tests with coverage"
+usage = '''
+flag "--race" default="false" help="Enable data race detection"
+'''
 run = """
 gotestsum -- {# -#}
   ./... {# run all tests -#}
-  -race={{flag(name='race')}} {# race detection -#}
+  -race={{usage.race}} {# race detection -#}
   -coverpkg=./... {# cover all packages -#}
   -coverprofile=cover.out {# -#}
 """
@@ -90,15 +96,21 @@ gotestsum -- {# -#}
 wait_for = ["generate"]
 depends_post = ["_cover_report"]
 description = "Run script tests with coverage"
+usage = '''
+flag "--race" default="false" help="Enable data race detection"
+
+flag "--shard-index <shard_index>" default="0" help="Shard index to run"
+flag "--shard-count <shard_count>" default="1" help="Total number of shards"
+'''
 run = """
 gotestsum -- {# -#}
   -tags=script {# enable script tests -#}
   -run '^TestScript$' {# run only script tests -#}
-  -race={{flag(name='race')}} {# race detection -#}
+  -race={{usage.race}} {# race detection -#}
   -coverpkg=./... {# cover all packages -#}
   -coverprofile=cover.out {# -#}
-  -shard-index={{option(name='shard-index', default='0')}} {# shard index -#}
-  -shard-count={{option(name='shard-count', default='1')}} {# shard count -#}
+  -shard-index={{usage.shard_index}} {# shard index -#}
+  -shard-count={{usage.shard_count}} {# shard count -#}
 """
 
 [tasks.tidy]
@@ -140,7 +152,7 @@ flag "--pprof" help="Build with pofiling flags"
 """
 run = """
 go build -o bin/git-spice -tags="
-  {%- if flag(name='pprof') == 'true' -%}
+  {%- if usage.pprof -%}
     profile
   {%- endif -%}
 " go.abhg.dev/gs
@@ -169,4 +181,7 @@ run = "cd doc && mise run build"
 
 [tasks."release:prepare"]
 description = "Prepare a release for publishing"
-run = "go run ./tools/ci/prepare-release -version {{arg(name='version')}}"
+usage = '''
+arg "<version>" help="Version to prepare"
+'''
+run = "go run ./tools/ci/prepare-release -version {{usage.version}}"


### PR DESCRIPTION
mise warns when task run scripts still use Tera argument functions.
Move tasks to usage-backed values.

Manual dry runs covered the default and flag-bearing task paths,
and `mise run build` completes without the deprecation warning.