### PR TITLE
fix(sync): Preserve deferred restack boundary

### DIFF
--- a/.changes/unreleased/Fixed-20260525-112137.yaml
+++ b/.changes/unreleased/Fixed-20260525-112137.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'repo sync: Fixed retargeted branches replaying already-present downstack commits during restack.'
+time: 2026-05-25T11:21:37-07:00

--- a/internal/spice/onto.go
+++ b/internal/spice/onto.go
@@ -127,13 +127,13 @@ func (s *Service) BranchOnto(ctx context.Context, req *BranchOntoRequest) error 
 
 	branchTx := s.store.BeginBranchTx()
 
-	// When SkipRebase is true, we update the base branch name
-	// but preserve the old base hash.
-	// This leaves the branch in a "needs restack" state
-	// that can be detected and corrected later.
+	// When SkipRebase is true, update the base branch name
+	// but preserve the upstream boundary for a future restack.
+	// This is usually the old recorded base hash, but may be the old
+	// base's actual head if that is already reachable from this branch.
 	baseHash := ontoHash
 	if req.SkipRebase {
-		baseHash = branch.BaseHash
+		baseHash = fromHash
 	}
 
 	if err := branchTx.Upsert(ctx, state.UpsertRequest{

--- a/internal/spice/onto_test.go
+++ b/internal/spice/onto_test.go
@@ -1,0 +1,132 @@
+package spice
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/git/gittest"
+	"go.abhg.dev/gs/internal/silog/silogtest"
+	"go.abhg.dev/gs/internal/spice/state"
+	"go.abhg.dev/gs/internal/text"
+)
+
+func TestService_BranchOnto_skipRebasePreservesActualBaseBoundary(t *testing.T) {
+	fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+		git init
+		git config user.name Test
+		git config user.email test@example.com
+		git config commit.gpgSign false
+		git commit --allow-empty -m 'Initial commit'
+
+		# Create the original downstack branch:
+		#
+		#   main -- B1 (base)
+		git add base.txt
+		git commit -m 'Add base file'
+		git branch base
+
+		# Create an upstack branch from the original base:
+		#
+		#   main -- B1 (base) -- S1 (stacked)
+		git checkout -b stacked
+		git add stacked.txt
+		git commit -m 'Add stacked file'
+
+		# Advance the downstack branch after stacked exists:
+		#
+		#   main -- B1 -- B2 -- B3 (base)
+		#            \
+		#             S1 (stacked)
+		#
+		# The test will seed git-spice state from this graph, so stacked's
+		# recorded base hash honestly reflects B1 at that point.
+		git checkout base
+		cp $WORK/extra/base-v2.txt base.txt
+		git add base.txt
+		git commit -m 'Update base file'
+
+		cp $WORK/extra/base-v3.txt base.txt
+		git add base.txt
+		git commit -m 'Update base file again'
+
+		# Leave stacked checked out. The test will rebase it outside
+		# git-spice after recording the state above.
+		git checkout stacked
+
+		-- base.txt --
+		base v1
+		-- stacked.txt --
+		stacked
+		-- extra/base-v2.txt --
+		base v2
+		-- extra/base-v3.txt --
+		base v3
+	`)))
+	require.NoError(t, err)
+	t.Cleanup(fixture.Cleanup)
+
+	ctx := t.Context()
+	wt, err := git.OpenWorktree(ctx, fixture.Dir(), git.OpenOptions{
+		Log: silogtest.New(t),
+	})
+	require.NoError(t, err)
+	repo := wt.Repository()
+
+	oldBaseHash, err := repo.PeelToCommit(ctx, "base~2")
+	require.NoError(t, err)
+	actualBaseHash, err := repo.PeelToCommit(ctx, "base")
+	require.NoError(t, err)
+
+	store := NewMemoryStore(t)
+	tx := store.BeginBranchTx()
+	require.NoError(t, tx.Upsert(ctx, state.UpsertRequest{
+		Name:     "base",
+		Base:     "main",
+		BaseHash: "main",
+	}))
+	require.NoError(t, tx.Upsert(ctx, state.UpsertRequest{
+		Name:     "stacked",
+		Base:     "base",
+		BaseHash: oldBaseHash,
+	}))
+	require.NoError(t, tx.Commit(ctx, "setup"))
+
+	svc := NewTestService(repo, wt, store, nil, silogtest.New(t))
+
+	// Simulate the user rebasing stacked with plain Git after git-spice
+	// recorded its state. stacked now contains B2 and B3, but git-spice
+	// still records B1 as the base hash:
+	//
+	//   main -- B1 -- B2 -- B3 (base) -- S1' (stacked)
+	t.Setenv("GIT_AUTHOR_NAME", "Test")
+	t.Setenv("GIT_AUTHOR_EMAIL", "test@example.com")
+	t.Setenv("GIT_COMMITTER_NAME", "Test")
+	t.Setenv("GIT_COMMITTER_EMAIL", "test@example.com")
+	require.NoError(t, wt.Rebase(ctx, git.RebaseRequest{
+		Branch:   "stacked",
+		Upstream: oldBaseHash.String(),
+		Onto:     actualBaseHash.String(),
+		Quiet:    true,
+	}))
+
+	require.NoError(t, svc.BranchOnto(ctx, &BranchOntoRequest{
+		Branch:     "stacked",
+		Onto:       "main",
+		SkipRebase: true,
+	}))
+
+	retargeted, err := svc.LookupBranch(ctx, "stacked")
+	require.NoError(t, err)
+	assert.Equal(t, "main", retargeted.Base)
+	assert.Equal(t, actualBaseHash, retargeted.BaseHash)
+
+	_, err = svc.Restack(ctx, "stacked")
+	require.NoError(t, err)
+
+	messages, err := repo.CommitMessageRange(ctx, "stacked", "main")
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "Add stacked file", messages[0].Subject)
+}

--- a/testdata/script/issue939_repo_sync_squash_merged_stale_base.txt
+++ b/testdata/script/issue939_repo_sync_squash_merged_stale_base.txt
@@ -50,7 +50,7 @@ gs branch submit --fill
 stderr 'Created #1'
 
 shamhub merge -squash -prune alice/example 1
-gs repo sync
+gs repo sync --restack=aboves
 stderr 'base: #1 was merged'
 
 # The downstack branch was deleted,

--- a/testdata/script/repo_sync_conflict.txt
+++ b/testdata/script/repo_sync_conflict.txt
@@ -1,6 +1,6 @@
 # Conflict with restacking remaining branches
 # after a base branch is merged
-# is deferred until an explicit restack.
+# is properly handled by 'repo sync --restack=aboves'.
 
 as 'Test <test@example.com>'
 at '2025-01-17T05:06:07Z'
@@ -49,11 +49,8 @@ git push origin main
 
 cd ../repo
 gs bco feat2
-gs repo sync
+! gs repo sync --restack=aboves
 stderr '#1 was merged'
-stderr 'feat2: retargeted upstack onto main'
-
-! gs branch restack
 stderr 'There was a conflict while rebasing'
 
 cp $WORK/extra/feat2-resolved.txt feat2.txt

--- a/testdata/script/repo_sync_dirty_tree_merged_pr.txt
+++ b/testdata/script/repo_sync_dirty_tree_merged_pr.txt
@@ -49,7 +49,7 @@ cp $WORK/extra/feature3_dirty.txt feature3.txt
 
 # merge feature1's PR server side and sync.
 shamhub merge alice/example 1
-gs repo sync
+gs repo sync --restack=aboves
 stderr 'feature1: #1 was merged'
 
 # dirty changes should still be present on feature3


### PR DESCRIPTION
Repo sync can retarget an upstack without rebasing it,
then restack that branch later when --restack=aboves is active.
The skipped rebase path must preserve the same upstream
boundary that an immediate BranchOnto rebase would have used.

Store that computed boundary so a later restack does not
replay downstack commits that the branch already contains.
This keeps deferred restacking aligned with the direct rebase path.

This is a follow-up to #1197 and #1199.
