### PR TITLE
feat(merge): Add merge method overrides

### DIFF
--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -618,9 +618,10 @@ when you don't want to wait for the merge to propagate.
 * `--branch=NAME`: Branch to start merging from
 * `--no-wait`: Skip polling for a single branch merge to propagate.
 * `--no-branch-check`: Skip stale base validation before merging.
+* `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
 * `--build-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.buildTimeout" }](/cli/config.md#spicemergebuildtimeout)): Max time to wait for CI checks before each merge. 0 means check once.
 
-**Configuration**: [spice.merge.buildTimeout](/cli/config.md#spicemergebuildtimeout)
+**Configuration**: [spice.merge.buildTimeout](/cli/config.md#spicemergebuildtimeout), [spice.merge.method](/cli/config.md#spicemergemethod)
 
 ### git-spice downstack edit {#gs-downstack-edit}
 

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -414,6 +414,23 @@ Set to `0` to fail immediately if checks aren't already passing.
 
 Defaults to `30m`.
 
+### spice.merge.method
+
+<!-- gs:version unreleased -->
+
+Preferred merge method for $$gs downstack merge$$.
+If unset, git-spice lets the forge use its default merge method.
+
+Merge methods are forge-specific.
+If the selected forge does not recognize the configured method,
+git-spice warns and lets the forge use its default merge method.
+
+**Accepted values:**
+
+- `merge`: create a merge commit
+- `squash`: squash commits before merging
+- `rebase`: rebase commits before merging
+
 ### spice.rebaseContinue.edit
 
 <!-- gs:version v0.10.0 -->

--- a/downstack_merge.go
+++ b/downstack_merge.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/handler/merge"
 	"go.abhg.dev/gs/internal/spice/state"
@@ -13,10 +14,11 @@ import (
 )
 
 type downstackMergeCmd struct {
-	Branch        string        `placeholder:"NAME" help:"Branch to start merging from" predictor:"trackedBranches"`
-	NoWait        bool          `help:"Skip polling for a single branch merge to propagate."`
-	NoBranchCheck bool          `help:"Skip stale base validation before merging."`
-	BuildTimeout  time.Duration `config:"merge.buildTimeout" default:"30m" help:"Max time to wait for CI checks before each merge. 0 means check once."`
+	Branch        string            `placeholder:"NAME" help:"Branch to start merging from" predictor:"trackedBranches"`
+	NoWait        bool              `help:"Skip polling for a single branch merge to propagate."`
+	NoBranchCheck bool              `help:"Skip stale base validation before merging."`
+	Method        forge.MergeMethod `placeholder:"METHOD" config:"merge.method" help:"Preferred merge method. One of 'merge', 'squash', and 'rebase'."`
+	BuildTimeout  time.Duration     `config:"merge.buildTimeout" default:"30m" help:"Max time to wait for CI checks before each merge. 0 means check once."`
 }
 
 func (*downstackMergeCmd) Help() string {
@@ -95,6 +97,7 @@ func (cmd *downstackMergeCmd) Run(
 		Branch:        cmd.Branch,
 		NoWait:        cmd.NoWait,
 		NoBranchCheck: cmd.NoBranchCheck,
+		Method:        cmd.Method,
 		BuildTimeout:  cmd.BuildTimeout,
 	})
 }

--- a/internal/forge/bitbucket/merge.go
+++ b/internal/forge/bitbucket/merge.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/gateway/bitbucket"
 )
 
 // MergeChange merges an open pull request into its base branch.
