### PR TITLE
branch onto: Extract onto handler

### DIFF
--- a/branch_onto.go
+++ b/branch_onto.go
@@ -7,7 +7,7 @@ import (
 
 	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/silog"
+	"go.abhg.dev/gs/internal/handler/onto"
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
@@ -49,6 +49,14 @@ func (*branchOntoCmd) Help() string {
 		Use '%[1]s upstack onto' to also move the upstack branches.
 	`, name))
 }
+
+// OntoHandler coordinates branch and upstack base changes.
+type OntoHandler interface {
+	BranchOnto(context.Context, *onto.BranchRequest) error
+	UpstackOnto(context.Context, *onto.UpstackRequest) error
+}
+
+var _ OntoHandler = (*onto.Handler)(nil)
 
 func (cmd *branchOntoCmd) AfterApply(
 	ctx context.Context,
@@ -104,58 +112,11 @@ func (cmd *branchOntoCmd) AfterApply(
 
 func (cmd *branchOntoCmd) Run(
 	ctx context.Context,
-	log *silog.Logger,
-	wt *git.Worktree,
-	svc *spice.Service,
-	restackHandler RestackHandler,
+	handler OntoHandler,
 ) error {
-	branch, err := svc.LookupBranch(ctx, cmd.Branch)
-	if err != nil {
-		if errors.Is(err, state.ErrNotExist) {
-			return fmt.Errorf("branch not tracked: %s", cmd.Branch)
-		}
-		return fmt.Errorf("get branch: %w", err)
-	}
-
-	aboves, err := svc.ListAbove(ctx, cmd.Branch)
-	if err != nil {
-		return fmt.Errorf("list branches above %s: %w", cmd.Branch, err)
-	}
-
-	// As long as there are any branches above this one,
-	// they need to be grafted onto this branch's original base.
-	// However, this move operation will be an 'upstack onto'
-	// as for each of these branches, we want to keep *their* upstacks.
-	for _, above := range aboves {
-		if err := (&upstackOntoCmd{
-			Branch: above,
-			Onto:   branch.Base,
-		}).Run(ctx, log, svc, restackHandler); err != nil {
-			return svc.RebaseRescue(ctx, spice.RebaseRescueRequest{
-				Err:     err,
-				Command: []string{"branch", "onto", cmd.Onto},
-				Branch:  cmd.Branch,
-				Message: fmt.Sprintf("interrupted: %s: branch onto %s", cmd.Branch, cmd.Onto),
-			})
-		}
-	}
-
-	// Only after the upstacks have been moved
-	// will we move the branch itself and update its internal state.
-	if err := svc.BranchOnto(ctx, &spice.BranchOntoRequest{
-		Branch: cmd.Branch,
-		Onto:   cmd.Onto,
-	}); err != nil {
-		// If the rebase is interrupted,
-		// we'll just re-run this command again later.
-		return svc.RebaseRescue(ctx, spice.RebaseRescueRequest{
-			Err:     err,
-			Command: []string{"branch", "onto", cmd.Onto},
-			Branch:  cmd.Branch,
-			Message: fmt.Sprintf("interrupted: %s: branch onto %s", cmd.Branch, cmd.Onto),
-		})
-	}
-
-	log.Infof("%s: moved onto %s", cmd.Branch, cmd.Onto)
-	return wt.CheckoutBranch(ctx, cmd.Branch)
+	return handler.BranchOnto(ctx, &onto.BranchRequest{
+		Branch:          cmd.Branch,
+		Onto:            cmd.Onto,
+		ContinueCommand: []string{"branch", "onto", cmd.Onto},
+	})
 }

--- a/internal/handler/delete/handler.go
+++ b/internal/handler/delete/handler.go
@@ -283,10 +283,13 @@ func (h *Handler) DeleteBranches(ctx context.Context, req *Request) error {
 			// The restack mode decides whether this worktree also rebases
 			// branches whose downstack base is being removed.
 			restackAbove := req.Restack.Includes(spice.RestackAboves)
-			skipRebase := !restackAbove
+			ontoMode := spice.BranchOntoRebase
+			if !restackAbove {
+				ontoMode = spice.BranchOntoRetargetOnly
+			}
 			if restackAbove && above != currentBranch {
 				if worktreePath, ok := branchWorktrees[above]; ok {
-					skipRebase = true
+					ontoMode = spice.BranchOntoRetargetOnly
 					log.Warnf("%v: checked out in another worktree (%v), skipping rebase", above, worktreePath)
 					log.Warnf("%v: Run '%s branch restack' from that worktree to complete the rebase", above, cli.Name())
 				}
@@ -295,9 +298,9 @@ func (h *Handler) DeleteBranches(ctx context.Context, req *Request) error {
 			log.Debug("Changing upstack branch to a new base",
 				"branch", above, "base", base)
 			if err := h.Service.BranchOnto(ctx, &spice.BranchOntoRequest{
-				Branch:     above,
-				Onto:       base,
-				SkipRebase: skipRebase,
+				Branch: above,
+				Onto:   base,
+				Mode:   ontoMode,
 			}); err != nil {
 				return h.Service.RebaseRescue(ctx, spice.RebaseRescueRequest{
 					Err:     err,
@@ -306,7 +309,7 @@ func (h *Handler) DeleteBranches(ctx context.Context, req *Request) error {
 					Message: fmt.Sprintf("interrupted: %v: deleting branch", branch),
 				})
 			}
-			if skipRebase {
+			if ontoMode == spice.BranchOntoRetargetOnly {
 				log.Infof("%v: retargeted upstack onto %v", above, base)
 				continue
 			}

--- a/internal/handler/onto/handler.go
+++ b/internal/handler/onto/handler.go
@@ -1,0 +1,130 @@
+// Package onto coordinates branch and upstack base changes.
+package onto
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/handler/restack"
+	"go.abhg.dev/gs/internal/silog"
+	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/state"
+)
+
+// RestackHandler restacks branches after their downstack base changes.
+type RestackHandler interface {
+	RestackUpstack(ctx context.Context, branch string, opts *restack.UpstackOptions) error
+}
+
+// Handler coordinates higher-level onto operations.
+//
+// The lower-level spice service moves one branch at a time.
+// Handler owns the command workflows that also retarget or restack
+// surrounding branches.
+type Handler struct {
+	Log      *silog.Logger  // required
+	Worktree *git.Worktree  // required
+	Service  *spice.Service // required
+	Restack  RestackHandler // required
+}
+
+// BranchRequest describes a branch onto operation.
+type BranchRequest struct {
+	// Branch is the branch to move.
+	Branch string // required
+
+	// Onto is the destination branch.
+	Onto string // required
+
+	// ContinueCommand resumes the operation after a rebase rescue.
+	ContinueCommand []string
+}
+
+// BranchOnto moves one branch onto another branch.
+//
+// Branches directly above the moved branch are first moved onto the moved
+// branch's original base,
+// preserving the command's historical behavior.
+func (h *Handler) BranchOnto(ctx context.Context, req *BranchRequest) error {
+	branch, err := h.Service.LookupBranch(ctx, req.Branch)
+	if err != nil {
+		if errors.Is(err, state.ErrNotExist) {
+			return fmt.Errorf("branch not tracked: %s", req.Branch)
+		}
+		return fmt.Errorf("get branch: %w", err)
+	}
+
+	aboves, err := h.Service.ListAbove(ctx, req.Branch)
+	if err != nil {
+		return fmt.Errorf("list branches above %s: %w", req.Branch, err)
+	}
+
+	for _, above := range aboves {
+		if err := h.UpstackOnto(ctx, &UpstackRequest{
+			Branch: above,
+			Onto:   branch.Base,
+			ContinueCommand: []string{
+				"upstack",
+				"onto",
+				branch.Base,
+			},
+		}); err != nil {
+			return h.Service.RebaseRescue(ctx, spice.RebaseRescueRequest{
+				Err:     err,
+				Command: req.ContinueCommand,
+				Branch:  req.Branch,
+				Message: fmt.Sprintf("interrupted: %s: branch onto %s", req.Branch, req.Onto),
+			})
+		}
+	}
+
+	if err := h.Service.BranchOnto(ctx, &spice.BranchOntoRequest{
+		Branch: req.Branch,
+		Onto:   req.Onto,
+	}); err != nil {
+		return h.Service.RebaseRescue(ctx, spice.RebaseRescueRequest{
+			Err:     err,
+			Command: req.ContinueCommand,
+			Branch:  req.Branch,
+			Message: fmt.Sprintf("interrupted: %s: branch onto %s", req.Branch, req.Onto),
+		})
+	}
+
+	h.Log.Infof("%s: moved onto %s", req.Branch, req.Onto)
+	return h.Worktree.CheckoutBranch(ctx, req.Branch)
+}
+
+// UpstackRequest describes an upstack onto operation.
+type UpstackRequest struct {
+	// Branch is the first branch to move.
+	Branch string // required
+
+	// Onto is the destination branch.
+	Onto string // required
+
+	// ContinueCommand resumes the operation after a rebase rescue.
+	ContinueCommand []string
+}
+
+// UpstackOnto moves one branch and restacks the branches above it.
+func (h *Handler) UpstackOnto(ctx context.Context, req *UpstackRequest) error {
+	err := h.Service.BranchOnto(ctx, &spice.BranchOntoRequest{
+		Branch: req.Branch,
+		Onto:   req.Onto,
+	})
+	if err != nil {
+		return h.Service.RebaseRescue(ctx, spice.RebaseRescueRequest{
+			Err:     err,
+			Command: req.ContinueCommand,
+			Branch:  req.Branch,
+			Message: fmt.Sprintf("interrupted: %s: upstack onto %s", req.Branch, req.Onto),
+		})
+	}
+	h.Log.Infof("%v: moved upstack onto %v", req.Branch, req.Onto)
+
+	return h.Restack.RestackUpstack(ctx, req.Branch, &restack.UpstackOptions{
+		SkipStart: true,
+	})
+}

--- a/internal/spice/onto.go
+++ b/internal/spice/onto.go
@@ -10,6 +10,21 @@ import (
 	"go.abhg.dev/gs/internal/spice/state"
 )
 
+// BranchOntoMode specifies how BranchOnto moves one branch to its new base.
+type BranchOntoMode int
+
+const (
+	// BranchOntoRebase updates state and rebases the branch's own commits.
+	BranchOntoRebase BranchOntoMode = iota
+
+	// BranchOntoRetargetOnly updates state
+	// without rebasing the branch's commits.
+	//
+	// The old upstream boundary is preserved
+	// so a future restack can replay the branch correctly.
+	BranchOntoRetargetOnly
+)
+
 // BranchOntoRequest is a request to move a branch onto another branch.
 type BranchOntoRequest struct {
 	// Branch is the branch to move.
@@ -23,11 +38,9 @@ type BranchOntoRequest struct {
 	// MergedDownstack for [Branch], if any.
 	MergedDownstack *[]json.RawMessage
 
-	// SkipRebase indicates that the branch's base should be updated,
-	// but no rebase should be performed.
-	// The old base hash is preserved to allow future restack operations
-	// to correctly rebase the branch.
-	SkipRebase bool
+	// Mode controls whether Branch's commits are rebased immediately
+	// or only retargeted in git-spice state.
+	Mode BranchOntoMode
 }
 
 // BranchOnto moves the commits of a branch onto a different base branch,
@@ -127,13 +140,15 @@ func (s *Service) BranchOnto(ctx context.Context, req *BranchOntoRequest) error 
 
 	branchTx := s.store.BeginBranchTx()
 
-	// When SkipRebase is true, update the base branch name
-	// but preserve the upstream boundary for a future restack.
-	// This is usually the old recorded base hash, but may be the old
-	// base's actual head if that is already reachable from this branch.
 	baseHash := ontoHash
-	if req.SkipRebase {
+	rebaseBranch := true
+	switch req.Mode {
+	case BranchOntoRebase:
+	case BranchOntoRetargetOnly:
 		baseHash = fromHash
+		rebaseBranch = false
+	default:
+		must.Failf("unknown branch onto mode: %v", req.Mode)
 	}
 
 	if err := branchTx.Upsert(ctx, state.UpsertRequest{
@@ -145,7 +160,7 @@ func (s *Service) BranchOnto(ctx context.Context, req *BranchOntoRequest) error 
 		return fmt.Errorf("set base of branch %s to %s: %w", req.Branch, req.Onto, err)
 	}
 
-	if !req.SkipRebase {
+	if rebaseBranch {
 		if err := s.wt.Rebase(ctx, git.RebaseRequest{
 			Branch:    req.Branch,
 			Upstream:  string(fromHash),

--- a/internal/spice/onto_test.go
+++ b/internal/spice/onto_test.go
@@ -112,9 +112,9 @@ func TestService_BranchOnto_skipRebasePreservesActualBaseBoundary(t *testing.T) 
 	}))
 
 	require.NoError(t, svc.BranchOnto(ctx, &BranchOntoRequest{
-		Branch:     "stacked",
-		Onto:       "main",
-		SkipRebase: true,
+		Branch: "stacked",
+		Onto:   "main",
+		Mode:   BranchOntoRetargetOnly,
 	}))
 
 	retargeted, err := svc.LookupBranch(ctx, "stacked")

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	"go.abhg.dev/gs/internal/handler/checkout"
 	"go.abhg.dev/gs/internal/handler/cherrypick"
 	"go.abhg.dev/gs/internal/handler/delete"
+	"go.abhg.dev/gs/internal/handler/onto"
 	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/handler/split"
 	"go.abhg.dev/gs/internal/handler/squash"
@@ -468,6 +469,19 @@ func (cmd *mainCmd) AfterApply(ctx context.Context, kctx *kong.Context, logger *
 				Worktree: worktree,
 				Store:    store,
 				Service:  svc,
+			}, nil
+		}),
+		kctx.BindSingletonProvider(func(
+			log *silog.Logger,
+			wt *git.Worktree,
+			svc *spice.Service,
+			restackHandler RestackHandler,
+		) (OntoHandler, error) {
+			return &onto.Handler{
+				Log:      log,
+				Worktree: wt,
+				Service:  svc,
+				Restack:  restackHandler,
 			}, nil
 		}),
 		kctx.BindSingletonProvider(func(

--- a/upstack_onto.go
+++ b/upstack_onto.go
@@ -7,7 +7,7 @@ import (
 
 	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/handler/restack"
+	"go.abhg.dev/gs/internal/handler/onto"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
@@ -109,32 +109,11 @@ func (cmd *upstackOntoCmd) AfterApply(
 
 func (cmd *upstackOntoCmd) Run(
 	ctx context.Context,
-	log *silog.Logger,
-	svc *spice.Service,
-	restackHandler RestackHandler,
+	handler OntoHandler,
 ) error {
-	// Implementation note:
-	// This is a pretty straightforward operation despite the large scope.
-	// It starts by rebasing only the current branch onto the target
-	// branch, updating internal state to point to the new base.
-	// Following that, an 'upstack restack' will handle the upstack branches.
-	err := svc.BranchOnto(ctx, &spice.BranchOntoRequest{
-		Branch: cmd.Branch,
-		Onto:   cmd.Onto,
-	})
-	if err != nil {
-		// If the rebase is interrupted,
-		// we'll just re-run this command again later.
-		return svc.RebaseRescue(ctx, spice.RebaseRescueRequest{
-			Err:     err,
-			Command: []string{"upstack", "onto", cmd.Onto},
-			Branch:  cmd.Branch,
-			Message: fmt.Sprintf("interrupted: %s: upstack onto %s", cmd.Branch, cmd.Onto),
-		})
-	}
-	log.Infof("%v: moved upstack onto %v", cmd.Branch, cmd.Onto)
-
-	return restackHandler.RestackUpstack(ctx, cmd.Branch, &restack.UpstackOptions{
-		SkipStart: true,
+	return handler.UpstackOnto(ctx, &onto.UpstackRequest{
+		Branch:          cmd.Branch,
+		Onto:            cmd.Onto,
+		ContinueCommand: []string{"upstack", "onto", cmd.Onto},
 	})
 }


### PR DESCRIPTION
Move branch and upstack onto orchestration out of the command
implementations and into `internal/handler/onto`.

`spice.Service.BranchOnto` remains the single-branch primitive,
but its request now uses a `BranchOntoMode` enum
instead of the `SkipRebase` boolean.
The zero-value mode preserves the existing rebase behavior,
and retarget-only callers use the explicit mode.

This keeps command files focused on parsing and prompting
while preserving the existing branch onto,
upstack onto,
and branch delete behavior.