### PR TITLE
repo sync: Add restack modes

### DIFF
--- a/.changes/unreleased/Changed-20260509-102052.yaml
+++ b/.changes/unreleased/Changed-20260509-102052.yaml
@@ -1,0 +1,8 @@
+kind: Changed
+body: >-
+  repo sync:
+  --restack option now runs in 'upstack' mode: all upstack branches of deleted merged branches will be restacked.
+  Override with --restack=aboves to restack only the branches directly above,
+  or --restack=none to disable restacking (this is the default behavior).
+  Change the default by setting the 'spice.repoSync.restack' configuration option.
+time: 2026-05-09T10:20:52.268442-07:00

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -610,3 +610,9 @@ on the next release.
   This requires breaking lines at natural grammatical boundaries
   (such as after complete sentences, clauses, or list items),
   while remaining within the 80-character limit.
+- Use the `$$...$$` shorthand only for command names
+  and configuration names that `doc/hooks/cliref.py` can link.
+  Examples: `$$gs repo sync$$` and `$$spice.repoSync.restack$$`.
+  Never include flags inside `$$...$$`;
+  write full command invocations with flags as inline code instead.
+  For example, write `gs repo sync --restack`.

--- a/config_test.go
+++ b/config_test.go
@@ -16,6 +16,7 @@ import (
 	"go.abhg.dev/gs/internal/cli/experiment"
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/handler/sync"
 	"go.abhg.dev/gs/internal/sigstack"
 	"go.abhg.dev/gs/internal/silog/silogtest"
 	"go.abhg.dev/gs/internal/spice"
@@ -220,6 +221,111 @@ func TestMainGitIndexLockTimeoutConfig(t *testing.T) {
 			_, err = parser.Parse(tt.args)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, cmd.Git.IndexLockTimeout)
+		})
+	}
+}
+
+func TestRepoSyncRestackConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  string
+		args    []string
+		want    sync.RestackMode
+		wantErr []string
+	}{
+		{
+			name: "Default",
+			args: []string{"repo", "sync"},
+			want: sync.RestackNone,
+		},
+		{
+			name: "FlagWithoutValue",
+			args: []string{"repo", "sync", "--restack"},
+			want: sync.RestackUpstack,
+		},
+		{
+			name: "FlagTrue",
+			args: []string{"repo", "sync", "--restack=true"},
+			want: sync.RestackUpstack,
+		},
+		{
+			name: "FlagFalse",
+			args: []string{"repo", "sync", "--restack=false"},
+			want: sync.RestackNone,
+		},
+		{
+			name: "FlagNone",
+			args: []string{"repo", "sync", "--restack=none"},
+			want: sync.RestackNone,
+		},
+		{
+			name: "FlagUpstack",
+			args: []string{"repo", "sync", "--restack=upstack"},
+			want: sync.RestackUpstack,
+		},
+		{
+			name: "FlagAboves",
+			args: []string{"repo", "sync", "--restack=aboves"},
+			want: sync.RestackAboves,
+		},
+		{
+			name: "Config",
+			config: joinLines(
+				`[spice "repoSync"]`,
+				`  restack = aboves`,
+			),
+			args: []string{"repo", "sync"},
+			want: sync.RestackAboves,
+		},
+		{
+			name: "FlagOverridesConfig",
+			config: joinLines(
+				`[spice "repoSync"]`,
+				`  restack = aboves`,
+			),
+			args: []string{"repo", "sync", "--restack=none"},
+			want: sync.RestackNone,
+		},
+		{
+			name: "Invalid",
+			args: []string{"repo", "sync", "--restack=invalid"},
+			wantErr: []string{
+				`--restack: invalid value "invalid": expected none, aboves, or upstack`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spicecfg := loadTestSpiceConfig(t, tt.config)
+
+			var cmd mainCmd
+			logger := silogtest.New(t)
+			var (
+				forges   forge.Registry
+				sigStack sigstack.Stack
+			)
+			parser, err := kong.New(
+				&cmd,
+				kong.Resolvers(spicecfg),
+				kong.Bind(logger, &forges, &sigStack),
+				kong.BindTo(t.Context(), (*context.Context)(nil)),
+				kong.BindTo(spicecfg, (*experiment.Enabler)(nil)),
+				kong.Vars{"defaultPrompt": "false"},
+			)
+			require.NoError(t, err)
+
+			_, err = parser.Parse(tt.args)
+			if len(tt.wantErr) > 0 {
+				require.Error(t, err)
+				for _, msg := range tt.wantErr {
+					assert.ErrorContains(t, err, msg)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, cmd.Repo.Sync.Restack)
 		})
 	}
 }

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -156,11 +156,17 @@ The repository must have a remote associated for syncing.
 A prompt will ask for one if the repository
 was not initialized with a remote.
 
+Branches above merged and deleted branches
+are retargeted to the trunk branch.
+Run with --restack to also restack them and their upstacks.
+Run with --restack=aboves to only restack direct upstacks
+of deleted branches, leaving higher branches in place.
+
 **Flags**
 
