### PR TITLE
branch delete: Add restack modes

### DIFF
--- a/.changes/unreleased/Changed-20260524-213158.yaml
+++ b/.changes/unreleased/Changed-20260524-213158.yaml
@@ -1,0 +1,7 @@
+kind: Changed
+body: >-
+  branch delete:
+  Branches above deleted branches are now retargeted without being restacked unless --restack is used.
+  --restack defaults to restacking all upstack branches of deleted branches.
+  Use --restack=aboves to restack only the branches directly above.
+time: 2026-05-24T21:31:58.061514-07:00

--- a/branch_delete.go
+++ b/branch_delete.go
@@ -6,6 +6,7 @@ import (
 
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/handler/delete"
+	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
 	"go.abhg.dev/gs/internal/ui"
@@ -14,16 +15,20 @@ import (
 type branchDeleteCmd struct {
 	BranchPromptConfig
 
-	Force    bool     `help:"Force deletion of the branch"`
-	Branches []string `arg:"" optional:"" help:"Names of the branches to delete" predictor:"branches"`
+	Force    bool              `help:"Force deletion of the branch"`
+	Restack  spice.RestackMode `default:"none" enum:"none,aboves,upstack" help:"How to restack branches above deleted branches. One of 'none', 'aboves', and 'upstack'."`
+	Branches []string          `arg:"" optional:"" help:"Names of the branches to delete" predictor:"branches"`
 }
 
 func (*branchDeleteCmd) Help() string {
 	return text.Dedent(`
 		The deleted branches and their commits are removed from the stack.
-		Branches above the deleted branches are first rebased onto
+		Branches above the deleted branches are retargeted onto
 		the next branches available downstack,
 		or onto trunk if there are no branches available below.
+
+		Use --restack to rebase those branches and their upstacks
+		immediately after retargeting.
 
 		Without any arguments,
 		a prompt will allow selecting the branch to delete.
@@ -82,8 +87,8 @@ func (cmd *branchDeleteCmd) Run(
 	handler DeleteHandler,
 ) error {
 	return handler.DeleteBranches(ctx, &delete.Request{
-		Branches:      cmd.Branches,
-		Force:         cmd.Force,
-		UpstackPolicy: delete.UpstackRestackAboves,
+		Branches: cmd.Branches,
+		Force:    cmd.Force,
+		Restack:  cmd.Restack,
 	})
 }

--- a/config_test.go
+++ b/config_test.go
@@ -16,9 +16,11 @@ import (
 	"go.abhg.dev/gs/internal/cli/experiment"
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/git/gittest"
 	"go.abhg.dev/gs/internal/sigstack"
 	"go.abhg.dev/gs/internal/silog/silogtest"
 	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/text"
 )
 
 // List of Git configuration sections besides "spice."
@@ -392,6 +394,14 @@ func TestBranchDeleteRestackFlag(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+				git init
+				git commit --allow-empty -m 'Initial commit'
+			`)))
+			require.NoError(t, err)
+			t.Cleanup(fixture.Cleanup)
+			t.Chdir(fixture.Dir())
+
 			spicecfg := loadTestSpiceConfig(t, tt.config)
 
 			var cmd mainCmd

--- a/config_test.go
+++ b/config_test.go
@@ -16,7 +16,6 @@ import (
 	"go.abhg.dev/gs/internal/cli/experiment"
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/handler/sync"
 	"go.abhg.dev/gs/internal/sigstack"
 	"go.abhg.dev/gs/internal/silog/silogtest"
 	"go.abhg.dev/gs/internal/spice"
@@ -230,43 +229,43 @@ func TestRepoSyncRestackConfig(t *testing.T) {
 		name    string
 		config  string
 		args    []string
-		want    sync.RestackMode
+		want    spice.RestackMode
 		wantErr []string
 	}{
 		{
 			name: "Default",
 			args: []string{"repo", "sync"},
-			want: sync.RestackNone,
+			want: spice.RestackNone,
 		},
 		{
 			name: "FlagWithoutValue",
 			args: []string{"repo", "sync", "--restack"},
-			want: sync.RestackUpstack,
+			want: spice.RestackUpstack,
 		},
 		{
 			name: "FlagTrue",
 			args: []string{"repo", "sync", "--restack=true"},
-			want: sync.RestackUpstack,
+			want: spice.RestackUpstack,
 		},
 		{
 			name: "FlagFalse",
 			args: []string{"repo", "sync", "--restack=false"},
-			want: sync.RestackNone,
+			want: spice.RestackNone,
 		},
 		{
 			name: "FlagNone",
 			args: []string{"repo", "sync", "--restack=none"},
-			want: sync.RestackNone,
+			want: spice.RestackNone,
 		},
 		{
 			name: "FlagUpstack",
 			args: []string{"repo", "sync", "--restack=upstack"},
-			want: sync.RestackUpstack,
+			want: spice.RestackUpstack,
 		},
 		{
 			name: "FlagAboves",
 			args: []string{"repo", "sync", "--restack=aboves"},
-			want: sync.RestackAboves,
+			want: spice.RestackAboves,
 		},
 		{
 			name: "Config",
@@ -275,7 +274,7 @@ func TestRepoSyncRestackConfig(t *testing.T) {
 				`  restack = aboves`,
 			),
 			args: []string{"repo", "sync"},
-			want: sync.RestackAboves,
+			want: spice.RestackAboves,
 		},
 		{
 			name: "FlagOverridesConfig",
@@ -284,7 +283,7 @@ func TestRepoSyncRestackConfig(t *testing.T) {
 				`  restack = aboves`,
 			),
 			args: []string{"repo", "sync", "--restack=none"},
-			want: sync.RestackNone,
+			want: spice.RestackNone,
 		},
 		{
 			name: "Invalid",
@@ -326,6 +325,102 @@ func TestRepoSyncRestackConfig(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, cmd.Repo.Sync.Restack)
+		})
+	}
+}
+
+func TestBranchDeleteRestackFlag(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  string
+		args    []string
+		want    spice.RestackMode
+		wantErr []string
+	}{
+		{
+			name: "Default",
+			args: []string{"branch", "delete", "feature"},
+			want: spice.RestackNone,
+		},
+		{
+			name: "FlagWithoutValue",
+			args: []string{"branch", "delete", "--restack", "feature"},
+			want: spice.RestackUpstack,
+		},
+		{
+			name: "FlagTrue",
+			args: []string{"branch", "delete", "--restack=true", "feature"},
+			want: spice.RestackUpstack,
+		},
+		{
+			name: "FlagFalse",
+			args: []string{"branch", "delete", "--restack=false", "feature"},
+			want: spice.RestackNone,
+		},
+		{
+			name: "FlagNone",
+			args: []string{"branch", "delete", "--restack=none", "feature"},
+			want: spice.RestackNone,
+		},
+		{
+			name: "FlagAboves",
+			args: []string{"branch", "delete", "--restack=aboves", "feature"},
+			want: spice.RestackAboves,
+		},
+		{
+			name: "FlagUpstack",
+			args: []string{"branch", "delete", "--restack=upstack", "feature"},
+			want: spice.RestackUpstack,
+		},
+		{
+			name: "RepoSyncConfigIgnored",
+			config: joinLines(
+				`[spice "repoSync"]`,
+				`  restack = upstack`,
+			),
+			args: []string{"branch", "delete", "feature"},
+			want: spice.RestackNone,
+		},
+		{
+			name: "Invalid",
+			args: []string{"branch", "delete", "--restack=invalid", "feature"},
+			wantErr: []string{
+				`--restack: invalid value "invalid": expected none, aboves, or upstack`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spicecfg := loadTestSpiceConfig(t, tt.config)
+
+			var cmd mainCmd
+			logger := silogtest.New(t)
+			var (
+				forges   forge.Registry
+				sigStack sigstack.Stack
+			)
+			parser, err := kong.New(
+				&cmd,
+				kong.Resolvers(spicecfg),
+				kong.Bind(logger, &forges, &sigStack),
+				kong.BindTo(t.Context(), (*context.Context)(nil)),
+				kong.BindTo(spicecfg, (*experiment.Enabler)(nil)),
+				kong.Vars{"defaultPrompt": "false"},
+			)
+			require.NoError(t, err)
+
+			_, err = parser.Parse(tt.args)
+			if len(tt.wantErr) > 0 {
+				require.Error(t, err)
+				for _, msg := range tt.wantErr {
+					assert.ErrorContains(t, err, msg)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, cmd.Branch.Delete.Restack)
 		})
 	}
 }

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -770,9 +770,12 @@ gs branch (b) delete (d,rm) [<branches> ...] [flags]
 Delete branches
 
 The deleted branches and their commits are removed from the stack.
