### PR TITLE
ui: Add downstack merge progress widget

### DIFF
--- a/internal/ui/widget/mergeprogress/cmd/demo/main.go
+++ b/internal/ui/widget/mergeprogress/cmd/demo/main.go
@@ -1,0 +1,185 @@
+// Command demo previews the merge progress widget.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"go.abhg.dev/gs/internal/ui"
+	"go.abhg.dev/gs/internal/ui/widget/mergeprogress"
+)
+
+func main() {
+	var req request
+	flag.IntVar(&req.items, "items", 12, "number of items")
+	flag.IntVar(&req.merged, "merged", 0, "initial merged item count")
+	flag.IntVar(&req.active, "active", 1, "initial active item count")
+	flag.IntVar(&req.failed, "failed", 0, "initial failed item count")
+	flag.IntVar(&req.skipped, "skipped", 0, "initial skipped item count")
+	flag.StringVar(&req.message, "message",
+		"feat1: waiting for CI checks",
+		"detail message")
+	flag.BoolVar(&req.animate, "animate", false, "animate progress")
+	flag.DurationVar(&req.tick, "tick", 750*time.Millisecond, "animation tick")
+	flag.IntVar(&req.width, "width", 0, "initial widget width")
+	flag.BoolVar(&req.dark, "dark", true, "use the dark theme")
+	flag.Parse()
+
+	if err := req.run(); err != nil {
+		fmt.Fprintf(os.Stderr, "mergeprogress demo: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// request is the flag-decoded demo configuration.
+type request struct {
+	items   int
+	merged  int
+	active  int
+	failed  int
+	skipped int
+
+	message string
+	animate bool
+	tick    time.Duration
+	width   int
+	dark    bool
+}
+
+func (r *request) run() error {
+	widget := mergeprogress.New(r.progressItems()...).
+		WithTheme(r.theme())
+	if r.message != "" {
+		_, _ = widget.Update(mergeprogress.Event{
+			Message: r.message,
+		})
+	}
+
+	var model tea.Model = widget
+	if r.animate {
+		model = &demoModel{
+			Widget: widget,
+			states: r.states(),
+			tick:   r.tick,
+		}
+	}
+
+	_, err := tea.NewProgram(model,
+		tea.WithInput(os.Stdin),
+		tea.WithOutput(os.Stdout),
+		tea.WithWindowSize(r.width, 20)).Run()
+	if err != nil {
+		return fmt.Errorf("run program: %w", err)
+	}
+	return nil
+}
+
+func (r *request) theme() ui.Theme {
+	if r.dark {
+		return ui.DefaultThemeDark()
+	}
+	return ui.DefaultThemeLight()
+}
+
+func (r *request) progressItems() []mergeprogress.Item {
+	states := r.states()
+	items := make([]mergeprogress.Item, len(states))
+	for idx, state := range states {
+		items[idx] = mergeprogress.Item{
+			ID:    itemID(idx),
+			State: state,
+		}
+	}
+	return items
+}
+
+func (r *request) states() []mergeprogress.State {
+	states := make([]mergeprogress.State, r.items)
+	idx := 0
+	for range r.merged {
+		states[idx] = mergeprogress.StateMerged
+		idx++
+	}
+	for range r.active {
+		states[idx] = mergeprogress.StateActive
+		idx++
+	}
+	for range r.failed {
+		states[idx] = mergeprogress.StateFailed
+		idx++
+	}
+	for range r.skipped {
+		states[idx] = mergeprogress.StateSkipped
+		idx++
+	}
+	return states
+}
+
+// demoModel adds synthetic timed progress to the real widget.
+type demoModel struct {
+	*mergeprogress.Widget
+
+	states []mergeprogress.State
+	tick   time.Duration
+}
+
+type tickMsg struct{}
+
+func (m *demoModel) Init() tea.Cmd {
+	return m.nextTick()
+}
+
+func (m *demoModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if _, ok := msg.(tickMsg); ok {
+		return m, m.advance()
+	}
+
+	model, cmd := m.Widget.Update(msg)
+	if widget, ok := model.(*mergeprogress.Widget); ok {
+		m.Widget = widget
+	}
+	return m, cmd
+}
+
+func (m *demoModel) advance() tea.Cmd {
+	for idx, state := range m.states {
+		if state == mergeprogress.StateActive {
+			m.states[idx] = mergeprogress.StateMerged
+			itemID := itemID(idx)
+			_, _ = m.Widget.Update(mergeprogress.Event{
+				ItemID:  itemID,
+				State:   mergeprogress.StateMerged,
+				Message: itemID + ": merged",
+			})
+			return m.nextTick()
+		}
+	}
+
+	for idx, state := range m.states {
+		if state == mergeprogress.StatePending {
+			m.states[idx] = mergeprogress.StateActive
+			itemID := itemID(idx)
+			_, _ = m.Widget.Update(mergeprogress.Event{
+				ItemID:  itemID,
+				State:   mergeprogress.StateActive,
+				Message: itemID + ": waiting for CI checks",
+			})
+			return m.nextTick()
+		}
+	}
+
+	return tea.Quit
+}
+
+func (m *demoModel) nextTick() tea.Cmd {
+	return tea.Tick(m.tick, func(time.Time) tea.Msg {
+		return tickMsg{}
+	})
+}
+
+func itemID(idx int) string {
+	return fmt.Sprintf("feat%d", idx+1)
+}

--- a/internal/ui/widget/mergeprogress/progress.go
+++ b/internal/ui/widget/mergeprogress/progress.go
@@ -1,0 +1,319 @@
+// Package mergeprogress renders progress for a stack merge operation.
+package mergeprogress
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+	"go.abhg.dev/gs/internal/ui"
+)
+
+const (
+	_defaultWidth = 80
+)
+
+// ErrCanceled reports that the user canceled progress rendering.
+var ErrCanceled = errors.New("merge progress canceled")
+
+// State is one item's position in the merge queue.
+//
+// The state belongs to the progress layer,
+// so callers can translate forge-specific states before updating the widget.
+type State uint8
+
+const (
+	// StatePending marks an item that has not started.
+	StatePending State = iota
+
+	// StateActive marks an item that is currently being prepared,
+	// checked, merged, or otherwise waited on.
+	StateActive
+
+	// StateMerged marks an item that has merged successfully.
+	StateMerged
+
+	// StateFailed marks an item that stopped the merge operation.
+	StateFailed
+
+	// StateSkipped marks an item that does not need to be merged.
+	StateSkipped
+)
+
+// Item is one slot in the progress bar.
+type Item struct {
+	// ID uniquely identifies the item for progress updates.
+	ID string
+
+	// State controls the glyph and color used for this item.
+	State State
+}
+
+// Event is a Bubble Tea message that updates [Widget] progress.
+//
+// Send Event through tea.Program.Send from the operation running alongside
+// the Bubble Tea loop.
+// The widget applies the event during [Widget.Update].
+type Event struct {
+	// ItemID identifies the item to update.
+	//
+	// Empty means the event updates only the operation message.
+	ItemID string
+
+	// State is the new state for the item.
+	State State
+
+	// Message is the current operation detail shown below the bar.
+	Message string
+}
+
+// KeyMap defines key bindings for [Widget].
+type KeyMap struct {
+	Cancel key.Binding
+}
+
+// DefaultKeyMap is the default key map for [Widget].
+var DefaultKeyMap = KeyMap{
+	Cancel: key.NewBinding(
+		key.WithKeys("ctrl+c"),
+		key.WithHelp("ctrl+c", "cancel"),
+	),
+}
+
+// Style defines the visual style of [Widget].
+type Style struct {
+	Merged  ui.Style // requires value
+	Active  ui.Style // requires value
+	Pending ui.Style // requires value
+	Failed  ui.Style // requires value
+	Skipped ui.Style // requires value
+
+	Title   ui.Style
+	Summary ui.Style
+	Detail  ui.Style
+	Hint    ui.Style
+}
+
+// DefaultStyle is the default visual style of [Widget].
+var DefaultStyle = Style{
+	Merged: ui.NewStyle().
+		Foreground(ui.Green).
+		SetString("■"),
+	Active: ui.NewStyle().
+		Foreground(ui.Yellow).
+		SetString("="),
+	Pending: ui.NewStyle().
+		Foreground(ui.Gray).
+		SetString("-"),
+	Failed: ui.NewStyle().
+		Foreground(ui.Red).
+		SetString("!"),
+	Skipped: ui.NewStyle().
+		Foreground(ui.Plain).
+		SetString("·"),
+
+	Title:   ui.NewStyle().Bold(true),
+	Summary: ui.NewStyle().Foreground(ui.Plain),
+	Detail:  ui.NewStyle().Foreground(ui.Plain),
+	Hint:    ui.NewStyle().Foreground(ui.Gray),
+}
+
+// Widget is a Bubble Tea model for stack merge progress.
+//
+// Callers provide the merge queue with [New],
+// then post [Event] messages to update each queue item.
+// The widget renders every item into one continuous horizontal bar.
+// Terminal width changes each item's segment width,
+// but not which fields are rendered:
+// branch names stay out of the bar,
+// and the current operation detail is shown below it.
+//
+// The widget does not import or depend on forge APIs.
+// Translate forge-specific states into [State] values at the command boundary.
+type Widget struct {
+	KeyMap KeyMap
+	Style  Style
+
+	items   []Item
+	index   map[string]int // item ID => items index
+	message string
+	err     error
+	width   int
+	theme   ui.Theme
+}
+
+var _ tea.Model = (*Widget)(nil)
+
+// New builds a progress widget for the given queue items.
+func New(items ...Item) *Widget {
+	w := &Widget{
+		KeyMap: DefaultKeyMap,
+		Style:  DefaultStyle,
+	}
+	w.setItems(items...)
+	return w
+}
+
+func (w *Widget) setItems(items ...Item) {
+	w.items = append(w.items[:0], items...)
+	w.index = make(map[string]int, len(items))
+	for idx, item := range items {
+		w.index[item.ID] = idx
+	}
+}
+
+func (w *Widget) apply(event Event) {
+	if event.ItemID != "" {
+		if idx, ok := w.index[event.ItemID]; ok {
+			w.items[idx].State = event.State
+		}
+	}
+	if event.Message != "" {
+		w.message = event.Message
+	}
+}
+
+// WithTheme sets the theme used by Bubble Tea rendering.
+func (w *Widget) WithTheme(theme ui.Theme) *Widget {
+	w.theme = theme
+	return w
+}
+
+// Err reports cancellation or another rendering error.
+func (w *Widget) Err() error {
+	return w.err
+}
+
+// Init initializes the Bubble Tea model.
+func (w *Widget) Init() tea.Cmd {
+	return nil
+}
+
+// Update updates the Bubble Tea model.
+func (w *Widget) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		w.width = msg.Width
+	case Event:
+		w.apply(msg)
+	case tea.KeyMsg:
+		if key.Matches(msg, w.KeyMap.Cancel) {
+			w.err = ErrCanceled
+			return w, tea.Quit
+		}
+	}
+	return w, nil
+}
+
+// View renders the Bubble Tea model.
+func (w *Widget) View() tea.View {
+	return tea.NewView(w.renderString())
+}
+
+func (w *Widget) renderString() string {
+	var out strings.Builder
+	w.render(&out, w.theme)
+	return out.String()
+}
+
+func (w *Widget) render(out ui.Writer, theme ui.Theme) {
+	var merged, active, pending, failed, skipped int
+	for _, item := range w.items {
+		switch item.State {
+		case StateActive:
+			active++
+		case StateMerged:
+			merged++
+		case StateFailed:
+			failed++
+		case StateSkipped:
+			skipped++
+		default:
+			pending++
+		}
+	}
+
+	out.WriteString(w.Style.Title.Render(theme, fmt.Sprintf(
+		"Merging: %d of %d changes",
+		merged, len(w.items),
+	)))
+	out.WriteString("\n\n")
+	w.renderBar(out, theme)
+	out.WriteString("\n")
+	fmt.Fprintf(out, "merged: %d   waiting: %d   pending: %d",
+		merged, active, pending)
+	if failed > 0 {
+		fmt.Fprintf(out, "   failed: %d", failed)
+	}
+	if skipped > 0 {
+		fmt.Fprintf(out, "   skipped: %d", skipped)
+	}
+	out.WriteString("\n\n")
+
+	if w.message != "" {
+		out.WriteString(w.Style.Detail.Render(theme, w.message))
+		out.WriteString("\n")
+	}
+	out.WriteString(w.Style.Hint.Render(theme,
+		"Press Ctrl-C to cancel merge operation."))
+}
+
+func (w *Widget) renderBar(out ui.Writer, theme ui.Theme) {
+	if len(w.items) == 0 {
+		out.WriteString(w.Style.Pending.String(theme))
+		return
+	}
+
+	width := w.width
+	if width <= 0 {
+		width = _defaultWidth
+	}
+	width = max(width, len(w.items))
+
+	segmentWidths := distribute(width, len(w.items))
+	for idx, item := range w.items {
+		out.WriteString(strings.Repeat(
+			w.styleFor(item.State).String(theme),
+			segmentWidths[idx],
+		))
+	}
+}
+
+func (w *Widget) styleFor(state State) ui.Style {
+	switch state {
+	case StateActive:
+		return w.Style.Active
+	case StateMerged:
+		return w.Style.Merged
+	case StateFailed:
+		return w.Style.Failed
+	case StateSkipped:
+		return w.Style.Skipped
+	default:
+		return w.Style.Pending
+	}
+}
+
+// distribute divides a bar width into contiguous item segment widths.
+//
+// Every segment receives the same base width.
+// Any leftover cells are assigned from left to right,
+// so the full bar width is used without changing item order.
+func distribute(width, segments int) []int {
+	if segments <= 0 {
+		return nil
+	}
+
+	base := width / segments
+	extra := width % segments
+	widths := make([]int, segments)
+	for idx := range widths {
+		widths[idx] = base
+		if idx < extra {
+			widths[idx]++
+		}
+	}
+	return widths
+}

