### PR TITLE
fix: prompt on commit amend after resolving a rebase conflict

### DIFF
--- a/.changes/unreleased/Fixed-20260603-080000.yaml
+++ b/.changes/unreleased/Fixed-20260603-080000.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'commit amend: Prompt before amending when a rebase stopped to resolve a conflict, even after the conflict has been staged.'
+time: 2026-06-03T08:00:00.000000-07:00

--- a/commit_amend.go
+++ b/commit_amend.go
@@ -133,16 +133,17 @@ func (cmd *commitAmendCmd) Run(
 		}
 	}
 
-	// Check if we're in the middle of a rebase with unmerged paths
+	// Check if we're in the middle of a rebase conflict resolution.
 	var rebasing bool
 	if _, err := wt.RebaseState(ctx); err == nil {
 		rebasing = true
 
 		// If we're in the middle of a rebase,
-		// and there are unmerged paths,
+		// and the rebase stopped for conflict resolution,
 		// what the user likely wants is 'git add' and 'git-spice rebase continue'.
 		//
-		// (If there are no unmerged paths, amending is fine.)
+		// (If the rebase stopped deliberately for edit/break,
+		// and there are no unmerged paths, amending is fine.)
 		var numUnmerged int
 		for _, err := range wt.ListFilesPaths(ctx, &git.ListFilesOptions{Unmerged: true}) {
 			if err == nil {
@@ -150,36 +151,77 @@ func (cmd *commitAmendCmd) Run(
 			}
 		}
 
-		if numUnmerged > 0 {
-			if !ui.Interactive(view) {
-				log.Warnf("You are in the middle of a rebase with unmerged paths.")
-				log.Warnf(`You probably want resolve the conflicts and run "git add", then "%s rebase continue" instead.`, cli.Name())
-			} else {
-				var continueAmend bool
-				fields := []ui.Field{
-					ui.NewList[bool]().
-						WithTitle("Do you want to amend the commit?").
-						WithDescription(fmt.Sprintf("You are in the middle of a rebase with unmerged paths.\n"+
-							"You might want to resolve the conflicts and run 'git add', then '%s rebase continue' instead.", cli.Name())).
-						WithItems(
-							ui.ListItem[bool]{
-								Title:       "Yes",
-								Description: func(ui.Theme, bool) string { return "Continue with commit amend" },
-								Value:       true,
-							},
-							ui.ListItem[bool]{
-								Title:       "No",
-								Description: func(ui.Theme, bool) string { return "Abort the operation" },
-								Value:       false,
-							},
-						).
-						WithValue(&continueAmend),
+		stopReason := git.RebaseInterruptConflict
+		if r, err := wt.RebaseStopReason(ctx); err == nil {
+			stopReason = r
+		}
+
+		conflictResolution := stopReason == git.RebaseInterruptConflict
+		shouldWarn := numUnmerged > 0 || conflictResolution
+		if shouldWarn {
+			if numUnmerged > 0 {
+				if !ui.Interactive(view) {
+					log.Warnf("You are in the middle of a rebase with unmerged paths.")
+					log.Warnf(`You probably want resolve the conflicts and run "git add", then "%s rebase continue" instead.`, cli.Name())
+				} else {
+					var continueAmend bool
+					fields := []ui.Field{
+						ui.NewList[bool]().
+							WithTitle("Do you want to amend the commit?").
+							WithDescription(fmt.Sprintf("You are in the middle of a rebase with unmerged paths.\n"+
+								"You might want to resolve the conflicts and run 'git add', then '%s rebase continue' instead.", cli.Name())).
+							WithItems(
+								ui.ListItem[bool]{
+									Title:       "Yes",
+									Description: func(ui.Theme, bool) string { return "Continue with commit amend" },
+									Value:       true,
+								},
+								ui.ListItem[bool]{
+									Title:       "No",
+									Description: func(ui.Theme, bool) string { return "Abort the operation" },
+									Value:       false,
+								},
+							).
+							WithValue(&continueAmend),
+					}
+					if err := ui.Run(view, fields...); err != nil {
+						return fmt.Errorf("run prompt: %w", err)
+					}
+					if !continueAmend {
+						return errors.New("operation aborted")
+					}
 				}
-				if err := ui.Run(view, fields...); err != nil {
-					return fmt.Errorf("run prompt: %w", err)
-				}
-				if !continueAmend {
-					return errors.New("operation aborted")
+			} else if conflictResolution {
+				if !ui.Interactive(view) {
+					log.Warnf("You appear to have resolved a rebase conflict.")
+					log.Warnf(`You probably want "%s rebase continue" instead of amending.`, cli.Name())
+				} else {
+					var continueAmend bool
+					fields := []ui.Field{
+						ui.NewList[bool]().
+							WithTitle("Do you want to amend the commit?").
+							WithDescription(fmt.Sprintf("You appear to have resolved a rebase conflict.\n"+
+								"You might want to run '%s rebase continue' instead of amending.", cli.Name())).
+							WithItems(
+								ui.ListItem[bool]{
+									Title:       "Yes",
+									Description: func(ui.Theme, bool) string { return "Continue with commit amend" },
+									Value:       true,
+								},
+								ui.ListItem[bool]{
+									Title:       "No",
+									Description: func(ui.Theme, bool) string { return "Abort the operation" },
+									Value:       false,
+								},
+							).
+							WithValue(&continueAmend),
+					}
+					if err := ui.Run(view, fields...); err != nil {
+						return fmt.Errorf("run prompt: %w", err)
+					}
+					if !continueAmend {
+						return errors.New("operation aborted")
+					}
 				}
 			}
 		}

--- a/commit_amend.go
+++ b/commit_amend.go
@@ -133,17 +133,21 @@ func (cmd *commitAmendCmd) Run(
 		}
 	}
 
-	// Check if we're in the middle of a rebase conflict resolution.
+	// rebaseAmendWarning carries the text for one warning before amend.
+	type rebaseAmendWarning struct {
+		logTitle          string
+		logSuggestion     string
+		promptDescription string
+	}
+
+	var rebaseWarning *rebaseAmendWarning
 	var rebasing bool
 	if _, err := wt.RebaseState(ctx); err == nil {
 		rebasing = true
 
-		// If we're in the middle of a rebase,
-		// and the rebase stopped for conflict resolution,
-		// what the user likely wants is 'git add' and 'git-spice rebase continue'.
-		//
-		// (If the rebase stopped deliberately for edit/break,
-		// and there are no unmerged paths, amending is fine.)
+		// If we're in the middle of a rebase and Git still has
+		// unmerged paths, the user likely wants to resolve conflicts,
+		// stage them, and run 'git-spice rebase continue'.
 		var numUnmerged int
 		for _, err := range wt.ListFilesPaths(ctx, &git.ListFilesOptions{Unmerged: true}) {
 			if err == nil {
@@ -151,78 +155,65 @@ func (cmd *commitAmendCmd) Run(
 			}
 		}
 
-		stopReason := git.RebaseInterruptConflict
-		if r, err := wt.RebaseStopReason(ctx); err == nil {
-			stopReason = r
+		if numUnmerged > 0 {
+			rebaseWarning = &rebaseAmendWarning{
+				logTitle:      "You are in the middle of a rebase with unmerged paths.",
+				logSuggestion: fmt.Sprintf(`You probably want resolve the conflicts and run "git add", then "%s rebase continue" instead.`, cli.Name()),
+				promptDescription: fmt.Sprintf("You are in the middle of a rebase with unmerged paths.\n"+
+					"You might want to resolve the conflicts and run 'git add', then '%s rebase continue' instead.", cli.Name()),
+			}
+		} else {
+			// Once conflicts have been staged,
+			// unmerged paths are gone but the rebase is still waiting
+			// for 'git-spice rebase continue'.
+			//
+			// Deliberate stops like edit, reword, break, or exec are
+			// allowed to amend here; RebaseStopReason separates those
+			// from conflict-resolution stops.
+			stopReason := git.RebaseInterruptConflict
+			if r, err := wt.RebaseStopReason(ctx); err == nil {
+				stopReason = r
+			}
+			if stopReason == git.RebaseInterruptConflict {
+				rebaseWarning = &rebaseAmendWarning{
+					logTitle:      "You appear to have resolved a rebase conflict.",
+					logSuggestion: fmt.Sprintf(`You probably want "%s rebase continue" instead of amending.`, cli.Name()),
+					promptDescription: fmt.Sprintf("You appear to have resolved a rebase conflict.\n"+
+						"You might want to run '%s rebase continue' instead of amending.", cli.Name()),
+				}
+			}
 		}
+	}
 
-		conflictResolution := stopReason == git.RebaseInterruptConflict
-		shouldWarn := numUnmerged > 0 || conflictResolution
-		if shouldWarn {
-			if numUnmerged > 0 {
-				if !ui.Interactive(view) {
-					log.Warnf("You are in the middle of a rebase with unmerged paths.")
-					log.Warnf(`You probably want resolve the conflicts and run "git add", then "%s rebase continue" instead.`, cli.Name())
-				} else {
-					var continueAmend bool
-					fields := []ui.Field{
-						ui.NewList[bool]().
-							WithTitle("Do you want to amend the commit?").
-							WithDescription(fmt.Sprintf("You are in the middle of a rebase with unmerged paths.\n"+
-								"You might want to resolve the conflicts and run 'git add', then '%s rebase continue' instead.", cli.Name())).
-							WithItems(
-								ui.ListItem[bool]{
-									Title:       "Yes",
-									Description: func(ui.Theme, bool) string { return "Continue with commit amend" },
-									Value:       true,
-								},
-								ui.ListItem[bool]{
-									Title:       "No",
-									Description: func(ui.Theme, bool) string { return "Abort the operation" },
-									Value:       false,
-								},
-							).
-							WithValue(&continueAmend),
-					}
-					if err := ui.Run(view, fields...); err != nil {
-						return fmt.Errorf("run prompt: %w", err)
-					}
-					if !continueAmend {
-						return errors.New("operation aborted")
-					}
-				}
-			} else if conflictResolution {
-				if !ui.Interactive(view) {
-					log.Warnf("You appear to have resolved a rebase conflict.")
-					log.Warnf(`You probably want "%s rebase continue" instead of amending.`, cli.Name())
-				} else {
-					var continueAmend bool
-					fields := []ui.Field{
-						ui.NewList[bool]().
-							WithTitle("Do you want to amend the commit?").
-							WithDescription(fmt.Sprintf("You appear to have resolved a rebase conflict.\n"+
-								"You might want to run '%s rebase continue' instead of amending.", cli.Name())).
-							WithItems(
-								ui.ListItem[bool]{
-									Title:       "Yes",
-									Description: func(ui.Theme, bool) string { return "Continue with commit amend" },
-									Value:       true,
-								},
-								ui.ListItem[bool]{
-									Title:       "No",
-									Description: func(ui.Theme, bool) string { return "Abort the operation" },
-									Value:       false,
-								},
-							).
-							WithValue(&continueAmend),
-					}
-					if err := ui.Run(view, fields...); err != nil {
-						return fmt.Errorf("run prompt: %w", err)
-					}
-					if !continueAmend {
-						return errors.New("operation aborted")
-					}
-				}
+	if rebaseWarning != nil {
+		if !ui.Interactive(view) {
+			log.Warnf("%s", rebaseWarning.logTitle)
+			log.Warnf("%s", rebaseWarning.logSuggestion)
+		} else {
+			var continueAmend bool
+			fields := []ui.Field{
+				ui.NewList[bool]().
+					WithTitle("Do you want to amend the commit?").
+					WithDescription(rebaseWarning.promptDescription).
+					WithItems(
+						ui.ListItem[bool]{
+							Title:       "Yes",
+							Description: func(ui.Theme, bool) string { return "Continue with commit amend" },
+							Value:       true,
+						},
+						ui.ListItem[bool]{
+							Title:       "No",
+							Description: func(ui.Theme, bool) string { return "Abort the operation" },
+							Value:       false,
+						},
+					).
+					WithValue(&continueAmend),
+			}
+			if err := ui.Run(view, fields...); err != nil {
+				return fmt.Errorf("run prompt: %w", err)
+			}
+			if !continueAmend {
+				return errors.New("operation aborted")
 			}
 		}
 	}

--- a/internal/git/rebase_stop_reason_test.go
+++ b/internal/git/rebase_stop_reason_test.go
@@ -1,0 +1,122 @@
+package git_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/git/gittest"
+	"go.abhg.dev/gs/internal/silog/silogtest"
+	"go.abhg.dev/gs/internal/text"
+)
+
+func TestWorktree_RebaseStopReason(t *testing.T) {
+	tests := []struct {
+		name       string
+		done       string
+		removeDone bool
+		// withAmend simulates Git's "amend" marker file,
+		// which it writes only for a deliberate "edit" stop
+		// where the commit was applied cleanly.
+		withAmend bool
+		want      git.RebaseInterruptKind
+	}{
+		{
+			name: "Conflict",
+			done: "\n pick cc51432 Add bar\n\n",
+			want: git.RebaseInterruptConflict,
+		},
+		{
+			// A deliberate "edit" stop applies the commit and
+			// leaves an "amend" file behind.
+			name:      "Edit",
+			done:      "pick cc51432 Add bar\nedit d62d116 Add baz\n",
+			withAmend: true,
+			want:      git.RebaseInterruptDeliberate,
+		},
+		{
+			name: "Break",
+			done: "pick cc51432 Add bar\nbreak\n",
+			want: git.RebaseInterruptDeliberate,
+		},
+		{
+			// An "edit" instruction whose commit conflicted while
+			// being applied leaves "edit ..." as the last done line
+			// but no "amend" file, since the commit never applied.
+			// That must still be treated as a conflict.
+			name:      "EditConflict",
+			done:      "pick cc51432 Add bar\nedit d62d116 Add baz\n",
+			withAmend: false,
+			want:      git.RebaseInterruptConflict,
+		},
+		{
+			name:       "MissingDone",
+			removeDone: true,
+			want:       git.RebaseInterruptConflict,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+				as 'Test <test@example.com>'
+				at '2026-06-03T08:00:00-07:00'
+
+				git init
+				git commit --allow-empty -m 'Initial commit'
+
+				git add bar.txt
+				git commit -m 'Add bar'
+
+				git checkout -b feature HEAD~
+				mv conflicting-bar.txt bar.txt
+				git add bar.txt
+				git commit -m 'Conflicting bar'
+
+				-- bar.txt --
+				Contents of bar
+
+				-- conflicting-bar.txt --
+				Different contents of bar
+			`)))
+			require.NoError(t, err)
+			t.Cleanup(fixture.Cleanup)
+
+			wt, err := git.OpenWorktree(t.Context(), fixture.Dir(), git.OpenOptions{
+				Log: silogtest.New(t),
+			})
+			require.NoError(t, err)
+
+			err = wt.Rebase(t.Context(), git.RebaseRequest{
+				Branch:   "feature",
+				Upstream: "main",
+			})
+			require.Error(t, err)
+			require.ErrorAs(t, err, new(*git.RebaseInterruptError))
+
+			stateDir := filepath.Join(fixture.Dir(), ".git", "rebase-merge")
+			donePath := filepath.Join(stateDir, "done")
+			if tt.removeDone {
+				require.NoError(t, os.Remove(donePath))
+			} else {
+				require.NoError(t, os.WriteFile(donePath, []byte(tt.done), 0o644))
+			}
+
+			// Control the "amend" marker independently of the real
+			// conflict that drove the rebase into this state.
+			amendPath := filepath.Join(stateDir, "amend")
+			if tt.withAmend {
+				require.NoError(t, os.WriteFile(amendPath, []byte("amend"), 0o644))
+			} else if err := os.Remove(amendPath); err != nil {
+				require.ErrorIs(t, err, os.ErrNotExist)
+			}
+
+			got, err := wt.RebaseStopReason(t.Context())
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/git/rebase_stop_reason_test.go
+++ b/internal/git/rebase_stop_reason_test.go
@@ -2,14 +2,18 @@ package git_test
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/git/gittest"
+	"go.abhg.dev/gs/internal/mockedit"
 	"go.abhg.dev/gs/internal/silog/silogtest"
+	"go.abhg.dev/gs/internal/sliceutil"
 	"go.abhg.dev/gs/internal/text"
 )
 
@@ -119,4 +123,116 @@ func TestWorktree_RebaseStopReason(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestWorktree_RebaseStopReason_rewordAwaitingAmend(t *testing.T) {
+	fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+		as 'Test <test@example.com>'
+		at '2026-06-03T08:00:00-07:00'
+
+		git init
+		git config commit.gpgsign false
+		git commit --allow-empty -m 'Initial commit'
+
+		git add one.txt
+		git commit -m 'Add one'
+
+		-- one.txt --
+		Contents of one
+	`)))
+	require.NoError(t, err)
+	t.Cleanup(fixture.Cleanup)
+
+	wt, err := git.OpenWorktree(t.Context(), fixture.Dir(), git.OpenOptions{
+		Log: silogtest.New(t),
+	})
+	require.NoError(t, err)
+
+	head, err := wt.Head(t.Context())
+	require.NoError(t, err)
+
+	// Use mockedit only for the rebase todo editor.
+	// The commit-message editor must fail so Git stops after applying the
+	// reworded commit and writes the amend marker.
+	t.Setenv("GIT_SEQUENCE_EDITOR", "mockedit")
+	t.Setenv("GIT_EDITOR", "false")
+	mockedit.Expect(t).GiveLines("reword " + string(head) + " Add one")
+
+	err = wt.Rebase(t.Context(), git.RebaseRequest{
+		Upstream:    "HEAD~1",
+		Interactive: true,
+	})
+	require.Error(t, err)
+	defer func() {
+		assert.NoError(t, wt.RebaseAbort(t.Context()))
+	}()
+
+	stateDir := filepath.Join(fixture.Dir(), ".git", "rebase-merge")
+	done, err := os.ReadFile(filepath.Join(stateDir, "done"))
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(string(done), "reword "))
+
+	_, err = os.Stat(filepath.Join(stateDir, "amend"))
+	require.NoError(t, err)
+
+	unmergedFiles, err := sliceutil.CollectErr(
+		wt.ListFilesPaths(t.Context(), &git.ListFilesOptions{Unmerged: true}))
+	require.NoError(t, err)
+	assert.Empty(t, unmergedFiles)
+
+	got, err := wt.RebaseStopReason(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, git.RebaseInterruptDeliberate, got)
+}
+
+func TestWorktree_RebaseStopReason_failedExec(t *testing.T) {
+	fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+		as 'Test <test@example.com>'
+		at '2026-06-03T08:00:00-07:00'
+
+		git init
+		git config commit.gpgsign false
+		git commit --allow-empty -m 'Initial commit'
+
+		git add one.txt
+		git commit -m 'Add one'
+
+		-- one.txt --
+		Contents of one
+	`)))
+	require.NoError(t, err)
+	t.Cleanup(fixture.Cleanup)
+
+	wt, err := git.OpenWorktree(t.Context(), fixture.Dir(), git.OpenOptions{
+		Log: silogtest.New(t),
+	})
+	require.NoError(t, err)
+
+	// Use Git directly because Worktree.Rebase does not expose --exec.
+	// This leaves the real sequencer state for a failed exec stop.
+	cmd := exec.Command("git", "rebase", "-i", "--exec", "false", "HEAD~1")
+	cmd.Dir = fixture.Dir()
+	cmd.Env = append(os.Environ(), "GIT_SEQUENCE_EDITOR=true")
+	err = cmd.Run()
+	require.Error(t, err)
+	defer func() {
+		assert.NoError(t, wt.RebaseAbort(t.Context()))
+	}()
+
+	stateDir := filepath.Join(fixture.Dir(), ".git", "rebase-merge")
+	done, err := os.ReadFile(filepath.Join(stateDir, "done"))
+	require.NoError(t, err)
+	assert.True(t, strings.HasSuffix(strings.TrimSpace(string(done)), "exec false"))
+
+	_, err = os.Stat(filepath.Join(stateDir, "amend"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+
+	unmergedFiles, err := sliceutil.CollectErr(
+		wt.ListFilesPaths(t.Context(), &git.ListFilesOptions{Unmerged: true}))
+	require.NoError(t, err)
+	assert.Empty(t, unmergedFiles)
+
+	got, err := wt.RebaseStopReason(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, git.RebaseInterruptDeliberate, got)
 }

--- a/internal/git/rebase_stop_reason_test.go
+++ b/internal/git/rebase_stop_reason_test.go
@@ -23,27 +23,69 @@ func TestWorktree_RebaseStopReason(t *testing.T) {
 		done       string
 		removeDone bool
 		// withAmend simulates Git's "amend" marker file,
-		// which it writes only for a deliberate "edit" stop
-		// where the commit was applied cleanly.
+		// which Git writes only for deliberate stops where the commit
+		// was applied cleanly and HEAD already holds it.
 		withAmend bool
 		want      git.RebaseInterruptKind
 	}{
 		{
 			name: "Conflict",
-			done: "\n pick cc51432 Add bar\n\n",
+			done: joinLines(
+				"",
+				" pick cc51432 Add bar",
+				"",
+			),
+			want: git.RebaseInterruptConflict,
+		},
+		{
+			name: "Revert",
+			done: joinLines(
+				"pick cc51432 Add bar",
+				"revert d62d116 Revert baz",
+			),
+			want: git.RebaseInterruptConflict,
+		},
+		{
+			name: "Fixup",
+			done: joinLines(
+				"pick cc51432 Add bar",
+				"fixup d62d116 fixup! Add bar",
+			),
+			want: git.RebaseInterruptConflict,
+		},
+		{
+			name: "Squash",
+			done: joinLines(
+				"pick cc51432 Add bar",
+				"squash d62d116 squash! Add bar",
+			),
+			want: git.RebaseInterruptConflict,
+		},
+		{
+			name: "Merge",
+			done: joinLines(
+				"pick cc51432 Add bar",
+				"merge -C d62d116 refs/heads/side",
+			),
 			want: git.RebaseInterruptConflict,
 		},
 		{
 			// A deliberate "edit" stop applies the commit and
 			// leaves an "amend" file behind.
-			name:      "Edit",
-			done:      "pick cc51432 Add bar\nedit d62d116 Add baz\n",
+			name: "Edit",
+			done: joinLines(
+				"pick cc51432 Add bar",
+				"edit d62d116 Add baz",
+			),
 			withAmend: true,
 			want:      git.RebaseInterruptDeliberate,
 		},
 		{
 			name: "Break",
-			done: "pick cc51432 Add bar\nbreak\n",
+			done: joinLines(
+				"pick cc51432 Add bar",
+				"break",
+			),
 			want: git.RebaseInterruptDeliberate,
 		},
 		{
@@ -51,10 +93,87 @@ func TestWorktree_RebaseStopReason(t *testing.T) {
 			// being applied leaves "edit ..." as the last done line
 			// but no "amend" file, since the commit never applied.
 			// That must still be treated as a conflict.
-			name:      "EditConflict",
-			done:      "pick cc51432 Add bar\nedit d62d116 Add baz\n",
+			name: "EditConflict",
+			done: joinLines(
+				"pick cc51432 Add bar",
+				"edit d62d116 Add baz",
+			),
 			withAmend: false,
 			want:      git.RebaseInterruptConflict,
+		},
+		{
+			name: "Reword",
+			done: joinLines(
+				"pick cc51432 Add bar",
+				"reword d62d116 Add baz",
+			),
+			withAmend: true,
+			want:      git.RebaseInterruptDeliberate,
+		},
+		{
+			name: "RewordConflict",
+			done: joinLines(
+				"pick cc51432 Add bar",
+				"reword d62d116 Add baz",
+			),
+			withAmend: false,
+			want:      git.RebaseInterruptConflict,
+		},
+		{
+			name: "Exec",
+			done: joinLines(
+				"pick cc51432 Add bar",
+				"exec make test",
+			),
+			want: git.RebaseInterruptDeliberate,
+		},
+		{
+			name: "Label",
+			done: joinLines(
+				"pick cc51432 Add bar",
+				"label branch-point",
+			),
+			want: git.RebaseInterruptDeliberate,
+		},
+		{
+			name: "Reset",
+			done: joinLines(
+				"pick cc51432 Add bar",
+				"reset branch-point",
+			),
+			want: git.RebaseInterruptDeliberate,
+		},
+		{
+			name: "UpdateRef",
+			done: joinLines(
+				"pick cc51432 Add bar",
+				"update-ref refs/heads/feature",
+			),
+			want: git.RebaseInterruptDeliberate,
+		},
+		{
+			name: "Noop",
+			done: joinLines(
+				"pick cc51432 Add bar",
+				"noop",
+			),
+			want: git.RebaseInterruptDeliberate,
+		},
+		{
+			name: "Drop",
+			done: joinLines(
+				"pick cc51432 Add bar",
+				"drop d62d116 Add baz",
+			),
+			want: git.RebaseInterruptDeliberate,
+		},
+		{
+			name: "UnknownCommand",
+			done: joinLines(
+				"pick cc51432 Add bar",
+				"unknown d62d116 Add baz",
+			),
+			want: git.RebaseInterruptConflict,
 		},
 		{
 			name:       "MissingDone",

--- a/internal/git/rebase_wt.go
+++ b/internal/git/rebase_wt.go
@@ -382,11 +382,11 @@ func (w *Worktree) RebaseState(context.Context) (*RebaseState, error) {
 //
 // It uses the last non-empty line of the rebase state's "done" file
 // to classify the stop:
-// "break" and "exec" instructions are deliberate interruptions,
+// "pick", "revert", "fixup", "squash", and "merge" apply commits,
+// so stops there are treated as conflicts;
 // "edit" and "reword" instructions are deliberate only if the commit
 // applied cleanly,
-// and commit-applying instructions (pick, merge, revert, fixup, squash, ...)
-// are conflicts that need resolution.
+// and other known instructions are non-conflict interruptions.
 //
 // The "edit" and "reword" cases need extra care: those instructions can
 // also conflict while being applied,
@@ -425,7 +425,9 @@ func (w *Worktree) RebaseStopReason(ctx context.Context) (RebaseInterruptKind, e
 	}
 
 	switch strings.ToLower(lastCommand) {
-	case "break", "exec":
+	case "pick", "revert", "fixup", "squash", "merge":
+		return RebaseInterruptConflict, nil
+	case "break", "exec", "label", "reset", "update-ref", "noop", "drop":
 		return RebaseInterruptDeliberate, nil
 	case "edit", "reword":
 		// A deliberate "edit" or "reword" stop applies the commit first

--- a/internal/git/rebase_wt.go
+++ b/internal/git/rebase_wt.go
@@ -416,7 +416,7 @@ func (w *Worktree) RebaseStopReason(ctx context.Context) (RebaseInterruptKind, e
 	}
 
 	var lastCommand string
-	for _, line := range strings.Split(string(done), "\n") {
+	for line := range strings.SplitSeq(string(done), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue

--- a/internal/git/rebase_wt.go
+++ b/internal/git/rebase_wt.go
@@ -382,18 +382,19 @@ func (w *Worktree) RebaseState(context.Context) (*RebaseState, error) {
 //
 // It uses the last non-empty line of the rebase state's "done" file
 // to classify the stop:
-// a "break" instruction is always a deliberate interruption,
-// an "edit" instruction is deliberate only if the commit applied cleanly,
-// and anything else (pick, merge, revert, fixup, squash, ...)
-// is a conflict that needs resolution.
+// "break" and "exec" instructions are deliberate interruptions,
+// "edit" and "reword" instructions are deliberate only if the commit
+// applied cleanly,
+// and commit-applying instructions (pick, merge, revert, fixup, squash, ...)
+// are conflicts that need resolution.
 //
-// The "edit" case needs extra care: an "edit" instruction whose commit
-// conflicts while being applied also leaves "edit ..." as the last done
-// line, but it is a conflict, not a deliberate stop. Git distinguishes
-// the two by writing an "amend" file only when the commit was applied
-// successfully and HEAD already holds it (the deliberate edit case).
-// A missing "amend" file on an "edit" stop therefore means the commit
-// failed to apply, i.e. a conflict.
+// The "edit" and "reword" cases need extra care: those instructions can
+// also conflict while being applied,
+// leaving their command as the last done line even though the stop was not
+// deliberate. Git distinguishes the two by writing an "amend" file only when
+// the commit was applied successfully and HEAD already holds it.
+// A missing "amend" file therefore means the commit failed to apply,
+// i.e. a conflict.
 //
 // It errs toward RebaseInterruptConflict (warn) when the signal is
 // ambiguous, including when the done file is missing (e.g. the apply
@@ -424,11 +425,11 @@ func (w *Worktree) RebaseStopReason(ctx context.Context) (RebaseInterruptKind, e
 	}
 
 	switch strings.ToLower(lastCommand) {
-	case "break":
+	case "break", "exec":
 		return RebaseInterruptDeliberate, nil
-	case "edit":
-		// A deliberate "edit" stop applies the commit first and
-		// leaves an "amend" file behind. Its absence means the
+	case "edit", "reword":
+		// A deliberate "edit" or "reword" stop applies the commit first
+		// and leaves an "amend" file behind. Its absence means the
 		// commit conflicted while being applied.
 		if _, err := os.Stat(filepath.Join(stateDir, "amend")); err == nil {
 			return RebaseInterruptDeliberate, nil

--- a/internal/git/rebase_wt.go
+++ b/internal/git/rebase_wt.go
@@ -378,6 +378,67 @@ func (w *Worktree) RebaseState(context.Context) (*RebaseState, error) {
 	return nil, ErrNoRebase
 }
 
+// RebaseStopReason reports why the current rebase stopped at the current step.
+//
+// It uses the last non-empty line of the rebase state's "done" file
+// to classify the stop:
+// a "break" instruction is always a deliberate interruption,
+// an "edit" instruction is deliberate only if the commit applied cleanly,
+// and anything else (pick, merge, revert, fixup, squash, ...)
+// is a conflict that needs resolution.
+//
+// The "edit" case needs extra care: an "edit" instruction whose commit
+// conflicts while being applied also leaves "edit ..." as the last done
+// line, but it is a conflict, not a deliberate stop. Git distinguishes
+// the two by writing an "amend" file only when the commit was applied
+// successfully and HEAD already holds it (the deliberate edit case).
+// A missing "amend" file on an "edit" stop therefore means the commit
+// failed to apply, i.e. a conflict.
+//
+// It errs toward RebaseInterruptConflict (warn) when the signal is
+// ambiguous, including when the done file is missing (e.g. the apply
+// backend), since a spurious warning is recoverable but a silent bad
+// amend is not.
+func (w *Worktree) RebaseStopReason(ctx context.Context) (RebaseInterruptKind, error) {
+	state, err := w.RebaseState(ctx)
+	if err != nil {
+		return RebaseInterruptConflict, err
+	}
+
+	stateDir := filepath.Join(w.gitDir, state.Backend.stateDir())
+	done, err := os.ReadFile(filepath.Join(stateDir, "done"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return RebaseInterruptConflict, nil
+		}
+		return RebaseInterruptConflict, fmt.Errorf("read rebase done: %w", err)
+	}
+
+	var lastCommand string
+	for _, line := range strings.Split(string(done), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		lastCommand = strings.Fields(line)[0]
+	}
+
+	switch strings.ToLower(lastCommand) {
+	case "break":
+		return RebaseInterruptDeliberate, nil
+	case "edit":
+		// A deliberate "edit" stop applies the commit first and
+		// leaves an "amend" file behind. Its absence means the
+		// commit conflicted while being applied.
+		if _, err := os.Stat(filepath.Join(stateDir, "amend")); err == nil {
+			return RebaseInterruptDeliberate, nil
+		}
+		return RebaseInterruptConflict, nil
+	default:
+		return RebaseInterruptConflict, nil
+	}
+}
+
 // stateDir reports the directory inside the .git directory
 // where rebase state is stored.
 //

--- a/testdata/script/commit_amend_rebase_edit_no_prompt.txt
+++ b/testdata/script/commit_amend_rebase_edit_no_prompt.txt
@@ -1,0 +1,53 @@
+# commit amend during a deliberate 'edit' rebase stop should not prompt:
+# the user intentionally paused to amend, so amending is correct.
+
+as 'Test <test@example.com>'
+at '2024-05-27T13:57:09Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git add feature1.txt
+gs bc -m 'Add feature 1' feature1
+
+git add feature2.txt
+gs bc -m 'Add feature 2' feature2
+
+gs bottom
+
+# Run a 'gs branch edit' that stops at an 'edit' instruction
+# for the current commit. This is a deliberate, conflict-free stop.
+env EDITOR=mockedit MOCKEDIT_GIVE=$WORK/input/rebase-todo.txt
+! gs branch edit
+stderr 'The rebase operation was interrupted'
+
+# 'gs commit amend' must NOT prompt here, even interactively:
+# there are no unmerged paths and the stop was deliberate.
+# If a prompt were shown, it would consume robot input and the
+# golden comparison below would differ.
+env ROBOT_INPUT=$WORK/golden/robot.txt ROBOT_OUTPUT=$WORK/robot.actual
+gs commit amend --no-edit -m 'Add feature 1 (amended)'
+cmp $WORK/robot.actual $WORK/golden/robot.txt
+
+gs rebase continue
+stderr 'feature2: restacked'
+
+git graph --branches
+cmp stdout $WORK/golden/branches.txt
+
+-- repo/feature1.txt --
+Contents of feature 1.
+
+-- repo/feature2.txt --
+Contents of feature 2.
+
+-- input/rebase-todo.txt --
+edit 3972713 Add feature 1
+
+-- golden/robot.txt --
+-- golden/branches.txt --
+* eaa2c2d (feature2) Add feature 2
+* 2d8d05c (HEAD -> feature1) Add feature 1 (amended)
+* a798a87 (main) Initial commit

--- a/testdata/script/commit_amend_rebase_resolution_prompt.txt
+++ b/testdata/script/commit_amend_rebase_resolution_prompt.txt
@@ -1,0 +1,58 @@
+# commit amend after resolving a rebase conflict should suggest rebase continue
+
+as 'Test <test@example.com>'
+at '2025-06-22T21:28:29Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# Create a conflict scenario.
+git add conflict.txt
+gs branch create feature -m 'Add conflict.txt with content A'
+
+gs trunk
+mv conflict-main.txt conflict.txt
+git add conflict.txt
+git commit -m 'Add conflict.txt with content B'
+
+gs bco feature
+! gs branch restack
+
+# Resolve the conflict before amending,
+# so there are no unmerged paths left in the index.
+cp $WORK/other/conflict-resolved.txt conflict.txt
+git add conflict.txt
+
+# Interactive mode should prompt with suggestion to run rebase continue.
+env ROBOT_INPUT=$WORK/golden/robot.txt ROBOT_OUTPUT=$WORK/robot.actual
+
+! gs commit amend --no-edit -a -m 'Another amend attempt'
+cmp $WORK/robot.actual $WORK/golden/robot.txt
+
+gs rebase continue --no-edit
+
+git graph --branches
+cmp stdout $WORK/golden/graph-after-rebase.txt
+
+-- repo/conflict.txt --
+Content A
+-- repo/conflict-main.txt --
+Content B
+-- other/conflict-resolved.txt --
+Content A and B
+-- golden/robot.txt --
+===
+> Do you want to amend the commit?: 
+> ▶ Yes                                                                         
+>   Continue with commit amend                                                   
+>   No                                                                          
+>   Abort the operation                                                         
+> You appear to have resolved a rebase conflict.
+> You might want to run 'gs rebase continue' instead of amending.
+"No"
+-- golden/graph-after-rebase.txt --
+* f8fc3c9 (HEAD -> feature) Add conflict.txt with content A
+* 2f55407 (main) Add conflict.txt with content B
+* f8331be Initial commit


### PR DESCRIPTION
## Summary

`gs commit amend` now warns before amending when a rebase stopped to resolve a
conflict, even after the conflict has already been staged with `git add`.

## Why this matters

Issue #911: a user finished resolving a rebase conflict (staged every conflicted
file) and then ran `gs commit amend` instead of `gs rebase continue`. Because
the existing guard only fired when there were still unmerged paths, `numUnmerged`
was already `0`, so no prompt appeared and the amend silently rewrote the wrong
commit, corrupting the rebase.

The maintainer's requested discriminator in the issue thread was a way to tell
"the commit we're about to make is a rebase resolution" apart from a deliberate
`edit`/`break` interruption, so the prompt only appears in the resolution case.

This change adds `Worktree.RebaseStopReason`, which classifies the current stop
from the rebase state directory without any new git subprocess:

- last line of `.git/rebase-merge/done` is `pick`/`merge`/`revert`/`fixup`/`squash`
  (or anything unrecognized) -> conflict resolution -> prompt.
- last line is `break` -> deliberate -> no prompt.
- last line is `edit` -> deliberate only if Git wrote the `amend` marker file
  (which it does when the commit applied cleanly and HEAD already holds it).
  An `edit` step whose commit conflicted leaves `edit ...` in `done` but no
  `amend` file, so it is correctly treated as a conflict and prompts.
- missing `done` (e.g. the apply backend) -> defaults to the conflict branch, so
  we err toward a recoverable warning rather than a silent bad amend.

`commit amend` keeps its existing unmerged-paths message and adds a second
message tuned to the resolved-conflict case, preserving the interactive prompt
and non-interactive warning conventions.

## Testing

- `go test ./internal/git/ -run TestWorktree_RebaseStopReason` (pick conflict,
  deliberate edit, break, edit-with-conflict, missing-done).
- `mise run test:script --run commit_amend_rebase_resolution_prompt`
  (resolve+stage a conflict, assert the new prompt appears, "No" aborts).
- `mise run test:script --run commit_amend_rebase_edit_no_prompt`
  (deliberate `edit` stop with a clean tree, assert `gs commit amend` does NOT
  prompt and amends normally).
- `go vet`, `go build`, `gofmt -l` clean; existing `commit_amend_rebase_prompt`
  and `internal/git` suites still pass.

Fixes #911

AI was used for assistance.
