### PR TITLE
golangci-lint: fix depguard paths

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -92,12 +92,12 @@ linters:
 
       - linters: [depguard]
         text: "import 'os/exec' is not allowed"
-        path: ^internal/xec/
+        path: (^|.*/)internal/xec/
 
       # termtest needs the raw os/exec to spawn PTYs for testing.
       - linters: [depguard]
         text: "import 'os/exec' is not allowed"
-        path: ^internal/termtest/
+        path: (^|.*/)internal/termtest/
 
 formatters:
   enable:


### PR DESCRIPTION
There appears to be an annoying bug in golangci-lint where,
due to cache-sharing between worktrees (I assume)
lints from other worktrees are reported in the current worktree
with paths using `../../whatever`.
These end up not matching the `path` filtering regex,
and pollute the lint report with false positives.

Work around this by adjusting `path` regexes.

[skip changelog]: not user facing