@@ -13,11 +14,28 @@ import (
 // opts.HeadHash is ignored.
 func (r *Repository) MergeChange(
 	ctx context.Context, fid forge.ChangeID,
-	_ forge.MergeChangeOptions,
+	opts forge.MergeChangeOptions,
 ) error {
 	id := mustPR(fid)
+
+	var strategy string
+	switch opts.Method {
+	case forge.MergeMethodDefault:
+	case forge.MergeMethodMerge:
+		strategy = "merge_commit"
+	case forge.MergeMethodSquash:
+		strategy = "squash"
+	case forge.MergeMethodRebase:
+		strategy = "rebase_merge"
+	default:
+		r.log.Warn(
+			"Unsupported merge method; using forge default",
+			"method", opts.Method,
+		)
+	}
 	if _, _, err := r.client.PullRequestMerge(
 		ctx, r.workspace, r.repo, id.Number,
+		&bitbucket.PullRequestMergeRequest{Strategy: strategy},
 	); err != nil {
 		return fmt.Errorf("merge pull request: %w", err)
 	}

--- a/internal/forge/bitbucket/operations_test.go
+++ b/internal/forge/bitbucket/operations_test.go
@@ -95,6 +95,69 @@ func TestPostChangeComment(t *testing.T) {
 	assert.Equal(t, int64(42), prComment.ID)
 }
 
+func TestMergeChange_method(t *testing.T) {
+	tests := []struct {
+		name         string
+		method       forge.MergeMethod
+		wantStrategy any
+	}{
+		{
+			name:         "Default",
+			method:       forge.MergeMethodDefault,
+			wantStrategy: nil,
+		},
+		{
+			name:         "Merge",
+			method:       forge.MergeMethodMerge,
+			wantStrategy: "merge_commit",
+		},
+		{
+			name:         "Squash",
+			method:       forge.MergeMethodSquash,
+			wantStrategy: "squash",
+		},
+		{
+			name:         "Rebase",
+			method:       forge.MergeMethodRebase,
+			wantStrategy: "rebase_merge",
+		},
+		{
+			name:   "Unsupported",
+			method: forge.MergeMethod(99),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var merged bool
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Contains(t, r.URL.Path, "/pullrequests/1/merge")
+
+				var body map[string]any
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+				if tt.wantStrategy == nil {
+					assert.NotContains(t, body, "merge_strategy")
+				} else {
+					assert.Equal(t, tt.wantStrategy, body["merge_strategy"])
+				}
+				merged = true
+
+				resp := bitbucket.PullRequest{ID: 1, State: "MERGED"}
+				assert.NoError(t, json.NewEncoder(w).Encode(resp))
+			}))
+			defer srv.Close()
+
+			repo := newTestRepository(srv.URL)
+			err := repo.MergeChange(t.Context(), &PR{Number: 1}, forge.MergeChangeOptions{
+				Method: tt.method,
+			})
+			require.NoError(t, err)
+			assert.True(t, merged)
+		})
+	}
+}
+
 func TestUpdateChangeComment(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -4,11 +4,13 @@ package forge
 
 import (
 	"context"
+	"encoding"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"iter"
 	"regexp"
+	"strings"
 	"sync"
 
 	"go.abhg.dev/gs/internal/git"
@@ -444,6 +446,10 @@ type EditChangeOptions struct {
 
 // MergeChangeOptions specifies options for a merge operation.
 type MergeChangeOptions struct {
+	// Method selects the forge merge strategy.
+	// If zero, the forge uses its repository default.
+	Method MergeMethod
+
 	// HeadHash, if non-empty, causes the merge to fail
 	// if the change's current head commit doesn't match.
 	// This prevents merging a change whose content
@@ -452,6 +458,76 @@ type MergeChangeOptions struct {
 	// Not all forges support this; unsupported forges
 	// ignore the field.
 	HeadHash git.Hash
+}
+
+// MergeMethod names a forge-level strategy for merging a change request.
+type MergeMethod int
+
+const (
+	// MergeMethodDefault leaves the merge strategy up to the forge.
+	MergeMethodDefault MergeMethod = iota
+
+	// MergeMethodMerge requests a two-parent merge commit.
+	MergeMethodMerge
+
+	// MergeMethodSquash requests a single squashed commit.
+	MergeMethodSquash
+
+	// MergeMethodRebase requests a rebase before merging.
+	MergeMethodRebase
+)
+
+var (
+	_ encoding.TextMarshaler   = MergeMethod(0)
+	_ encoding.TextUnmarshaler = (*MergeMethod)(nil)
+)
+
+// UnmarshalText decodes a merge method from text.
+func (m *MergeMethod) UnmarshalText(bs []byte) error {
+	switch strings.ToLower(string(bs)) {
+	case "", "default":
+		*m = MergeMethodDefault
+	case "merge":
+		*m = MergeMethodMerge
+	case "squash":
+		*m = MergeMethodSquash
+	case "rebase":
+		*m = MergeMethodRebase
+	default:
+		return fmt.Errorf(
+			"invalid value %q: expected merge, squash, or rebase",
+			string(bs),
+		)
+	}
+	return nil
+}
+
+// MarshalText encodes a merge method to text.
+func (m MergeMethod) MarshalText() ([]byte, error) {
+	switch m {
+	case MergeMethodDefault:
+		return []byte("default"), nil
+	case MergeMethodMerge:
+		return []byte("merge"), nil
+	case MergeMethodSquash:
+		return []byte("squash"), nil
+	case MergeMethodRebase:
+		return []byte("rebase"), nil
+	default:
+		return nil, fmt.Errorf("unknown merge method: %d", m)
+	}
+}
+
+// String returns the text form of the merge method.
+func (m MergeMethod) String() string {
+	if m == MergeMethodDefault {
+		return "default"
+	}
+	bs, err := m.MarshalText()
+	if err != nil {
+		return fmt.Sprintf("MergeMethod(%d)", int(m))
+	}
+	return string(bs)
 }
 
 // FindChangeItem is a single result from searching for changes in the

--- a/internal/forge/forge_test.go
+++ b/internal/forge/forge_test.go
@@ -123,3 +123,55 @@ func TestChangeState(t *testing.T) {
 		})
 	})
 }