-Branches above the deleted branches are first rebased onto
+Branches above the deleted branches are retargeted onto
 the next branches available downstack,
 or onto trunk if there are no branches available below.
+
+Use --restack to rebase those branches and their upstacks
+immediately after retargeting.
 
 Without any arguments,
 a prompt will allow selecting the branch to delete.
@@ -788,6 +791,7 @@ Use --force to delete the branch regardless of unmerged changes.
 **Flags**
 
 * `--force`: Force deletion of the branch
+* `--restack`: How to restack branches above deleted branches. One of 'none', 'aboves', and 'upstack'.
 
 **Configuration**: [spice.branchPrompt.sort](/cli/config.md#spicebranchpromptsort)
 

--- a/doc/src/guide/branch.md
+++ b/doc/src/guide/branch.md
@@ -637,12 +637,18 @@ of other changes in the stack.
 Use $$gs branch delete$$ to remove a branch from the stack
 and delete it from the repository.
 Branches that are upstack from the deleted branch
-will be restacked on top of the deleted branch's original base branch.
+are retargeted onto the deleted branch's original base branch.
+
+<!-- gs:version unreleased -->,
+Branches upstack from deleted branches are not rebased by default,
+so you must run $$gs branch restack$$ later to replay the surviving branches,
+or use `gs branch delete --restack` to rebase them as part of the operation.
 
 <div class="grid" markdown>
 
 ```freeze language="terminal"
 {green}${reset} gs branch delete feat2
+{green}INF{reset} feat3: retargeted upstack onto feat1
 {green}INF{reset} feat2: deleted (was 644a286)
 ```
 

--- a/internal/handler/delete/handler.go
+++ b/internal/handler/delete/handler.go
@@ -13,6 +13,7 @@ import (
 	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/graph"
+	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/must"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/spice"
@@ -58,14 +59,22 @@ type Service interface {
 
 var _ Service = (*spice.Service)(nil)
 
+// RestackHandler restacks branches after branch deletion has moved their base.
+type RestackHandler interface {
+	Restack(ctx context.Context, req *restack.Request) (int, error)
+}
+
+var _ RestackHandler = (*restack.Handler)(nil)
+
 // Handler implements support for branch deletion with git-spice.
 type Handler struct {
-	Log        *silog.Logger // required
-	View       ui.View       // required
-	Repository GitRepository // required
-	Worktree   GitWorktree   // required
-	Store      Store         // required
-	Service    Service       // required
+	Log        *silog.Logger  // required
+	View       ui.View        // required
+	Repository GitRepository  // required
+	Worktree   GitWorktree    // required
+	Store      Store          // required
+	Service    Service        // required
+	Restack    RestackHandler // required
 }
 
 // Request is a request to delete one or more branches.
@@ -74,24 +83,12 @@ type Request struct {
 
 	Force bool
 
-	// UpstackPolicy controls how surviving upstacks are moved
+	// Restack controls how surviving upstacks are moved
 	// after their base branches are deleted.
 	//
 	// The zero value leaves upstacks for an explicit restack later.
-	UpstackPolicy UpstackPolicy
+	Restack spice.RestackMode
 }
-
-// UpstackPolicy controls how branch deletion handles surviving upstacks.
-type UpstackPolicy int
-
-const (
-	// UpstackDoNothing moves surviving upstacks by updating state only.
-	UpstackDoNothing UpstackPolicy = iota
-
-	// UpstackRestackAboves moves surviving upstacks
-	// by replaying their commits immediately.
-	UpstackRestackAboves
-)
 
 // DeleteBranches deletes the specified branches from the repository,
 // updating all internal state as necessary.
@@ -282,12 +279,12 @@ func (h *Handler) DeleteBranches(ctx context.Context, req *Request) error {
 				continue
 			}
 
-			// Skip the rebase if the caller requested bookkeeping-only
-			// retargeting, or if the upstack branch cannot be rebased
-			// from this worktree.
-			restackAbove := req.UpstackPolicy == UpstackRestackAboves
+			// BranchOnto always updates git-spice state.
+			// The restack mode decides whether this worktree also rebases
+			// branches whose downstack base is being removed.
+			restackAbove := req.Restack.Includes(spice.RestackAboves)
 			skipRebase := !restackAbove
-			if !skipRebase && above != currentBranch {
+			if restackAbove && above != currentBranch {
 				if worktreePath, ok := branchWorktrees[above]; ok {
 					skipRebase = true
 					log.Warnf("%v: checked out in another worktree (%v), skipping rebase", above, worktreePath)
@@ -302,22 +299,31 @@ func (h *Handler) DeleteBranches(ctx context.Context, req *Request) error {
 				Onto:       base,
 				SkipRebase: skipRebase,
 			}); err != nil {
-				contCmd := []string{"branch", "delete"}
-				if req.Force {
-					contCmd = append(contCmd, "--force")
-				}
-				contCmd = append(contCmd, req.Branches...)
 				return h.Service.RebaseRescue(ctx, spice.RebaseRescueRequest{
 					Err:     err,
-					Command: contCmd,
+					Command: req.continueCommand(),
 					Branch:  checkoutTarget,
 					Message: fmt.Sprintf("interrupted: %v: deleting branch", branch),
 				})
 			}
-			if restackAbove {
-				log.Infof("%v: moved upstack onto %v", above, base)
-			} else {
+			if skipRebase {
 				log.Infof("%v: retargeted upstack onto %v", above, base)
+				continue
+			}
+
+			log.Infof("%v: moved upstack onto %v", above, base)
+
+			if req.Restack.Includes(spice.RestackUpstack) {
+				// The direct upstack has already been rebased above.
+				// Restack only branches above it so the old branch-delete
+				// continuation command remains the recovery path.
+				if _, err := h.Restack.Restack(ctx, &restack.Request{
+					Branch:          above,
+					ContinueCommand: req.continueCommand(),
+					Scope:           restack.ScopeUpstackExclusive,
+				}); err != nil {
+					return fmt.Errorf("restack upstack above %q: %w", above, err)
+				}
 			}
 		}
 	}
@@ -391,4 +397,15 @@ func (h *Handler) DeleteBranches(ctx context.Context, req *Request) error {
 	}
 
 	return nil
+}
+
+func (req *Request) continueCommand() []string {
+	contCmd := []string{"branch", "delete"}
+	if req.Force {
+		contCmd = append(contCmd, "--force")
+	}
+	if !req.Restack.Includes(spice.RestackNone) {
+		contCmd = append(contCmd, "--restack="+req.Restack.String())
+	}
+	return append(contCmd, req.Branches...)
 }

--- a/internal/handler/sync/handler.go
+++ b/internal/handler/sync/handler.go
@@ -169,8 +169,8 @@ func (c ClosedChanges) String() string {
 type TrunkOptions struct {
 	// TODO: flag to not delete merged branches?
 
-	Restack       RestackMode   `default:"none" config:"repoSync.restack" enum:"none,aboves,upstack" help:"How to restack branches above deleted branches. One of 'none', 'aboves', and 'upstack'."`
-	ClosedChanges ClosedChanges `default:"ask" config:"repoSync.closedChanges" enum:"ask,ignore" help:"How to handle closed change requests. One of 'ask' and 'ignore'." hidden:""`
+	Restack       spice.RestackMode `default:"none" config:"repoSync.restack" enum:"none,aboves,upstack" help:"How to restack branches above deleted branches. One of 'none', 'aboves', and 'upstack'."`
+	ClosedChanges ClosedChanges     `default:"ask" config:"repoSync.closedChanges" enum:"ask,ignore" help:"How to handle closed change requests. One of 'ask' and 'ignore'." hidden:""`
 }
 
 // SyncTrunk syncs the trunk branch with the remote repository,
@@ -933,11 +933,11 @@ type branchDeletion struct {
 type deletedBranchRestackPlan map[string][]string // branch => surviving aboves
 
 func planDeletedBranchRestacks(
-	mode RestackMode,
+	mode spice.RestackMode,
 	branchesToDelete []branchDeletion,
 	branchGraph *spice.BranchGraph,
 ) deletedBranchRestackPlan {
-	if mode == RestackNone || len(branchesToDelete) == 0 {
+	if !mode.Includes(spice.RestackAboves) || len(branchesToDelete) == 0 {
 		return nil
 	}
 
@@ -978,19 +978,19 @@ func (p deletedBranchRestackPlan) targets(deletedBranches []string) []string {
 
 func (h *Handler) restackDeletedBranchUpstack(
 	ctx context.Context,
-	mode RestackMode,
+	mode spice.RestackMode,
 	target string,
 ) error {
-	switch mode {
-	case RestackAboves:
-		if err := h.Restack.RestackBranch(ctx, target); err != nil {
-			return fmt.Errorf("restack branch %q: %w", target, err)
-		}
-	case RestackUpstack:
+	switch {
+	case mode.Includes(spice.RestackUpstack):
 		if err := h.Restack.RestackUpstack(ctx, target, nil); err != nil {
 			return fmt.Errorf("restack upstack %q: %w", target, err)
 		}
-	case RestackNone:
+	case mode.Includes(spice.RestackAboves):
+		if err := h.Restack.RestackBranch(ctx, target); err != nil {
+			return fmt.Errorf("restack branch %q: %w", target, err)
+		}
+	case mode.Includes(spice.RestackNone):
 		return nil
 	default:
 		return fmt.Errorf("unknown restack mode: %v", mode)

--- a/internal/handler/sync/handler_test.go
+++ b/internal/handler/sync/handler_test.go
@@ -302,7 +302,7 @@ func TestHandler_SyncTrunk_autostashLazy(t *testing.T) {
 			Remote:     "origin",
 		}
 
-		require.NoError(t, handler.SyncTrunk(t.Context(), &TrunkOptions{Restack: RestackUpstack}))
+		require.NoError(t, handler.SyncTrunk(t.Context(), &TrunkOptions{Restack: spice.RestackUpstack}))
 		assert.Equal(t, 1, cleanupCalls)
 		assert.Equal(t, "main", rescueBranch)
 	})
@@ -394,7 +394,7 @@ func TestHandler_SyncTrunk_restackDeletedUpstacks(t *testing.T) {
 		}
 
 		require.NoError(t, handler.SyncTrunk(t.Context(), &TrunkOptions{
-			Restack: RestackAboves,
+			Restack: spice.RestackAboves,
 		}))
 	})
 
@@ -483,7 +483,7 @@ func TestHandler_SyncTrunk_restackDeletedUpstacks(t *testing.T) {
 		}
 
 		require.NoError(t, handler.SyncTrunk(t.Context(), &TrunkOptions{
-			Restack: RestackUpstack,
+			Restack: spice.RestackUpstack,
 		}))
 	})
 
@@ -577,7 +577,7 @@ func TestHandler_SyncTrunk_restackDeletedUpstacks(t *testing.T) {
 		}
 
 		require.NoError(t, handler.SyncTrunk(t.Context(), &TrunkOptions{
-			Restack: RestackUpstack,
+			Restack: spice.RestackUpstack,
 		}))
 	})
 
@@ -661,7 +661,7 @@ func TestHandler_SyncTrunk_restackDeletedUpstacks(t *testing.T) {
 		}
 
 		require.NoError(t, handler.SyncTrunk(t.Context(), &TrunkOptions{
-			Restack: RestackUpstack,
+			Restack: spice.RestackUpstack,
 		}))
 	})
 }

