### PR TITLE
repo sync: Retarget deleted upstacks

### DIFF
--- a/.changes/unreleased/Changed-20260501-204224.yaml
+++ b/.changes/unreleased/Changed-20260501-204224.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'repo sync: Branches above deleted branches are now retargeted without being restacked unless --restack is used.'
+time: 2026-05-01T20:42:24.138949-07:00

--- a/branch_delete.go
+++ b/branch_delete.go
@@ -82,7 +82,8 @@ func (cmd *branchDeleteCmd) Run(
 	handler DeleteHandler,
 ) error {
 	return handler.DeleteBranches(ctx, &delete.Request{
-		Branches: cmd.Branches,
-		Force:    cmd.Force,
+		Branches:      cmd.Branches,
+		Force:         cmd.Force,
+		UpstackPolicy: delete.UpstackRestackAboves,
 	})
 }

--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -106,7 +106,7 @@ $ gs repo sync
     [parts of](cli/reference.md#gs-upstack-submit)
     [the stack](cli/reference.md#gs-downstack-submit).
     If a branch has already been submitted, git-spice will update the submission.
-    If it has been merged, git-spice will automatically restack branches that depend on it.
+    If it has been merged, git-spice will automatically retarget branches that depend on it.
 
 -   [:material-stairs:{ .lg .middle } __Incremental improvements__](start/stack.md)
 

--- a/doc/src/start/submit.md
+++ b/doc/src/start/submit.md
@@ -205,7 +205,8 @@ it will prompt you to create a CR for it.
 - [x] $$gs branch submit$$ creates or updates a CR for the current branch.
 - [x] $$gs stack submit$$ creates or updates CRs for the entire stack.
 - [x] $$gs repo sync$$ syncs the stack with the trunk branch,
-      deletes merged branches, and rebases the remaining branches.
+      deletes merged branches,
+      and retargets the remaining branches without rebasing them.
 
 ## Next steps
 

--- a/internal/handler/delete/handler.go
+++ b/internal/handler/delete/handler.go
@@ -71,8 +71,27 @@ type Handler struct {
 // Request is a request to delete one or more branches.
 type Request struct {
 	Branches []string
-	Force    bool
+
+	Force bool
+
+	// UpstackPolicy controls how surviving upstacks are moved
+	// after their base branches are deleted.
+	//
+	// The zero value leaves upstacks for an explicit restack later.
+	UpstackPolicy UpstackPolicy
 }
+
+// UpstackPolicy controls how branch deletion handles surviving upstacks.
+type UpstackPolicy int
+
+const (
+	// UpstackDoNothing moves surviving upstacks by updating state only.
+	UpstackDoNothing UpstackPolicy = iota
+
+	// UpstackRestackAboves moves surviving upstacks
+	// by replaying their commits immediately.
+	UpstackRestackAboves
+)
 
 // DeleteBranches deletes the specified branches from the repository,
 // updating all internal state as necessary.
@@ -263,11 +282,12 @@ func (h *Handler) DeleteBranches(ctx context.Context, req *Request) error {
 				continue
 			}
 
-			// Check if the upstack branch is checked out in another worktree.
-			// If so, we need to skip the rebase operation
-			// and leave the branch in a "needs restack" state.
-			var skipRebase bool
-			if above != currentBranch {
+			// Skip the rebase if the caller requested bookkeeping-only
+			// retargeting, or if the upstack branch cannot be rebased
+			// from this worktree.
+			restackAbove := req.UpstackPolicy == UpstackRestackAboves
+			skipRebase := !restackAbove
+			if !skipRebase && above != currentBranch {
 				if worktreePath, ok := branchWorktrees[above]; ok {
 					skipRebase = true
 					log.Warnf("%v: checked out in another worktree (%v), skipping rebase", above, worktreePath)
@@ -294,7 +314,11 @@ func (h *Handler) DeleteBranches(ctx context.Context, req *Request) error {
 					Message: fmt.Sprintf("interrupted: %v: deleting branch", branch),
 				})
 			}
-			log.Infof("%v: moved upstack onto %v", above, base)
+			if restackAbove {
+				log.Infof("%v: moved upstack onto %v", above, base)
+			} else {
+				log.Infof("%v: retargeted upstack onto %v", above, base)
+			}
 		}
 	}
 

--- a/testdata/script/issue1134_repo_sync_no_implicit_restack.txt
+++ b/testdata/script/issue1134_repo_sync_no_implicit_restack.txt
@@ -1,0 +1,99 @@
+# 'repo sync' must not implicitly restack branches after merged deletions.
+#
+# https://github.com/abhinav/git-spice/issues/1134
+
+as 'Test <test@example.com>'
+at '2026-05-01T12:00:00Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# Create a stack: main -> a -> b -> c.
+git add a.txt
+gs bc -m 'Add a' a
+git add b.txt
+gs bc -m 'Add b' b
+git add c.txt
+gs bc -m 'Add c' c
+gs stack submit --fill
+
+# Merge the bottom two branches server-side and sync without --restack.
+shamhub merge alice/example 2
+shamhub merge alice/example 1
+gs repo sync
+stderr 'a: #1 was merged'
+stderr 'b: #2 was merged'
+stderr 'c: retargeted upstack onto main'
+! stderr 'c: moved upstack onto main'
+
+# a and b are gone, but c has only been retargeted in state.
+! git rev-parse --verify a
+! git rev-parse --verify b
+git rev-parse --verify c
+
+gs ll -a
+cmp stderr $WORK/golden/ll-after-sync.txt
+
+git graph --branches
+cmp stdout $WORK/golden/graph-after-sync.txt
+
+# An explicit restack replays c onto main.
+gs branch restack --branch c
+stderr 'c: restacked on main'
+
+gs ll -a
+cmp stderr $WORK/golden/ll-after-restack.txt
+
+git graph --branches
+cmp stdout $WORK/golden/graph-after-restack.txt
+
+-- repo/a.txt --
+a
+-- repo/b.txt --
+b
+-- repo/c.txt --
+c
+-- golden/ll-after-sync.txt --
+┏━■ c (#3) (needs restack) ◀
+┃   bd749dc Add c (now)
+main
+-- golden/graph-after-sync.txt --
+* bd749dc (HEAD -> c, origin/c) Add c
+| *   6195e00 (origin/main, main) Merge change #1
+| |\  
+| | *   26e3162 Merge change #2
+| | |\  
+| |_|/  
+|/| |   
+* | | 8e43bef Add b
+| |/  
+|/|   
+* | 0fa8ccf Add a
+|/  
+* b567761 Initial commit
+-- golden/ll-after-restack.txt --
+┏━■ c (#3) (needs push) ◀
+┃   9eaaa26 Add c (now)
+main
+-- golden/graph-after-restack.txt --
+* 9eaaa26 (HEAD -> c) Add c
+*   6195e00 (origin/main, main) Merge change #1
+|\  
+| *   26e3162 Merge change #2
+| |\  
+| | * 8e43bef Add b
+| |/  
+| * 0fa8ccf Add a
+|/  
+* b567761 Initial commit

--- a/testdata/script/issue398_repo_sync_many_merged.txt
+++ b/testdata/script/issue398_repo_sync_many_merged.txt
@@ -91,6 +91,9 @@ gs repo sync
 git graph --branches
 cmp stdout $WORK/golden/graph.txt
 
+gs ll -a
+cmp stderr $WORK/golden/ll.final.txt
+
 -- repo/feat1.txt --
 feat1
 -- repo/feat2.txt --
@@ -136,27 +139,38 @@ main ◀
 ┏━┻□ feat1 (#1)
 main ◀
 -- golden/graph.txt --
-* ab3dc43 (feat1-part2) feat1.part2
-| * 9bffe4e (feat2-part2) feat2.part2
-|/  
-| * f27faaa (feat3-part2) feat3.part2
-|/  
-| * 43f356c (feat4-part2) feat4.part2
-|/  
-*   d744bd8 (HEAD -> main, origin/main) Merge change #1
-|\  
-| *   a2aa887 Merge change #2
-| |\  
-| | *   0e75bc3 Merge change #3
-| | |\  
-| | | *   50c346f Merge change #4
-| | | |\  
-| | | | * 267a7ec feat4
-| | | |/  
-| | | * fcb4332 feat3
-| | |/  
-| | * aee78bc feat2
-| |/  
-| * fc49b37 feat1
+* 3b90c1c (origin/feat1-part2, feat1-part2) feat1.part2
+| * a252f85 (origin/feat2-part2, feat2-part2) feat2.part2
+| | * 9a90907 (origin/feat3-part2, feat3-part2) feat3.part2
+| | | * d568d96 (origin/feat4-part2, feat4-part2) feat4.part2
+| | | | *   d744bd8 (HEAD -> main, origin/main) Merge change #1
+| | | | |\  
+| | | | | * a2aa887 Merge change #2
+| |_|_|_|/| 
+|/| | | | | 
+| | | | | * 0e75bc3 Merge change #3
+| | |_|_|/| 
+| |/| | | | 
+| | | | | * 50c346f Merge change #4
+| | | |_|/| 
+| | |/| |/  
+| | | |/|   
+| | | * | 267a7ec feat4
+| | |/ /  
+| | * / fcb4332 feat3
+| |/ /  
+| * / aee78bc feat2
+|/ /  
+* / fc49b37 feat1
 |/  
 * f6036b5 Initial commit
+-- golden/ll.final.txt --
+┏━□ feat1-part2 (#5) (needs restack)
+┃   3b90c1c feat1.part2 (now)
+┣━□ feat2-part2 (#6) (needs restack)
+┃   a252f85 feat2.part2 (now)
+┣━□ feat3-part2 (#7) (needs restack)
+┃   9a90907 feat3.part2 (now)
+┣━□ feat4-part2 (#8) (needs restack)
+┃   d568d96 feat4.part2 (now)
+main ◀

--- a/testdata/script/issue897_repo_sync_merged_branch_in_worktree.txt
+++ b/testdata/script/issue897_repo_sync_merged_branch_in_worktree.txt
@@ -1,6 +1,6 @@
 # 'repo sync' when a downstack branch is merged but upstack branches are in worktrees.
-# This reproduces the original bug where repo sync would fail trying to rebase
-# upstack branches that are checked out in other worktrees.
+# This reproduces the original bug where repo sync would fail when upstack
+# branches are checked out in other worktrees.
 #
 # https://github.com/abhinav/git-spice/issues/897
 
@@ -48,13 +48,11 @@ git worktree add ../wt-feature3 feature3
 shamhub merge alice/example.git 1
 
 # sync the original repo
-# This should delete feature1 and skip rebasing feature2 since it's in a worktree
+# This should delete feature1 and retarget feature2 without rebasing.
 gs repo sync
 stderr 'feature1.*was merged'
 
-# feature2 should get a warning about being in a worktree
-# (feature3 doesn't need rebasing since feature2 wasn't rebased)
-stderr 'feature2: checked out in another worktree.*skipping rebase'
+stderr 'feature2: retargeted upstack onto main'
 
 # feature1 should be deleted (merged and not in worktree)
 ! git rev-parse --verify feature1

--- a/testdata/script/issue897_repo_sync_with_worktree_branch.txt
+++ b/testdata/script/issue897_repo_sync_with_worktree_branch.txt
@@ -1,5 +1,5 @@
 # When 'repo sync' attempts to delete the merged branch
-# it has to first rebase the upstack branches of the merged branch.
+# it retargets the upstack branches of the merged branch.
 # It should gracefully handle the case where an upstack branch
 # is checked out in another worktree.
 #
@@ -41,7 +41,7 @@ shamhub merge alice/example.git 1
 gs repo sync
 stderr 'feat-1: .* was merged'
 stderr 'feat-1: deleted'
-stderr 'feat-2: checked out in another worktree .*/feat-2., skipping rebase'
+stderr 'feat-2: retargeted upstack onto main'
 
 # feat-1 was deleted and feat-2 still exists
 ! git rev-parse --verify feat-1

--- a/testdata/script/repo_sync_closed_pr_prompt.txt
+++ b/testdata/script/repo_sync_closed_pr_prompt.txt
@@ -53,5 +53,5 @@ main
 > #1 was closed but not merged.
 true
 -- golden/closed.txt --
-┏━■ feature2 (#2) (needs push) ◀
+┏━■ feature2 (#2) (needs restack) ◀
 main

--- a/testdata/script/repo_sync_conflict.txt
+++ b/testdata/script/repo_sync_conflict.txt
@@ -1,6 +1,6 @@
 # Conflict with restacking remaining branches
 # after a base branch is merged
-# is properly handled by 'repo sync'
+# is deferred until an explicit restack.
 
 as 'Test <test@example.com>'
 at '2025-01-17T05:06:07Z'
@@ -49,8 +49,11 @@ git push origin main
 
 cd ../repo
 gs bco feat2
-! gs repo sync
+gs repo sync
 stderr '#1 was merged'
+stderr 'feat2: retargeted upstack onto main'
+
+! gs branch restack
 stderr 'There was a conflict while rebasing'
 
 cp $WORK/extra/feat2-resolved.txt feat2.txt

--- a/testdata/script/repo_sync_merged_pr.txt
+++ b/testdata/script/repo_sync_merged_pr.txt
@@ -39,7 +39,7 @@ git branch -r
 
 # we should now be on main,
 # feature1 branch should be gone,
-# and feature2 should be restacked.
+# and feature2 should be retargeted without restacking.
 exists feature1.txt
 git graph --branches
 cmp stdout $WORK/golden/merged-log.txt
@@ -80,9 +80,11 @@ Contents of feature2
 }
 
 -- golden/merged-log.txt --
-* bd70ef4 (feature2) Add feature2
-*   614e5f2 (HEAD -> main, origin/main) Merge change #1
-|\  
-| * 9f1c9af Add feature1
+* b75bc0c (feature2) Add feature2
+| *   614e5f2 (HEAD -> main, origin/main) Merge change #1
+| |\  
+| |/  
+|/|   
+* | 9f1c9af Add feature1
 |/  
 * d90607e Initial commit

--- a/testdata/script/stale_base_repo_sync_recovery.txt
+++ b/testdata/script/stale_base_repo_sync_recovery.txt
@@ -40,10 +40,14 @@ stderr 'gs repo sync'
 # recover by syncing
 gs repo sync
 stderr 'feature1: #1 was merged'
+stderr 'feature2: retargeted upstack onto main'
 
-# feature2 is now restacked onto main.
-# switch to feature2 and submit — should succeed
+# feature2 is now retargeted onto main.
+# Restack feature2 explicitly, then submit.
 gs bco feature2
+stderr 'feature2: needs to be restacked'
+gs branch restack
+stderr 'feature2: restacked on main'
 gs ss --fill
 stderr 'Updated #2'
 


### PR DESCRIPTION
`repo sync` should delete finished branches without silently
rebasing the surviving branch above each deletion.
That keeps sync focused on state and branch cleanup,
while `--restack` remains the explicit command for replaying commits.

Branch deletion now accepts an upstack policy so sync can retarget
surviving upstacks by updating bookkeeping only.
The normal branch delete commands keep their existing rebase behavior.

Script coverage includes the multi-delete stack where `a` and `b`
are deleted from `main -> a -> b -> c`.
After sync, `c` still has its original commit,
is based on `main` in state,
and needs an explicit restack.

Supersedes #1149
Resolves #1134