+
+func TestMergeMethod(t *testing.T) {
+	tests := []struct {
+		method forge.MergeMethod
+		text   string
+	}{
+		{forge.MergeMethodDefault, "default"},
+		{forge.MergeMethodMerge, "merge"},
+		{forge.MergeMethodSquash, "squash"},
+		{forge.MergeMethodRebase, "rebase"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method.String(), func(t *testing.T) {
+			t.Run("Marshal", func(t *testing.T) {
+				got, err := tt.method.MarshalText()
+				require.NoError(t, err)
+				assert.Equal(t, tt.text, string(got))
+			})
+
+			t.Run("Unmarshal", func(t *testing.T) {
+				var got forge.MergeMethod
+				require.NoError(t, got.UnmarshalText([]byte(tt.text)))
+				assert.Equal(t, tt.method, got)
+			})
+		})
+	}
+
+	t.Run("unknown", func(t *testing.T) {
+		method := forge.MergeMethod(42)
+
+		t.Run("String", func(t *testing.T) {
+			assert.Equal(t, "MergeMethod(42)", method.String())
+		})
+
+		t.Run("Marshal", func(t *testing.T) {
+			_, err := method.MarshalText()
+			assert.Error(t, err)
+		})
+
+		t.Run("Unmarshal", func(t *testing.T) {
+			err := method.UnmarshalText([]byte("fast-forward"))
+			assert.Error(t, err)
+		})
+	})
+
+	t.Run("emptyDefault", func(t *testing.T) {
+		var got forge.MergeMethod
+		require.NoError(t, got.UnmarshalText(nil))
+		assert.Equal(t, forge.MergeMethodDefault, got)
+	})
+}

--- a/internal/forge/github/merge.go
+++ b/internal/forge/github/merge.go
@@ -42,6 +42,20 @@ func (r *Repository) mergePullRequest(
 		oid := githubv4.GitObjectID(opts.HeadHash)
 		input.ExpectedHeadOid = &oid
 	}
+	switch opts.Method {
+	case forge.MergeMethodDefault:
+	case forge.MergeMethodMerge:
+		input.MergeMethod = new(githubv4.PullRequestMergeMethodMerge)
+	case forge.MergeMethodSquash:
+		input.MergeMethod = new(githubv4.PullRequestMergeMethodSquash)
+	case forge.MergeMethodRebase:
+		input.MergeMethod = new(githubv4.PullRequestMergeMethodRebase)
+	default:
+		r.log.Warn(
+			"Unsupported merge method; using forge default",
+			"method", opts.Method,
+		)
+	}
 	if err := r.client.Mutate(ctx, &m, input, nil); err != nil {
 		return fmt.Errorf("merge pull request: %w", err)
 	}