--- a/internal/spice/restack_mode.go
+++ b/internal/spice/restack_mode.go
@@ -1,4 +1,4 @@
-package sync
+package spice
 
 import (
 	"encoding"
@@ -8,22 +8,25 @@ import (
 	"github.com/alecthomas/kong"
 )
 
-// RestackMode specifies how repo sync restacks branches
-// after deleting merged branches.
+// RestackMode specifies how a command should restack branches affected by an
+// operation that moves or removes their downstack branches.
 type RestackMode int
 
 const (
 	// RestackNone leaves surviving upstacks retargeted in state
 	// for a later explicit restack.
-	RestackNone RestackMode = iota
+	RestackNone RestackMode = 0
+)
+
+const (
+	// RestackAboves restacks only surviving direct upstacks.
+	RestackAboves RestackMode = 1 << iota
+
+	restackUpstackBranches
 
 	// RestackUpstack restacks each surviving direct upstack
-	// of a deleted branch, plus everything above it.
-	RestackUpstack
-
-	// RestackAboves restacks only surviving direct upstacks
-	// of deleted branches.
-	RestackAboves
+	// plus everything above it.
+	RestackUpstack = RestackAboves | restackUpstackBranches
 )
 
 var (
@@ -32,9 +35,17 @@ var (
 	_ encoding.TextMarshaler   = RestackMode(0)
 )
 
+// Includes reports whether this mode includes all behavior in scope.
+func (m RestackMode) Includes(scope RestackMode) bool {
+	if scope == RestackNone {
+		return m == RestackNone
+	}
+	return m&scope == scope
+}
+
 // Decode decodes RestackMode from a Kong flag value.
 //
-// It behaves like a bool flag for compatibility with the old --restack:
+// It behaves like a bool flag for compatibility with legacy --restack flags:
 // omitting the value means true/upstack,
 // and explicit true/false values map to upstack/none.
 func (m *RestackMode) Decode(ctx *kong.DecodeContext) error {

--- a/internal/spice/restack_mode_test.go
+++ b/internal/spice/restack_mode_test.go
@@ -1,4 +1,4 @@
-package sync
+package spice
 
 import (
 	"testing"
@@ -77,4 +77,14 @@ func TestRestackMode_String(t *testing.T) {
 			assert.Equal(t, tt.want, tt.give.String())
 		})
 	}
+}
+
+func TestRestackMode_Includes(t *testing.T) {
+	assert.True(t, RestackNone.Includes(RestackNone))
+	assert.False(t, RestackAboves.Includes(RestackNone))
+
+	assert.True(t, RestackAboves.Includes(RestackAboves))
+	assert.True(t, RestackUpstack.Includes(RestackAboves))
+	assert.True(t, RestackUpstack.Includes(RestackUpstack))
+	assert.False(t, RestackAboves.Includes(RestackUpstack))
 }

--- a/main.go
+++ b/main.go
@@ -475,6 +475,7 @@ func (cmd *mainCmd) AfterApply(ctx context.Context, kctx *kong.Context, logger *
 			store *state.Store,
 			wt *git.Worktree,
 			svc *spice.Service,
+			restackHandler RestackHandler,
 		) (DeleteHandler, error) {
 			return &delete.Handler{
 				Log:        log,
@@ -483,6 +484,7 @@ func (cmd *mainCmd) AfterApply(ctx context.Context, kctx *kong.Context, logger *
 				Worktree:   wt,
 				Store:      store,
 				Service:    svc,
+				Restack:    restackHandler,
 			}, nil
 		}),
 		kctx.BindSingletonProvider(func(

--- a/testdata/help/branch_delete.txt
+++ b/testdata/help/branch_delete.txt
@@ -3,8 +3,11 @@ Usage: gs branch (b) delete (d,rm) [<branches> ...] [flags]
 Delete branches
 
 The deleted branches and their commits are removed from the stack. Branches
-above the deleted branches are first rebased onto the next branches available
+above the deleted branches are retargeted onto the next branches available
 downstack, or onto trunk if there are no branches available below.
+
+Use --restack to rebase those branches and their upstacks immediately after
+retargeting.
 
 Without any arguments, a prompt will allow selecting the branch to delete.
 
@@ -15,7 +18,9 @@ Arguments:
   [<branches> ...]    Names of the branches to delete
 
 Flags:
-  --force    Force deletion of the branch
+  --force      Force deletion of the branch
+  --restack    How to restack branches above deleted branches. One of 'none',
+               'aboves', and 'upstack'.
 
 Global Flags:
   -h, --help           Show help for the command

--- a/testdata/script/branch_delete_rebase_conflict.txt
+++ b/testdata/script/branch_delete_rebase_conflict.txt
@@ -18,7 +18,7 @@ gs bc -m feature2
 
 # attempt to delete feature1
 gs trunk
-! gs branch delete --force feature1
+! gs branch delete --force --restack=aboves feature1
 
 # feature2 conflict
 stderr -count=1 'There was a conflict while rebasing'

--- a/testdata/script/branch_delete_restack_aboves.txt
+++ b/testdata/script/branch_delete_restack_aboves.txt
@@ -1,8 +1,7 @@
-# 'gs branch delete' retargets upstacks by default.
-# The deleted branch's changes are removed after an explicit restack.
+# 'gs branch delete --restack=aboves' restacks only direct upstacks.
 
 as 'Test <test@example.com>'
-at '2024-03-30T14:59:32Z'
+at '2026-05-26T10:00:00Z'
 
 cd repo
 git init
@@ -18,15 +17,15 @@ gs bc -m feature2
 git add feature3.txt
 gs bc -m feature3
 
-gs branch delete feature2 --force
+gs branch delete --force --restack=aboves feature1
 gs branch checkout feature3
 
 exists feature1.txt feature2.txt feature3.txt
 
 gs branch restack
 
-exists feature1.txt feature3.txt
-! exists feature2.txt
+exists feature2.txt feature3.txt
+! exists feature1.txt
 
 git graph --branches
 cmp stdout $WORK/golden/branches.txt
@@ -39,6 +38,6 @@ feature 2
 feature 3
 
 -- golden/branches.txt --
-* 7ed7e4b (HEAD -> feature3) feature3
-* 0ad3bcf (feature1) feature1
-* 3b9a56f (main) initial commit
+* 9f62b28 (HEAD -> feature3) feature3
+* 6ee6545 (feature2) feature2
+* 8709cff (main) initial commit

--- a/testdata/script/branch_delete_restack_upstack.txt
+++ b/testdata/script/branch_delete_restack_upstack.txt
@@ -1,8 +1,7 @@
-# 'gs branch delete' retargets upstacks by default.
-# The deleted branch's changes are removed after an explicit restack.
+# 'gs branch delete --restack' restacks the affected branch's full upstack.
 
 as 'Test <test@example.com>'
-at '2024-03-30T14:59:32Z'
+at '2026-05-26T10:00:00Z'
 
 cd repo
 git init
@@ -18,15 +17,11 @@ gs bc -m feature2
 git add feature3.txt
 gs bc -m feature3
 
-gs branch delete feature2 --force
+gs branch delete --force --restack feature1
 gs branch checkout feature3
 
-exists feature1.txt feature2.txt feature3.txt
-
-gs branch restack
-
-exists feature1.txt feature3.txt
-! exists feature2.txt
+exists feature2.txt feature3.txt
+! exists feature1.txt
 
 git graph --branches
 cmp stdout $WORK/golden/branches.txt
@@ -39,6 +34,6 @@ feature 2
 feature 3
 
 -- golden/branches.txt --
-* 7ed7e4b (HEAD -> feature3) feature3
-* 0ad3bcf (feature1) feature1
-* 3b9a56f (main) initial commit
+* 9f62b28 (HEAD -> feature3) feature3
+* 6ee6545 (feature2) feature2
+* 8709cff (main) initial commit


### PR DESCRIPTION
Branch deletion now retargets surviving upstacks by default
instead of rebasing them immediately.
This matches the repo sync behavior
and lets users decide when to replay affected commits.

The new `branch delete --restack` flag keeps the old immediate
rebase workflow available.
Bare `--restack` and `--restack=upstack` restack the moved branch
and everything above it,
while `--restack=aboves` restacks only direct surviving upstacks.
`--restack=false` and `--restack=none` leave the default
retarget-only behavior in place.

Unit and script tests cover the shared parser contract,
the branch-delete default,
the direct-above mode,
and the full-upstack mode.