### PR TITLE
fix(restack): Detect retargeted branch bases

### DIFF
--- a/.changes/unreleased/Fixed-20260524-142735.yaml
+++ b/.changes/unreleased/Fixed-20260524-142735.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'restack: Branches retargeted without rebasing are now correctly detected as needing restack when their old base remains in history.'
+time: 2026-05-24T14:27:35.419155-07:00

--- a/internal/spice/restack.go
+++ b/internal/spice/restack.go
@@ -166,6 +166,20 @@ func (s *Service) CheckRestacked(ctx context.Context, name string) (baseHash git
 		}
 	}
 
+	// A branch retargeted without rebasing preserves its old base hash
+	// as the upstream boundary for the next explicit restack.
+	// Do not treat that as stale metadata just because the new base
+	// is already an ancestor of the branch head.
+	if b.BaseHash != baseHash &&
+		!b.BaseHash.IsZero() &&
+		s.repo.IsAncestor(ctx, baseHash, b.BaseHash) &&
+		s.repo.IsAncestor(ctx, b.BaseHash, b.Head) {
+		return git.ZeroHash, &BranchNeedsRestackError{
+			Base:     b.Base,
+			BaseHash: baseHash,
+		}
+	}
+
 	// Branch does not need to be restacked
 	// but the base hash stored in state may be out of date.
 	if b.BaseHash != baseHash {


### PR DESCRIPTION
Branches retargeted without rebasing preserve their old base hash
as the upstream boundary for the next explicit restack.

`CheckRestacked` previously treated those branches as already
restacked whenever the new base was an ancestor of the branch head.
That could erase the preserved boundary and prevent explicit restack
from replaying the surviving branch without the old base commit.

Treat that preserved base hash as a restack boundary instead of stale
metadata, so explicit restack rewrites the branch correctly.