--- a/internal/forge/github/merge_test.go
+++ b/internal/forge/github/merge_test.go
@@ -1,0 +1,101 @@
+package github
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/shurcooL/githubv4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/silog/silogtest"
+)
+
+func TestRepository_MergeChange_method(t *testing.T) {
+	tests := []struct {
+		name       string
+		method     forge.MergeMethod
+		wantMethod string
+	}{
+		{
+			name:   "Default",
+			method: forge.MergeMethodDefault,
+		},
+		{
+			name:       "Merge",
+			method:     forge.MergeMethodMerge,
+			wantMethod: "MERGE",
+		},
+		{
+			name:       "Squash",
+			method:     forge.MergeMethodSquash,
+			wantMethod: "SQUASH",
+		},
+		{
+			name:       "Rebase",
+			method:     forge.MergeMethodRebase,
+			wantMethod: "REBASE",
+		},
+		{
+			name:   "Unsupported",
+			method: forge.MergeMethod(99),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var merged bool
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, http.MethodPost, r.Method)
+
+				var body struct {
+					Variables struct {
+						Input struct {
+							PullRequestID string  `json:"pullRequestId"`
+							MergeMethod   *string `json:"mergeMethod,omitempty"`
+						} `json:"input"`
+					} `json:"variables"`
+				}
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+
+				input := body.Variables.Input
+				assert.Equal(t, "prID", input.PullRequestID)
+				if tt.wantMethod == "" {
+					assert.Nil(t, input.MergeMethod)
+				} else {
+					require.NotNil(t, input.MergeMethod)
+					assert.Equal(t, tt.wantMethod, *input.MergeMethod)
+				}
+				merged = true
+
+				require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+					"data": map[string]any{
+						"mergePullRequest": map[string]any{
+							"pullRequest": map[string]any{
+								"id": "prID",
+							},
+						},
+					},
+				}))
+			}))
+			defer srv.Close()
+
+			repo, err := newRepository(
+				t.Context(), new(Forge),
+				"owner", "repo",
+				silogtest.New(t),
+				githubv4.NewEnterpriseClient(srv.URL, nil),
+				"repoID",
+			)
+			require.NoError(t, err)
+
+			err = repo.mergePullRequest(t.Context(), &PR{Number: 1}, "prID", forge.MergeChangeOptions{
+				Method: tt.method,
+			})
+			require.NoError(t, err)
+			assert.True(t, merged)
+		})
+	}
+}

--- a/internal/forge/gitlab/merge.go
+++ b/internal/forge/gitlab/merge.go
@@ -20,6 +20,14 @@ func (r *Repository) MergeChange(
 		sha := string(opts.HeadHash)
 		mrOpts.SHA = &sha
 	}
