### PR TITLE
fix(submit): Update no-publish branches

### DIFF
--- a/.changes/unreleased/Fixed-20260602-193332.yaml
+++ b/.changes/unreleased/Fixed-20260602-193332.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'submit: Branches submitted with --no-publish are now updated by --update-only.'
+time: 2026-06-02T19:33:32.583799-07:00

--- a/internal/handler/submit/handler.go
+++ b/internal/handler/submit/handler.go
@@ -840,6 +840,17 @@ func (h *Handler) submitBranch(
 
 	// At this point, existingChange is nil only if we need to create a new CR.
 	if existingChange == nil {
+		if opts.UpdateOnly != nil && *opts.UpdateOnly {
+			if branch.Change != nil || storedUpstream == "" {
+				if !opts.DryRun {
+					// TODO: config to disable this message?
+					log.Infof("%v: Skipping unsubmitted branch: --update-only", branchToSubmit)
+				}
+				return status, nil
+			}
+			opts.Publish = false
+		}
+
 		if upstreamBranch == "" {
 			unique, err := svc.UnusedBranchName(ctx, remote.Push, branchToSubmit)
 			if err != nil {
@@ -851,14 +862,6 @@ func (h *Handler) submitBranch(
 				log.Infof("%v: Using upstream name '%v' instead", branchToSubmit, unique)
 			}
 			upstreamBranch = unique
-		}
-
-		if opts.UpdateOnly != nil && *opts.UpdateOnly {
-			if !opts.DryRun {
-				// TODO: config to disable this message?
-				log.Infof("%v: Skipping unsubmitted branch: --update-only", branchToSubmit)
-			}
-			return status, nil
 		}
 	}
 

--- a/testdata/script/issue1156_submit_update_only_closed_change.txt
+++ b/testdata/script/issue1156_submit_update_only_closed_change.txt
@@ -1,0 +1,70 @@
+# Regression test for #1156:
+# branch submit --update-only skips branches without an open change request.
+
+as 'Test <test@example.com>'
+at '2026-06-02T19:00:00Z'
+
+# Set up an initialized repository with a ShamHub remote.
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# A plain Git upstream does not count as a submitted branch.
+git add git-upstream-only.txt
+gs branch create git-upstream-only -m 'git upstream only'
+git push --set-upstream origin git-upstream-only
+
+cp $WORK/extra/git-upstream-only-new.txt git-upstream-only.txt
+git add git-upstream-only.txt
+gs commit create -m 'update git upstream only'
+
+gs branch submit --update-only --fill
+stderr 'git-upstream-only: Skipping unsubmitted branch'
+
+# A branch whose change was closed also has no open change request to update.
+gs bco main
+
+git add closed-change.txt
+gs branch create closed-change -m 'closed change'
+gs branch submit --fill
+stderr 'Created #1'
+
+shamhub reject alice/example 1
+
+cp $WORK/extra/closed-change-new.txt closed-change.txt
+git add closed-change.txt
+gs commit create -m 'update closed change'
+
+gs branch submit --update-only --fill
+stderr 'closed-change: Ignoring CR #1 as it was closed'
+stderr 'closed-change: Skipping unsubmitted branch'
+
+# Verify that neither skipped branch was pushed after its local update.
+cd ..
+git clone $SHAMHUB_URL/alice/example.git clone
+cd clone
+git show origin/git-upstream-only:git-upstream-only.txt
+cmp stdout $WORK/golden/git-upstream-only.txt
+git show origin/closed-change:closed-change.txt
+cmp stdout $WORK/golden/closed-change.txt
+
+-- repo/git-upstream-only.txt --
+git upstream only
+-- extra/git-upstream-only-new.txt --
+git upstream only new
+-- repo/closed-change.txt --
+closed change
+-- extra/closed-change-new.txt --
+closed change new
+-- golden/git-upstream-only.txt --
+git upstream only
+-- golden/closed-change.txt --
+closed change

--- a/testdata/script/issue1156_submit_update_only_no_publish.txt
+++ b/testdata/script/issue1156_submit_update_only_no_publish.txt
@@ -1,0 +1,49 @@
+# Regression test for #1156:
+# branch submit --update-only updates branches submitted with --no-publish.
+
+as 'Test <test@example.com>'
+at '2026-06-02T18:30:00Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+git add feature.txt
+gs branch create -m feature
+gs branch submit --no-publish
+stderr 'Pushed feature'
+
+cp $WORK/extra/feature-new.txt feature.txt
+git add feature.txt
+gs commit create -m 'update feature'
+
+gs branch submit --update-only --fill
+stderr 'Pushed feature'
+
+shamhub dump changes
+cmp stdout $WORK/golden/no-changes.txt
+
+cd ..
+git clone $SHAMHUB_URL/alice/example.git clone
+cd clone
+git graph --branches --remotes
+cmp stdout $WORK/golden/graph.txt
+
+-- repo/feature.txt --
+feature
+-- extra/feature-new.txt --
+feature new
+-- golden/no-changes.txt --
+[]
+-- golden/graph.txt --
+* f9bc080 (origin/feature) update feature
+* cc878e1 feature
+* 95c3588 (HEAD -> main, origin/main) Initial commit


### PR DESCRIPTION
`submit --update-only` should update a branch that was submitted
with `--no-publish`.
That workflow records the upstream branch in git-spice state
without creating a change request,
so it still has a remote branch that can be updated.

Use recorded git-spice upstream state to identify that case.
Branches with only Git upstream configuration,
or with recorded change metadata for a closed change request,
continue to be skipped because there is no open change request to update.

Resolves #1156
