### PR TITLE
fix(top): honor --detach at stack top

### DIFF
--- a/.changes/unreleased/Fixed-20260523-180244.yaml
+++ b/.changes/unreleased/Fixed-20260523-180244.yaml
@@ -1,0 +1,4 @@
+kind: Fixed
+body: >-
+  top: Fix --detach not being honored when already on the top-most branch.
+time: 2026-05-23T18:02:44.277084-07:00

--- a/testdata/script/nav_detach_dry_run.txt
+++ b/testdata/script/nav_detach_dry_run.txt
@@ -54,6 +54,12 @@ gs top --detach
 git branch
 cmp stdout $WORK/golden/feat5_branch.txt
 
+# top should still honor --detach when already on the top branch.
+gs bco feat5
+gs top --detach
+git branch
+cmp stdout $WORK/golden/feat5_branch.txt
+
 gs trunk --detach
 git branch
 cmp stdout $WORK/golden/trunk_branch.txt

--- a/top.go
+++ b/top.go
@@ -75,7 +75,7 @@ func (cmd *topCmd) Run(
 		}
 	}
 
-	if branch == current && !cmd.DryRun {
+	if branch == current && !cmd.DryRun && !cmd.Detach {
 		log.Info("Already on the top-most branch in this stack")
 		return nil
 	}


### PR DESCRIPTION
`git-spice top --detach` should still detach `HEAD`
when the current branch is already the top-most branch.
Before this change,
`top` returned early as a no-op
and skipped the checkout handler detach path.

This keeps ordinary `top` as a no-op at the stack top
while routing `--detach` through checkout.
The regression script covers both reaching the top branch
and detaching when already there.