+	if opts.Method == forge.MergeMethodSquash {
+		mrOpts.Squash = new(true)
+	} else if opts.Method != forge.MergeMethodDefault {
+		r.log.Warn(
+			"Unsupported merge method; using forge default",
+			"method", opts.Method,
+		)
+	}
 
 	if _, _, err := r.client.MergeRequestAccept(
 		ctx, r.repoID, id.Number, mrOpts,

--- a/internal/forge/gitlab/merge_test.go
+++ b/internal/forge/gitlab/merge_test.go
@@ -1,0 +1,88 @@
+package gitlab
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/forge"
+	gatewaygitlab "go.abhg.dev/gs/internal/gateway/gitlab"
+	"go.abhg.dev/gs/internal/silog/silogtest"
+)
+
+func TestRepository_MergeChange_method(t *testing.T) {
+	tests := []struct {
+		name      string
+		method    forge.MergeMethod
+		wantField bool
+	}{
+		{
+			name: "Default",
+		},
+		{
+			name:   "Merge",
+			method: forge.MergeMethodMerge,
+		},
+		{
+			name:   "Rebase",
+			method: forge.MergeMethodRebase,
+		},
+		{
+			name:      "Squash",
+			method:    forge.MergeMethodSquash,
+			wantField: true,
+		},
+		{
+			name:   "Unsupported",
+			method: forge.MergeMethod(99),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPut, r.Method)
+				assert.Equal(t, "/api/v4/projects/100/merge_requests/55/merge", r.URL.Path)
+
+				var body map[string]any
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+				if tt.wantField {
+					assert.Equal(t, true, body["squash"])
+				} else {
+					assert.NotContains(t, body, "squash")
+				}
+
+				writeGitLabJSON(t, w, http.StatusOK, gatewaygitlab.MergeRequest{
+					BasicMergeRequest: gatewaygitlab.BasicMergeRequest{
+						IID:   55,
+						State: "merged",
+					},
+				})
+			}))
+			defer srv.Close()
+
+			client, err := gatewaygitlab.NewClient(
+				gatewaygitlab.StaticTokenSource(gatewaygitlab.Token{
+					Type:  gatewaygitlab.TokenTypePrivateToken,
+					Value: "test-token",
+				}),
+				&gatewaygitlab.ClientOptions{BaseURL: srv.URL},
+			)
+			require.NoError(t, err)
+
+			repo := &Repository{
+				client: client,
+				repoID: 100,
+				log:    silogtest.New(t),
+			}
+			require.NoError(t, repo.MergeChange(
+				t.Context(),
+				&MR{Number: 55},
+				forge.MergeChangeOptions{Method: tt.method},
+			))
+		})
+	}
+}

--- a/internal/forge/shamhub/states.go
+++ b/internal/forge/shamhub/states.go
@@ -432,6 +432,17 @@ func (r *forgeRepository) MergeChange(
 	body := mergeChangeRequest{
 		HeadHash: string(opts.HeadHash),
 	}
+	switch opts.Method {
+	case forge.MergeMethodMerge, forge.MergeMethodSquash:
+		body.MergeMethod = opts.Method.String()
+	case forge.MergeMethodDefault:
+	default:
+		r.log.Warn(
+			"Unsupported merge method; using forge default",
+			"method", opts.Method,
+		)
+	}
+
 	var res mergeChangeResponse
 	if err := r.client.Post(ctx, u.String(), body, &res); err != nil {
 		return fmt.Errorf("merge change: %w", err)

--- a/internal/forge/shamhub/states_test.go
+++ b/internal/forge/shamhub/states_test.go
@@ -1,0 +1,85 @@
+package shamhub
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/silog"
+)
+
+func TestForgeRepository_MergeChange_mergeMethod(t *testing.T) {
+	tests := []struct {
+		name string
+		give forge.MergeMethod
+		want string
+	}{
+		{
+			name: "Default",
+		},
+		{
+			name: "Squash",
+			give: forge.MergeMethodSquash,
+			want: "squash",
+		},
+		{
+			name: "Rebase",
+			give: forge.MergeMethodRebase,
+		},
+		{
+			name: "Unsupported",
+			give: forge.MergeMethod(99),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got map[string]string
+			srv := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, r *http.Request) {
+					assert.Equal(
+						t,
+						"/owner/repo/change/42/merge",
+						r.URL.Path,
+					)
+					require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+					_, _ = w.Write([]byte(`{}`))
+				},
+			))
+			t.Cleanup(srv.Close)
+
+			repo, err := newRepository(
+				&Forge{
+					Options: Options{
+						URL:    "https://example.com",
+						APIURL: srv.URL,
+					},
+					Log: silog.Nop(),
+				},
+				&AuthenticationToken{tok: "token"},
+				&RepositoryID{
+					url:   "https://example.com",
+					owner: "owner",
+					repo:  "repo",
+				},
+				srv.Client(),
+			)
+			require.NoError(t, err)
+
+			err = repo.MergeChange(t.Context(), ChangeID(42), forge.MergeChangeOptions{
+				Method: tt.give,
+			})
+			require.NoError(t, err)
+
+			if tt.want == "" {
+				assert.NotContains(t, got, "mergeMethod")
+			} else {
+				assert.Equal(t, tt.want, got["mergeMethod"])
+			}
+		})
+	}
+}

