### PR TITLE
feat(navigation): Reattach from detached branch

### DIFF
--- a/.changes/unreleased/Added-20260524-180520.yaml
+++ b/.changes/unreleased/Added-20260524-180520.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'navigation: Allow up, down, top, and bottom to navigate from a detached HEAD when it points at exactly one local branch.'
+time: 2026-05-24T18:05:20.72981-07:00

--- a/bottom.go
+++ b/bottom.go
@@ -34,10 +34,9 @@ func (cmd *bottomCmd) Run(
 	svc *spice.Service,
 	checkoutHandler CheckoutHandler,
 ) error {
-	current, err := wt.CurrentBranch(ctx)
+	current, _, err := currentBranchForNavigation(ctx, wt)
 	if err != nil {
-		// TODO: handle not a branch
-		return fmt.Errorf("get current branch: %w", err)
+		return err
 	}
 
 	if current == store.Trunk() {

--- a/down.go
+++ b/down.go
@@ -40,10 +40,9 @@ func (cmd *downCmd) Run(
 		return errors.New("number of branches must be positive")
 	}
 
-	current, err := wt.CurrentBranch(ctx)
+	current, _, err := currentBranchForNavigation(ctx, wt)
 	if err != nil {
-		// TODO: handle not a branch
-		return fmt.Errorf("get current branch: %w", err)
+		return err
 	}
 
 	var below string

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"iter"
+	"strings"
 )
 
 // LocalBranch represents a local branch in a repository.
@@ -88,6 +89,36 @@ func (r *Repository) LocalBranches(ctx context.Context, opts *LocalBranchesOptio
 				Worktree: string(bytes.TrimSpace(worktree)),
 			}
 			if !yield(localBranch, nil) {
+				return
+			}
+		}
+	}
+}
+
+// BranchesAtCommitish reports local branches that point at commitish.
+func (r *Repository) BranchesAtCommitish(
+	ctx context.Context,
+	commitish string,
+) iter.Seq2[string, error] {
+	return func(yield func(string, error) bool) {
+		cmd := r.gitCmd(
+			ctx,
+			"for-each-ref",
+			"--format=%(refname:short)",
+			"--points-at", commitish,
+			"refs/heads/",
+		)
+		for line, err := range cmd.Lines() {
+			if err != nil {
+				yield("", fmt.Errorf("git for-each-ref: %w", err))
+				return
+			}
+
+			name := strings.TrimSpace(string(line))
+			if name == "" {
+				continue
+			}
+			if !yield(name, nil) {
 				return
 			}
 		}

--- a/internal/git/branch_test.go
+++ b/internal/git/branch_test.go
@@ -2,6 +2,7 @@ package git_test
 
 import (
 	"bytes"
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -109,6 +110,47 @@ func TestIntegrationBranches(t *testing.T) {
 
 		_, err := wt.CurrentBranch(t.Context())
 		assert.ErrorIs(t, err, git.ErrDetachedHead)
+	})
+
+	t.Run("BranchesAtCommitish", func(t *testing.T) {
+		branches, err := sliceutil.CollectErr(
+			repo.BranchesAtCommitish(t.Context(), "feature1"))
+		require.NoError(t, err)
+		assert.Equal(t, []string{"feature1"}, branches)
+	})
+
+	t.Run("BranchesAtHead", func(t *testing.T) {
+		t.Cleanup(func() {
+			assert.NoError(t,
+				wt.CheckoutBranch(context.WithoutCancel(t.Context()), "main"))
+		})
+
+		require.NoError(t, wt.DetachHead(t.Context(), "feature1"))
+
+		branches, err := sliceutil.CollectErr(wt.BranchesAtHead(t.Context()))
+		require.NoError(t, err)
+		assert.Equal(t, []string{"feature1"}, branches)
+	})
+
+	t.Run("BranchesAtHead_ambiguous", func(t *testing.T) {
+		require.NoError(t, repo.CreateBranch(t.Context(), git.CreateBranchRequest{
+			Name: "feature1-copy",
+			Head: "feature1",
+		}))
+		t.Cleanup(func() {
+			ctx := context.WithoutCancel(t.Context())
+			assert.NoError(t, wt.CheckoutBranch(ctx, "main"))
+			assert.NoError(t,
+				repo.DeleteBranch(ctx, "feature1-copy", git.BranchDeleteOptions{
+					Force: true,
+				}))
+		})
+
+		require.NoError(t, wt.DetachHead(t.Context(), "feature1"))
+
+		branches, err := sliceutil.CollectErr(wt.BranchesAtHead(t.Context()))
+		require.NoError(t, err)
+		assert.Equal(t, []string{"feature1", "feature1-copy"}, branches)
 	})
 
 	t.Run("CreateBranch", func(t *testing.T) {

--- a/internal/git/branch_wt.go
+++ b/internal/git/branch_wt.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
 	"strings"
 )
 
@@ -26,6 +27,26 @@ func (w *Worktree) CurrentBranch(ctx context.Context) (string, error) {
 		return "", ErrDetachedHead
 	}
 	return name, nil
+}
+
+// BranchesAtHead reports local branches that point at the worktree's HEAD.
+func (w *Worktree) BranchesAtHead(ctx context.Context) iter.Seq2[string, error] {
+	return func(yield func(string, error) bool) {
+		head, err := w.Head(ctx)
+		if err != nil {
+			yield("", fmt.Errorf("get HEAD: %w", err))
+			return
+		}
+
+		for branch, err := range w.repo.BranchesAtCommitish(ctx, head.String()) {
+			if !yield(branch, err) {
+				return
+			}
+			if err != nil {
+				return
+			}
+		}
+	}
 }
 
 // DetachHead detaches the HEAD from the current branch

--- a/nav.go
+++ b/nav.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/sliceutil"
+)
+
+// currentBranchForNavigation reports the branch that navigation commands
+// should treat as the user's starting point.
+//
+// Detached HEAD is accepted only when it points at exactly one local branch.
+// That keeps Git's detached state visible to command logic
+// while still letting navigation commands reattach or move from
+// `gs ... --detach` output.
+func currentBranchForNavigation(
+	ctx context.Context,
+	wt *git.Worktree,
+) (branch string, attached bool, err error) {
+	current, err := wt.CurrentBranch(ctx)
+	if err == nil {
+		return current, true, nil
+	}
+	if !errors.Is(err, git.ErrDetachedHead) {
+		return "", false, fmt.Errorf("get current branch: %w", err)
+	}
+
+	branches, err := sliceutil.CollectErr(wt.BranchesAtHead(ctx))
+	if err != nil {
+		return "", false, fmt.Errorf("get current branch: %w", err)
+	}
+	switch len(branches) {
+	case 0:
+		return "", false, errors.New(
+			"detached HEAD does not point at a local branch")
+	case 1:
+		return branches[0], false, nil
+	default:
+		return "", false, fmt.Errorf(
+			"detached HEAD points at multiple local branches: %s",
+			strings.Join(branches, ", "),
+		)
+	}
+}

--- a/testdata/script/nav_detach_dry_run.txt
+++ b/testdata/script/nav_detach_dry_run.txt
@@ -32,9 +32,13 @@ gs down --detach
 git branch
 cmp stdout $WORK/golden/feat4_branch.txt
 
-# TODO: maybe we can match detached head to branch in the future.
-! gs up
-stderr 'in detached HEAD state'
+gs up
+git branch
+cmp stdout $WORK/golden/feat5_checked_out.txt
+
+gs down --detach
+gs down -n
+stdout '^feat3$'
 
 gs bco feat1 -n
 stdout '^feat1$'
@@ -53,6 +57,16 @@ stdout '^feat5$'
 gs top --detach
 git branch
 cmp stdout $WORK/golden/feat5_branch.txt
+gs top
+git branch
+cmp stdout $WORK/golden/feat5_checked_out.txt
+gs top --detach
+git branch
+cmp stdout $WORK/golden/feat5_branch.txt
+gs bottom -n
+stdout '^feat1$'
+gs top -n
+stdout '^feat5$'
 
 # top should still honor --detach when already on the top branch.
 gs bco feat5
@@ -63,6 +77,11 @@ cmp stdout $WORK/golden/feat5_branch.txt
 gs trunk --detach
 git branch
 cmp stdout $WORK/golden/trunk_branch.txt
+
+git branch feat5-copy feat5
+gs bco feat5 --detach
+! gs top -n
+stderr 'detached HEAD points at multiple local branches: feat5, feat5-copy'
 
 -- golden/feat5_graph.txt --
 * 372d1de (HEAD -> feat5) feat5
@@ -94,6 +113,13 @@ cmp stdout $WORK/golden/trunk_branch.txt
   feat3
   feat4
   feat5
+  main
+-- golden/feat5_checked_out.txt --
+  feat1
+  feat2
+  feat3
+  feat4
+* feat5
   main
 -- golden/trunk_branch.txt --
 * (HEAD detached at refs/heads/main)

--- a/top.go
+++ b/top.go
@@ -35,10 +35,9 @@ func (cmd *topCmd) Run(
 	svc *spice.Service,
 	checkoutHandler CheckoutHandler,
 ) error {
-	current, err := wt.CurrentBranch(ctx)
+	current, attached, err := currentBranchForNavigation(ctx, wt)
 	if err != nil {
-		// TODO: handle not a branch
-		return fmt.Errorf("get current branch: %w", err)
+		return err
 	}
 
 	tops, err := svc.FindTop(ctx, current)
@@ -75,7 +74,7 @@ func (cmd *topCmd) Run(
 		}
 	}
 
-	if branch == current && !cmd.DryRun && !cmd.Detach {
+	if branch == current && attached && !cmd.DryRun && !cmd.Detach {
 		log.Info("Already on the top-most branch in this stack")
 		return nil
 	}

--- a/up.go
+++ b/up.go
@@ -42,10 +42,9 @@ func (cmd *upCmd) Run(
 		return errors.New("number of branches must be positive")
 	}
 
-	current, err := wt.CurrentBranch(ctx)
+	current, _, err := currentBranchForNavigation(ctx, wt)
 	if err != nil {
-		// TODO: handle not a branch
-		return fmt.Errorf("get current branch: %w", err)
+		return err
 	}
 
 	graph, err := svc.BranchGraph(ctx, nil)


### PR DESCRIPTION
Navigation commands should treat a detached HEAD at exactly one local
branch as a branch-shaped starting point.
This lets `up`, `down`, `top`, and `bottom` move through the stack
without forcing the user to check out the branch manually first.

`top` still reports a no-op when already attached at the top,
but it now honors `--detach` and reattaches when the top branch was
only inferred from detached HEAD.

Targeted tests cover the branch inference boundary and the detached
navigation workflow.