### PR TITLE
down: Reuse graph across hops

### DIFF
--- a/.changes/unreleased/Changed-20260531-090129.yaml
+++ b/.changes/unreleased/Changed-20260531-090129.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'down: Improved performance when navigating multiple branches down a stack.'
+time: 2026-05-31T09:01:29.487706-07:00

--- a/down.go
+++ b/down.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/handler/checkout"
@@ -45,35 +46,22 @@ func (cmd *downCmd) Run(
 		return err
 	}
 
+	graph, err := svc.BranchGraph(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("load branch graph: %w", err)
+	}
+
+	downstack := slices.Collect(graph.Downstack(current))
+	if len(downstack) == 0 {
+		return fmt.Errorf("%v: no branches found downstack", current)
+	}
+
 	var below string
-outer:
-	for range cmd.N {
-		downstack, err := svc.ListDownstack(ctx, current)
-		if err != nil {
-			return fmt.Errorf("list downstacks: %w", err)
-		}
-
-		switch len(downstack) {
-		case 0:
-			if below != "" {
-				// If we've already moved up once,
-				// and there are no branches above the current one,
-				// we're done.
-				break outer
-			}
-			return fmt.Errorf("%v: no branches found downstack", current)
-
-		case 1:
-			// Current branch is bottom of stack.
-			// Move to trunk.
-			log.Info("moving to trunk: end of stack")
-			below = store.Trunk()
-
-		default:
-			below = downstack[1]
-		}
-
-		current = below
+	if cmd.N >= len(downstack) {
+		log.Info("moving to trunk: end of stack")
+		below = store.Trunk()
+	} else {
+		below = downstack[cmd.N]
 	}
 
 	return checkoutHandler.CheckoutBranch(ctx, &checkout.Request{


### PR DESCRIPTION
`gs down N` selects a final checkout target from one stack snapshot.
Rebuilding branch topology for every hop is just a gross inefficiency.

Switch to loading the graph once.
This turns it from an O(M*N) operation to O(M),
where M is the number of branches in the stack
and N is the number of hops.
(We still have to load all branches to build the graph,
but we only do it once instead of N times.)

**Benchmark**

For a degenerate case of a 100-deep stack,
navigating down 50 branches (resetting back to top after each turn),
this is about 38x faster:

| State  | Mean               | Range              |
| ------ | ------------------ | ------------------ |
| Before | 24.445s +/- 1.849s | 22.717s .. 26.396s |
| After  | 633.0ms +/- 81.2ms | 550.3ms .. 712.5ms |