--- a/internal/gateway/bitbucket/api.go
+++ b/internal/gateway/bitbucket/api.go
@@ -53,6 +53,12 @@ type PullRequestUpdateRequest struct {
 	Draft       *bool      `json:"draft,omitempty"`
 }
 
+// PullRequestMergeRequest is the request body for merging a pull request.
+type PullRequestMergeRequest struct {
+	// Strategy selects one of Bitbucket Cloud's supported merge strategies.
+	Strategy string `json:"merge_strategy,omitempty"`
+}
+
 // PullRequestList is the paginated response for listing pull requests.
 type PullRequestList struct {
 	Values []PullRequest `json:"values"`
@@ -364,7 +370,13 @@ func (c *Client) PullRequestMerge(
 	workspace string,
 	repo string,
 	prID int64,
+	req *PullRequestMergeRequest,
 ) (*PullRequest, *Response, error) {
+	var body any
+	if req != nil {
+		body = req
+	}
+
 	var response PullRequest
 	resp, err := c.post(
 		ctx,
@@ -372,7 +384,7 @@ func (c *Client) PullRequestMerge(
 			"/repositories/%s/%s/pullrequests/%d/merge",
 			workspace, repo, prID,
 		),
-		nil, nil, &response,
+		nil, body, &response,
 	)
 	if err != nil {
 		return nil, resp, err

--- a/internal/gateway/bitbucket/api_test.go
+++ b/internal/gateway/bitbucket/api_test.go
@@ -1,6 +1,7 @@
 package bitbucket
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -95,6 +96,29 @@ func TestClient_PullRequestMerge(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "/2.0/repositories/engineering/warp-core/pullrequests/55/merge", r.URL.Path)
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		assert.Empty(t, body)
+		writeJSON(t, w, http.StatusOK, PullRequest{
+			ID:    55,
+			State: "MERGED",
+		})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	pr, _, err := client.PullRequestMerge(
+		t.Context(), "engineering", "warp-core", 55, nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "MERGED", pr.State)
+}
+
+func TestClient_PullRequestMerge_strategy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/2.0/repositories/engineering/warp-core/pullrequests/55/merge", r.URL.Path)
+		assertJSONBody(t, r, `{"merge_strategy":"squash"}`)
 		writeJSON(t, w, http.StatusOK, PullRequest{
 			ID:    55,
 			State: "MERGED",
@@ -105,6 +129,7 @@ func TestClient_PullRequestMerge(t *testing.T) {
 	client := newTestClient(t, srv)
 	pr, _, err := client.PullRequestMerge(
 		t.Context(), "engineering", "warp-core", 55,
+		&PullRequestMergeRequest{Strategy: "squash"},
 	)
 	require.NoError(t, err)
 	assert.Equal(t, "MERGED", pr.State)

--- a/internal/gateway/gitlab/api.go
+++ b/internal/gateway/gitlab/api.go
@@ -669,6 +669,7 @@ func (o *ListProjectMergeRequestsOptions) encodeQuery() url.Values {
 type AcceptMergeRequestOptions struct {
 	ShouldRemoveSourceBranch *bool   `json:"should_remove_source_branch,omitempty"`
 	SHA                      *string `json:"sha,omitempty"`
+	Squash                   *bool   `json:"squash,omitempty"`
 }
 
 // SetCommitStatusOptions configures commit status creation.

--- a/internal/gateway/gitlab/api_test.go
+++ b/internal/gateway/gitlab/api_test.go
@@ -313,6 +313,34 @@ func TestClient_MergeRequestAccept_withSHA(t *testing.T) {
 	assert.Equal(t, "merged", mr.State)
 }
 
+func TestClient_MergeRequestAccept_withSquash(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v4/projects/42/merge_requests/55/merge", r.URL.Path)
+		assertJSONBody(t, r, `{"squash":true}`)
+		writeJSON(t, w, http.StatusOK, MergeRequest{
+			BasicMergeRequest: BasicMergeRequest{
+				IID:   55,
+				State: "merged",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	squash := true
+	mr, _, err := client.MergeRequestAccept(
+		t.Context(),
+		int64(42),
+		55,
+		&AcceptMergeRequestOptions{
+			Squash: &squash,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "merged", mr.State)
+}
+
 func TestClient_CommitStatusSet(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)

--- a/internal/handler/merge/handler.go
+++ b/internal/handler/merge/handler.go
@@ -69,6 +69,10 @@ type Request struct {
 	// NoBranchCheck skips stale base validation.
 	NoBranchCheck bool
 
+	// Method selects the forge merge strategy.
+	// Empty means use the forge default.
+	Method forge.MergeMethod
+
 	// BuildTimeout is the maximum time to wait
 	// for CI checks to pass before each merge.
 	// Zero means check once and fail if not ready.
@@ -384,7 +388,10 @@ func (h *Handler) executePlan(
 		)
 		if err := h.RemoteRepository.MergeChange(
 			ctx, item.changeID,
-			forge.MergeChangeOptions{HeadHash: item.headHash},
+			forge.MergeChangeOptions{
+				Method:   req.Method,
+				HeadHash: item.headHash,
+			},
 		); err != nil {
 			return fmt.Errorf("merge %q: %w", item.branch, err)
 		}

--- a/internal/handler/merge/handler_test.go
+++ b/internal/handler/merge/handler_test.go
@@ -362,6 +362,47 @@ func TestExecutePlan_singleBranch(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestExecutePlan_mergeMethod(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockForge := forgetest.NewMockRepository(ctrl)
+	mockStore := NewMockStore(ctrl)
+	mockStore.EXPECT().Trunk().Return("main")
+
+	pr1 := fakeChangeID("pr-1")
+
+	mockForge.EXPECT().
+		FindChangeByID(gomock.Any(), pr1).
+		Return(fakeFindResult("main"), nil)
+	mockForge.EXPECT().
+		ChangeChecksState(gomock.Any(), pr1).
+		Return(forge.ChecksPassed, nil)
+	mockForge.EXPECT().
+		MergeChange(gomock.Any(), pr1, forge.MergeChangeOptions{
+			Method:   forge.MergeMethodSquash,
+			HeadHash: git.Hash("head1"),
+		}).
+		Return(nil)
+
+	h := newTestHandler(t, ctrl, testHandlerOpts{
+		forgeRepo: mockForge,
+		store:     mockStore,
+	})
+
+	err := h.executePlan(t.Context(), []*mergeItem{
+		{
+			branch:   "feat1",
+			changeID: pr1,
+			headHash: git.Hash("head1"),
+		},
+	}, &Request{
+		Branch: "feat1",
+		Method: forge.MergeMethodSquash,
+		NoWait: true,
+	})
+	require.NoError(t, err)
+}
+
 func TestExecutePlan_retargetsStaleFirstItem(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	var logBuffer bytes.Buffer

--- a/testdata/help/downstack_merge.txt
+++ b/testdata/help/downstack_merge.txt
@@ -37,6 +37,8 @@ Flags:
   --branch=NAME          Branch to start merging from
   --no-wait              Skip polling for a single branch merge to propagate.
   --no-branch-check      Skip stale base validation before merging.
+  --method=METHOD        Preferred merge method. One of 'merge', 'squash',
+                         and 'rebase'. (🔧 spice.merge.method)
   --build-timeout=30m    Max time to wait for CI checks before each merge.
                          0 means check once. (🔧 spice.merge.buildTimeout)
 


### PR DESCRIPTION
Allow `gs downstack merge` to request a preferred forge merge
method without forcing every forge to support the same strategy set.
The new `spice.merge.method` setting and `--method` flag accept
`merge`, `squash`, `rebase`, and `default`.

The merge handler now carries the selected method through the forge
merge API. Forge implementations translate supported methods at their
own boundary and warn before falling back to the forge default when the
method is not recognized for that forge.

Unit tests cover the shared text encoding contract and the per-forge
request payloads.