### PR TITLE
sync: Reuse graph for merged history

### DIFF
--- a/internal/handler/sync/handler.go
+++ b/internal/handler/sync/handler.go
@@ -66,7 +66,6 @@ var _ Store = (*state.Store)(nil)
 // Service is a subset of the spice.Service interface.
 type Service interface {
 	BranchGraph(ctx context.Context, opts *spice.BranchGraphOptions) (*spice.BranchGraph, error)
-	ListAbove(ctx context.Context, name string) ([]string, error)
 }
 
 var _ Service = (*spice.Service)(nil)
@@ -401,7 +400,7 @@ func (h *Handler) SyncTrunk(ctx context.Context, opts *TrunkOptions) (retErr err
 		}
 	} else {
 		// Supported forge. Check for merged CRs and upstream branches.
-		branchesToDelete, err = h.findForgeFinishedBranches(ctx, candidates, opts.ClosedChanges)
+		branchesToDelete, err = h.findForgeFinishedBranches(ctx, branchGraph, candidates, opts.ClosedChanges)
 		if err != nil {
 			return fmt.Errorf("find finished CRs: %w", err)
 		}
@@ -504,6 +503,7 @@ func (h *Handler) findLocalMergedBranches(
 
 func (h *Handler) findForgeFinishedBranches(
 	ctx context.Context,
+	branchGraph *spice.BranchGraph,
 	knownBranches []spice.LoadBranchItem,
 	closedChangeHandling ClosedChanges,
 ) ([]branchDeletion, error) {
@@ -773,13 +773,6 @@ func (h *Handler) findForgeFinishedBranches(
 		must.Bef(ok, "topologically sorted branch %q must be finished", name)
 		must.Bef(branch.Merged, "topologically sorted branch %q must be merged", name)
 
-		aboves, err := h.Service.ListAbove(ctx, name)
-		if err != nil {
-			h.Log.Warn("Unable to query merged branch's upstacks. Not propagating to merge history.",
-				"branch", name, "error", err)
-			continue
-		}
-
 		changeIDJSON, err := h.RemoteRepository.Forge().MarshalChangeID(branch.ChangeID)
 		if err != nil {
 			h.Log.Warn("Unable to serialize ChangeID for merged branch. Not propagating to merge history.",
@@ -787,7 +780,7 @@ func (h *Handler) findForgeFinishedBranches(
 			continue
 		}
 
-		for _, above := range aboves {
+		for above := range branchGraph.Aboves(name) {
 			// MergedDownstack for the upstack of the branch being merged
 			// is the branch's own merged downstack and the branch itself.
 			var newHistory []json.RawMessage

--- a/internal/handler/sync/mocks_test.go
+++ b/internal/handler/sync/mocks_test.go
@@ -695,45 +695,6 @@ func (c *MockServiceBranchGraphCall) DoAndReturn(f func(context.Context, *spice.
 	return c
 }
 
-// ListAbove mocks base method.
-func (m *MockService) ListAbove(ctx context.Context, name string) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAbove", ctx, name)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListAbove indicates an expected call of ListAbove.
-func (mr *MockServiceMockRecorder) ListAbove(ctx, name any) *MockServiceListAboveCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAbove", reflect.TypeOf((*MockService)(nil).ListAbove), ctx, name)
-	return &MockServiceListAboveCall{Call: call}
-}
-
-// MockServiceListAboveCall wrap *gomock.Call
-type MockServiceListAboveCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockServiceListAboveCall) Return(arg0 []string, arg1 error) *MockServiceListAboveCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockServiceListAboveCall) Do(f func(context.Context, string) ([]string, error)) *MockServiceListAboveCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockServiceListAboveCall) DoAndReturn(f func(context.Context, string) ([]string, error)) *MockServiceListAboveCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // MockDeleteHandler is a mock of DeleteHandler interface.
 type MockDeleteHandler struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
Repo sync already loads branch topology before checking supported
forge state.
Merged-branch propagation should use that snapshot instead of
rebuilding topology for every merged branch.

This commit keeps forge queries, deletion planning, and retargeting
behavior unchanged.
It only changes the source of direct upstack data to the existing
`BranchGraph`.

[skip changelog]: user facing impact not measurable