### PR TITLE
ci: write only failed test output to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,12 +85,11 @@ jobs:
         mise run
         ${{ matrix.cover && 'cover:default' || 'test:default' }}
         ${{ matrix.race && '--race' || '' }}
+        --format github-actions-fails
       # NB:
       # Windows tests are already slow.
       # Run them without race detection to avoid slowing them further.
       shell: bash
-      env:
-        GOTESTSUM_FORMAT: github-actions
 
     - name: Script tests
       if: ${{ matrix.suite == 'script' }}
@@ -98,11 +97,10 @@ jobs:
         mise run \
           ${{ matrix.cover && 'cover:script' || 'test:script' }} \
           ${{ matrix.race && '--race' || '' }} \
+          --format github-actions-fails \
           --shard-index "${{ matrix.shard-index || '0' }}" \
           --shard-count "${{ matrix.shard-count || '1' }}"
       shell: bash
-      env:
-        GOTESTSUM_FORMAT: github-actions
 
     - name: Upload coverage
       uses: codecov/codecov-action@v6.0.0

--- a/mise.lock
+++ b/mise.lock
@@ -42,6 +42,45 @@ checksum = "sha256:4a90748c1da0179afe282599b562e75ef2cb5ce34e25d5f67e70ef20725b9
 url = "https://github.com/miniscruff/changie/releases/download/v1.24.0/changie_1.24.0_windows_amd64.zip"
 url_api = "https://api.github.com/repos/miniscruff/changie/releases/assets/319542125"
 
+[[tools."github:abhinav/gotestsum"]]
+version = "v1.14.0-beta.1+github-actions-fails"
+backend = "github:abhinav/gotestsum"
+
+[tools."github:abhinav/gotestsum"."platforms.linux-arm64"]
+checksum = "sha256:fa961de48575b038a6a6afa1d9ba877bdf42960e7376df30377640f6335e7615"
+url = "https://github.com/abhinav/gotestsum/releases/download/v1.14.0-beta.1%2Bgithub-actions-fails/gotestsum_1.14.0-beta.1%2Bgithub-actions-fails_linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/abhinav/gotestsum/releases/assets/428166816"
+
+[tools."github:abhinav/gotestsum"."platforms.linux-arm64-musl"]
+checksum = "sha256:fa961de48575b038a6a6afa1d9ba877bdf42960e7376df30377640f6335e7615"
+url = "https://github.com/abhinav/gotestsum/releases/download/v1.14.0-beta.1%2Bgithub-actions-fails/gotestsum_1.14.0-beta.1%2Bgithub-actions-fails_linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/abhinav/gotestsum/releases/assets/428166816"
+
+[tools."github:abhinav/gotestsum"."platforms.linux-x64"]
+checksum = "sha256:4a193038f8277411004bc26e18e568733904c832e85eacd7e48b3c314de0d1d1"
+url = "https://github.com/abhinav/gotestsum/releases/download/v1.14.0-beta.1%2Bgithub-actions-fails/gotestsum_1.14.0-beta.1%2Bgithub-actions-fails_linux_amd64.tar.gz"
+url_api = "https://api.github.com/repos/abhinav/gotestsum/releases/assets/428166817"
+
+[tools."github:abhinav/gotestsum"."platforms.linux-x64-musl"]
+checksum = "sha256:4a193038f8277411004bc26e18e568733904c832e85eacd7e48b3c314de0d1d1"
+url = "https://github.com/abhinav/gotestsum/releases/download/v1.14.0-beta.1%2Bgithub-actions-fails/gotestsum_1.14.0-beta.1%2Bgithub-actions-fails_linux_amd64.tar.gz"
+url_api = "https://api.github.com/repos/abhinav/gotestsum/releases/assets/428166817"
+
+[tools."github:abhinav/gotestsum"."platforms.macos-arm64"]
+checksum = "sha256:40cf41a260c2036ec3239fdf7e40179a237fbb05e090a1e3601b52226a31d527"
+url = "https://github.com/abhinav/gotestsum/releases/download/v1.14.0-beta.1%2Bgithub-actions-fails/gotestsum_1.14.0-beta.1%2Bgithub-actions-fails_darwin_arm64.tar.gz"
+url_api = "https://api.github.com/repos/abhinav/gotestsum/releases/assets/428166812"
+
+[tools."github:abhinav/gotestsum"."platforms.macos-x64"]
+checksum = "sha256:6405031b835b55e3429082a6b25ef7361f27390465b338e83d938dc63b7ce35c"
+url = "https://github.com/abhinav/gotestsum/releases/download/v1.14.0-beta.1%2Bgithub-actions-fails/gotestsum_1.14.0-beta.1%2Bgithub-actions-fails_darwin_amd64.tar.gz"
+url_api = "https://api.github.com/repos/abhinav/gotestsum/releases/assets/428166828"
+
+[tools."github:abhinav/gotestsum"."platforms.windows-x64"]
+checksum = "sha256:54b8a6d80741dd6faf0a64296446e14e52bfb3411c88762afd46327b8716115e"
+url = "https://github.com/abhinav/gotestsum/releases/download/v1.14.0-beta.1%2Bgithub-actions-fails/gotestsum_1.14.0-beta.1%2Bgithub-actions-fails_windows_amd64.tar.gz"
+url_api = "https://api.github.com/repos/abhinav/gotestsum/releases/assets/428166818"
+
 [[tools.go]]
 version = "1.26.3"
 backend = "core:go"