-* `--restack`: Restack the current stack after syncing
+* `--restack` ([:material-wrench:{ .middle title="spice.repoSync.restack" }](/cli/config.md#spicereposyncrestack)): How to restack branches above deleted branches. One of 'none', 'aboves', and 'upstack'.
 
-**Configuration**: [spice.repoSync.closedChanges](/cli/config.md#spicereposyncclosedchanges)
+**Configuration**: [spice.repoSync.closedChanges](/cli/config.md#spicereposyncclosedchanges), [spice.repoSync.restack](/cli/config.md#spicereposyncrestack)
 
 ### git-spice repo restack {#gs-repo-restack}
 

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -663,6 +663,23 @@ a warning is logged to indicate that the branch is outdated.
 The `--force` flag always bypasses the check
 regardless of this setting.
 
+### spice.repoSync.restack
+
+<!-- gs:version unreleased -->
+
+Which branches to restack after syncing trunk
+and deleting merged branches with $$gs repo sync$$.
+
+**Accepted values:**
+
+- `none` (default): do not restack anything
+- `aboves`: restack only direct upstacks of deleted branches
+- `upstack`: restack all upstacks of deleted branches
+
+The command-line flag uses the same values.
+Bare `gs repo sync --restack` selects `upstack`.
+`gs repo sync --restack=false` selects `none`.
+
 ### spice.repoSync.closedChanges
 
 <!-- gs:version v0.17.0 -->

--- a/doc/src/community/recipes.md
+++ b/doc/src/community/recipes.md
@@ -163,6 +163,8 @@ there are some options that can help your workflow.
 
 - $$gs repo sync$$ will detect branches that were merged
   with merge commits or fast-forwards, and delete them locally.
+  Use `gs repo sync --restack` to also restack surviving branches
+  above the deleted merged branches.
   For branches that were merged by rebasing or squashing,
   you'll need to manually delete merged branches with $$gs branch delete$$.
 

--- a/doc/src/guide/cr.md
+++ b/doc/src/guide/cr.md
@@ -254,6 +254,21 @@ This will update the trunk branch (e.g. `main`)
 with the latest changes from the upstream repository,
 and delete any local branches whose PRs have been merged.
 
+If merged branches had other branches stacked on top of them,
+$$gs repo sync$$ will retarget those surviving branches
+onto the next available branch downstack,
+or onto trunk.
+It does not rebase them by default,
+so those branches may need an explicit $$gs branch restack$$
+before they can be submitted.
+
+To sync and restack all surviving branches above deleted merged branches
+in one step, use the `--restack` flag:
+
+```freeze language="terminal"
+{green}${reset} gs repo sync --restack
+```
+
 ### Handling closed Change Requests
 
 When running $$gs repo sync$$, if a Change Request was closed

--- a/doc/src/guide/limits.md
+++ b/doc/src/guide/limits.md
@@ -108,7 +108,9 @@ arrow " restack" ljust from Y.s to Z.n
 As a result of this, when a branch is squash-merged into the trunk branch,
 branches upstack from it need to be restacked, and all their CRs updated.
 
-To restack and re-submit the current stack after a squash merge, you can run:
+To restack all branches above deleted merged branches
+and then submit the current stack after a squash merge,
+you can run:
 
 ```freeze language="terminal"
 {green}${reset} gs repo sync --restack

--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -106,7 +106,8 @@ $ gs repo sync
     [parts of](cli/reference.md#gs-upstack-submit)
     [the stack](cli/reference.md#gs-downstack-submit).
     If a branch has already been submitted, git-spice will update the submission.
-    If it has been merged, git-spice will automatically retarget branches that depend on it.
+    If it has been merged, git-spice will automatically retarget branches
+    that depend on it.
 
 -   [:material-stairs:{ .lg .middle } __Incremental improvements__](start/stack.md)
 

--- a/doc/src/start/submit.md
+++ b/doc/src/start/submit.md
@@ -188,8 +188,10 @@ it will prompt you to create a CR for it.
     gs repo sync
     ```
 
-    This will delete `feat1` locally,
-    and rebase `feat2` on top of `main`.
+    This will delete `feat1` locally
+    and retarget `feat2` onto `main`.
+    To rebase `feat2` immediately,
+    run `gs repo sync --restack` instead.
 
 3. Submit the CR for `feat2` to update the pull request
    if necessary.

--- a/internal/handler/sync/handler.go
+++ b/internal/handler/sync/handler.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"maps"
 	"runtime"
 	"slices"
 	"sort"
@@ -20,6 +21,7 @@ import (
 	"go.abhg.dev/gs/internal/graph"
 	"go.abhg.dev/gs/internal/handler/autostash"
 	branchdel "go.abhg.dev/gs/internal/handler/delete"
+	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/must"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/spice"
@@ -74,9 +76,11 @@ type DeleteHandler interface {
 	DeleteBranches(context.Context, *branchdel.Request) error
 }
 
-// RestackHandler allows restacking the current stack.
+// RestackHandler allows restacking branches after sync
+// has removed their downstack branches.
 type RestackHandler interface {
-	RestackStack(ctx context.Context, branch string) error
+	RestackBranch(ctx context.Context, branch string) error
+	RestackUpstack(ctx context.Context, branch string, opts *restack.UpstackOptions) error
 }
 
 // AutostashHandler is a subset of the autostash.Handler interface.
@@ -165,7 +169,7 @@ func (c ClosedChanges) String() string {
 type TrunkOptions struct {
 	// TODO: flag to not delete merged branches?
 
-	Restack       bool          `help:"Restack the current stack after syncing"`
+	Restack       RestackMode   `default:"none" config:"repoSync.restack" enum:"none,aboves,upstack" help:"How to restack branches above deleted branches. One of 'none', 'aboves', and 'upstack'."`
 	ClosedChanges ClosedChanges `default:"ask" config:"repoSync.closedChanges" enum:"ask,ignore" help:"How to handle closed change requests. One of 'ask' and 'ignore'." hidden:""`
 }
 
@@ -185,13 +189,13 @@ func (h *Handler) SyncTrunk(ctx context.Context, opts *TrunkOptions) (retErr err
 		currentBranch = "" // detached head
 	}
 
-	autostashCleanupOptions := autostash.CleanupOptions{
-		RescueBranch: currentBranch,
-	}
+	autostashRescueBranch := currentBranch
 	var autostashCleanup func(*error, *autostash.CleanupOptions)
 	defer func() {
 		if autostashCleanup != nil {
-			autostashCleanup(&retErr, &autostashCleanupOptions)
+			autostashCleanup(&retErr, &autostash.CleanupOptions{
+				RescueBranch: autostashRescueBranch,
+			})
 		}
 	}()
 
@@ -403,64 +407,69 @@ func (h *Handler) SyncTrunk(ctx context.Context, opts *TrunkOptions) (retErr err
 		}
 	}
 
-	if len(branchesToDelete) > 0 {
-		if err := beginAutostash(); err != nil {
-			return err
-		}
+	if len(branchesToDelete) == 0 {
+		return nil
+	}
 
-		// If sync deletes the branch we started on,
-		// a later rescued rebase cannot resume on that branch.
-		// Point autostash rescue
-		// at the branch sync intends to leave us on after deletion instead:
-		// trunk in the usual case,
-		// or no branch at all if trunk is checked out
-		// in another worktree
-		// and deletion leaves this worktree detached.
-		//
-		// If the current branch is not being deleted,
-		// keep rescuing onto that branch.
-		deletingCurrentBranch := slices.ContainsFunc(branchesToDelete, func(b branchDeletion) bool {
-			return b.BranchName == currentBranch
-		})
-		if deletingCurrentBranch {
-			if trunkCheckedOutElsewhere {
-				autostashCleanupOptions.RescueBranch = ""
-			} else {
-				autostashCleanupOptions.RescueBranch = trunk
-			}
+	// Build the restack plan before deletion,
+	// while the branch graph still contains the soon-to-be-deleted bases.
+	// The plan is filtered after deletion
+	// because branches checked out in other worktrees are skipped.
+	restackPlan := planDeletedBranchRestacks(opts.Restack, branchesToDelete, branchGraph)
+
+	if err := beginAutostash(); err != nil {
+		return err
+	}
+
+	// If sync deletes the branch we started on,
+	// a later rescued operation cannot resume there.
+	// Rescue onto the branch sync intends to leave checked out instead:
+	// trunk in the usual case,
+	// or no branch if trunk is checked out elsewhere.
+	// Otherwise, keep rescuing onto the original current branch.
+	branchAfterDelete := currentBranch
+	deletingCurrentBranch := slices.ContainsFunc(branchesToDelete, func(b branchDeletion) bool {
+		return b.BranchName == currentBranch
+	})
+	if deletingCurrentBranch {
+		if trunkCheckedOutElsewhere {
+			branchAfterDelete = ""
 		} else {
-			autostashCleanupOptions.RescueBranch = currentBranch
+			branchAfterDelete = trunk
 		}
+	}
+	autostashRescueBranch = branchAfterDelete
 
-		if err := h.deleteBranches(ctx, branchesToDelete); err != nil {
-			return err
-		}
+	deletedBranchNames, err := h.deleteBranches(ctx, branchesToDelete)
+	if err != nil {
+		return err
 	}
 
 	// Retarget surviving upstack PRs on the forge
 	// around branches that are finished there.
 	if h.RemoteRepository != nil {
 		h.retargetUpstackChanges(ctx,
-			collectRetargetCandidates(
-				branchesToDelete, branchGraph,
-			))
+			collectRetargetCandidates(branchesToDelete, branchGraph))
 	}
 
-	if opts.Restack {
-		if err := beginAutostash(); err != nil {
-			return err
+	if targets := restackPlan.targets(deletedBranchNames); len(targets) > 0 {
+		for _, target := range targets {
+			// Autostash cleanup records the rescue branch
+			// if this restack is interrupted.
+			// Keep it aligned with the restack target currently in flight,
+			// not merely the first target in the plan.
+			autostashRescueBranch = target
+			if err := h.restackDeletedBranchUpstack(ctx, opts.Restack, target); err != nil {
+				return err
+			}
 		}
-
-		// current branch may have changed after deletion
-		// of merged branches.
-		currentBranch, err := h.Worktree.CurrentBranch(ctx)
-		if err != nil {
-			log.Warn("Failed to get current branch, skipping restack", "error", err)
-		} else {
-			autostashCleanupOptions.RescueBranch = currentBranch
-			// TODO: if the merged branch leaves us on trunk
-			// --restack will end up restacking all known branches.
-			return h.Restack.RestackStack(ctx, currentBranch)
+		// Successful restacks may leave us on the final target.
+		// Return to the branch that sync would have selected after deletion.
+		if branchAfterDelete != "" && branchAfterDelete != targets[len(targets)-1] {
+			autostashRescueBranch = branchAfterDelete
+			if err := h.Worktree.CheckoutBranch(ctx, branchAfterDelete); err != nil {
+				return fmt.Errorf("checkout branch %v: %w", branchAfterDelete, err)
+			}
 		}
 	}
 
@@ -903,14 +912,95 @@ func mergedChangeHeadCheck(
 	return mergedChangeHeadMismatch
 }
 
+// branchDeletion describes a local branch that repo sync may delete
+// because its upstream change is finished
+// or its commits are already reachable from trunk.
 type branchDeletion struct {
-	BranchName   string
+	// BranchName is the local branch to delete.
+	BranchName string
+
+	// UpstreamName is the remote-tracking branch to delete with it,
+	// when one exists.
 	UpstreamName string
 }
 
-func (h *Handler) deleteBranches(ctx context.Context, branchesToDelete []branchDeletion) error {
-	if len(branchesToDelete) == 0 {
+// deletedBranchRestackPlan records direct upstacks that survive deletion.
+//
+// The map is keyed by deletion candidate,
+// not by branches that were actually deleted.
+// This keeps planning separate from worktree-safety filtering:
+// targets applies the delete handler's result before restacking.
+type deletedBranchRestackPlan map[string][]string // branch => surviving aboves
+
+func planDeletedBranchRestacks(
+	mode RestackMode,
+	branchesToDelete []branchDeletion,
+	branchGraph *spice.BranchGraph,
+) deletedBranchRestackPlan {
+	if mode == RestackNone || len(branchesToDelete) == 0 {
 		return nil
+	}
+
+	deleted := make(map[string]struct{}, len(branchesToDelete))
+	for _, branch := range branchesToDelete {
+		deleted[branch.BranchName] = struct{}{}
+	}
+
+	plan := make(deletedBranchRestackPlan, len(branchesToDelete))
+	for _, branch := range branchesToDelete {
+		for above := range branchGraph.Aboves(branch.BranchName) {
+			if _, ok := deleted[above]; ok {
+				continue
+			}
+			plan[branch.BranchName] = append(plan[branch.BranchName], above)
+		}
+	}
+	return plan
+}
+
+func (p deletedBranchRestackPlan) targets(deletedBranches []string) []string {
+	if len(p) == 0 || len(deletedBranches) == 0 {
+		return nil
+	}
+
+	// Multiple adjacent deletions can point at the same surviving branch.
+	// For example, deleting both a and b in a -> b -> c
+	// should restack only from c.
+	targetSet := make(map[string]struct{})
+	for _, branch := range deletedBranches {
+		for _, above := range p[branch] {
+			targetSet[above] = struct{}{}
+		}
+	}
+
+	return slices.Sorted(maps.Keys(targetSet))
+}
+
+func (h *Handler) restackDeletedBranchUpstack(
+	ctx context.Context,
+	mode RestackMode,
+	target string,
+) error {
+	switch mode {
+	case RestackAboves:
+		if err := h.Restack.RestackBranch(ctx, target); err != nil {
+			return fmt.Errorf("restack branch %q: %w", target, err)
+		}
+	case RestackUpstack:
+		if err := h.Restack.RestackUpstack(ctx, target, nil); err != nil {
+			return fmt.Errorf("restack upstack %q: %w", target, err)
+		}
+	case RestackNone:
+		return nil
+	default:
+		return fmt.Errorf("unknown restack mode: %v", mode)
+	}
+	return nil
+}
+
+func (h *Handler) deleteBranches(ctx context.Context, branchesToDelete []branchDeletion) ([]string, error) {
+	if len(branchesToDelete) == 0 {
+		return nil, nil
 	}
 
 	allBranchNames := make([]string, len(branchesToDelete))
@@ -943,7 +1033,7 @@ func (h *Handler) deleteBranches(ctx context.Context, branchesToDelete []branchD
 		Force:    true,
 	})
 	if err != nil {
-		return fmt.Errorf("delete merged branches: %w", err)
+		return nil, fmt.Errorf("delete merged branches: %w", err)
 	}
 
 	// Also delete the remote tracking branch for this branch
@@ -964,7 +1054,7 @@ func (h *Handler) deleteBranches(ctx context.Context, branchesToDelete []branchD
 		}
 	}
 
-	return nil
+	return deleteBranchNames, nil
 }
 
 // retargetCandidate is a branch whose forge change
@@ -985,43 +1075,42 @@ type retargetCandidate struct {
 func collectRetargetCandidates(
 	deletions []branchDeletion,
 	branchGraph *spice.BranchGraph,
-) []retargetCandidate {
-	deletedNames := make(map[string]struct{}, len(deletions))
-	for _, d := range deletions {
-		deletedNames[d.BranchName] = struct{}{}
-	}
-
-	var result []retargetCandidate
-	for c := range branchGraph.All() {
-		if _, deleted := deletedNames[c.Name]; deleted {
-			continue
-		}
-		if c.Change == nil {
-			continue
-		}
-		if _, baseDeleted := deletedNames[c.Base]; !baseDeleted {
-			continue
+) iter.Seq[retargetCandidate] {
+	return func(yield func(retargetCandidate) bool) {
+		deletedNames := make(map[string]struct{}, len(deletions))
+		for _, d := range deletions {
+			deletedNames[d.BranchName] = struct{}{}
 		}
 
-		result = append(result, retargetCandidate{
-			branch:   c.Name,
-			changeID: c.Change.ChangeID(),
-			newBase: branchGraph.NextBase(c.Name, func(branch string) bool {
-				_, deleted := deletedNames[branch]
-				return deleted
-			}),
-		})
+		for c := range branchGraph.All() {
+			if _, deleted := deletedNames[c.Name]; deleted {
+				continue
+			}
+			if c.Change == nil {
+				continue
+			}
+			if _, baseDeleted := deletedNames[c.Base]; !baseDeleted {
+				continue
+			}
+
+			if !yield(retargetCandidate{
+				branch:   c.Name,
+				changeID: c.Change.ChangeID(),
+				newBase: branchGraph.NextBase(c.Name, func(branch string) bool {
+					_, deleted := deletedNames[branch]
+					return deleted
+				}),
+			}) {
+				return
+			}
+		}
 	}
-	return result
 }
 
 // retargetUpstackChanges retargets forge changes
 // for upstack branches surviving deletion.
-func (h *Handler) retargetUpstackChanges(
-	ctx context.Context,
-	candidates []retargetCandidate,
-) {
-	for _, c := range candidates {
+func (h *Handler) retargetUpstackChanges(ctx context.Context, candidates iter.Seq[retargetCandidate]) {
+	for c := range candidates {
 		h.Log.Infof("Retargeting %s to %s...",
 			c.branch, c.newBase)
 		err := h.RemoteRepository.EditChange(

--- a/internal/handler/sync/handler_test.go
+++ b/internal/handler/sync/handler_test.go
@@ -231,14 +231,16 @@ func TestHandler_SyncTrunk_autostashLazy(t *testing.T) {
 			Times(1)
 
 		mockWorktree := NewMockGitWorktree(ctrl)
-		gomock.InOrder(
-			mockWorktree.EXPECT().
-				CurrentBranch(gomock.Any()).
-				Return("feature", nil),
-			mockWorktree.EXPECT().
-				CurrentBranch(gomock.Any()).
-				Return("feature", nil),
-		)
+		mockWorktree.EXPECT().
+			CurrentBranch(gomock.Any()).
+			Return("feature", nil)
+		mockWorktree.EXPECT().
+			RootDir().
+			Return("/repo").
+			AnyTimes()
+		mockWorktree.EXPECT().
+			CheckoutBranch(gomock.Any(), "main").
+			Return(nil)
 
 		mockStore := NewMockStore(ctrl)
 		mockStore.EXPECT().
@@ -246,16 +248,45 @@ func TestHandler_SyncTrunk_autostashLazy(t *testing.T) {
 			Return("main")
 
 		mockRepo := newFetchOnlyRepoMocks(ctrl)
+		mockRepo.EXPECT().
+			LocalBranches(gomock.Any(), &git.LocalBranchesOptions{
+				Patterns: []string{"feature"},
+			}).
+			Return(branchIter(git.LocalBranch{Name: "feature"}))
+
 		mockService := NewMockService(ctrl)
 		mockService.EXPECT().
 			BranchGraph(gomock.Any(), (*spice.BranchGraphOptions)(nil)).
 			Return(spicetest.NewBranchGraph(t, spicetest.BranchGraphConfig{
 				Trunk: "main",
+				Branches: []spice.LoadBranchItem{
+					{
+						Name: "feature",
+						Head: git.Hash("trunk"),
+						Base: "main",
+					},
+					{
+						Name: "child",
+						Head: git.Hash("child-head"),
+						Base: "feature",
+					},
+				},
 			}), nil)
+		mockRepo.EXPECT().
+			IsAncestor(gomock.Any(), git.Hash("child-head"), git.Hash("trunk")).
+			Return(false)
+
+		mockDelete := NewMockDeleteHandler(ctrl)
+		mockDelete.EXPECT().
+			DeleteBranches(gomock.Any(), &branchdel.Request{
+				Branches: []string{"feature"},
+				Force:    true,
+			}).
+			Return(nil)
 
 		mockRestack := NewMockRestackHandler(ctrl)
 		mockRestack.EXPECT().
-			RestackStack(gomock.Any(), "feature").
+			RestackUpstack(gomock.Any(), "child", nil).
 			Return(nil)
 
 		handler := &Handler{
@@ -265,15 +296,373 @@ func TestHandler_SyncTrunk_autostashLazy(t *testing.T) {
 			Worktree:   mockWorktree,
 			Store:      mockStore,
 			Service:    mockService,
-			Delete:     NewMockDeleteHandler(ctrl),
+			Delete:     mockDelete,
 			Restack:    mockRestack,
 			Autostash:  mockAutostash,
 			Remote:     "origin",
 		}
 
-		require.NoError(t, handler.SyncTrunk(t.Context(), &TrunkOptions{Restack: true}))
+		require.NoError(t, handler.SyncTrunk(t.Context(), &TrunkOptions{Restack: RestackUpstack}))
 		assert.Equal(t, 1, cleanupCalls)
-		assert.Equal(t, "feature", rescueBranch)
+		assert.Equal(t, "main", rescueBranch)
+	})
+}
+
+func TestHandler_SyncTrunk_restackDeletedUpstacks(t *testing.T) {
+	t.Run("Aboves", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		mockRepo := newFetchOnlyRepoMocks(ctrl)
+		mockRepo.EXPECT().
+			LocalBranches(gomock.Any(), &git.LocalBranchesOptions{
+				Patterns: []string{"feature"},
+			}).
+			Return(branchIter(git.LocalBranch{Name: "feature"}))
+
+		mockWorktree := NewMockGitWorktree(ctrl)
+		mockWorktree.EXPECT().
+			CurrentBranch(gomock.Any()).
+			Return("feature", nil)
+		mockWorktree.EXPECT().
+			RootDir().
+			Return("/repo").
+			AnyTimes()
+		mockWorktree.EXPECT().
+			CheckoutBranch(gomock.Any(), "main").
+			Return(nil)
+
+		mockStore := NewMockStore(ctrl)
+		mockStore.EXPECT().
+			Trunk().
+			Return("main")
+
+		mockService := NewMockService(ctrl)
+		mockService.EXPECT().
+			BranchGraph(gomock.Any(), (*spice.BranchGraphOptions)(nil)).
+			Return(spicetest.NewBranchGraph(t, spicetest.BranchGraphConfig{
+				Trunk: "main",
+				Branches: []spice.LoadBranchItem{
+					{
+						Name: "feature",
+						Head: git.Hash("trunk"),
+						Base: "main",
+					},
+					{
+						Name: "child",
+						Head: git.Hash("child-head"),
+						Base: "feature",
+					},
+				},
+			}), nil)
+		mockRepo.EXPECT().
+			IsAncestor(gomock.Any(), git.Hash("child-head"), git.Hash("trunk")).
+			Return(false)
+
+		mockDelete := NewMockDeleteHandler(ctrl)
+		mockDelete.EXPECT().
+			DeleteBranches(gomock.Any(), &branchdel.Request{
+				Branches: []string{"feature"},
+				Force:    true,
+			}).
+			Return(nil)
+
+		mockRestack := NewMockRestackHandler(ctrl)
+		mockRestack.EXPECT().
+			RestackBranch(gomock.Any(), "child").
+			Return(nil)
+
+		mockAutostash := NewMockAutostashHandler(ctrl)
+		mockAutostash.EXPECT().
+			BeginAutostash(gomock.Any(), &autostash.Options{
+				Message:   "git-spice: autostash before sync",
+				ResetMode: autostash.ResetHard,
+			}).
+			Return(func(*error, *autostash.CleanupOptions) {}, nil).
+			AnyTimes()
+
+		handler := &Handler{
+			Log:        silogtest.New(t),
+			View:       ui.NewFileView(t.Output()),
+			Repository: mockRepo,
+			Worktree:   mockWorktree,
+			Store:      mockStore,
+			Service:    mockService,
+			Delete:     mockDelete,
+			Restack:    mockRestack,
+			Autostash:  mockAutostash,
+			Remote:     "origin",
+		}
+
+		require.NoError(t, handler.SyncTrunk(t.Context(), &TrunkOptions{
+			Restack: RestackAboves,
+		}))
+	})
+
+	t.Run("Upstack", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		mockRepo := newFetchOnlyRepoMocks(ctrl)
+		mockRepo.EXPECT().
+			LocalBranches(gomock.Any(), &git.LocalBranchesOptions{
+				Patterns: []string{"feature"},
+			}).
+			Return(branchIter(git.LocalBranch{Name: "feature"}))
+
+		mockWorktree := NewMockGitWorktree(ctrl)
+		mockWorktree.EXPECT().
+			CurrentBranch(gomock.Any()).
+			Return("feature", nil)
+		mockWorktree.EXPECT().
+			RootDir().
+			Return("/repo").
+			AnyTimes()
+		mockWorktree.EXPECT().
+			CheckoutBranch(gomock.Any(), "main").
+			Return(nil)
+
+		mockStore := NewMockStore(ctrl)
+		mockStore.EXPECT().
+			Trunk().
+			Return("main")
+
+		mockService := NewMockService(ctrl)
+		mockService.EXPECT().
+			BranchGraph(gomock.Any(), (*spice.BranchGraphOptions)(nil)).
+			Return(spicetest.NewBranchGraph(t, spicetest.BranchGraphConfig{
+				Trunk: "main",
+				Branches: []spice.LoadBranchItem{
+					{
+						Name: "feature",
+						Head: git.Hash("trunk"),
+						Base: "main",
+					},
+					{
+						Name: "child",
+						Head: git.Hash("child-head"),
+						Base: "feature",
+					},
+				},
+			}), nil)
+		mockRepo.EXPECT().
+			IsAncestor(gomock.Any(), git.Hash("child-head"), git.Hash("trunk")).
+			Return(false)
+
+		mockDelete := NewMockDeleteHandler(ctrl)
+		mockDelete.EXPECT().
+			DeleteBranches(gomock.Any(), &branchdel.Request{
+				Branches: []string{"feature"},
+				Force:    true,
+			}).
+			Return(nil)
+
+		mockRestack := NewMockRestackHandler(ctrl)
+		mockRestack.EXPECT().
+			RestackUpstack(gomock.Any(), "child", nil).
+			Return(nil)
+
+		mockAutostash := NewMockAutostashHandler(ctrl)
+		mockAutostash.EXPECT().
+			BeginAutostash(gomock.Any(), &autostash.Options{
+				Message:   "git-spice: autostash before sync",
+				ResetMode: autostash.ResetHard,
+			}).
+			Return(func(*error, *autostash.CleanupOptions) {}, nil).
+			AnyTimes()
+
+		handler := &Handler{
+			Log:        silogtest.New(t),
+			View:       ui.NewFileView(t.Output()),
+			Repository: mockRepo,
+			Worktree:   mockWorktree,
+			Store:      mockStore,
+			Service:    mockService,
+			Delete:     mockDelete,
+			Restack:    mockRestack,
+			Autostash:  mockAutostash,
+			Remote:     "origin",
+		}
+
+		require.NoError(t, handler.SyncTrunk(t.Context(), &TrunkOptions{
+			Restack: RestackUpstack,
+		}))
+	})
+
+	t.Run("MultipleAdjacentDeletions", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		mockRepo := newFetchOnlyRepoMocks(ctrl)
+		mockRepo.EXPECT().
+			LocalBranches(gomock.Any(), &git.LocalBranchesOptions{
+				Patterns: []string{"a", "b"},
+			}).
+			Return(branchIter(
+				git.LocalBranch{Name: "a"},
+				git.LocalBranch{Name: "b"},
+			))
+
+		mockWorktree := NewMockGitWorktree(ctrl)
+		mockWorktree.EXPECT().
+			CurrentBranch(gomock.Any()).
+			Return("c", nil)
+		mockWorktree.EXPECT().
+			RootDir().
+			Return("/repo").
+			AnyTimes()
+
+		mockStore := NewMockStore(ctrl)
+		mockStore.EXPECT().
+			Trunk().
+			Return("main")
+
+		mockService := NewMockService(ctrl)
+		mockService.EXPECT().
+			BranchGraph(gomock.Any(), (*spice.BranchGraphOptions)(nil)).
+			Return(spicetest.NewBranchGraph(t, spicetest.BranchGraphConfig{
+				Trunk: "main",
+				Branches: []spice.LoadBranchItem{
+					{
+						Name: "a",
+						Head: git.Hash("trunk"),
+						Base: "main",
+					},
+					{
+						Name: "b",
+						Head: git.Hash("trunk"),
+						Base: "a",
+					},
+					{
+						Name: "c",
+						Head: git.Hash("c-head"),
+						Base: "b",
+					},
+				},
+			}), nil)
+		mockRepo.EXPECT().
+			IsAncestor(gomock.Any(), git.Hash("c-head"), git.Hash("trunk")).
+			Return(false)
+
+		mockDelete := NewMockDeleteHandler(ctrl)
+		mockDelete.EXPECT().
+			DeleteBranches(gomock.Any(), &branchdel.Request{
+				Branches: []string{"a", "b"},
+				Force:    true,
+			}).
+			Return(nil)
+
+		mockRestack := NewMockRestackHandler(ctrl)
+		mockRestack.EXPECT().
+			RestackUpstack(gomock.Any(), "c", nil).
+			Return(nil)
+
+		mockAutostash := NewMockAutostashHandler(ctrl)
+		mockAutostash.EXPECT().
+			BeginAutostash(gomock.Any(), &autostash.Options{
+				Message:   "git-spice: autostash before sync",
+				ResetMode: autostash.ResetHard,
+			}).
+			Return(func(*error, *autostash.CleanupOptions) {}, nil).
+			AnyTimes()
+
+		handler := &Handler{
+			Log:        silogtest.New(t),
+			View:       ui.NewFileView(t.Output()),
+			Repository: mockRepo,
+			Worktree:   mockWorktree,
+			Store:      mockStore,
+			Service:    mockService,
+			Delete:     mockDelete,
+			Restack:    mockRestack,
+			Autostash:  mockAutostash,
+			Remote:     "origin",
+		}
+
+		require.NoError(t, handler.SyncTrunk(t.Context(), &TrunkOptions{
+			Restack: RestackUpstack,
+		}))
+	})
+
+	t.Run("SkippedDeletion", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		mockRepo := newFetchOnlyRepoMocks(ctrl)
+		mockRepo.EXPECT().
+			LocalBranches(gomock.Any(), &git.LocalBranchesOptions{
+				Patterns: []string{"feature"},
+			}).
+			Return(branchIter(git.LocalBranch{
+				Name:     "feature",
+				Worktree: "/other",
+			}))
+
+		mockWorktree := NewMockGitWorktree(ctrl)
+		mockWorktree.EXPECT().
+			CurrentBranch(gomock.Any()).
+			Return("child", nil)
+		mockWorktree.EXPECT().
+			RootDir().
+			Return("/repo").
+			AnyTimes()
+
+		mockStore := NewMockStore(ctrl)
+		mockStore.EXPECT().
+			Trunk().
+			Return("main")
+
+		mockService := NewMockService(ctrl)
+		mockService.EXPECT().
+			BranchGraph(gomock.Any(), (*spice.BranchGraphOptions)(nil)).
+			Return(spicetest.NewBranchGraph(t, spicetest.BranchGraphConfig{
+				Trunk: "main",
+				Branches: []spice.LoadBranchItem{
+					{
+						Name: "feature",
+						Head: git.Hash("trunk"),
+						Base: "main",
+					},
+					{
+						Name: "child",
+						Head: git.Hash("child-head"),
+						Base: "feature",
+					},
+				},
+			}), nil)
+		mockRepo.EXPECT().
+			IsAncestor(gomock.Any(), git.Hash("child-head"), git.Hash("trunk")).
+			Return(false)
+
+		mockDelete := NewMockDeleteHandler(ctrl)
+		mockDelete.EXPECT().
+			DeleteBranches(gomock.Any(), &branchdel.Request{
+				Branches: []string{},
+				Force:    true,
+			}).
+			Return(nil)
+
+		mockAutostash := NewMockAutostashHandler(ctrl)
+		mockAutostash.EXPECT().
+			BeginAutostash(gomock.Any(), &autostash.Options{
+				Message:   "git-spice: autostash before sync",
+				ResetMode: autostash.ResetHard,
+			}).
+			Return(func(*error, *autostash.CleanupOptions) {}, nil).
+			AnyTimes()
+
+		handler := &Handler{
+			Log:        silogtest.New(t),
+			View:       ui.NewFileView(t.Output()),
+			Repository: mockRepo,
+			Worktree:   mockWorktree,
+			Store:      mockStore,
+			Service:    mockService,
+			Delete:     mockDelete,
+			Restack:    NewMockRestackHandler(ctrl),
+			Autostash:  mockAutostash,
+			Remote:     "origin",
+		}
+
+		require.NoError(t, handler.SyncTrunk(t.Context(), &TrunkOptions{
+			Restack: RestackUpstack,
+		}))
 	})
 }
 
@@ -292,7 +681,7 @@ func newFetchOnlyRepoMocks(ctrl *gomock.Controller) *MockGitRepository {
 		Return(singleBranchIter(git.LocalBranch{Name: "main"})).
 		AnyTimes()
 	mockRepo.EXPECT().
-		IsAncestor(gomock.Any(), gomock.Any(), gomock.Any()).
+		IsAncestor(gomock.Any(), git.Hash("trunk"), git.Hash("trunk")).
 		Return(true).
 		AnyTimes()
 	mockRepo.EXPECT().
@@ -304,11 +693,23 @@ func newFetchOnlyRepoMocks(ctrl *gomock.Controller) *MockGitRepository {
 		}).
 		Return(nil).
 		AnyTimes()
+	mockRepo.EXPECT().
+		RemoteURL(gomock.Any(), "origin").
+		Return("https://github.com/owner/repo", nil).
+		AnyTimes()
 	return mockRepo
 }
 
 func singleBranchIter(branch git.LocalBranch) iter.Seq2[git.LocalBranch, error] {
+	return branchIter(branch)
+}
+
+func branchIter(branches ...git.LocalBranch) iter.Seq2[git.LocalBranch, error] {
 	return func(yield func(git.LocalBranch, error) bool) {
-		yield(branch, nil)
+		for _, branch := range branches {
+			if !yield(branch, nil) {
+				return
+			}
+		}
 	}
 }

--- a/internal/handler/sync/mocks_test.go
+++ b/internal/handler/sync/mocks_test.go
@@ -17,6 +17,7 @@ import (
 	git "go.abhg.dev/gs/internal/git"
 	autostash "go.abhg.dev/gs/internal/handler/autostash"
 	delete "go.abhg.dev/gs/internal/handler/delete"
+	restack "go.abhg.dev/gs/internal/handler/restack"
 	spice "go.abhg.dev/gs/internal/spice"
 	state "go.abhg.dev/gs/internal/spice/state"
 	gomock "go.uber.org/mock/gomock"
@@ -819,40 +820,78 @@ func (m *MockRestackHandler) EXPECT() *MockRestackHandlerMockRecorder {
 	return m.recorder
 }
 
-// RestackStack mocks base method.
-func (m *MockRestackHandler) RestackStack(ctx context.Context, branch string) error {
+// RestackBranch mocks base method.
+func (m *MockRestackHandler) RestackBranch(ctx context.Context, branch string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestackStack", ctx, branch)
+	ret := m.ctrl.Call(m, "RestackBranch", ctx, branch)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// RestackStack indicates an expected call of RestackStack.
-func (mr *MockRestackHandlerMockRecorder) RestackStack(ctx, branch any) *MockRestackHandlerRestackStackCall {
+// RestackBranch indicates an expected call of RestackBranch.
+func (mr *MockRestackHandlerMockRecorder) RestackBranch(ctx, branch any) *MockRestackHandlerRestackBranchCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackStack", reflect.TypeOf((*MockRestackHandler)(nil).RestackStack), ctx, branch)
-	return &MockRestackHandlerRestackStackCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackBranch", reflect.TypeOf((*MockRestackHandler)(nil).RestackBranch), ctx, branch)
+	return &MockRestackHandlerRestackBranchCall{Call: call}
 }
 
-// MockRestackHandlerRestackStackCall wrap *gomock.Call
-type MockRestackHandlerRestackStackCall struct {
+// MockRestackHandlerRestackBranchCall wrap *gomock.Call
+type MockRestackHandlerRestackBranchCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockRestackHandlerRestackStackCall) Return(arg0 error) *MockRestackHandlerRestackStackCall {
+func (c *MockRestackHandlerRestackBranchCall) Return(arg0 error) *MockRestackHandlerRestackBranchCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRestackHandlerRestackStackCall) Do(f func(context.Context, string) error) *MockRestackHandlerRestackStackCall {
+func (c *MockRestackHandlerRestackBranchCall) Do(f func(context.Context, string) error) *MockRestackHandlerRestackBranchCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRestackHandlerRestackStackCall) DoAndReturn(f func(context.Context, string) error) *MockRestackHandlerRestackStackCall {
+func (c *MockRestackHandlerRestackBranchCall) DoAndReturn(f func(context.Context, string) error) *MockRestackHandlerRestackBranchCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// RestackUpstack mocks base method.
+func (m *MockRestackHandler) RestackUpstack(ctx context.Context, branch string, opts *restack.UpstackOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RestackUpstack", ctx, branch, opts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RestackUpstack indicates an expected call of RestackUpstack.
+func (mr *MockRestackHandlerMockRecorder) RestackUpstack(ctx, branch, opts any) *MockRestackHandlerRestackUpstackCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackUpstack", reflect.TypeOf((*MockRestackHandler)(nil).RestackUpstack), ctx, branch, opts)
+	return &MockRestackHandlerRestackUpstackCall{Call: call}
+}
+
+// MockRestackHandlerRestackUpstackCall wrap *gomock.Call
+type MockRestackHandlerRestackUpstackCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockRestackHandlerRestackUpstackCall) Return(arg0 error) *MockRestackHandlerRestackUpstackCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockRestackHandlerRestackUpstackCall) Do(f func(context.Context, string, *restack.UpstackOptions) error) *MockRestackHandlerRestackUpstackCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockRestackHandlerRestackUpstackCall) DoAndReturn(f func(context.Context, string, *restack.UpstackOptions) error) *MockRestackHandlerRestackUpstackCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/handler/sync/restack_mode.go
+++ b/internal/handler/sync/restack_mode.go
@@ -1,0 +1,112 @@
+package sync
+
+import (
+	"encoding"
+	"fmt"
+	"strings"
+
+	"github.com/alecthomas/kong"
+)
+
+// RestackMode specifies how repo sync restacks branches
+// after deleting merged branches.
+type RestackMode int
+
+const (
+	// RestackNone leaves surviving upstacks retargeted in state
+	// for a later explicit restack.
+	RestackNone RestackMode = iota
+
+	// RestackUpstack restacks each surviving direct upstack
+	// of a deleted branch, plus everything above it.
+	RestackUpstack
+
+	// RestackAboves restacks only surviving direct upstacks
+	// of deleted branches.
+	RestackAboves
+)
+
+var (
+	_ kong.BoolMapperValue     = (*RestackMode)(nil)
+	_ encoding.TextUnmarshaler = (*RestackMode)(nil)
+	_ encoding.TextMarshaler   = RestackMode(0)
+)
+
+// Decode decodes RestackMode from a Kong flag value.
+//
+// It behaves like a bool flag for compatibility with the old --restack:
+// omitting the value means true/upstack,
+// and explicit true/false values map to upstack/none.
+func (m *RestackMode) Decode(ctx *kong.DecodeContext) error {
+	if ctx.Scan.Peek().Type != kong.FlagValueToken {
+		*m = RestackUpstack
+		return nil
+	}
+
+	token := ctx.Scan.Pop()
+	switch v := token.Value.(type) {
+	case string:
+		return m.UnmarshalText([]byte(v))
+	case bool:
+		if v {
+			*m = RestackUpstack
+		} else {
+			*m = RestackNone
+		}
+		return nil
+	default:
+		return fmt.Errorf("expected restack mode but got %q (%T)", token.Value, token.Value)
+	}
+}
+
+// IsBool reports that RestackMode can be used as a bool-like flag.
+func (*RestackMode) IsBool() bool {
+	return true
+}
+
+// UnmarshalText decodes RestackMode from text.
+func (m *RestackMode) UnmarshalText(bs []byte) error {
+	switch strings.ToLower(string(bs)) {
+	case "none", "false", "0", "no":
+		*m = RestackNone
+	case "upstack", "true", "1", "yes":
+		*m = RestackUpstack
+	case "aboves":
+		*m = RestackAboves
+	default:
+		return fmt.Errorf(
+			"invalid value %q:"+
+				" expected none, aboves, or upstack",
+			bs,
+		)
+	}
+	return nil
+}
+
+// MarshalText encodes RestackMode to text.
+func (m RestackMode) MarshalText() ([]byte, error) {
+	switch m {
+	case RestackNone:
+		return []byte("none"), nil
+	case RestackUpstack:
+		return []byte("upstack"), nil
+	case RestackAboves:
+		return []byte("aboves"), nil
+	default:
+		return nil, fmt.Errorf("invalid value: %d", int(m))
+	}
+}
+
+// String returns the string representation of RestackMode.
+func (m RestackMode) String() string {
+	switch m {
+	case RestackNone:
+		return "none"
+	case RestackUpstack:
+		return "upstack"
+	case RestackAboves:
+		return "aboves"
+	default:
+		return fmt.Sprintf("RestackMode(%d)", int(m))
+	}
+}

--- a/internal/handler/sync/restack_mode_test.go
+++ b/internal/handler/sync/restack_mode_test.go
@@ -1,0 +1,80 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRestackMode_UnmarshalText(t *testing.T) {
+	tests := []struct {
+		give string
+		want RestackMode
+	}{
+		{"none", RestackNone},
+		{"false", RestackNone},
+		{"upstack", RestackUpstack},
+		{"true", RestackUpstack},
+		{"aboves", RestackAboves},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.give, func(t *testing.T) {
+			var got RestackMode
+			require.NoError(t, got.UnmarshalText([]byte(tt.give)))
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	t.Run("Invalid", func(t *testing.T) {
+		var mode RestackMode
+		err := mode.UnmarshalText([]byte("invalid"))
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "invalid value")
+		assert.ErrorContains(t, err, "expected none, aboves, or upstack")
+	})
+}
+
+func TestRestackMode_MarshalText(t *testing.T) {
+	tests := []struct {
+		give RestackMode
+		want string
+	}{
+		{RestackNone, "none"},
+		{RestackUpstack, "upstack"},
+		{RestackAboves, "aboves"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got, err := tt.give.MarshalText()
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, string(got))
+		})
+	}
+
+	t.Run("Unknown", func(t *testing.T) {
+		_, err := RestackMode(42).MarshalText()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid value: 42")
+	})
+}
+
+func TestRestackMode_String(t *testing.T) {
+	tests := []struct {
+		give RestackMode
+		want string
+	}{
+		{RestackNone, "none"},
+		{RestackUpstack, "upstack"},
+		{RestackAboves, "aboves"},
+		{42, "RestackMode(42)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.give.String())
+		})
+	}
+}

--- a/internal/handler/sync/retarget_test.go
+++ b/internal/handler/sync/retarget_test.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,7 +40,7 @@ func TestCollectRetargetCandidates(t *testing.T) {
 
 	t.Run("SingleDeletion", func(t *testing.T) {
 		// main -> A -> B; A deleted, B survives with change.
-		got := collectRetargetCandidates(
+		got := slices.Collect(collectRetargetCandidates(
 			[]branchDeletion{{BranchName: "A"}},
 			branchGraph([]spice.LoadBranchItem{
 				{Name: "A", Base: "main"},
@@ -49,7 +50,7 @@ func TestCollectRetargetCandidates(t *testing.T) {
 					Change: &fakeChangeMetadata{id: fakeChangeID("pr-2")},
 				},
 			}),
-		)
+		))
 
 		assert.Equal(t, []retargetCandidate{
 			{branch: "B", changeID: fakeChangeID("pr-2"), newBase: "main"},
@@ -58,7 +59,7 @@ func TestCollectRetargetCandidates(t *testing.T) {
 
 	t.Run("MultiLevel", func(t *testing.T) {
 		// main -> A -> B -> C; A and B deleted, C survives.
-		got := collectRetargetCandidates(
+		got := slices.Collect(collectRetargetCandidates(
 			[]branchDeletion{
 				{BranchName: "A"},
 				{BranchName: "B"},
@@ -72,7 +73,7 @@ func TestCollectRetargetCandidates(t *testing.T) {
 					Change: &fakeChangeMetadata{id: fakeChangeID("pr-3")},
 				},
 			}),
-		)
+		))
 
 		assert.Equal(t, []retargetCandidate{
 			{branch: "C", changeID: fakeChangeID("pr-3"), newBase: "main"},
@@ -81,20 +82,20 @@ func TestCollectRetargetCandidates(t *testing.T) {
 
 	t.Run("NoChange", func(t *testing.T) {
 		// A deleted, B survives but has no published change.
-		got := collectRetargetCandidates(
+		got := slices.Collect(collectRetargetCandidates(
 			[]branchDeletion{{BranchName: "A"}},
 			branchGraph([]spice.LoadBranchItem{
 				{Name: "A", Base: "main"},
 				{Name: "B", Base: "A"},
 			}),
-		)
+		))
 
 		assert.Empty(t, got)
 	})
 
 	t.Run("UpstackAlsoDeleted", func(t *testing.T) {
 		// A and B both deleted — no retarget candidates.
-		got := collectRetargetCandidates(
+		got := slices.Collect(collectRetargetCandidates(
 			[]branchDeletion{
 				{BranchName: "A"},
 				{BranchName: "B"},
@@ -107,14 +108,14 @@ func TestCollectRetargetCandidates(t *testing.T) {
 					Change: &fakeChangeMetadata{id: fakeChangeID("pr-2")},
 				},
 			}),
-		)
+		))
 
 		assert.Empty(t, got)
 	})
 
 	t.Run("BaseNotDeleted", func(t *testing.T) {
 		// A is not deleted; B's base is not in the deletion set.
-		got := collectRetargetCandidates(
+		got := slices.Collect(collectRetargetCandidates(
 			[]branchDeletion{{BranchName: "X"}},
 			branchGraph([]spice.LoadBranchItem{
 				{Name: "A", Base: "main"},
@@ -124,7 +125,7 @@ func TestCollectRetargetCandidates(t *testing.T) {
 					Change: &fakeChangeMetadata{id: fakeChangeID("pr-2")},
 				},
 			}),
-		)
+		))
 
 		assert.Empty(t, got)
 	})
@@ -132,7 +133,7 @@ func TestCollectRetargetCandidates(t *testing.T) {
 	t.Run("CyclicBases", func(t *testing.T) {
 		// A -> B -> A (cycle), both deleted, C survives.
 		// Should fall back to trunk instead of looping.
-		got := collectRetargetCandidates(
+		got := slices.Collect(collectRetargetCandidates(
 			[]branchDeletion{
 				{BranchName: "A"},
 				{BranchName: "B"},
@@ -146,7 +147,7 @@ func TestCollectRetargetCandidates(t *testing.T) {
 					Change: &fakeChangeMetadata{id: fakeChangeID("pr-3")},
 				},
 			}),
-		)
+		))
 
 		assert.Equal(t, []retargetCandidate{
 			{branch: "C", changeID: fakeChangeID("pr-3"), newBase: "main"},
@@ -156,7 +157,7 @@ func TestCollectRetargetCandidates(t *testing.T) {
 	t.Run("SurvivingNonTrunkAncestor", func(t *testing.T) {
 		// main -> A -> B -> C; B deleted, A survives.
 		// C should retarget to A, not main.
-		got := collectRetargetCandidates(
+		got := slices.Collect(collectRetargetCandidates(
 			[]branchDeletion{{BranchName: "B"}},
 			branchGraph([]spice.LoadBranchItem{
 				{Name: "A", Base: "main"},
@@ -167,7 +168,7 @@ func TestCollectRetargetCandidates(t *testing.T) {
 					Change: &fakeChangeMetadata{id: fakeChangeID("pr-3")},
 				},
 			}),
-		)
+		))
 
 		assert.Equal(t, []retargetCandidate{
 			{branch: "C", changeID: fakeChangeID("pr-3"), newBase: "A"},

--- a/repo_sync.go
+++ b/repo_sync.go
@@ -19,6 +19,12 @@ func (*repoSyncCmd) Help() string {
 		The repository must have a remote associated for syncing.
 		A prompt will ask for one if the repository
 		was not initialized with a remote.
+
+		Branches above merged and deleted branches
+		are retargeted to the trunk branch.
+		Run with --restack to also restack them and their upstacks.
+		Run with --restack=aboves to only restack direct upstacks
+		of deleted branches, leaving higher branches in place.
 	`)
 }
 

--- a/testdata/help/repo_sync.txt
+++ b/testdata/help/repo_sync.txt
@@ -7,8 +7,14 @@ Branches with merged Change Requests will be deleted after syncing.
 The repository must have a remote associated for syncing. A prompt will ask for
 one if the repository was not initialized with a remote.
 
+Branches above merged and deleted branches are retargeted to the trunk branch.
+Run with --restack to also restack them and their upstacks. Run with
+--restack=aboves to only restack direct upstacks of deleted branches, leaving
+higher branches in place.
+
 Flags:
-  --restack    Restack the current stack after syncing
+  --restack    How to restack branches above deleted branches. One of 'none',
+               'aboves', and 'upstack'. (🔧 spice.repoSync.restack)
 
 Global Flags:
   -h, --help           Show help for the command

--- a/testdata/script/issue1019_repo_sync_restack_drops_commits.txt
+++ b/testdata/script/issue1019_repo_sync_restack_drops_commits.txt
@@ -1,8 +1,8 @@
 # Regression test for https://github.com/abhinav/git-spice/issues/1019
 #
-# When a single branch sits on trunk with multiple commits,
+# When a single branch sits on trunk with multiple commits
 # and trunk advances on the remote,
-# 'repo sync --restack' must preserve all commits on the branch.
+# restacking after 'repo sync' must preserve all commits on the branch.
 #
 # The bug: during restack, the fork-point fallback guard
 # checked whether the *current* base branch hash
@@ -89,8 +89,10 @@ git checkout main
 git pull origin main
 git checkout feature
 
-# Run repo sync with restack.
-gs repo sync --restack
+# Run repo sync, then restack explicitly
+# since no branches were merged (and won't restack automatically).
+gs repo sync
+gs branch restack
 
 # Verify both commits are still present after restack.
 gs ll

--- a/testdata/script/repo_sync_restack.txt
+++ b/testdata/script/repo_sync_restack.txt
@@ -1,4 +1,4 @@
-# 'repo sync' with --restack flag restacks branches after syncing
+# 'repo sync --restack' restacks upstacks of deleted merged branches.
 
 as 'Test <test@example.com>'
 at '2024-05-18T13:59:12Z'

--- a/testdata/script/repo_sync_restack_aboves.txt
+++ b/testdata/script/repo_sync_restack_aboves.txt
@@ -1,0 +1,65 @@
+# 'repo sync --restack=aboves' restacks only direct upstacks
+# of deleted merged branches.
+
+as 'Test <test@example.com>'
+at '2026-05-09T12:00:00Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# Create a stack: main -> a -> b -> c.
+git add a.txt
+gs bc -m 'Add a' a
+git add b.txt
+gs bc -m 'Add b' b
+git add c.txt
+gs bc -m 'Add c' c
+gs stack submit --fill
+
+# Merge the bottom branch server-side. Aboves mode should restack b,
+# but leave c needing restack because c is not directly above a.
+shamhub merge alice/example 1
+gs repo sync --restack=aboves
+stderr 'a: #1 was merged'
+stderr 'b: restacked on main'
+! stderr 'c: restacked'
+
+gs ll -a
+cmp stderr $WORK/golden/ll-after-sync.txt
+
+git graph --branches
+cmp stdout $WORK/golden/graph-after-sync.txt
+
+-- repo/a.txt --
+a
+-- repo/b.txt --
+b
+-- repo/c.txt --
+c
+-- golden/ll-after-sync.txt --
+  ┏━■ c (#3) (needs restack) ◀
+  ┃   b62d5a6 Add c (now)
+┏━┻□ b (#2) (needs push)
+┃    a0b8ffd Add b (now)
+main
+-- golden/graph-after-sync.txt --
+* a0b8ffd (b) Add b
+*   c82f7b8 (origin/main, main) Merge change #1
+|\  
+| | * b62d5a6 (HEAD -> c, origin/c) Add c
+| | * 68ce96f (origin/b) Add b
+| |/  
+| * aa6c339 Add a
+|/  
+* 72e2705 Initial commit

--- a/testdata/script/repo_sync_restack_autostash_second_target_conflict.txt
+++ b/testdata/script/repo_sync_restack_autostash_second_target_conflict.txt
@@ -1,0 +1,101 @@
+# 'repo sync --restack' restores autostashed changes
+# on the restack target that was interrupted.
+
+as 'Test <test@example.com>'
+at '2026-05-24T12:00:00Z'
+
+# Set up a repository with a ShamHub remote.
+cd repo
+git init
+git add conflict.txt dirty.txt
+git commit -m 'Initial commit'
+
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# Create two independent stacks:
+#
+#   main -> a -> x
+#   main -> b -> y
+#
+# The final sync will delete a and b, then restack x followed by y.
+git add a.txt
+gs bc a -m 'Add a'
+git add x.txt
+gs bc x -m 'Add x'
+
+gs trunk
+git add b.txt
+gs bc b -m 'Add b'
+cp $WORK/extra/y-conflict.txt conflict.txt
+git add conflict.txt
+gs bc y -m 'Change conflict in y'
+
+# Move main forward and merge a and b through the forge.
+# y's change to conflict.txt will conflict when replayed onto main.
+gs branch submit --branch a --fill
+gs branch submit --branch b --fill
+
+gs trunk
+cp $WORK/extra/main-conflict.txt conflict.txt
+git add conflict.txt
+git commit -m 'Change conflict on main'
+git push origin main
+shamhub merge alice/example 1
+shamhub merge alice/example 2
+
+# Start on y with dirty changes that repo sync must autostash.
+gs bco y
+cp $WORK/extra/dirty-change.txt dirty.txt
+git status --porcelain
+cmp stdout $WORK/golden/dirty-before.txt
+
+! gs repo sync --restack
+stderr 'There was a conflict while rebasing'
+stderr 'rebase of y interrupted by a conflict'
+
+# The dirty change is stashed while the rebase conflict is active.
+git status --porcelain
+cmp stdout $WORK/golden/conflict-status.txt
+
+# Resolve y's conflict and continue.
+# The autostash continuation should restore on y.
+cp $WORK/extra/resolved-conflict.txt conflict.txt
+git add conflict.txt
+gs rebase continue --no-edit
+
+git branch --show-current
+stdout 'y'
+git status --porcelain
+cmp stdout $WORK/golden/dirty-after.txt
+cmp dirty.txt $WORK/extra/dirty-change.txt
+
+-- repo/conflict.txt --
+base conflict
+-- repo/dirty.txt --
+clean dirty file
+-- repo/a.txt --
+a
+-- repo/x.txt --
+x
+-- repo/b.txt --
+b
+-- extra/y-conflict.txt --
+y conflict
+-- extra/main-conflict.txt --
+main conflict
+-- extra/resolved-conflict.txt --
+resolved conflict
+-- extra/dirty-change.txt --
+dirty change
+-- golden/dirty-before.txt --
+ M dirty.txt
+-- golden/conflict-status.txt --
+UU conflict.txt
+-- golden/dirty-after.txt --
+ M dirty.txt

--- a/testdata/script/repo_sync_restack_config.txt
+++ b/testdata/script/repo_sync_restack_config.txt
@@ -1,0 +1,71 @@
+# 'repo sync' uses repoSync.restack as its default restack mode,
+# and an explicit --restack=none overrides that configuration.
+
+as 'Test <test@example.com>'
+at '2026-05-09T12:30:00Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+git config spice.repoSync.restack aboves
+
+# With repoSync.restack=aboves, repo sync restacks direct upstacks.
+git add a.txt
+gs bc -m 'Add a' a
+git add b.txt
+gs bc -m 'Add b' b
+gs stack submit --fill
+
+shamhub merge alice/example 1
+gs repo sync
+stderr 'a: #1 was merged'
+stderr 'b: restacked on main'
+
+gs ll -a
+cmp stderr $WORK/golden/config-branch-ll.txt
+
+# A CLI --restack=none override should leave the surviving upstack
+# retargeted in state without rebasing it.
+git switch main
+git add c.txt
+gs bc -m 'Add c' c
+git add d.txt
+gs bc -m 'Add d' d
+gs stack submit --fill
+
+shamhub merge alice/example 3
+gs repo sync --restack=none
+stderr 'c: #3 was merged'
+! stderr 'd: restacked'
+
+gs ll -a
+cmp stderr $WORK/golden/override-none-ll.txt
+
+-- repo/a.txt --
+a
+-- repo/b.txt --
+b
+-- repo/c.txt --
+c
+-- repo/d.txt --
+d
+-- golden/config-branch-ll.txt --
+┏━■ b (#2) (needs push) ◀
+┃   b57bc06 Add b (now)
+main
+-- golden/override-none-ll.txt --
+┏━□ b (#2) (needs restack) (needs push)
+┃   b57bc06 Add b (now)
+┣━■ d (#4) (needs restack) ◀
+┃   c40282a Add d (now)
+main


### PR DESCRIPTION
The previous `repo sync --restack` flag behaved like a bool
and restacked the current stack after sync. That was incorrect.

With #1197, `repo sync` merely retargets base branches of surviving
upstacks, and leaves restacking to the user.

This change teaches --restack to work nicely with that:

- --restack=none (default) does not restack anything
- --restack=aboves restacks only direct upstacks of deleted branches
  (this is the old behavior prior to #1197)
- --restack, --restack=true, --restack=upstack restacks all upstacks of
  deleted branches

The `spice.repoSync.restack` configuration option allows
changing the default restack mode for `repo sync`,

Resolves #1135