### PR TITLE
branch delete: Add restack config

### DIFF
--- a/.changes/unreleased/Changed-20260524-213158.yaml
+++ b/.changes/unreleased/Changed-20260524-213158.yaml
@@ -4,4 +4,5 @@ body: >-
   Branches above deleted branches are now retargeted without being restacked unless --restack is used.
   --restack defaults to restacking all upstack branches of deleted branches.
   Use --restack=aboves to restack only the branches directly above.
+  Change the default by setting the 'spice.branchDelete.restack' configuration option.
 time: 2026-05-24T21:31:58.061514-07:00

--- a/branch_delete.go
+++ b/branch_delete.go
@@ -16,7 +16,7 @@ type branchDeleteCmd struct {
 	BranchPromptConfig
 
 	Force    bool              `help:"Force deletion of the branch"`
-	Restack  spice.RestackMode `default:"none" enum:"none,aboves,upstack" help:"How to restack branches above deleted branches. One of 'none', 'aboves', and 'upstack'."`
+	Restack  spice.RestackMode `default:"none" config:"branchDelete.restack" enum:"none,aboves,upstack" help:"How to restack branches above deleted branches. One of 'none', 'aboves', and 'upstack'."`
 	Branches []string          `arg:"" optional:"" help:"Names of the branches to delete" predictor:"branches"`
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -375,6 +375,24 @@ func TestBranchDeleteRestackFlag(t *testing.T) {
 			want: spice.RestackUpstack,
 		},
 		{
+			name: "Config",
+			config: joinLines(
+				`[spice "branchDelete"]`,
+				`  restack = aboves`,
+			),
+			args: []string{"branch", "delete", "feature"},
+			want: spice.RestackAboves,
+		},
+		{
+			name: "FlagOverridesConfig",
+			config: joinLines(
+				`[spice "branchDelete"]`,
+				`  restack = upstack`,
+			),
+			args: []string{"branch", "delete", "--restack=none", "feature"},
+			want: spice.RestackNone,
+		},
+		{
 			name: "RepoSyncConfigIgnored",
 			config: joinLines(
 				`[spice "repoSync"]`,

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -791,9 +791,9 @@ Use --force to delete the branch regardless of unmerged changes.
 **Flags**
 
 * `--force`: Force deletion of the branch
-* `--restack`: How to restack branches above deleted branches. One of 'none', 'aboves', and 'upstack'.
+* `--restack` ([:material-wrench:{ .middle title="spice.branchDelete.restack" }](/cli/config.md#spicebranchdeleterestack)): How to restack branches above deleted branches. One of 'none', 'aboves', and 'upstack'.
 
-**Configuration**: [spice.branchPrompt.sort](/cli/config.md#spicebranchpromptsort)
+**Configuration**: [spice.branchDelete.restack](/cli/config.md#spicebranchdeleterestack), [spice.branchPrompt.sort](/cli/config.md#spicebranchpromptsort)
 
 ### git-spice branch fold {#gs-branch-fold}
 

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -124,6 +124,24 @@ Commonly used values are:
 - `<name>/`: the committer's name
 - `<username>/`: the committer's username
 
+### spice.branchDelete.restack
+
+<!-- gs:version unreleased -->
+
+Controls how $$gs branch delete$$ restacks branches above deleted branches.
+
+Supported values are:
+
+- `none` (default): retarget branches above deleted branches,
+  so they can be restacked later
+- `aboves`: restack only direct branches above deleted branches
+- `upstack`: restack all upstack branches above deleted branches
+
+Passing `gs branch delete --restack`,
+`gs branch delete --restack=aboves`,
+or `gs branch delete --restack=none`
+overrides this configuration for that command.
+
 ### spice.branchCreate.generatedBranchNameLimit
 
 <!-- gs:version v0.20.0 -->

--- a/doc/src/guide/branch.md
+++ b/doc/src/guide/branch.md
@@ -643,6 +643,7 @@ are retargeted onto the deleted branch's original base branch.
 Branches upstack from deleted branches are not rebased by default,
 so you must run $$gs branch restack$$ later to replay the surviving branches,
 or use `gs branch delete --restack` to rebase them as part of the operation.
+Set $$spice.branchDelete.restack$$ to change the default mode.
 
 <div class="grid" markdown>
 

--- a/testdata/help/branch_delete.txt
+++ b/testdata/help/branch_delete.txt
@@ -20,7 +20,7 @@ Arguments:
 Flags:
   --force      Force deletion of the branch
   --restack    How to restack branches above deleted branches. One of 'none',
-               'aboves', and 'upstack'.
+               'aboves', and 'upstack'. (🔧 spice.branchDelete.restack)
 
 Global Flags:
   -h, --help           Show help for the command

--- a/testdata/script/branch_delete_restack_config.txt
+++ b/testdata/script/branch_delete_restack_config.txt
@@ -1,0 +1,73 @@
+# 'spice.branchDelete.restack' configures branch delete restack behavior.
+
+as 'Test <test@example.com>'
+at '2026-05-26T10:00:00Z'
+
+# Configured aboves mode preserves the old direct-above rebase behavior.
+cd repo
+git init
+git commit --allow-empty -m 'initial commit'
+gs repo init
+
+git add feature1.txt
+gs bc -m feature1
+
+git add feature2.txt
+gs bc -m feature2
+
+git add feature3.txt
+gs bc -m feature3
+
+git config spice.branchDelete.restack aboves
+gs branch delete --force feature1
+stderr 'feature2: moved upstack onto main'
+! stderr 'feature3: restacked'
+
+gs branch checkout feature3
+exists feature1.txt feature2.txt feature3.txt
+
+gs branch restack
+exists feature2.txt feature3.txt
+! exists feature1.txt
+
+# CLI flags override the configured mode.
+cd ../repo-override
+git init
+git commit --allow-empty -m 'initial commit'
+gs repo init
+
+git add feature1.txt
+gs bc -m feature1
+
+git add feature2.txt
+gs bc -m feature2
+
+git add feature3.txt
+gs bc -m feature3
+
+git config spice.branchDelete.restack upstack
+gs branch delete --force --restack=none feature1
+stderr 'feature2: retargeted upstack onto main'
+! stderr 'moved upstack'
+
+gs branch checkout feature2
+stderr 'feature2: needs to be restacked'
+exists feature1.txt feature2.txt
+
+gs branch restack
+exists feature2.txt
+! exists feature1.txt
+
+-- repo/feature1.txt --
+feature 1
+-- repo/feature2.txt --
+feature 2
+-- repo/feature3.txt --
+feature 3
+
+-- repo-override/feature1.txt --
+feature 1
+-- repo-override/feature2.txt --
+feature 2
+-- repo-override/feature3.txt --
+feature 3


### PR DESCRIPTION
`spice.branchDelete.restack` now configures
the default restack mode for `branch delete`.

This gives users who want immediate restacking
a persistent way to keep that behavior.
Explicit `--restack` flags continue to override
the configured default.

Parser tests cover the new config key
and CLI override behavior.
A script test verifies configured `aboves` mode
and an explicit `--restack=none` override.