@@ -112,38 +151,6 @@ provenance = "github-attestations"
 checksum = "sha256:bd42e3ebc8cb4ececb86941983baaf1dc221bbb04d838e94ce63b49cc91e02bb"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-windows-amd64.zip"
 provenance = "github-attestations"
-
-[[tools.gotestsum]]
-version = "1.13.0"
-backend = "aqua:gotestyourself/gotestsum"
-
-[tools.gotestsum."platforms.linux-arm64"]
-checksum = "sha256:7644a4c5cd1bb978d56245aeab25a586ac5ac62adebed20a399548867c13499d"
-url = "https://github.com/gotestyourself/gotestsum/releases/download/v1.13.0/gotestsum_1.13.0_linux_arm64.tar.gz"
-
-[tools.gotestsum."platforms.linux-arm64-musl"]
-checksum = "sha256:7644a4c5cd1bb978d56245aeab25a586ac5ac62adebed20a399548867c13499d"
-url = "https://github.com/gotestyourself/gotestsum/releases/download/v1.13.0/gotestsum_1.13.0_linux_arm64.tar.gz"
-
-[tools.gotestsum."platforms.linux-x64"]
-checksum = "sha256:11ccddeaf708ef228889f9fe2f68291a75b27013ddfc3b18156e094f5f40e8ee"
-url = "https://github.com/gotestyourself/gotestsum/releases/download/v1.13.0/gotestsum_1.13.0_linux_amd64.tar.gz"
-
-[tools.gotestsum."platforms.linux-x64-musl"]
-checksum = "sha256:11ccddeaf708ef228889f9fe2f68291a75b27013ddfc3b18156e094f5f40e8ee"
-url = "https://github.com/gotestyourself/gotestsum/releases/download/v1.13.0/gotestsum_1.13.0_linux_amd64.tar.gz"
-
-[tools.gotestsum."platforms.macos-arm64"]
-checksum = "sha256:509cb27aef747f48faf9bce424f59dcf79572c905204b990ee935bbfcc7fa0e9"
-url = "https://github.com/gotestyourself/gotestsum/releases/download/v1.13.0/gotestsum_1.13.0_darwin_arm64.tar.gz"
-
-[tools.gotestsum."platforms.macos-x64"]
-checksum = "sha256:99529350f4c7b780b1efc543ca0d9721b09f0a4228f0efa9281261f58fefa05a"
-url = "https://github.com/gotestyourself/gotestsum/releases/download/v1.13.0/gotestsum_1.13.0_darwin_amd64.tar.gz"
-
-[tools.gotestsum."platforms.windows-x64"]
-checksum = "sha256:fd5a6dc69e46a0970593e70d85a7e75f16714e9c61d6d72ccc324eb82df5bb8a"
-url = "https://github.com/gotestyourself/gotestsum/releases/download/v1.13.0/gotestsum_1.13.0_windows_amd64.tar.gz"
 
 [[tools.requiredfield]]
 version = "0.9.0"

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,6 @@
 experimental = true
 
 [env]
