### PR TITLE
refactor: Add remote forge resolver

### DIFF
--- a/flag_test.go
+++ b/flag_test.go
@@ -2,4 +2,12 @@ package main
 
 import "flag"
 
-var _update = flag.Bool("update", false, "update golden files")
+func init() {
+	if flag.Lookup("update") == nil {
+		flag.Bool("update", false, "update golden files")
+	}
+}
+
+func updateFlag() bool {
+	return flag.Lookup("update").Value.(flag.Getter).Get().(bool)
+}

--- a/help_test.go
+++ b/help_test.go
@@ -91,7 +91,7 @@ func TestHelp(t *testing.T) {
 			filename := strings.ReplaceAll(tc.name, " ", "_") + ".txt"
 			goldenPath := filepath.Join("testdata", "help", filename)
 
-			if *_update {
+			if updateFlag() {
 				// Update mode: write actual output to golden file
 				err := os.MkdirAll(filepath.Dir(goldenPath), 0o755)
 				require.NoError(t, err)

--- a/remote.go
+++ b/remote.go
@@ -30,6 +30,60 @@ func (e *notLoggedInError) Error() string {
 	return "not logged in to " + e.Forge.ID()
 }
 
+// remoteURLer reads Git's resolved URL for a named remote.
+type remoteURLer interface {
+	// RemoteURL accepts a Git remote name and returns the URL that Git uses
+	// after applying its remote URL rewriting rules.
+	//
+	// It is equivalent to `git remote get-url <name>`.
+	RemoteURL(context.Context, string) (string, error)
+}
+
+var _ remoteURLer = (*git.Repository)(nil)
+
+// remoteResolver resolves git-spice remotes to forge repository identities.
+type remoteResolver struct {
+	// Forges is the registry of forge implementations that may own a remote.
+	Forges *forge.Registry
+
+	// Repository is the Git repository whose remotes should be resolved.
+	Repository remoteURLer
+}
+
+// Resolve identifies the forge and repository for a configured Git remote.
+func (r *remoteResolver) Resolve(
+	ctx context.Context,
+	remote string,
+) (forge.Forge, forge.RepositoryID, error) {
+	remoteURL, err := r.Repository.RemoteURL(ctx, remote)
+	if err != nil {
+		return nil, nil, fmt.Errorf("get remote URL: %w", err)
+	}
+
+	parsedRemoteURL, err := giturl.Parse(remoteURL)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse remote URL: %w", err)
+	}
+
+	f, repoID, ok := forge.FromRemoteURL(r.Forges, parsedRemoteURL)
+	if !ok {
+		return nil, nil, &unsupportedForgeError{
+			Remote:    remote,
+			RemoteURL: remoteURL,
+		}
+	}
+	return f, repoID, nil
+}
+
+// ResolveID identifies the repository for a configured Git remote.
+func (r *remoteResolver) ResolveID(
+	ctx context.Context,
+	remote string,
+) (forge.RepositoryID, error) {
+	_, repoID, err := r.Resolve(ctx, remote)
+	return repoID, err
+}
+
 // Attempts to open the forge.Repository associated with the given Git remote.
 //
 // Does not print any error messages to the user.
@@ -45,7 +99,10 @@ func openRemoteRepositorySilent(
 	gitRepo *git.Repository,
 	remote string,
 ) (forge.Repository, error) {
-	f, repoID, err := resolveRemoteRepositorySilent(ctx, forges, gitRepo, remote)
+	f, repoID, err := (&remoteResolver{
+		Forges:     forges,
+		Repository: gitRepo,
+	}).Resolve(ctx, remote)
 	if err != nil {
 		return nil, err
 	}
@@ -59,21 +116,10 @@ func resolveRemoteRepositoryID(
 	gitRepo *git.Repository,
 	remote string,
 ) (forge.RepositoryID, error) {
-	remoteURL, err := gitRepo.RemoteURL(ctx, remote)
-	if err != nil {
-		return nil, fmt.Errorf("get remote URL: %w", err)
-	}
-
-	parsedRemoteURL, err := giturl.Parse(remoteURL)
-	if err != nil {
-		return nil, fmt.Errorf("parse remote URL: %w", err)
-	}
-
-	_, repoID, ok := forge.FromRemoteURL(forges, parsedRemoteURL)
-	if !ok {
-		return nil, fmt.Errorf("no forge matches remote URL %q", remoteURL)
-	}
-	return repoID, nil
+	return (&remoteResolver{
+		Forges:     forges,
+		Repository: gitRepo,
+	}).ResolveID(ctx, remote)
 }
 
 func resolveRemoteRepositorySilent(
@@ -82,24 +128,10 @@ func resolveRemoteRepositorySilent(
 	gitRepo *git.Repository,
 	remote string,
 ) (forge.Forge, forge.RepositoryID, error) {
-	remoteURL, err := gitRepo.RemoteURL(ctx, remote)
-	if err != nil {
-		return nil, nil, fmt.Errorf("get remote URL: %w", err)
-	}
-
-	parsedRemoteURL, err := giturl.Parse(remoteURL)
-	if err != nil {
-		return nil, nil, fmt.Errorf("parse remote URL: %w", err)
-	}
-
-	f, repoID, ok := forge.FromRemoteURL(forges, parsedRemoteURL)
-	if !ok {
-		return nil, nil, &unsupportedForgeError{
-			Remote:    remote,
-			RemoteURL: remoteURL,
-		}
-	}
-	return f, repoID, nil
+	return (&remoteResolver{
+		Forges:     forges,
+		Repository: gitRepo,
+	}).Resolve(ctx, remote)
 }
 
 func openForgeRepository(

--- a/remote_test.go
+++ b/remote_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/forge/forgetest"
+	"go.uber.org/mock/gomock"
+)
+
+func TestRemoteResolver_Resolve(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	repoID := forgetest.NewMockRepositoryID(ctrl)
+	testForge := forgetest.NewMockForge(ctrl)
+	testForge.EXPECT().ID().Return("test").AnyTimes()
+	testForge.EXPECT().BaseURL().Return("https://example.com")
+	testForge.EXPECT().
+		ParseRepositoryPath("/owner/repo").
+		Return(repoID, nil)
+
+	var forges forge.Registry
+	forges.Register(testForge)
+
+	gotForge, gotRepoID, err := (&remoteResolver{
+		Forges:     &forges,
+		Repository: remoteURLMap{"origin": "https://example.com/owner/repo"},
+	}).Resolve(t.Context(), "origin")
+	require.NoError(t, err)
+
+	assert.Same(t, testForge, gotForge)
+	assert.Equal(t, repoID, gotRepoID)
+}
+
+func TestRemoteResolver_ResolveID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	repoID := forgetest.NewMockRepositoryID(ctrl)
+	testForge := forgetest.NewMockForge(ctrl)
+	testForge.EXPECT().ID().Return("test").AnyTimes()
+	testForge.EXPECT().BaseURL().Return("https://example.com")
+	testForge.EXPECT().
+		ParseRepositoryPath("/owner/repo").
+		Return(repoID, nil)
+
+	var forges forge.Registry
+	forges.Register(testForge)
+
+	gotRepoID, err := (&remoteResolver{
+		Forges:     &forges,
+		Repository: remoteURLMap{"origin": "https://example.com/owner/repo"},
+	}).ResolveID(t.Context(), "origin")
+	require.NoError(t, err)
+
+	assert.Equal(t, repoID, gotRepoID)
+}
+
+func TestRemoteResolver_Resolve_unsupported(t *testing.T) {
+	var forges forge.Registry
+	_, _, err := (&remoteResolver{
+		Forges:     &forges,
+		Repository: remoteURLMap{"origin": "https://example.com/owner/repo"},
+	}).Resolve(t.Context(), "origin")
+	require.Error(t, err)
+
+	var unsupported *unsupportedForgeError
+	require.ErrorAs(t, err, &unsupported)
+	assert.Equal(t, "origin", unsupported.Remote)
+	assert.Equal(t, "https://example.com/owner/repo", unsupported.RemoteURL)
+}
+
+type remoteURLMap map[string]string
+
+func (m remoteURLMap) RemoteURL(_ context.Context, remote string) (string, error) {
+	return m[remote], nil
+}

--- a/script_test.go
+++ b/script_test.go
@@ -73,7 +73,7 @@ func TestScript(t *testing.T) {
 
 	testscript.Run(t, testscript.Params{
 		Dir:                scriptDir,
-		UpdateScripts:      *_update,
+		UpdateScripts:      updateFlag(),
 		RequireUniqueNames: true,
 		Setup: func(e *testscript.Env) error {
 			t := e.T().(testing.TB)


### PR DESCRIPTION
Remote repository resolution is shared by submit, sync, auth,
and branch listing flows.
Keeping URL matching policy behind one resolver gives the configurable
forge-kind feature a single boundary to extend.

The resolver preserves URL inference as the default behavior
and keeps the existing unsupported-remote error contract.
Unit tests cover successful forge resolution,
repository ID-only resolution,
and unsupported remotes.

[skip changelog]: no user facing changes