### PR TITLE
branch onto: Add restack modes

### DIFF
--- a/.changes/unreleased/Changed-20260525-151108.yaml
+++ b/.changes/unreleased/Changed-20260525-151108.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'branch onto: Branches above moved branches are now retargeted without being restacked unless --restack is used. --restack defaults to restacking all upstack branches above moved branches. Use --restack=aboves to restack only the branches directly above. Change the default by setting the ''spice.branchOnto.restack'' configuration option.'
+time: 2026-05-25T15:11:08.777717-07:00

--- a/branch_onto.go
+++ b/branch_onto.go
@@ -17,8 +17,9 @@ import (
 type branchOntoCmd struct {
 	BranchPromptConfig
 
-	Branch string `help:"Branch to move" placeholder:"NAME" predictor:"trackedBranches"`
-	Onto   string `arg:"" optional:"" help:"Destination branch" predictor:"trackedBranches"`
+	Branch  string            `help:"Branch to move" placeholder:"NAME" predictor:"trackedBranches"`
+	Restack spice.RestackMode `default:"none" config:"branchOnto.restack" enum:"none,aboves,upstack" help:"How to restack branches above the moved branch. One of 'none', 'aboves', and 'upstack'."`
+	Onto    string            `arg:"" optional:"" help:"Destination branch" predictor:"trackedBranches"`
 }
 
 func (*branchOntoCmd) Help() string {
@@ -28,8 +29,11 @@ func (*branchOntoCmd) Help() string {
 		are transplanted onto another branch
 		while leaving the rest of the stack intact.
 		That is, branches above the current branch
-		are first rebased onto its original base,
+		are retargeted onto its original base,
 		and then the current branch is moved onto the new base.
+
+		Use --restack to rebase those branches and their upstacks
+		immediately after retargeting.
 
 		A prompt will allow selecting the new base for the branch.
 		Provide an argument to skip the prompt.
@@ -117,6 +121,15 @@ func (cmd *branchOntoCmd) Run(
 	return handler.BranchOnto(ctx, &onto.BranchRequest{
 		Branch:          cmd.Branch,
 		Onto:            cmd.Onto,
-		ContinueCommand: []string{"branch", "onto", cmd.Onto},
+		Restack:         cmd.Restack,
+		ContinueCommand: cmd.continueCommand(),
 	})
+}
+
+func (cmd *branchOntoCmd) continueCommand() []string {
+	contCmd := []string{"branch", "onto", "--branch", cmd.Branch}
+	if !cmd.Restack.Includes(spice.RestackNone) {
+		contCmd = append(contCmd, "--restack="+cmd.Restack.String())
+	}
+	return append(contCmd, cmd.Onto)
 }

--- a/config_test.go
+++ b/config_test.go
@@ -453,6 +453,104 @@ func TestBranchDeleteRestackFlag(t *testing.T) {
 	}
 }
 
+func TestBranchOntoRestackConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  string
+		args    []string
+		want    spice.RestackMode
+		wantErr []string
+	}{
+		{
+			name: "Default",
+			args: []string{"branch", "onto", "--branch", "feature", "main"},
+			want: spice.RestackNone,
+		},
+		{
+			name: "FlagWithoutValue",
+			args: []string{"branch", "onto", "--branch", "feature", "--restack", "main"},
+			want: spice.RestackUpstack,
+		},
+		{
+			name: "FlagFalse",
+			args: []string{"branch", "onto", "--branch", "feature", "--restack=false", "main"},
+			want: spice.RestackNone,
+		},
+		{
+			name: "FlagAboves",
+			args: []string{"branch", "onto", "--branch", "feature", "--restack=aboves", "main"},
+			want: spice.RestackAboves,
+		},
+		{
+			name: "Config",
+			config: joinLines(
+				`[spice "branchOnto"]`,
+				`  restack = aboves`,
+			),
+			args: []string{"branch", "onto", "--branch", "feature", "main"},
+			want: spice.RestackAboves,
+		},
+		{
+			name: "FlagOverridesConfig",
+			config: joinLines(
+				`[spice "branchOnto"]`,
+				`  restack = upstack`,
+			),
+			args: []string{"branch", "onto", "--branch", "feature", "--restack=none", "main"},
+			want: spice.RestackNone,
+		},
+		{
+			name: "Invalid",
+			args: []string{"branch", "onto", "--branch", "feature", "--restack=invalid", "main"},
+			wantErr: []string{
+				`--restack: invalid value "invalid": expected none, aboves, or upstack`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+				git init
+				git commit --allow-empty -m 'Initial commit'
+			`)))
+			require.NoError(t, err)
+			t.Cleanup(fixture.Cleanup)
+			t.Chdir(fixture.Dir())
+
+			spicecfg := loadTestSpiceConfig(t, tt.config)
+
+			var cmd mainCmd
+			logger := silogtest.New(t)
+			var (
+				forges   forge.Registry
+				sigStack sigstack.Stack
+			)
+			parser, err := kong.New(
+				&cmd,
+				kong.Resolvers(spicecfg),
+				kong.Bind(logger, &forges, &sigStack),
+				kong.BindTo(t.Context(), (*context.Context)(nil)),
+				kong.BindTo(spicecfg, (*experiment.Enabler)(nil)),
+				kong.Vars{"defaultPrompt": "false"},
+			)
+			require.NoError(t, err)
+
+			_, err = parser.Parse(tt.args)
+			if len(tt.wantErr) > 0 {
+				require.Error(t, err)
+				for _, msg := range tt.wantErr {
+					assert.ErrorContains(t, err, msg)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, cmd.Branch.Onto.Restack)
+		})
+	}
+}
+
 func loadTestSpiceConfig(t *testing.T, cfg string) *spice.Config {
 	t.Helper()
 

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -963,8 +963,11 @@ Commits of the current branch
 are transplanted onto another branch
 while leaving the rest of the stack intact.
 That is, branches above the current branch
-are first rebased onto its original base,
+are retargeted onto its original base,
 and then the current branch is moved onto the new base.
+
+Use --restack to rebase those branches and their upstacks
+immediately after retargeting.
 
 A prompt will allow selecting the new base for the branch.
 Provide an argument to skip the prompt.
@@ -990,8 +993,9 @@ Use 'gs upstack onto' to also move the upstack branches.
 **Flags**
 
 * `--branch=NAME`: Branch to move
+* `--restack` ([:material-wrench:{ .middle title="spice.branchOnto.restack" }](/cli/config.md#spicebranchontorestack)): How to restack branches above the moved branch. One of 'none', 'aboves', and 'upstack'.
 
-**Configuration**: [spice.branchPrompt.sort](/cli/config.md#spicebranchpromptsort)
+**Configuration**: [spice.branchOnto.restack](/cli/config.md#spicebranchontorestack), [spice.branchPrompt.sort](/cli/config.md#spicebranchpromptsort)
 
 ### git-spice branch diff {#gs-branch-diff}
 

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -142,6 +142,24 @@ Passing `gs branch delete --restack`,
 or `gs branch delete --restack=none`
 overrides this configuration for that command.
 
+### spice.branchOnto.restack
+
+<!-- gs:version unreleased -->
+
+Controls how `gs branch onto` restacks branches above the moved branch.
+
+Supported values are:
+
+- `none` (default): retarget branches above the moved branch,
+  so they can be restacked later
+- `aboves`: restack only direct branches above the moved branch
+- `upstack`: restack all upstack branches above the moved branch
+
+Passing `gs branch onto --restack`,
+`gs branch onto --restack=aboves`,
+or `gs branch onto --restack=none`
+overrides this configuration for that command.
+
 ### spice.branchCreate.generatedBranchNameLimit
 
 <!-- gs:version v0.20.0 -->

--- a/doc/src/guide/branch.md
+++ b/doc/src/guide/branch.md
@@ -589,6 +589,12 @@ and move it to a different base branch,
 while leaving the upstack branches where they are.
 
 Use $$gs branch onto$$ for this purpose.
+Branches above the moved branch are retargeted in git-spice state
+and can be restacked later with $$gs branch restack$$,
+$$gs upstack restack$$,
+or another restack command.
+Use `gs branch onto --restack`
+to rebase those branches and their upstacks during the move.
 
 <div class="grid" markdown>
 

--- a/internal/handler/onto/handler.go
+++ b/internal/handler/onto/handler.go
@@ -38,15 +38,21 @@ type BranchRequest struct {
 	// Onto is the destination branch.
 	Onto string // required
 
+	// Restack decides how branches above Branch are replayed
+	// after being retargeted onto Branch's original base.
+	Restack spice.RestackMode
+
 	// ContinueCommand resumes the operation after a rebase rescue.
 	ContinueCommand []string
 }
 
 // BranchOnto moves one branch onto another branch.
 //
-// Branches directly above the moved branch are first moved onto the moved
-// branch's original base,
-// preserving the command's historical behavior.
+// Branches directly above the moved branch are first retargeted onto the
+// moved branch's original base.
+// The request's restack mode decides whether those direct aboves,
+// and their own upstacks,
+// are also rebased immediately.
 func (h *Handler) BranchOnto(ctx context.Context, req *BranchRequest) error {
 	branch, err := h.Service.LookupBranch(ctx, req.Branch)
 	if err != nil {
@@ -61,15 +67,36 @@ func (h *Handler) BranchOnto(ctx context.Context, req *BranchRequest) error {
 		return fmt.Errorf("list branches above %s: %w", req.Branch, err)
 	}
 
+	ontoMode := spice.BranchOntoRetargetOnly
+	if req.Restack.Includes(spice.RestackAboves) {
+		ontoMode = spice.BranchOntoRebase
+	}
+
 	for _, above := range aboves {
-		if err := h.UpstackOnto(ctx, &UpstackRequest{
+		if err := h.Service.BranchOnto(ctx, &spice.BranchOntoRequest{
 			Branch: above,
 			Onto:   branch.Base,
-			ContinueCommand: []string{
-				"upstack",
-				"onto",
-				branch.Base,
-			},
+			Mode:   ontoMode,
+		}); err != nil {
+			return h.Service.RebaseRescue(ctx, spice.RebaseRescueRequest{
+				Err:     err,
+				Command: req.ContinueCommand,
+				Branch:  req.Branch,
+				Message: fmt.Sprintf("interrupted: %s: branch onto %s", req.Branch, req.Onto),
+			})
+		}
+		if req.Restack.None() {
+			h.Log.Infof("%s: retargeted upstack onto %s", above, branch.Base)
+			continue
+		}
+
+		h.Log.Infof("%s: moved upstack onto %s", above, branch.Base)
+		if !req.Restack.Includes(spice.RestackUpstack) {
+			continue
+		}
+
+		if err := h.Restack.RestackUpstack(ctx, above, &restack.UpstackOptions{
+			SkipStart: true,
 		}); err != nil {
 			return h.Service.RebaseRescue(ctx, spice.RebaseRescueRequest{
 				Err:     err,

--- a/internal/spice/restack_mode.go
+++ b/internal/spice/restack_mode.go
@@ -16,17 +16,13 @@ const (
 	// RestackNone leaves surviving upstacks retargeted in state
 	// for a later explicit restack.
 	RestackNone RestackMode = 0
-)
 
-const (
 	// RestackAboves restacks only surviving direct upstacks.
-	RestackAboves RestackMode = 1 << iota
-
-	restackUpstackBranches
+	RestackAboves RestackMode = 0b01
 
 	// RestackUpstack restacks each surviving direct upstack
 	// plus everything above it.
-	RestackUpstack = RestackAboves | restackUpstackBranches
+	RestackUpstack RestackMode = 0b11
 )
 
 var (
@@ -34,6 +30,11 @@ var (
 	_ encoding.TextUnmarshaler = (*RestackMode)(nil)
 	_ encoding.TextMarshaler   = RestackMode(0)
 )
+
+// None reports whether this mode retargets without restacking.
+func (m RestackMode) None() bool {
+	return m == RestackNone
+}
 
 // Includes reports whether this mode includes all behavior in scope.
 func (m RestackMode) Includes(scope RestackMode) bool {

--- a/testdata/help/branch_onto.txt
+++ b/testdata/help/branch_onto.txt
@@ -4,8 +4,11 @@ Move a branch onto another branch
 
 Commits of the current branch are transplanted onto another branch while leaving
 the rest of the stack intact. That is, branches above the current branch are
-first rebased onto its original base, and then the current branch is moved onto
-the new base.
+retargeted onto its original base, and then the current branch is moved onto the
+new base.
+
+Use --restack to rebase those branches and their upstacks immediately after
+retargeting.
 
 A prompt will allow selecting the new base for the branch. Provide an argument
 to skip the prompt. Use the --branch flag to target a different branch for the
@@ -28,6 +31,8 @@ Arguments:
 
 Flags:
   --branch=NAME    Branch to move
+  --restack        How to restack branches above the moved branch. One of
+                   'none', 'aboves', and 'upstack'. (🔧 spice.branchOnto.restack)
 
 Global Flags:
   -h, --help           Show help for the command

--- a/testdata/script/branch_onto_conflict_hell.txt
+++ b/testdata/script/branch_onto_conflict_hell.txt
@@ -50,7 +50,7 @@ gs bc -m feature0
 env EDITOR=true GIT_SPICE_VERBOSE=1
 
 gs bco feature1
-! gs branch onto feature0
+! gs branch onto --restack=aboves feature0
 
 # feature2 conflict
 stderr 'There was a conflict while rebasing'

--- a/testdata/script/branch_onto_conflict_loop_repro.txt
+++ b/testdata/script/branch_onto_conflict_loop_repro.txt
@@ -37,7 +37,7 @@ cmp stderr $WORK/golden/ll-before.txt
 # That will first try to move three onto main
 # and fail.
 git checkout two
-! gs branch onto one
+! gs branch onto --restack=aboves one
 stderr 'There was a conflict'
 stderr 'rebase of three interrupted'
 cp $WORK/extra/three.txt value.txt
@@ -56,7 +56,7 @@ cmp stderr $WORK/golden/ll-after-two-onto-one.txt
 
 # Now move three onto two.
 git checkout three
-! gs branch onto two
+! gs branch onto --restack=aboves two
 stderr 'There was a conflict'
 stderr 'rebase of three interrupted'
 cp $WORK/extra/three.txt value.txt

--- a/testdata/script/branch_onto_extract.txt
+++ b/testdata/script/branch_onto_extract.txt
@@ -19,9 +19,9 @@ gs bc -m feature2
 git add feature3.txt
 gs bc -m feature3
 
-# move feature2 onto main
+# move feature2 onto main and restack the branch above it
 git checkout feature2
-gs branch onto main
+gs branch onto --restack main
 stderr 'feature3: moved upstack onto feature1'
 stderr 'feature2: moved onto main'
 

--- a/testdata/script/branch_onto_restack_config.txt
+++ b/testdata/script/branch_onto_restack_config.txt
@@ -1,0 +1,86 @@
+# branch onto supports the spice.branchOnto.restack config.
+
+as 'Test <test@example.com>'
+at '2026-05-26T10:45:00Z'
+
+# set up
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git config spice.branchOnto.restack aboves
+
+git add base1.txt
+gs bc -m base1
+
+git add move1.txt
+gs bc -m move1
+
+git add above1.txt
+gs bc -m above1
+
+# With branchOnto.restack=aboves,
+# branch onto restacks the direct branch above the moved branch.
+git checkout move1
+gs branch onto main
+stderr 'above1: moved upstack onto base1'
+stderr 'move1: moved onto main'
+
+gs ll -a
+cmp stderr $WORK/golden/config-ll.txt
+
+# An explicit CLI flag overrides the configured restack mode.
+git checkout main
+git add base2.txt
+gs bc -m base2
+
+git add move2.txt
+gs bc -m move2
+
+git add above2.txt
+gs bc -m above2
+
+git checkout move2
+gs branch onto --restack=none main
+stderr 'above2: retargeted upstack onto base2'
+! stderr 'above2: moved upstack onto base2'
+stderr 'move2: moved onto main'
+
+gs ll -a
+cmp stderr $WORK/golden/override-ll.txt
+
+-- repo/base1.txt --
+Base 1
+-- repo/move1.txt --
+Move 1
+-- repo/above1.txt --
+Above 1
+-- repo/base2.txt --
+Base 2
+-- repo/move2.txt --
+Move 2
+-- repo/above2.txt --
+Above 2
+-- golden/config-ll.txt --
+  ┏━□ above1
+  ┃   35e266d above1 (now)
+┏━┻□ base1
+┃    18643f6 base1 (now)
+┣━■ move1 ◀
+┃   5ee462d move1 (now)
+main
+-- golden/override-ll.txt --
+  ┏━□ above1
+  ┃   35e266d above1 (now)
+┏━┻□ base1
+┃    18643f6 base1 (now)
+┃ ┏━□ above2 (needs restack)
+┃ ┃   89eb1d3 above2 (now)
+┣━┻□ base2
+┃    239cefd base2 (now)
+┣━□ move1
+┃   5ee462d move1 (now)
+┣━■ move2 ◀
+┃   122e24b move2 (now)
+main

--- a/testdata/script/branch_onto_retarget_upstack.txt
+++ b/testdata/script/branch_onto_retarget_upstack.txt
@@ -1,0 +1,60 @@
+# 'branch onto' retargets branches above the moved branch by default.
+
+as 'Test <test@example.com>'
+at '2026-05-26T10:30:00Z'
+
+# set up
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git add feature1.txt
+gs bc -m feature1
+
+git add feature2.txt
+gs bc -m feature2
+
+git add feature3.txt
+gs bc -m feature3
+
+# Move feature2 onto main.
+# feature3 is retargeted in state,
+# and can be restacked explicitly later.
+git checkout feature2
+gs branch onto main
+stderr 'feature3: retargeted upstack onto feature1'
+! stderr 'feature3: moved upstack onto feature1'
+stderr 'feature2: moved onto main'
+
+gs ll -a
+cmp stderr $WORK/golden/ll-after-onto.txt
+
+gs branch restack --branch feature3
+stderr 'feature3: restacked on feature1'
+
+gs ll -a
+cmp stderr $WORK/golden/ll-after-restack.txt
+
+-- repo/feature1.txt --
+Feature 1
+-- repo/feature2.txt --
+Feature 2
+-- repo/feature3.txt --
+Feature 3
+-- golden/ll-after-onto.txt --
+  ┏━□ feature3 (needs restack)
+  ┃   cda485e feature3 (now)
+┏━┻□ feature1
+┃    33bdea5 feature1 (now)
+┣━■ feature2 ◀
+┃   879767a feature2 (now)
+main
+-- golden/ll-after-restack.txt --
+  ┏━■ feature3 ◀
+  ┃   4723867 feature3 (now)
+┏━┻□ feature1
+┃    33bdea5 feature1 (now)
+┣━□ feature2
+┃   879767a feature2 (now)
+main


### PR DESCRIPTION
Branches above a moved branch are now retargeted by default
instead of being rebased immediately.

`--restack` keeps an immediate-rebase workflow available
for users who want the affected upstack handled during the move.
Bare `--restack` uses the full upstack mode.
`--restack=aboves` limits the replay
to the direct branches above the moved branch.

`spice.branchOnto.restack` configures the default mode
for `branch onto`.
Explicit CLI flags override the configured value.
