### PR TITLE
test: stabilize TestRebase_interactiveRetryPreservesTerminal on Windows

### DIFF
--- a/internal/git/rebase_wt_int_test.go
+++ b/internal/git/rebase_wt_int_test.go
@@ -58,14 +58,16 @@ func TestRebase_interactiveRetryPreservesTerminal(t *testing.T) {
 
 	lockPath := filepath.Join(wt.gitDir, "index.lock")
 	require.NoError(t, os.WriteFile(lockPath, nil, 0o644))
-	go func() {
-		time.Sleep(20 * time.Millisecond)
-		_ = os.Remove(lockPath)
-	}()
 
 	mockExec.EXPECT().
 		Run(gomock.Any()).
 		DoAndReturn(func(cmd *exec.Cmd) error {
+			// Remove the lock before returning the lock-conflict
+			// error so the retry path observes a clean state.
+			// A goroutine sleep+remove here flaked on Windows
+			// runners when the goroutine did not get scheduled
+			// before the retry observed the lock.
+			_ = os.Remove(lockPath)
 			_, _ = fmt.Fprintln(cmd.Stderr, "fatal: Unable to create '.git/index.lock'")
 			return &exec.ExitError{}
 		})
@@ -127,10 +129,11 @@ func TestRebase_recoveryFailureReturnsRecoveryErr(t *testing.T) {
 
 	lockPath := filepath.Join(wt.gitDir, "index.lock")
 	require.NoError(t, os.WriteFile(lockPath, nil, 0o644))
-	go func() {
-		time.Sleep(20 * time.Millisecond)
-		_ = os.Remove(lockPath)
-	}()
+	// The fake git binary removes this lock on its first invocation
+	// (see gitRebaseRecoveryFailure). Removing from a goroutine with
+	// time.Sleep flaked on Windows when the scheduler did not run
+	// the goroutine before the retry path observed the lock.
+	t.Setenv("GIT_REBASE_LOCK_PATH", lockPath)
 
 	err := wt.Rebase(t.Context(), RebaseRequest{
 		Branch:   "feature",
@@ -171,6 +174,13 @@ func gitRebaseRecoveryFailure() {
 	marker := os.Getenv("GIT_REBASE_RECOVERY_MARKER")
 	if _, err := os.Stat(marker); errors.Is(err, os.ErrNotExist) {
 		_ = os.WriteFile(marker, nil, 0o644)
+		// Remove the test's fake index.lock so the retry path
+		// observes a clean state. Done synchronously here so the
+		// test does not rely on a goroutine sleep, which flaked
+		// on Windows.
+		if lock := os.Getenv("GIT_REBASE_LOCK_PATH"); lock != "" {
+			_ = os.Remove(lock)
+		}
 		fmt.Fprintln(os.Stderr, "fatal: Unable to create '.git/index.lock'")
 		os.Exit(1)
 	}


### PR DESCRIPTION
## Summary

- `TestRebase_interactiveRetryPreservesTerminal` flakes on Windows because the test relies on a goroutine sleeping 20ms before removing a fake `.git/index.lock`. On Windows runners the scheduler doesn't always release the goroutine before the retry path runs — when it doesn't, the test sees the lock still present and fails.
- Replace the goroutine + sleep with atomic lock removal in the first mock call. The lock is removed *before* the mock returns the lock-conflict error, so when the retry path executes there is no timing dependency to lose.

## Before

```go
go func() {
    time.Sleep(20 * time.Millisecond)
    _ = os.Remove(lockPath)
}()

mockExec.EXPECT().
    Run(gomock.Any()).
    DoAndReturn(func(cmd *exec.Cmd) error {
        _, _ = fmt.Fprintln(cmd.Stderr, "fatal: Unable to create '.git/index.lock'")
        return &exec.ExitError{}
    })
```

## After

```go
mockExec.EXPECT().
    Run(gomock.Any()).
    DoAndReturn(func(cmd *exec.Cmd) error {
        // Remove the lock before returning the lock-conflict
        // error so the retry path observes a clean state.
        _ = os.Remove(lockPath)
        _, _ = fmt.Fprintln(cmd.Stderr, "fatal: Unable to create '.git/index.lock'")
        return &exec.ExitError{}
    })
```

No sleep, no goroutine, no race.

## Why this matters

The flake masked CI on multiple unrelated PRs in the current stack (e.g. #1221), wasting workflow runs and obscuring real failures. Fix is independent of any feature work.

## Test plan

- [x] `go test -run TestRebase_interactiveRetryPreservesTerminal -count=10 ./internal/git/` — 10/10 passing locally
- [ ] Verify on Windows CI runner once this lands