### PR TITLE
merge: Rename merge experiment gate

### DIFF
--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -570,7 +570,7 @@ only if there are multiple CRs in the stack.
 gs downstack (ds) merge (m) [flags]
 ```
 
-<span class="mdx-badge mdx-badge--experiment"><span class="mdx-badge__icon">:material-test-tube:{ title="Experimental" }</span><span class="mdx-badge__text">[downstackMerge](/cli/experiments.md#downstackmerge)</span></span>
+<span class="mdx-badge mdx-badge--experiment"><span class="mdx-badge__icon">:material-test-tube:{ title="Experimental" }</span><span class="mdx-badge__text">[merge](/cli/experiments.md#merge)</span></span>
 
 Merge a branch and those below it
 

--- a/doc/src/cli/experiments.md
+++ b/doc/src/cli/experiments.md
@@ -55,12 +55,13 @@ This command is a stack-aware variant of `git cherry-pick`.
 It will automatically restack upstack branches
 after cherry-picking a commit.
 
-### downstackMerge
+### merge
 
 **Added**: <!-- gs:version unreleased -->
 <!-- TODO: **Removed**: -->
 
-Enables the $$gs downstack merge$$ command.
-This command acts as a local merge queue
+Enables experimental merge commands,
+including the $$gs downstack merge$$ command.
+The downstack merge command acts as a local merge queue
 that merges a stack of Change Requests
 from the bottom up.

--- a/downstack.go
+++ b/downstack.go
@@ -3,7 +3,7 @@ package main
 type downstackCmd struct {
 	Track   downstackTrackCmd   `cmd:"" aliases:"tr" help:"Track all untracked branches below a branch"`
 	Submit  downstackSubmitCmd  `cmd:"" aliases:"s" help:"Submit a branch and those below it"`
-	Merge   downstackMergeCmd   `cmd:"" aliases:"m" experiment:"downstackMerge" help:"Merge a branch and those below it"`
+	Merge   downstackMergeCmd   `cmd:"" aliases:"m" experiment:"merge" help:"Merge a branch and those below it"`
 	Edit    downstackEditCmd    `cmd:"" aliases:"e" help:"Edit the order of branches below a branch"`
 	Restack downstackRestackCmd `cmd:"" aliases:"r" help:"Restack a branch and its downstack"`
 }

--- a/testdata/script/downstack_merge.txt
+++ b/testdata/script/downstack_merge.txt
@@ -6,7 +6,7 @@ at '2024-04-05T16:40:32Z'
 # setup
 cd repo
 git init
-git config spice.experiment.downstackMerge true
+git config spice.experiment.merge true
 git commit --allow-empty -m 'Initial commit'
 
 # set up a fake GitHub remote

--- a/testdata/script/downstack_merge_already_merged.txt
+++ b/testdata/script/downstack_merge_already_merged.txt
@@ -6,7 +6,7 @@ at '2024-04-05T16:40:32Z'
 # setup
 cd repo
 git init
-git config spice.experiment.downstackMerge true
+git config spice.experiment.merge true
 git commit --allow-empty -m 'Initial commit'
 
 # set up a fake GitHub remote

--- a/testdata/script/downstack_merge_checks_fail_next.txt
+++ b/testdata/script/downstack_merge_checks_fail_next.txt
@@ -6,7 +6,7 @@ at '2026-05-31T08:07:00Z'
 # setup
 cd repo
 git init
-git config spice.experiment.downstackMerge true
+git config spice.experiment.merge true
 git commit --allow-empty -m 'Initial commit'
 
 # set up a fake GitHub remote

--- a/testdata/script/downstack_merge_checks_failed.txt
+++ b/testdata/script/downstack_merge_checks_failed.txt
@@ -6,7 +6,7 @@ at '2026-05-31T08:05:00Z'
 # setup
 cd repo
 git init
-git config spice.experiment.downstackMerge true
+git config spice.experiment.merge true
 git commit --allow-empty -m 'Initial commit'
 
 # set up a fake GitHub remote

--- a/testdata/script/downstack_merge_checks_pending.txt
+++ b/testdata/script/downstack_merge_checks_pending.txt
@@ -6,7 +6,7 @@ at '2026-05-31T08:06:00Z'
 # setup
 cd repo
 git init
-git config spice.experiment.downstackMerge true
+git config spice.experiment.merge true
 git commit --allow-empty -m 'Initial commit'
 
 # set up a fake GitHub remote

--- a/testdata/script/downstack_merge_closed_in_downstack.txt
+++ b/testdata/script/downstack_merge_closed_in_downstack.txt
@@ -6,7 +6,7 @@ at '2024-04-05T16:40:32Z'
 # setup
 cd repo
 git init
-git config spice.experiment.downstackMerge true
+git config spice.experiment.merge true
 git commit --allow-empty -m 'Initial commit'
 
 # set up a fake GitHub remote

--- a/testdata/script/downstack_merge_decline.txt
+++ b/testdata/script/downstack_merge_decline.txt
@@ -6,7 +6,7 @@ at '2024-04-05T16:40:32Z'
 # setup
 cd repo
 git init
-git config spice.experiment.downstackMerge true
+git config spice.experiment.merge true
 git commit --allow-empty -m 'Initial commit'
 
 # set up a fake GitHub remote

--- a/testdata/script/downstack_merge_explicit_branch.txt
+++ b/testdata/script/downstack_merge_explicit_branch.txt
@@ -6,7 +6,7 @@ at '2024-04-05T16:40:32Z'
 # setup
 cd repo
 git init
-git config spice.experiment.downstackMerge true
+git config spice.experiment.merge true
 git commit --allow-empty -m 'Initial commit'
 
 # set up a fake GitHub remote

--- a/testdata/script/downstack_merge_multiple_merged.txt
+++ b/testdata/script/downstack_merge_multiple_merged.txt
@@ -6,7 +6,7 @@ at '2024-04-05T16:40:32Z'
 # setup
 cd repo
 git init
-git config spice.experiment.downstackMerge true
+git config spice.experiment.merge true
 git commit --allow-empty -m 'Initial commit'
 
 # set up a fake GitHub remote

--- a/testdata/script/downstack_merge_no_wait.txt
+++ b/testdata/script/downstack_merge_no_wait.txt
@@ -7,7 +7,7 @@ at '2024-04-05T16:40:32Z'
 # setup
 cd repo
 git init
-git config spice.experiment.downstackMerge true
+git config spice.experiment.merge true
 git commit --allow-empty -m 'Initial commit'
 
 # set up a fake GitHub remote

--- a/testdata/script/downstack_merge_on_trunk.txt
+++ b/testdata/script/downstack_merge_on_trunk.txt
@@ -6,7 +6,7 @@ at '2024-04-05T16:40:32Z'
 # setup
 cd repo
 git init
-git config spice.experiment.downstackMerge true
+git config spice.experiment.merge true
 git commit --allow-empty -m 'Initial commit'
 
 # set up a fake GitHub remote

--- a/testdata/script/downstack_merge_squash.txt
+++ b/testdata/script/downstack_merge_squash.txt
@@ -6,7 +6,7 @@ at '2026-05-24T19:33:15Z'
 # setup
 cd repo
 git init
-git config spice.experiment.downstackMerge true
+git config spice.experiment.merge true
 git commit --allow-empty -m 'Initial commit'
 
 # set up a fake GitHub remote

--- a/testdata/script/downstack_merge_stale_base.txt
+++ b/testdata/script/downstack_merge_stale_base.txt
@@ -6,7 +6,7 @@ at '2024-04-05T16:40:32Z'
 # setup
 cd repo
 git init
-git config spice.experiment.downstackMerge true
+git config spice.experiment.merge true
 git commit --allow-empty -m 'Initial commit'
 
 # set up a fake GitHub remote

--- a/testdata/script/downstack_merge_top_already_merged.txt
+++ b/testdata/script/downstack_merge_top_already_merged.txt
@@ -7,7 +7,7 @@ at '2024-04-05T16:40:32Z'
 # setup
 cd repo
 git init
-git config spice.experiment.downstackMerge true
+git config spice.experiment.merge true
 git commit --allow-empty -m 'Initial commit'
 
 # set up a fake GitHub remote

--- a/testdata/script/downstack_merge_unpublished_in_downstack.txt
+++ b/testdata/script/downstack_merge_unpublished_in_downstack.txt
@@ -6,7 +6,7 @@ at '2024-04-05T16:40:32Z'
 # setup
 cd repo
 git init
-git config spice.experiment.downstackMerge true
+git config spice.experiment.merge true
 git commit --allow-empty -m 'Initial commit'
 
 # set up a fake GitHub remote

--- a/testdata/script/downstack_merge_unpushed.txt
+++ b/testdata/script/downstack_merge_unpushed.txt
@@ -7,7 +7,7 @@ at '2024-04-05T16:40:32Z'
 # setup
 cd repo
 git init
-git config spice.experiment.downstackMerge true
+git config spice.experiment.merge true
 git commit --allow-empty -m 'Initial commit'
 
 # set up a fake GitHub remote

--- a/testdata/script/downstack_merge_upstack_chain.txt
+++ b/testdata/script/downstack_merge_upstack_chain.txt
@@ -7,7 +7,7 @@ at '2024-04-05T16:40:32Z'
 # setup
 cd repo
 git init
-git config spice.experiment.downstackMerge true
+git config spice.experiment.merge true
 git commit --allow-empty -m 'Initial commit'
 
 # set up a fake GitHub remote

--- a/testdata/script/downstack_merge_upstack_rebase.txt
+++ b/testdata/script/downstack_merge_upstack_rebase.txt
@@ -8,7 +8,7 @@ at '2024-04-05T16:40:32Z'
 # setup
 cd repo
 git init
-git config spice.experiment.downstackMerge true
+git config spice.experiment.merge true
 git commit --allow-empty -m 'Initial commit'
 
 # set up a fake GitHub remote


### PR DESCRIPTION
Rename the downstack merge command tag,
the experiment documentation,
and script fixtures to use `merge`.

We'll put other merge commands behind this.