--- a/internal/ui/widget/mergeprogress/progress_test.go
+++ b/internal/ui/widget/mergeprogress/progress_test.go
@@ -1,0 +1,170 @@
+package mergeprogress
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/hexops/autogold/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/ui"
+)
+
+func TestWidget_RenderProgression(t *testing.T) {
+	widget := New(makeItems(10)...).WithTheme(ui.DefaultThemeDark())
+	mustUpdate(t, widget, tea.WindowSizeMsg{Width: 40})
+
+	autogold.Expect(`Merging: 0 of 10 changes
+
+----------------------------------------
+merged: 0   waiting: 0   pending: 10
+
+Press Ctrl-C to cancel merge operation.`).Equal(t, renderPlain(widget))
+
+	mustUpdate(t, widget, Event{
+		ItemID:  "1",
+		State:   StateActive,
+		Message: "Waiting for CI checks on feature-01 (#101).",
+	})
+	autogold.Expect(`Merging: 0 of 10 changes
+
+====------------------------------------
+merged: 0   waiting: 1   pending: 9
+
+Waiting for CI checks on feature-01 (#101).
+Press Ctrl-C to cancel merge operation.`).Equal(t, renderPlain(widget))
+
+	mustUpdate(t, widget, Event{
+		ItemID:  "1",
+		State:   StateMerged,
+		Message: "Merged feature-01 (#101).",
+	})
+	mustUpdate(t, widget, Event{
+		ItemID:  "2",
+		State:   StateActive,
+		Message: "Waiting for CI checks on feature-02 (#102).",
+	})
+	mustUpdate(t, widget, Event{
+		ItemID:  "3",
+		State:   StateActive,
+		Message: "Waiting for CI checks on feature-02 (#102) and feature-03 (#103).",
+	})
+	autogold.Expect(`Merging: 1 of 10 changes
+
+■■■■========----------------------------
+merged: 1   waiting: 2   pending: 7
+
+Waiting for CI checks on feature-02 (#102) and feature-03 (#103).
+Press Ctrl-C to cancel merge operation.`).Equal(t, renderPlain(widget))
+
+	mustUpdate(t, widget, Event{
+		ItemID:  "2",
+		State:   StateMerged,
+		Message: "Merged feature-02 (#102); still waiting for feature-03 (#103).",
+	})
+	autogold.Expect(`Merging: 2 of 10 changes
+
+■■■■■■■■====----------------------------
+merged: 2   waiting: 1   pending: 7
+
+Merged feature-02 (#102); still waiting for feature-03 (#103).
+Press Ctrl-C to cancel merge operation.`).Equal(t, renderPlain(widget))
+
+	mustUpdate(t, widget, Event{
+		ItemID:  "3",
+		State:   StateFailed,
+		Message: "CI checks failed for feature-03 (#103).",
+	})
+	autogold.Expect(`Merging: 2 of 10 changes
+
+■■■■■■■■!!!!----------------------------
+merged: 2   waiting: 0   pending: 7   failed: 1
+
+CI checks failed for feature-03 (#103).
+Press Ctrl-C to cancel merge operation.`).Equal(t, renderPlain(widget))
+}
+
+func TestWidget_Render_scalingKeepsShape(t *testing.T) {
+	items := makeItems(18)
+	for idx := range 7 {
+		items[idx].State = StateMerged
+	}
+	items[7].State = StateActive
+
+	wideWidget := New(items...).WithTheme(ui.DefaultThemeDark())
+	mustUpdate(t, wideWidget, tea.WindowSizeMsg{Width: 72})
+	mustUpdate(t, wideWidget, Event{
+		Message: "Waiting for CI checks on feature-08 (#108).",
+	})
+	wide := renderPlain(wideWidget)
+
+	narrowWidget := New(items...).WithTheme(ui.DefaultThemeDark())
+	mustUpdate(t, narrowWidget, tea.WindowSizeMsg{Width: 24})
+	mustUpdate(t, narrowWidget, Event{
+		Message: "Waiting for CI checks on feature-08 (#108).",
+	})
+	narrow := renderPlain(narrowWidget)
+
+	assert.Contains(t, wide, "Merging: 7 of 18 changes")
+	assert.Contains(t, wide, "merged: 7   waiting: 1   pending: 10")
+	assert.Contains(t, wide,
+		"Waiting for CI checks on feature-08 (#108).")
+	assert.NotContains(t, barLine(wide), "feature")
+	assert.NotContains(t, barLine(narrow), "feature")
+	assert.Equal(t, 72, lipgloss.Width(barLine(wide)))
+	assert.Equal(t, 24, lipgloss.Width(barLine(narrow)))
+	assert.Contains(t, barLine(wide), "■")
+	assert.Contains(t, barLine(wide), "=")
+	assert.Contains(t, barLine(wide), "-")
+}
+
+func TestWidget_Render_failedAndSkipped(t *testing.T) {
+	items := makeItems(5)
+	items[0].State = StateMerged
+	items[1].State = StateSkipped
+	items[2].State = StateActive
+	items[3].State = StateFailed
+
+	widget := New(items...).WithTheme(ui.DefaultThemeDark())
+	mustUpdate(t, widget, tea.WindowSizeMsg{Width: 20})
+	mustUpdate(t, widget, Event{
+		Message: "CI checks failed for feature-04 (#104).",
+	})
+	got := renderPlain(widget)
+
+	assert.Contains(t, got, "merged: 1   waiting: 1   pending: 1")
+	assert.Contains(t, got, "failed: 1")
+	assert.Contains(t, got, "skipped: 1")
+	assert.Equal(t, "■■■■····====!!!!----", barLine(got))
+}
+
+func renderPlain(widget *Widget) string {
+	return ansi.Strip(widget.View().Content)
+}
+
+func mustUpdate(t *testing.T, widget *Widget, msg tea.Msg) {
+	t.Helper()
+
+	model, cmd := widget.Update(msg)
+	require.Nil(t, cmd)
+	require.Same(t, widget, model)
+}
+
+func barLine(rendered string) string {
+	lines := strings.Split(rendered, "\n")
+	return lines[2]
+}
+
+func makeItems(n int) []Item {
+	items := make([]Item, n)
+	for idx := range items {
+		items[idx] = Item{
+			ID: strconv.Itoa(idx + 1),
+		}
+	}
+	return items
+}


### PR DESCRIPTION
`gs downstack merge` needs a terminal progress view that can represent a
merge stack without depending on any forge implementation.

Add a `mergeprogress` widget for rendering queue progress as one continuous
bar. Each queue item has its own state, so future merge flows can mark
multiple branches as active at the same time.

The bar uses both glyphs and colors for state:
merged, active, pending, failed, and skipped.
Render tests cover wide and narrow bars, larger stacks, multiple active
items, and event-driven updates.

<img width="1200" height="600" alt="progress-bar" src="https://github.com/user-attachments/assets/76e691e2-8676-435e-bbec-3f295df0a3ef" />