-GOTESTSUM_FORMAT = "testname"
 GOBIN = "{{ config_root }}/bin"
 PROJECT_ROOT = "{{ config_root }}"
 _.path = ["{{ config_root }}/bin"]
@@ -18,7 +17,8 @@ requiredfield = "github:abhinav/requiredfield"
 go = "latest"
 
 # Test runner with prettier output.
-gotestsum = "latest"
+# https://github.com/gotestyourself/gotestsum/pull/568
+"github:abhinav/gotestsum" = "v1.14.0-beta.1+github-actions-fails"
 
 # Collection of linters.
 golangci-lint = "latest"
@@ -43,8 +43,9 @@ wait_for = ["generate"]
 description = "Run default tests"
 usage = '''
 flag "--race" default="false" help="Enable data race detection"
+flag "--format <format>" default="standard-verbose" help="gotestsum output format"
 '''
-run = "gotestsum -- ./... -race={{usage.race}}"
+run = "gotestsum --format={{usage.format}} -- ./... -race={{usage.race}}"
 
 [tasks."test:script"]
 wait_for = ["generate"]
@@ -54,6 +55,7 @@ flag "-v --verbose" default="false" help="Enable verbose output"
 flag "--race" default="false" help="Enable data race detection"
 flag "--update" default="false" help="Update expected results"
 flag "--count <count>" default="1" help="Number of times to run tests"
+flag "--format <format>" default="standard-verbose" help="gotestsum output format"
 
 flag "--shard-index <shard_index>" default="0" help="Shard index to run"
 flag "--shard-count <shard_count>" default="1" help="Total number of shards"
@@ -62,9 +64,7 @@ flag "--run <script>" default="" help="Regex to select which script tests to run
 complete "script" run="ls testdata/script/*.txt | cut -d/ -f3 | sed 's/.txt$//'"
 '''
 run = """
-gotestsum
-  {%- if usage.verbose %} --format=standard-verbose
-  {%- endif %} -- {# -#}
+gotestsum --format={{usage.format}} -- {# -#}
   -tags=script {# enable script tests -#}
   -run TestScript/{{usage.run}} {# run only script tests -#}
   -count {{usage.count}} {# number of times to run tests -#}
@@ -83,9 +83,10 @@ depends_post = ["_cover_report"]
 description = "Run default tests with coverage"
 usage = '''
 flag "--race" default="false" help="Enable data race detection"
+flag "--format <format>" default="standard-verbose" help="gotestsum output format"
 '''
 run = """
-gotestsum -- {# -#}
+gotestsum --format={{usage.format}} -- {# -#}
   ./... {# run all tests -#}
   -race={{usage.race}} {# race detection -#}
   -coverpkg=./... {# cover all packages -#}
@@ -98,12 +99,13 @@ depends_post = ["_cover_report"]
 description = "Run script tests with coverage"
 usage = '''
 flag "--race" default="false" help="Enable data race detection"
+flag "--format <format>" default="standard-verbose" help="gotestsum output format"
 
 flag "--shard-index <shard_index>" default="0" help="Shard index to run"
 flag "--shard-count <shard_count>" default="1" help="Total number of shards"
 '''
 run = """
-gotestsum -- {# -#}
+gotestsum --format={{usage.format}} -- {# -#}
   -tags=script {# enable script tests -#}
   -run '^TestScript$' {# run only script tests -#}
   -race={{usage.race}} {# race detection -#}

--- a/script_test.go
+++ b/script_test.go
@@ -61,8 +61,6 @@ func TestScript(t *testing.T) {
 				continue
 			}
 
-			t.Logf("Selected script: %s", script)
-
 			bs, err := os.ReadFile(script)
 			require.NoError(t, err)
 			dst := filepath.Join(shardScriptDir, filepath.Base(script))


### PR DESCRIPTION
gotestsum's github-actions formatter writes grouped output
for all tests across all packages to the logs.
This ends up really slowing down GitHub Actions log browser
because of the sheer volume of output.

Switch to the github-actions-fails formatter
implemented in https://github.com/gotestyourself/gotestsum/pull/568
to fix this.

[skip changelog]: no user facing changes