### PR TITLE
feat(forge): Add configurable forge kind

### DIFF
--- a/.changes/unreleased/Added-20260517-102624.yaml
+++ b/.changes/unreleased/Added-20260517-102624.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'forge: Repositories whose remote host does not identify the forge can now be configured with ''spice.forge.kind''.'
+time: 2026-05-17T10:26:24.393005-07:00

--- a/auth.go
+++ b/auth.go
@@ -32,9 +32,10 @@ func (c *authCmd) AfterApply(
 	kctx *kong.Context,
 	log *silog.Logger,
 	forges *forge.Registry,
+	cmd *mainCmd,
 	view ui.View,
 ) error {
-	f, err := resolveForge(ctx, forges, log, view, c.Forge)
+	f, err := resolveForge(ctx, forges, log, view, c.Forge, cmd.Forge.Kind)
 	if err != nil {
 		return err
 	}
@@ -48,7 +49,14 @@ func (c *authCmd) AfterApply(
 // repository's remote URL.
 // If the forge cannot be guessed, it will prompt the user to select one
 // if we're in interactive mode.
-func resolveForge(ctx context.Context, forges *forge.Registry, log *silog.Logger, view ui.View, forgeID string) (forge.Forge, error) {
+func resolveForge(
+	ctx context.Context,
+	forges *forge.Registry,
+	log *silog.Logger,
+	view ui.View,
+	forgeID string,
+	configuredKind string,
+) (forge.Forge, error) {
 	if forgeID != "" {
 		f, ok := forges.Lookup(forgeID)
 		if !ok {
@@ -62,6 +70,10 @@ func resolveForge(ctx context.Context, forges *forge.Registry, log *silog.Logger
 			return nil, fmt.Errorf("unknown forge: %s", forgeID)
 		}
 		return f, nil
+	}
+
+	if configuredKind != "" {
+		return lookupForgeKind(forges, configuredKind)
 	}
 
 	f, _, err := guessCurrentForge(ctx, forges, log)

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/forge/forgetest"
+	"go.abhg.dev/gs/internal/silog/silogtest"
+	"go.abhg.dev/gs/internal/ui"
+	"go.uber.org/mock/gomock"
+)
+
+func TestResolveForge_explicitForgeWins(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	github := forgetest.NewMockForge(ctrl)
+	github.EXPECT().ID().Return("github").AnyTimes()
+	gitlab := forgetest.NewMockForge(ctrl)
+	gitlab.EXPECT().ID().Return("gitlab").AnyTimes()
+
+	var forges forge.Registry
+	forges.Register(github)
+	forges.Register(gitlab)
+
+	got, err := resolveForge(
+		t.Context(),
+		&forges,
+		silogtest.New(t),
+		ui.NewFileView(io.Discard),
+		"gitlab",
+		"github",
+	)
+	require.NoError(t, err)
+
+	assert.Same(t, gitlab, got)
+}
+
+func TestResolveForge_configuredKind(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	github := forgetest.NewMockForge(ctrl)
+	github.EXPECT().ID().Return("github").AnyTimes()
+	gitlab := forgetest.NewMockForge(ctrl)
+	gitlab.EXPECT().ID().Return("gitlab").AnyTimes()
+
+	var forges forge.Registry
+	forges.Register(github)
+	forges.Register(gitlab)
+
+	got, err := resolveForge(
+		t.Context(),
+		&forges,
+		silogtest.New(t),
+		ui.NewFileView(io.Discard),
+		"",
+		"github",
+	)
+	require.NoError(t, err)
+
+	assert.Same(t, github, got)
+}
+
+func TestResolveForge_noForgeSignalPreservesNoninteractiveError(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	ctrl := gomock.NewController(t)
+
+	github := forgetest.NewMockForge(ctrl)
+	github.EXPECT().ID().Return("github").AnyTimes()
+	gitlab := forgetest.NewMockForge(ctrl)
+	gitlab.EXPECT().ID().Return("gitlab").AnyTimes()
+
+	var forges forge.Registry
+	forges.Register(github)
+	forges.Register(gitlab)
+
+	_, err := resolveForge(
+		t.Context(),
+		&forges,
+		silogtest.New(t),
+		ui.NewFileView(io.Discard),
+		"",
+		"",
+	)
+	require.Error(t, err)
+
+	assert.ErrorIs(t, err, errNoPrompt)
+}

--- a/config_test.go
+++ b/config_test.go
@@ -551,6 +551,72 @@ func TestBranchOntoRestackConfig(t *testing.T) {
 	}
 }
 
+func TestMainForgeKindConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		env    string
+		config string
+		want   string
+	}{
+		{
+			name: "Default",
+			want: "",
+		},
+		{
+			name: "Environment",
+			env:  "github",
+			want: "github",
+		},
+		{
+			name: "Config",
+			config: joinLines(
+				`[spice "forge"]`,
+				`  kind = gitlab`,
+			),
+			want: "gitlab",
+		},
+		{
+			name: "ConfigOverridesEnvironment",
+			env:  "github",
+			config: joinLines(
+				`[spice "forge"]`,
+				`  kind = gitlab`,
+			),
+			want: "gitlab",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.env != "" {
+				t.Setenv("GIT_SPICE_FORGE_KIND", tt.env)
+			}
+
+			spicecfg := loadTestSpiceConfig(t, tt.config)
+
+			var cmd mainCmd
+			logger := silogtest.New(t)
+			var (
+				forges   forge.Registry
+				sigStack sigstack.Stack
+			)
+			parser, err := kong.New(
+				&cmd,
+				kong.Resolvers(spicecfg),
+				kong.Bind(logger, &forges, &sigStack),
+				kong.BindTo(t.Context(), (*context.Context)(nil)),
+				kong.BindTo(spicecfg, (*experiment.Enabler)(nil)),
+				kong.Vars{"defaultPrompt": "false"},
+			)
+			require.NoError(t, err)
+
+			_, err = parser.Parse([]string{"version"})
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, cmd.Forge.Kind)
+		})
+	}
+}
+
 func loadTestSpiceConfig(t *testing.T, cfg string) *spice.Config {
 	t.Helper()
 

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -12,7 +12,7 @@ git-spice is a command line tool for stacking Git branches.
 * `-C`, `--dir=DIR`: Change to DIR before doing anything
 * `--[no-]prompt`: Whether to prompt for missing information
 
-**Configuration**: [spice.forge.bitbucket.apiURL](/cli/config.md#spiceforgebitbucketapiurl), [spice.forge.bitbucket.url](/cli/config.md#spiceforgebitbucketurl), [spice.forge.github.apiUrl](/cli/config.md#spiceforgegithubapiurl), [spice.forge.github.url](/cli/config.md#spiceforgegithuburl), [spice.forge.gitlab.apiURL](/cli/config.md#spiceforgegitlabapiurl), [spice.forge.gitlab.oauth.clientID](/cli/config.md#spiceforgegitlaboauthclientid), [spice.forge.gitlab.removeSourceBranch](/cli/config.md#spiceforgegitlabremovesourcebranch), [spice.forge.gitlab.url](/cli/config.md#spiceforgegitlaburl), [spice.git.indexLockTimeout](/cli/config.md#spicegitindexlocktimeout), [spice.secret.backend](/cli/config.md#spicesecretbackend)
+**Configuration**: [spice.forge.bitbucket.apiURL](/cli/config.md#spiceforgebitbucketapiurl), [spice.forge.bitbucket.url](/cli/config.md#spiceforgebitbucketurl), [spice.forge.github.apiUrl](/cli/config.md#spiceforgegithubapiurl), [spice.forge.github.url](/cli/config.md#spiceforgegithuburl), [spice.forge.gitlab.apiURL](/cli/config.md#spiceforgegitlabapiurl), [spice.forge.gitlab.oauth.clientID](/cli/config.md#spiceforgegitlaboauthclientid), [spice.forge.gitlab.removeSourceBranch](/cli/config.md#spiceforgegitlabremovesourcebranch), [spice.forge.gitlab.url](/cli/config.md#spiceforgegitlaburl), [spice.forge.kind](/cli/config.md#spiceforgekind), [spice.git.indexLockTimeout](/cli/config.md#spicegitindexlocktimeout), [spice.secret.backend](/cli/config.md#spicesecretbackend)
 
 ## Shell
 

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -196,6 +196,31 @@ should print a message when switching branches.
 - `true` (default)
 - `false`
 
+### spice.forge.kind
+
+<!-- gs:version unreleased -->
+
+The forge kind to use when a remote URL does not identify the forge by host.
+
+By default, git-spice infers the forge from the remote URL.
+For example, `https://github.com/OWNER/REPO.git` identifies GitHub.
+If the remote uses an SSH host alias,
+such as `git@github-work:OWNER/REPO.git`,
+the host may not identify a supported forge.
+Set this option to tell git-spice which forge implementation should parse
+the repository path.
+
+```freeze language="terminal"
+{green}${reset} git config {red}spice.forge.kind{reset} {mag}github{reset}
+```
+
+Accepted values are registered forge IDs,
+including `github`, `gitlab`, and `bitbucket`.
+Test repositories may also use `shamhub`.
+
+Alternatively, set this option with the `GIT_SPICE_FORGE_KIND`
+environment variable.
+
 ### spice.forge.github.apiUrl
 
 URL at which the GitHub API is available.

--- a/doc/src/setup/auth.md
+++ b/doc/src/setup/auth.md
@@ -389,6 +389,37 @@ The $$gs auth login$$ operation will always fail if you use this method.
 and the least secure method. End users should typically never pick this.
 It is intended only for CI/CD environments where you have no other choice.
 
+## Aliased SSH remotes
+
+<!-- gs:version unreleased -->
+
+git-spice usually identifies the forge from the Git remote URL.
+For example, a remote hosted on `github.com` identifies GitHub.
+
+If your SSH configuration uses a host alias,
+the remote URL may not identify the forge:
+
+```freeze language="terminal"
+{green}${reset} git remote -v
+origin  git@github-work:OWNER/REPO.git (fetch)
+origin  git@github-work:OWNER/REPO.git (push)
+```
+
+In that case, configure the forge kind explicitly:
+
+```freeze language="terminal"
+{green}${reset} git config {red}spice.forge.kind{reset} {mag}github{reset}
+```
+
+After this, run $$gs auth login$$ and other forge-backed commands normally.
+The configured kind selects the forge implementation;
+the configured forge URL,
+such as $$spice.forge.github.url$$ for GitHub Enterprise,
+still controls web links and API requests.
+
+You may also set the same value for one command with the
+`GIT_SPICE_FORGE_KIND` environment variable.
+
 ## Self-hosted instances
 
 ### GitHub Enterprise

--- a/help.go
+++ b/help.go
@@ -276,6 +276,12 @@ func (w *helpWriter) writeConfigOnlyOptions(node *kong.Node) {
 			continue
 		}
 
+		// Some global escape hatches are documented on the configuration page
+		// without repeating them in every command's generated help.
+		if flag.Tag.Get("configHelp") == "-" {
+			continue
+		}
+
 		// If deprecated, don't show in the help.
 		if flag.Tag.Has("deprecated") {
 			continue

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -46,6 +46,18 @@ func (r *Repository) RemoteURL(ctx context.Context, remote string) (string, erro
 	return url, nil
 }
 
+// RemoteConfigURL reports the URL stored in Git configuration for a remote.
+//
+// Unlike [Repository.RemoteURL],
+// this does not apply Git's url.*.insteadOf rewriting.
+func (r *Repository) RemoteConfigURL(ctx context.Context, remote string) (string, error) {
+	url, err := r.gitCmd(ctx, "config", "--get", "remote."+remote+".url").OutputChomp()
+	if err != nil {
+		return "", fmt.Errorf("config get remote.%s.url: %w", remote, err)
+	}
+	return url, nil
+}
+
 // RemoteDefaultBranch reports the default branch of a remote.
 // The remote must be known to the repository.
 func (r *Repository) RemoteDefaultBranch(ctx context.Context, remote string) (string, error) {

--- a/internal/handler/list/handler.go
+++ b/internal/handler/list/handler.go
@@ -14,7 +14,6 @@ import (
 
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/git"
-	"go.abhg.dev/gs/internal/git/giturl"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/sliceutil"
 	"go.abhg.dev/gs/internal/spice"
@@ -50,11 +49,17 @@ var _ Service = (*spice.Service)(nil)
 
 // Handler implements the business logic for git-spice's log commands.
 type Handler struct {
-	Log        *silog.Logger   // required
-	Repository GitRepository   // required
-	Store      Store           // required
-	Service    Service         // required
-	Forges     *forge.Registry // required
+	Log        *silog.Logger // required
+	Repository GitRepository // required
+	Store      Store         // required
+	Service    Service       // required
+
+	// ResolveRepository resolves an upstream remote
+	// to its forge repository identity.
+	ResolveRepository func(
+		context.Context,
+		string,
+	) (forge.Forge, forge.RepositoryID, error) // required
 
 	// OpenRemoteRepository opens the remote repository
 	// for the given remote URL.
@@ -197,23 +202,9 @@ func (h *Handler) ListBranches(ctx context.Context, req *BranchesRequest) (*Bran
 				return nil
 			}
 
-			remoteURL, err := h.Repository.RemoteURL(ctx, remote.Upstream)
-			if err != nil {
-				return fmt.Errorf("get remote URL: %w", err)
-			}
-
-			parsedRemoteURL, err := giturl.Parse(remoteURL)
-			if err != nil {
-				return fmt.Errorf("parse remote URL: %w", err)
-			}
-
-			var ok bool
-			remoteForge, remoteRepoID, ok = forge.FromRemoteURL(h.Forges, parsedRemoteURL)
-			if !ok {
-				return nil
-			}
-
-			return nil
+			var err error
+			remoteForge, remoteRepoID, err = h.ResolveRepository(ctx, remote.Upstream)
+			return err
 		}()
 		if err != nil {
 			log.Warn("Could not find information about the remote", "error", err)

--- a/log.go
+++ b/log.go
@@ -36,7 +36,7 @@ func (*logCmd) AfterApply(kctx *kong.Context) error {
 		repo *git.Repository,
 		store *state.Store,
 		svc *spice.Service,
-		forges *forge.Registry,
+		remoteResolver *remoteResolver,
 		stash secret.Stash,
 	) (ListHandler, error) {
 		return &list.Handler{
@@ -44,7 +44,14 @@ func (*logCmd) AfterApply(kctx *kong.Context) error {
 			Repository: repo,
 			Store:      store,
 			Service:    svc,
-			Forges:     forges,
+			ResolveRepository: func(ctx context.Context, remote string) (forge.Forge, forge.RepositoryID, error) {
+				f, repoID, err := remoteResolver.Resolve(ctx, remote)
+				var unsupported *unsupportedForgeError
+				if errors.As(err, &unsupported) {
+					return nil, nil, nil
+				}
+				return f, repoID, err
+			},
 			OpenRemoteRepository: func(ctx context.Context, f forge.Forge, repo forge.RepositoryID) (forge.Repository, error) {
 				return openForgeRepository(ctx, stash, f, repo)
 			},

--- a/main.go
+++ b/main.go
@@ -167,7 +167,8 @@ func main() {
 		kong.Name(cmdName),
 		kong.Description("git-spice is a command line tool for stacking Git branches."),
 		kong.Resolvers(spiceConfig),
-		kong.Bind(logger, &forges, &sigStack),
+		kong.Bind(logger, &forges, &sigStack, &cmd),
+		kong.BindTo(&cmd.Forge, (*forgeOptions)(nil)),
 		kong.BindTo(ctx, (*context.Context)(nil)),
 		kong.BindTo(spiceConfig, (*experiment.Enabler)(nil)),
 		kong.Vars{
@@ -290,6 +291,8 @@ type mainCmd struct {
 		IndexLockTimeout time.Duration `name:"git-index-lock-timeout" hidden:"" default:"5s" config:"git.indexLockTimeout" help:"Total time to spend retrying git commands that fail due to index.lock contention. Set to 0 to disable retries."`
 	} `embed:""`
 
+	Forge forgeOptions `embed:""`
+
 	Shell shellCmd `cmd:"" group:"Shell"`
 	Auth  authCmd  `cmd:"" group:"Authentication"`
 
@@ -318,6 +321,14 @@ type mainCmd struct {
 
 	// Hidden commands:
 	DumpMD dumpMarkdownCmd `name:"dumpmd" hidden:"" cmd:"" help:"Dump a Markdown reference to stdout and quit"`
+}
+
+// forgeOptions defines application-wide forge selection options.
+type forgeOptions struct {
+	// Kind names the forge to use when a Git remote URL does not identify one.
+	// It is hidden from command help because forge selection is a repository
+	// or environment setting rather than a per-invocation control.
+	Kind string `name:"forge-kind" hidden:"" config:"forge.kind" env:"GIT_SPICE_FORGE_KIND" configHelp:"-" help:"Forge kind to use when remote URLs do not identify a supported Git host."`
 }
 
 func (cmd *mainCmd) AfterApply(ctx context.Context, kctx *kong.Context, logger *silog.Logger) error {
@@ -360,6 +371,7 @@ func (cmd *mainCmd) AfterApply(ctx context.Context, kctx *kong.Context, logger *
 		}
 	}
 	kctx.BindTo(secretStash, (*secret.Stash)(nil))
+	kctx.BindTo(&cmd.Forge, (*forgeOptions)(nil))
 
 	// TODO: bind interfaces, not values
 	// TODO:
@@ -376,6 +388,16 @@ func (cmd *mainCmd) AfterApply(ctx context.Context, kctx *kong.Context, logger *
 		}),
 		kctx.BindSingletonProvider(func(wt *git.Worktree) (*git.Repository, error) {
 			return wt.Repository(), nil
+		}),
+		kctx.BindSingletonProvider(func(
+			repo *git.Repository,
+			forges *forge.Registry,
+		) *remoteResolver {
+			return &remoteResolver{
+				Forges:     forges,
+				Repository: repo,
+				ForgeKind:  cmd.Forge.Kind,
+			}
 		}),
 		kctx.BindSingletonProvider(func(repo *git.Repository, wt *git.Worktree) (*state.Store, error) {
 			return ensureStore(ctx, repo, wt, logger, view)
@@ -438,7 +460,7 @@ func (cmd *mainCmd) AfterApply(ctx context.Context, kctx *kong.Context, logger *
 			wt *git.Worktree,
 			svc *spice.Service,
 			secretStash secret.Stash,
-			forges *forge.Registry,
+			remoteResolver *remoteResolver,
 		) (SubmitHandler, error) {
 			return &submit.Handler{
 				Log:        log,
@@ -452,7 +474,7 @@ func (cmd *mainCmd) AfterApply(ctx context.Context, kctx *kong.Context, logger *
 					return ensureRemote(ctx, wt.Repository(), store, log, view)
 				},
 				ResolveRepository: func(ctx context.Context, remote string) (forge.Forge, forge.RepositoryID, error) {
-					return resolveRemoteRepository(ctx, log, forges, wt.Repository(), remote)
+					return resolveRemoteRepository(ctx, log, remoteResolver, remote)
 				},
 				OpenRepository: func(ctx context.Context, f forge.Forge, repo forge.RepositoryID) (forge.Repository, error) {
 					return openRepository(ctx, log, secretStash, f, repo)
@@ -560,7 +582,7 @@ func (cmd *mainCmd) AfterApply(ctx context.Context, kctx *kong.Context, logger *
 			store *state.Store,
 			svc *spice.Service,
 			secretStash secret.Stash,
-			forges *forge.Registry,
+			remoteResolver *remoteResolver,
 			deleteHandler DeleteHandler,
 			restackHandler RestackHandler,
 			autostashHandler AutostashHandler,
@@ -571,7 +593,7 @@ func (cmd *mainCmd) AfterApply(ctx context.Context, kctx *kong.Context, logger *
 				return nil, err
 			}
 
-			remoteRepo, err := openRemoteRepositorySilent(ctx, secretStash, forges, repo, remote.Upstream)
+			remoteRepo, err := remoteResolver.Open(ctx, secretStash, remote.Upstream)
 			if err != nil {
 				var unsupported *unsupportedForgeError
 				if !errors.As(err, &unsupported) {
@@ -582,7 +604,7 @@ func (cmd *mainCmd) AfterApply(ctx context.Context, kctx *kong.Context, logger *
 
 			var pushRepository forge.RepositoryID
 			if remote.ForkMode() {
-				pushRepository, err = resolveRemoteRepositoryID(ctx, forges, repo, remote.Push)
+				pushRepository, err = remoteResolver.ResolveID(ctx, remote.Push)
 				if err != nil {
 					return nil, fmt.Errorf("resolve push repository: %w", err)
 				}
@@ -631,12 +653,11 @@ func (cmd *mainCmd) AfterApply(ctx context.Context, kctx *kong.Context, logger *
 		kctx.BindSingletonProvider(func(
 			log *silog.Logger,
 			secretStash secret.Stash,
-			forges *forge.Registry,
-			repo *git.Repository,
+			remoteResolver *remoteResolver,
 			remote state.Remote,
 		) (forge.Repository, error) {
 			f, repoID, err := resolveRemoteRepository(
-				ctx, log, forges, repo, remote.Upstream,
+				ctx, log, remoteResolver, remote.Upstream,
 			)
 			if err != nil {
 				return nil, fmt.Errorf(

--- a/remote.go
+++ b/remote.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
+	"strings"
 
 	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/forge"
@@ -30,24 +33,27 @@ func (e *notLoggedInError) Error() string {
 	return "not logged in to " + e.Forge.ID()
 }
 
-// remoteURLer reads Git's resolved URL for a named remote.
-type remoteURLer interface {
-	// RemoteURL accepts a Git remote name and returns the URL that Git uses
-	// after applying its remote URL rewriting rules.
-	//
-	// It is equivalent to `git remote get-url <name>`.
-	RemoteURL(context.Context, string) (string, error)
+// remoteConfigURLer reads the remote URL before Git transport rewriting.
+type remoteConfigURLer interface {
+	// RemoteConfigURL accepts a Git remote name and returns the configured
+	// `remote.<name>.url` value before applying `url.*.insteadOf` rewriting.
+	RemoteConfigURL(context.Context, string) (string, error)
 }
 
-var _ remoteURLer = (*git.Repository)(nil)
+var _ remoteConfigURLer = (*git.Repository)(nil)
 
 // remoteResolver resolves git-spice remotes to forge repository identities.
 type remoteResolver struct {
 	// Forges is the registry of forge implementations that may own a remote.
-	Forges *forge.Registry
+	Forges *forge.Registry // required
 
 	// Repository is the Git repository whose remotes should be resolved.
-	Repository remoteURLer
+	Repository remoteConfigURLer // required
+
+	// ForgeKind names the forge selected by configuration.
+	//
+	// If unset, remote URLs must identify their forge by host.
+	ForgeKind string // required
 }
 
 // Resolve identifies the forge and repository for a configured Git remote.
@@ -55,7 +61,7 @@ func (r *remoteResolver) Resolve(
 	ctx context.Context,
 	remote string,
 ) (forge.Forge, forge.RepositoryID, error) {
-	remoteURL, err := r.Repository.RemoteURL(ctx, remote)
+	remoteURL, err := r.Repository.RemoteConfigURL(ctx, remote)
 	if err != nil {
 		return nil, nil, fmt.Errorf("get remote URL: %w", err)
 	}
@@ -63,6 +69,19 @@ func (r *remoteResolver) Resolve(
 	parsedRemoteURL, err := giturl.Parse(remoteURL)
 	if err != nil {
 		return nil, nil, fmt.Errorf("parse remote URL: %w", err)
+	}
+
+	if r.ForgeKind != "" {
+		f, err := lookupForgeKind(r.Forges, r.ForgeKind)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		repoID, err := f.ParseRepositoryPath(parsedRemoteURL.Path)
+		if err != nil {
+			return nil, nil, fmt.Errorf("parse remote path as %s: %w", f.ID(), err)
+		}
+		return f, repoID, nil
 	}
 
 	f, repoID, ok := forge.FromRemoteURL(r.Forges, parsedRemoteURL)
@@ -75,6 +94,23 @@ func (r *remoteResolver) Resolve(
 	return f, repoID, nil
 }
 
+func lookupForgeKind(forges *forge.Registry, kind string) (forge.Forge, error) {
+	f, ok := forges.Lookup(kind)
+	if ok {
+		return f, nil
+	}
+
+	ids := make(map[string]struct{})
+	for f := range forges.All() {
+		ids[f.ID()] = struct{}{}
+	}
+	return nil, fmt.Errorf(
+		"unknown forge kind %q: expected one of: %s",
+		kind,
+		strings.Join(slices.Sorted(maps.Keys(ids)), ", "),
+	)
+}
+
 // ResolveID identifies the repository for a configured Git remote.
 func (r *remoteResolver) ResolveID(
 	ctx context.Context,
@@ -84,54 +120,18 @@ func (r *remoteResolver) ResolveID(
 	return repoID, err
 }
 
-// Attempts to open the forge.Repository associated with the given Git remote.
-//
-// Does not print any error messages to the user.
-// Instead, returns one of the following errors:
-//
-//   - unsupportedForgeError if the remote URL does not match
-//     any any known forges.
-//   - notLoggedInError if the user is not authenticated with the forge.
-func openRemoteRepositorySilent(
+// Open opens the forge repository associated with a configured Git remote.
+func (r *remoteResolver) Open(
 	ctx context.Context,
 	stash secret.Stash,
-	forges *forge.Registry,
-	gitRepo *git.Repository,
 	remote string,
 ) (forge.Repository, error) {
-	f, repoID, err := (&remoteResolver{
-		Forges:     forges,
-		Repository: gitRepo,
-	}).Resolve(ctx, remote)
+	f, repoID, err := r.Resolve(ctx, remote)
 	if err != nil {
 		return nil, err
 	}
 
 	return openForgeRepository(ctx, stash, f, repoID)
-}
-
-func resolveRemoteRepositoryID(
-	ctx context.Context,
-	forges *forge.Registry,
-	gitRepo *git.Repository,
-	remote string,
-) (forge.RepositoryID, error) {
-	return (&remoteResolver{
-		Forges:     forges,
-		Repository: gitRepo,
-	}).ResolveID(ctx, remote)
-}
-
-func resolveRemoteRepositorySilent(
-	ctx context.Context,
-	forges *forge.Registry,
-	gitRepo *git.Repository,
-	remote string,
-) (forge.Forge, forge.RepositoryID, error) {
-	return (&remoteResolver{
-		Forges:     forges,
-		Repository: gitRepo,
-	}).Resolve(ctx, remote)
 }
 
 func openForgeRepository(
@@ -154,15 +154,15 @@ func openForgeRepository(
 func resolveRemoteRepository(
 	ctx context.Context,
 	log *silog.Logger,
-	forges *forge.Registry,
-	gitRepo *git.Repository,
+	resolver *remoteResolver,
 	remote string,
 ) (forge.Forge, forge.RepositoryID, error) {
-	f, repoID, err := resolveRemoteRepositorySilent(ctx, forges, gitRepo, remote)
+	f, repoID, err := resolver.Resolve(ctx, remote)
 
 	if unsupportedErr, ok := errors.AsType[*unsupportedForgeError](err); ok {
 		log.Error("Could not guess repository from remote URL", "url", unsupportedErr.RemoteURL)
 		log.Error("Are you sure the remote identifies a supported Git host?")
+		log.Error("If this remote uses a Git host alias, run `git config spice.forge.kind <forge>`.")
 	}
 
 	return f, repoID, err

--- a/remote_test.go
+++ b/remote_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/forge/forgetest"
+	"go.abhg.dev/gs/internal/silog"
 	"go.uber.org/mock/gomock"
 )
 
@@ -28,6 +30,7 @@ func TestRemoteResolver_Resolve(t *testing.T) {
 	gotForge, gotRepoID, err := (&remoteResolver{
 		Forges:     &forges,
 		Repository: remoteURLMap{"origin": "https://example.com/owner/repo"},
+		ForgeKind:  "",
 	}).Resolve(t.Context(), "origin")
 	require.NoError(t, err)
 
@@ -52,10 +55,47 @@ func TestRemoteResolver_ResolveID(t *testing.T) {
 	gotRepoID, err := (&remoteResolver{
 		Forges:     &forges,
 		Repository: remoteURLMap{"origin": "https://example.com/owner/repo"},
+		ForgeKind:  "",
 	}).ResolveID(t.Context(), "origin")
 	require.NoError(t, err)
 
 	assert.Equal(t, repoID, gotRepoID)
+}
+
+func TestRemoteResolver_Resolve_configuredKind(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	repoID := forgetest.NewMockRepositoryID(ctrl)
+	testForge := forgetest.NewMockForge(ctrl)
+	testForge.EXPECT().ID().Return("github").AnyTimes()
+	testForge.EXPECT().
+		ParseRepositoryPath("/owner/repo.git").
+		Return(repoID, nil)
+
+	var forges forge.Registry
+	forges.Register(testForge)
+
+	gotForge, gotRepoID, err := (&remoteResolver{
+		Forges:     &forges,
+		Repository: remoteURLMap{"origin": "ssh://githubaccount1/owner/repo.git"},
+		ForgeKind:  "github",
+	}).Resolve(t.Context(), "origin")
+	require.NoError(t, err)
+
+	assert.Same(t, testForge, gotForge)
+	assert.Equal(t, repoID, gotRepoID)
+}
+
+func TestRemoteResolver_Resolve_unknownConfiguredKind(t *testing.T) {
+	var forges forge.Registry
+	_, _, err := (&remoteResolver{
+		Forges:     &forges,
+		Repository: remoteURLMap{"origin": "ssh://githubaccount1/owner/repo.git"},
+		ForgeKind:  "github",
+	}).Resolve(t.Context(), "origin")
+	require.Error(t, err)
+
+	assert.ErrorContains(t, err, `unknown forge kind "github"`)
 }
 
 func TestRemoteResolver_Resolve_unsupported(t *testing.T) {
@@ -63,6 +103,7 @@ func TestRemoteResolver_Resolve_unsupported(t *testing.T) {
 	_, _, err := (&remoteResolver{
 		Forges:     &forges,
 		Repository: remoteURLMap{"origin": "https://example.com/owner/repo"},
+		ForgeKind:  "",
 	}).Resolve(t.Context(), "origin")
 	require.Error(t, err)
 
@@ -72,8 +113,26 @@ func TestRemoteResolver_Resolve_unsupported(t *testing.T) {
 	assert.Equal(t, "https://example.com/owner/repo", unsupported.RemoteURL)
 }
 
+func TestResolveRemoteRepository_unsupportedRecommendsForgeKind(t *testing.T) {
+	var logBuffer bytes.Buffer
+	var forges forge.Registry
+	_, _, err := resolveRemoteRepository(
+		t.Context(),
+		silog.New(&logBuffer, nil),
+		&remoteResolver{
+			Forges:     &forges,
+			Repository: remoteURLMap{"origin": "ssh://githubalias/owner/repo.git"},
+			ForgeKind:  "",
+		},
+		"origin",
+	)
+	require.Error(t, err)
+
+	assert.Contains(t, logBuffer.String(), "git config spice.forge.kind <forge>")
+}
+
 type remoteURLMap map[string]string
 
-func (m remoteURLMap) RemoteURL(_ context.Context, remote string) (string, error) {
+func (m remoteURLMap) RemoteConfigURL(_ context.Context, remote string) (string, error) {
 	return m[remote], nil
 }

--- a/testdata/script/forge_kind_alias_remote.txt
+++ b/testdata/script/forge_kind_alias_remote.txt
@@ -1,0 +1,51 @@
+# Configured forge kind allows submit to use an aliased Git remote host.
+
+as 'Test <test@example.com>'
+at '2026-05-17T10:12:00Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+shamhub init
+shamhub register alice
+shamhub new origin alice/example.git
+git push origin main
+
+# The configured remote URL uses an alias host that does not identify ShamHub,
+# while Git still rewrites the URL to the real ShamHub endpoint for transport.
+git remote set-url origin ssh://shamhub-alias/alice/example.git
+git config url.$SHAMHUB_URL/.insteadOf ssh://shamhub-alias/
+
+gs repo init
+
+env SHAMHUB_USERNAME=alice
+gs auth login --forge shamhub
+
+# Without an explicit forge kind, the alias host is not enough to identify
+# the forge. The diagnostic points at the escape hatch.
+git add no-config.txt
+gs branch create no-config -m 'No config feature'
+! gs branch submit --fill
+stderr 'Could not guess repository from remote URL'
+stderr 'git config spice.forge.kind <forge>'
+
+# With the Git config escape hatch, the same alias-host remote submits
+# successfully and reports the real ShamHub change URL.
+git config spice.forge.kind shamhub
+gs branch submit --fill
+stderr $SHAMHUB_URL/alice/example/change/1
+
+# The environment variable works as the same escape hatch when the Git config
+# value is absent.
+git config --unset spice.forge.kind
+git add env-kind.txt
+gs branch create env-kind --target main -m 'Environment kind feature'
+env GIT_SPICE_FORGE_KIND=shamhub
+gs branch submit --fill
+stderr $SHAMHUB_URL/alice/example/change/2
+
+-- repo/no-config.txt --
+configured forge kind
+-- repo/env-kind.txt --
+environment forge kind


### PR DESCRIPTION
Some Git remotes use host aliases that are valid for Git transport but do
not identify the forge to git-spice. Add the hidden `spice.forge.kind`
configuration option and `GIT_SPICE_FORGE_KIND` environment variable so users
can select a registered forge without changing their remote URL.

Remote resolution now uses the configured remote URL before Git transport
rewriting for forge detection, while Git operations still use normal Git
transport behavior. Submit, sync, auth selection, and list/log paths share
the same resolver boundary.

Document the setup flow for aliased SSH remotes and cover the config and
environment paths with unit and script tests.

Resolves #336, #603