### PR TITLE
ui: Share Bubble Tea model runner

### DIFF
--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -150,8 +150,8 @@ func NewForm(fields ...Field) *Form {
 	}
 }
 
-// FormRunOptions specifies options for [Form.Run].
-type FormRunOptions struct {
+// RunOptions specifies options for running a Bubble Tea model.
+type RunOptions struct {
 	// Input is the input source.
 	//
 	// Defaults to os.Stdin.
@@ -181,11 +181,12 @@ type FormRunOptions struct {
 	WithoutSignals bool
 }
 
-// Run runs the form and blocks until it's accepted or canceled.
-// It returns a combination of all errors returned by the fields.
-func (f *Form) Run(opts *FormRunOptions) error {
-	opts = cmp.Or(opts, &FormRunOptions{})
-	f.theme = opts.Theme
+// FormRunOptions specifies options for [Form.Run].
+type FormRunOptions = RunOptions
+
+// RunModel runs the given Bubble Tea model.
+func RunModel(model tea.Model, opts *RunOptions) error {
+	opts = cmp.Or(opts, &RunOptions{})
 
 	var teaOpts []tea.ProgramOption
 	if i := opts.Input; i != nil {
@@ -205,11 +206,21 @@ func (f *Form) Run(opts *FormRunOptions) error {
 		teaOpts = append(teaOpts, tea.WithoutSignals())
 	}
 
-	prog := tea.NewProgram(f, teaOpts...)
+	program := tea.NewProgram(model, teaOpts...)
 	if msg := opts.SendMsg; msg != nil {
-		go prog.Send(msg)
+		go program.Send(msg)
 	}
-	if _, err := prog.Run(); err != nil {
+	_, err := program.Run()
+	return err
+}
+
+// Run runs the form and blocks until it's accepted or canceled.
+// It returns a combination of all errors returned by the fields.
+func (f *Form) Run(opts *FormRunOptions) error {
+	opts = cmp.Or(opts, &FormRunOptions{})
+	f.theme = opts.Theme
+
+	if err := RunModel(f, opts); err != nil {
 		return err
 	}
 

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -1,11 +1,13 @@
 package ui
 
 import (
+	"cmp"
 	"errors"
 	"io"
 	"os"
 	"sync"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/colorprofile"
 )
 
@@ -35,6 +37,14 @@ type InteractiveView interface {
 
 	// Prompt prompts the user for input with the given interactive fields.
 	Prompt(...Field) error
+}
+
+// ModelView is a view that can run a Bubble Tea model.
+type ModelView interface {
+	View
+
+	// RunModel runs the given Bubble Tea model against this view.
+	RunModel(tea.Model, *RunOptions) error
 }
 
 // Interactive reports whether the given view is interactive.
@@ -112,4 +122,22 @@ func (tv *TerminalView) Prompt(fields ...Field) error {
 		Output: tv.w,
 		Theme:  tv.theme(),
 	})
+}
+
+// RunModel runs the given Bubble Tea model against the terminal.
+func (tv *TerminalView) RunModel(
+	model tea.Model,
+	opts *RunOptions,
+) error {
+	opts = cmp.Or(opts, &RunOptions{})
+	if opts.Input == nil {
+		opts.Input = tv.r
+	}
+	if opts.Output == nil {
+		opts.Output = tv.w
+	}
+	if opts.Theme == (Theme{}) {
+		opts.Theme = tv.theme()
+	}
+	return RunModel(model, opts)
 }


### PR DESCRIPTION
Terminal-only widgets need the same Bubble Tea program setup that forms use.
Without a shared runner, standalone models can miss options such as injected
input, output, window size, TERM, startup messages, and signal handling.

Add `RunOptions` and `RunModel` as the common model execution path.
`Form.Run` now delegates to that path, and `TerminalView.RunModel` fills the
terminal defaults before calling the same runner.