### PR TITLE
feat: add --skip-conflicts to restack commands

### DIFF
--- a/.changes/unreleased/Added-20260609-045211.yaml
+++ b/.changes/unreleased/Added-20260609-045211.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'restack: Add ''--skip-conflicts'' to ''gs repo restack'', ''gs stack restack'', ''gs upstack restack'', ''gs downstack restack'', and ''gs branch restack'' to skip branches that cannot be rebased cleanly and their upstacks instead of stopping for conflict resolution.'
+time: 2026-06-09T04:52:11.175578-07:00

--- a/branch_create.go
+++ b/branch_create.go
@@ -8,6 +8,7 @@ import (
 
 	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
@@ -324,7 +325,9 @@ func (cmd *branchCreateCmd) Run(
 	}
 
 	if cmd.Below || cmd.Insert {
-		return restackHandler.RestackUpstack(ctx, branchName, nil)
+		return restackHandler.RestackUpstack(ctx, &restack.UpstackRequest{
+			Branch: branchName,
+		})
 	}
 
 	return nil

--- a/branch_edit.go
+++ b/branch_edit.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
@@ -59,5 +60,7 @@ func (*branchEditCmd) Run(
 		})
 	}
 
-	return restackHandler.RestackUpstack(ctx, currentBranch, nil)
+	return restackHandler.RestackUpstack(ctx, &restack.UpstackRequest{
+		Branch: currentBranch,
+	})
 }

--- a/branch_restack.go
+++ b/branch_restack.go
@@ -5,11 +5,14 @@ import (
 	"fmt"
 
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/text"
 )
 
 type branchRestackCmd struct {
 	Branch string `placeholder:"NAME" help:"Branch to restack" predictor:"trackedBranches"`
+
+	SkipConflicts bool `help:"Skip branches that cannot be rebased due to conflicts"`
 }
 
 func (*branchRestackCmd) Help() string {
@@ -32,5 +35,7 @@ func (cmd *branchRestackCmd) AfterApply(ctx context.Context, wt *git.Worktree) e
 }
 
 func (cmd *branchRestackCmd) Run(ctx context.Context, handler RestackHandler) error {
-	return handler.RestackBranch(ctx, cmd.Branch)
+	return handler.RestackBranch(ctx, cmd.Branch, &restack.BranchOptions{
+		SkipConflicts: cmd.SkipConflicts,
+	})
 }

--- a/branch_restack.go
+++ b/branch_restack.go
@@ -35,7 +35,10 @@ func (cmd *branchRestackCmd) AfterApply(ctx context.Context, wt *git.Worktree) e
 }
 
 func (cmd *branchRestackCmd) Run(ctx context.Context, handler RestackHandler) error {
-	return handler.RestackBranch(ctx, cmd.Branch, &restack.BranchOptions{
-		SkipConflicts: cmd.SkipConflicts,
+	return handler.RestackBranch(ctx, &restack.BranchRequest{
+		Branch: cmd.Branch,
+		Options: &restack.Options{
+			SkipConflicts: cmd.SkipConflicts,
+		},
 	})
 }

--- a/commit_amend.go
+++ b/commit_amend.go
@@ -241,7 +241,10 @@ func (cmd *commitAmendCmd) Run(
 		return nil
 	}
 
-	return restackHandler.RestackUpstack(ctx, currentBranch, &restack.UpstackOptions{
-		SkipStart: true,
+	return restackHandler.RestackUpstack(ctx, &restack.UpstackRequest{
+		Branch: currentBranch,
+		Options: &restack.UpstackOptions{
+			SkipStart: true,
+		},
 	})
 }

--- a/commit_create.go
+++ b/commit_create.go
@@ -79,7 +79,10 @@ func (cmd *commitCreateCmd) Run(
 		return fmt.Errorf("get current branch: %w", err)
 	}
 
-	return restackHandler.RestackUpstack(ctx, currentBranch, &restack.UpstackOptions{
-		SkipStart: true,
+	return restackHandler.RestackUpstack(ctx, &restack.UpstackRequest{
+		Branch: currentBranch,
+		Options: &restack.UpstackOptions{
+			SkipStart: true,
+		},
 	})
 }

--- a/commit_split.go
+++ b/commit_split.go
@@ -110,7 +110,10 @@ func (cmd *commitSplitCmd) Run(
 		return fmt.Errorf("get current branch: %w", err)
 	}
 
-	return restackHandler.RestackUpstack(ctx, currentBranch, &restack.UpstackOptions{
-		SkipStart: true,
+	return restackHandler.RestackUpstack(ctx, &restack.UpstackRequest{
+		Branch: currentBranch,
+		Options: &restack.UpstackOptions{
+			SkipStart: true,
+		},
 	})
 }

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -171,7 +171,7 @@ of deleted branches, leaving higher branches in place.
 ### git-spice repo restack {#gs-repo-restack}
 
 ```
-gs repo (r) restack (r)
+gs repo (r) restack (r) [flags]
 ```
 
 <span class="mdx-badge"><span class="mdx-badge__icon">:material-tag:{ title="Released in version" }</span><span class="mdx-badge__text">[v0.16.0](/changelog.md#v0.16.0)</span></span>
@@ -180,6 +180,12 @@ Restack all tracked branches
 
 All tracked branches in the repository are rebased on top of their
 respective bases in dependency order, ensuring a linear history.
+
+Use --skip-conflicts to skip branches that cannot be rebased cleanly.
+
+**Flags**
+
+* `--skip-conflicts`: Skip branches that cannot be rebased due to conflicts
 
 ## Log
 
@@ -299,9 +305,12 @@ respective bases, ensuring a linear history.
 
 Use --branch to rebase the stack of a different branch.
 
+Use --skip-conflicts to skip branches that cannot be rebased cleanly.
+
 **Flags**
 
 * `--branch=NAME`: Branch to restack the stack of
+* `--skip-conflicts`: Skip branches that cannot be rebased due to conflicts
 
 ### git-spice stack edit {#gs-stack-edit}
 
@@ -429,6 +438,7 @@ but still rebase all branches above it.
 **Flags**
 
 * `--skip-start`: Do not restack the starting branch
+* `--skip-conflicts`: Skip branches that cannot be rebased due to conflicts
 * `--branch=NAME`: Branch to restack the upstack of
 
 ### git-spice upstack onto {#gs-upstack-onto}
@@ -664,6 +674,7 @@ Use --branch to start at a different branch.
 **Flags**
 
 * `--branch=NAME`: Branch to restack the downstack of
+* `--skip-conflicts`: Skip branches that cannot be rebased due to conflicts
 
 ## Branch
 
@@ -1009,6 +1020,7 @@ Use --branch to target a different branch.
 **Flags**
 
 * `--branch=NAME`: Branch to restack
+* `--skip-conflicts`: Skip branches that cannot be rebased due to conflicts
 
 ### git-spice branch onto {#gs-branch-onto}
 

--- a/downstack_restack.go
+++ b/downstack_restack.go
@@ -6,12 +6,15 @@ import (
 	"fmt"
 
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
 )
 
 type downstackRestackCmd struct {
 	Branch string `help:"Branch to restack the downstack of" placeholder:"NAME" predictor:"trackedBranches"`
+
+	SkipConflicts bool `help:"Skip branches that cannot be rebased due to conflicts"`
 }
 
 func (*downstackRestackCmd) Help() string {
@@ -44,5 +47,7 @@ func (cmd *downstackRestackCmd) Run(
 		return errors.New("nothing to restack below trunk")
 	}
 
-	return handler.RestackDownstack(ctx, cmd.Branch)
+	return handler.RestackDownstack(ctx, cmd.Branch, &restack.DownstackOptions{
+		SkipConflicts: cmd.SkipConflicts,
+	})
 }

--- a/downstack_restack.go
+++ b/downstack_restack.go
@@ -47,7 +47,10 @@ func (cmd *downstackRestackCmd) Run(
 		return errors.New("nothing to restack below trunk")
 	}
 
-	return handler.RestackDownstack(ctx, cmd.Branch, &restack.DownstackOptions{
-		SkipConflicts: cmd.SkipConflicts,
+	return handler.RestackDownstack(ctx, &restack.DownstackRequest{
+		Branch: cmd.Branch,
+		Options: &restack.Options{
+			SkipConflicts: cmd.SkipConflicts,
+		},
 	})
 }

--- a/internal/handler/cherrypick/handler.go
+++ b/internal/handler/cherrypick/handler.go
@@ -19,7 +19,7 @@ import (
 
 // RestackHandler is a subset of the restack.Handler interface.
 type RestackHandler interface {
-	RestackUpstack(ctx context.Context, branch string, opts *restack.UpstackOptions) error
+	RestackUpstack(ctx context.Context, req *restack.UpstackRequest) error
 }
 
 var _ RestackHandler = (*restack.Handler)(nil)
@@ -225,7 +225,10 @@ func (h *Handler) CherryPickCommit(ctx context.Context, req *Request) (retErr er
 
 	h.Log.Infof("%v: cherry-picked %v: %v", req.Branch, req.Commit.Short(), commit.Subject)
 
-	return h.Restack.RestackUpstack(ctx, req.Branch, &restack.UpstackOptions{
-		SkipStart: true,
+	return h.Restack.RestackUpstack(ctx, &restack.UpstackRequest{
+		Branch: req.Branch,
+		Options: &restack.UpstackOptions{
+			SkipStart: true,
+		},
 	})
 }

--- a/internal/handler/fixup/handler.go
+++ b/internal/handler/fixup/handler.go
@@ -23,7 +23,7 @@ import (
 
 // RestackHandler is a subset of the restack.Handler interface.
 type RestackHandler interface {
-	RestackUpstack(ctx context.Context, branch string, opts *restack.UpstackOptions) error
+	RestackUpstack(ctx context.Context, req *restack.UpstackRequest) error
 }
 
 var _ RestackHandler = (*restack.Handler)(nil)
@@ -266,8 +266,11 @@ func (h *Handler) FixupCommit(ctx context.Context, req *Request) error {
 		return fmt.Errorf("rebase onto new commit: %w", err)
 	}
 
-	return h.Restack.RestackUpstack(ctx, req.TargetBranch, &restack.UpstackOptions{
-		SkipStart: true,
+	return h.Restack.RestackUpstack(ctx, &restack.UpstackRequest{
+		Branch: req.TargetBranch,
+		Options: &restack.UpstackOptions{
+			SkipStart: true,
+		},
 	})
 }
 

--- a/internal/handler/fixup/handler_test.go
+++ b/internal/handler/fixup/handler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/git/gittest"
+	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/sigstack"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/silog/silogtest"
@@ -228,7 +229,12 @@ func TestFixupCommit_success(t *testing.T) {
 	// Will try to restack the upstack of feature1 (target branch)
 	mockRestack := NewMockRestackHandler(mockCtrl)
 	mockRestack.EXPECT().
-		RestackUpstack(gomock.Any(), "feature1", gomock.Any()).
+		RestackUpstack(gomock.Any(), &restack.UpstackRequest{
+			Branch: "feature1",
+			Options: &restack.UpstackOptions{
+				SkipStart: true,
+			},
+		}).
 		Return(nil)
 
 		// Sanity check: feature1:staged.txt does not exist yet.
@@ -333,7 +339,12 @@ func TestFixupCommit_edit(t *testing.T) {
 
 	mockRestack := NewMockRestackHandler(mockCtrl)
 	mockRestack.EXPECT().
-		RestackUpstack(gomock.Any(), "feature1", gomock.Any()).
+		RestackUpstack(gomock.Any(), &restack.UpstackRequest{
+			Branch: "feature1",
+			Options: &restack.UpstackOptions{
+				SkipStart: true,
+			},
+		}).
 		Return(nil)
 
 	var signals sigstack.Stack

--- a/internal/handler/fixup/mocks_test.go
+++ b/internal/handler/fixup/mocks_test.go
@@ -46,17 +46,17 @@ func (m *MockRestackHandler) EXPECT() *MockRestackHandlerMockRecorder {
 }
 
 // RestackUpstack mocks base method.
-func (m *MockRestackHandler) RestackUpstack(ctx context.Context, branch string, opts *restack.UpstackOptions) error {
+func (m *MockRestackHandler) RestackUpstack(ctx context.Context, req *restack.UpstackRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestackUpstack", ctx, branch, opts)
+	ret := m.ctrl.Call(m, "RestackUpstack", ctx, req)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RestackUpstack indicates an expected call of RestackUpstack.
-func (mr *MockRestackHandlerMockRecorder) RestackUpstack(ctx, branch, opts any) *MockRestackHandlerRestackUpstackCall {
+func (mr *MockRestackHandlerMockRecorder) RestackUpstack(ctx, req any) *MockRestackHandlerRestackUpstackCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackUpstack", reflect.TypeOf((*MockRestackHandler)(nil).RestackUpstack), ctx, branch, opts)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackUpstack", reflect.TypeOf((*MockRestackHandler)(nil).RestackUpstack), ctx, req)
 	return &MockRestackHandlerRestackUpstackCall{Call: call}
 }
 
@@ -72,13 +72,13 @@ func (c *MockRestackHandlerRestackUpstackCall) Return(arg0 error) *MockRestackHa
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRestackHandlerRestackUpstackCall) Do(f func(context.Context, string, *restack.UpstackOptions) error) *MockRestackHandlerRestackUpstackCall {
+func (c *MockRestackHandlerRestackUpstackCall) Do(f func(context.Context, *restack.UpstackRequest) error) *MockRestackHandlerRestackUpstackCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRestackHandlerRestackUpstackCall) DoAndReturn(f func(context.Context, string, *restack.UpstackOptions) error) *MockRestackHandlerRestackUpstackCall {
+func (c *MockRestackHandlerRestackUpstackCall) DoAndReturn(f func(context.Context, *restack.UpstackRequest) error) *MockRestackHandlerRestackUpstackCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/handler/merge/handler.go
+++ b/internal/handler/merge/handler.go
@@ -14,6 +14,7 @@ import (
 
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/ui"
@@ -35,7 +36,7 @@ type Service interface {
 
 // RestackHandler restacks branches after their bases are merged.
 type RestackHandler interface {
-	RestackBranch(context.Context, string) error
+	RestackBranch(context.Context, string, *restack.BranchOptions) error
 }
 
 // SubmitHandler updates change requests after branch restacks.
@@ -470,7 +471,7 @@ func (h *Handler) prepareForMerge(
 			return fmt.Errorf("verify restacked: %w", err)
 		}
 
-		if err := h.Restack.RestackBranch(ctx, item.branch); err != nil {
+		if err := h.Restack.RestackBranch(ctx, item.branch, nil); err != nil {
 			return fmt.Errorf("restack branch: %w", err)
 		}
 

--- a/internal/handler/merge/handler.go
+++ b/internal/handler/merge/handler.go
@@ -36,7 +36,7 @@ type Service interface {
 
 // RestackHandler restacks branches after their bases are merged.
 type RestackHandler interface {
-	RestackBranch(context.Context, string, *restack.BranchOptions) error
+	RestackBranch(ctx context.Context, req *restack.BranchRequest) error
 }
 
 // SubmitHandler updates change requests after branch restacks.
@@ -471,7 +471,9 @@ func (h *Handler) prepareForMerge(
 			return fmt.Errorf("verify restacked: %w", err)
 		}
 
-		if err := h.Restack.RestackBranch(ctx, item.branch, nil); err != nil {
+		if err := h.Restack.RestackBranch(ctx, &restack.BranchRequest{
+			Branch: item.branch,
+		}); err != nil {
 			return fmt.Errorf("restack branch: %w", err)
 		}
 

--- a/internal/handler/merge/handler_test.go
+++ b/internal/handler/merge/handler_test.go
@@ -230,10 +230,10 @@ func TestExecutePlan_retargets(t *testing.T) {
 
 	mockRestack := NewMockRestackHandler(ctrl)
 	mockRestack.EXPECT().
-		RestackBranch(gomock.Any(), "feat2").
+		RestackBranch(gomock.Any(), "feat2", nil).
 		Return(nil)
 	mockRestack.EXPECT().
-		RestackBranch(gomock.Any(), "feat3").
+		RestackBranch(gomock.Any(), "feat3", nil).
 		Return(nil)
 
 	mockSubmit := NewMockSubmitHandler(ctrl)

--- a/internal/handler/merge/handler_test.go
+++ b/internal/handler/merge/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/handler/submit"
 	"go.abhg.dev/gs/internal/handler/sync"
 
@@ -230,10 +231,14 @@ func TestExecutePlan_retargets(t *testing.T) {
 
 	mockRestack := NewMockRestackHandler(ctrl)
 	mockRestack.EXPECT().
-		RestackBranch(gomock.Any(), "feat2", nil).
+		RestackBranch(gomock.Any(), &restack.BranchRequest{
+			Branch: "feat2",
+		}).
 		Return(nil)
 	mockRestack.EXPECT().
-		RestackBranch(gomock.Any(), "feat3", nil).
+		RestackBranch(gomock.Any(), &restack.BranchRequest{
+			Branch: "feat3",
+		}).
 		Return(nil)
 
 	mockSubmit := NewMockSubmitHandler(ctrl)

--- a/internal/handler/merge/mocks_test.go
+++ b/internal/handler/merge/mocks_test.go
@@ -13,6 +13,7 @@ import (
 	reflect "reflect"
 
 	git "go.abhg.dev/gs/internal/git"
+	restack "go.abhg.dev/gs/internal/handler/restack"
 	submit "go.abhg.dev/gs/internal/handler/submit"
 	sync "go.abhg.dev/gs/internal/handler/sync"
 	spice "go.abhg.dev/gs/internal/spice"
@@ -207,17 +208,17 @@ func (m *MockRestackHandler) EXPECT() *MockRestackHandlerMockRecorder {
 }
 
 // RestackBranch mocks base method.
-func (m *MockRestackHandler) RestackBranch(arg0 context.Context, arg1 string) error {
+func (m *MockRestackHandler) RestackBranch(arg0 context.Context, arg1 string, arg2 *restack.BranchOptions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestackBranch", arg0, arg1)
+	ret := m.ctrl.Call(m, "RestackBranch", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RestackBranch indicates an expected call of RestackBranch.
-func (mr *MockRestackHandlerMockRecorder) RestackBranch(arg0, arg1 any) *MockRestackHandlerRestackBranchCall {
+func (mr *MockRestackHandlerMockRecorder) RestackBranch(arg0, arg1, arg2 any) *MockRestackHandlerRestackBranchCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackBranch", reflect.TypeOf((*MockRestackHandler)(nil).RestackBranch), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackBranch", reflect.TypeOf((*MockRestackHandler)(nil).RestackBranch), arg0, arg1, arg2)
 	return &MockRestackHandlerRestackBranchCall{Call: call}
 }
 
@@ -233,13 +234,13 @@ func (c *MockRestackHandlerRestackBranchCall) Return(arg0 error) *MockRestackHan
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRestackHandlerRestackBranchCall) Do(f func(context.Context, string) error) *MockRestackHandlerRestackBranchCall {
+func (c *MockRestackHandlerRestackBranchCall) Do(f func(context.Context, string, *restack.BranchOptions) error) *MockRestackHandlerRestackBranchCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRestackHandlerRestackBranchCall) DoAndReturn(f func(context.Context, string) error) *MockRestackHandlerRestackBranchCall {
+func (c *MockRestackHandlerRestackBranchCall) DoAndReturn(f func(context.Context, string, *restack.BranchOptions) error) *MockRestackHandlerRestackBranchCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/handler/merge/mocks_test.go
+++ b/internal/handler/merge/mocks_test.go
@@ -208,17 +208,17 @@ func (m *MockRestackHandler) EXPECT() *MockRestackHandlerMockRecorder {
 }
 
 // RestackBranch mocks base method.
-func (m *MockRestackHandler) RestackBranch(arg0 context.Context, arg1 string, arg2 *restack.BranchOptions) error {
+func (m *MockRestackHandler) RestackBranch(ctx context.Context, req *restack.BranchRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestackBranch", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "RestackBranch", ctx, req)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RestackBranch indicates an expected call of RestackBranch.
-func (mr *MockRestackHandlerMockRecorder) RestackBranch(arg0, arg1, arg2 any) *MockRestackHandlerRestackBranchCall {
+func (mr *MockRestackHandlerMockRecorder) RestackBranch(ctx, req any) *MockRestackHandlerRestackBranchCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackBranch", reflect.TypeOf((*MockRestackHandler)(nil).RestackBranch), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackBranch", reflect.TypeOf((*MockRestackHandler)(nil).RestackBranch), ctx, req)
 	return &MockRestackHandlerRestackBranchCall{Call: call}
 }
 
@@ -234,13 +234,13 @@ func (c *MockRestackHandlerRestackBranchCall) Return(arg0 error) *MockRestackHan
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRestackHandlerRestackBranchCall) Do(f func(context.Context, string, *restack.BranchOptions) error) *MockRestackHandlerRestackBranchCall {
+func (c *MockRestackHandlerRestackBranchCall) Do(f func(context.Context, *restack.BranchRequest) error) *MockRestackHandlerRestackBranchCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRestackHandlerRestackBranchCall) DoAndReturn(f func(context.Context, string, *restack.BranchOptions) error) *MockRestackHandlerRestackBranchCall {
+func (c *MockRestackHandlerRestackBranchCall) DoAndReturn(f func(context.Context, *restack.BranchRequest) error) *MockRestackHandlerRestackBranchCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/handler/onto/handler.go
+++ b/internal/handler/onto/handler.go
@@ -15,7 +15,7 @@ import (
 
 // RestackHandler restacks branches after their downstack base changes.
 type RestackHandler interface {
-	RestackUpstack(ctx context.Context, branch string, opts *restack.UpstackOptions) error
+	RestackUpstack(ctx context.Context, req *restack.UpstackRequest) error
 }
 
 // Handler coordinates higher-level onto operations.
@@ -95,8 +95,11 @@ func (h *Handler) BranchOnto(ctx context.Context, req *BranchRequest) error {
 			continue
 		}
 
-		if err := h.Restack.RestackUpstack(ctx, above, &restack.UpstackOptions{
-			SkipStart: true,
+		if err := h.Restack.RestackUpstack(ctx, &restack.UpstackRequest{
+			Branch: above,
+			Options: &restack.UpstackOptions{
+				SkipStart: true,
+			},
 		}); err != nil {
 			return h.Service.RebaseRescue(ctx, spice.RebaseRescueRequest{
 				Err:     err,
@@ -151,7 +154,10 @@ func (h *Handler) UpstackOnto(ctx context.Context, req *UpstackRequest) error {
 	}
 	h.Log.Infof("%v: moved upstack onto %v", req.Branch, req.Onto)
 
-	return h.Restack.RestackUpstack(ctx, req.Branch, &restack.UpstackOptions{
-		SkipStart: true,
+	return h.Restack.RestackUpstack(ctx, &restack.UpstackRequest{
+		Branch: req.Branch,
+		Options: &restack.UpstackOptions{
+			SkipStart: true,
+		},
 	})
 }

--- a/internal/handler/restack/branch.go
+++ b/internal/handler/restack/branch.go
@@ -1,12 +1,23 @@
 package restack
 
-import "context"
+import (
+	"cmp"
+	"context"
+)
+
+// BranchOptions holds options for restacking a branch.
+type BranchOptions struct {
+	// SkipConflicts indicates that conflicting branches should be skipped.
+	SkipConflicts bool `help:"Skip branches that cannot be rebased due to conflicts"`
+}
 
 // RestackBranch restacks the given branch onto its base.
-func (h *Handler) RestackBranch(ctx context.Context, branch string) error {
+func (h *Handler) RestackBranch(ctx context.Context, branch string, opts *BranchOptions) error {
+	opts = cmp.Or(opts, &BranchOptions{})
 	_, err := h.Restack(ctx, &Request{
 		Branch:          branch,
 		ContinueCommand: []string{"branch", "restack"},
+		SkipConflicts:   opts.SkipConflicts,
 	})
 	return err
 }

--- a/internal/handler/restack/branch.go
+++ b/internal/handler/restack/branch.go
@@ -5,17 +5,19 @@ import (
 	"context"
 )
 
-// BranchOptions holds options for restacking a branch.
-type BranchOptions struct {
-	// SkipConflicts indicates that conflicting branches should be skipped.
-	SkipConflicts bool `help:"Skip branches that cannot be rebased due to conflicts"`
+// BranchRequest is a request to restack one branch onto its base.
+type BranchRequest struct {
+	// Branch is the branch to restack.
+	Branch string // required
+
+	Options *Options // optional
 }
 
 // RestackBranch restacks the given branch onto its base.
-func (h *Handler) RestackBranch(ctx context.Context, branch string, opts *BranchOptions) error {
-	opts = cmp.Or(opts, &BranchOptions{})
+func (h *Handler) RestackBranch(ctx context.Context, req *BranchRequest) error {
+	opts := cmp.Or(req.Options, &Options{})
 	_, err := h.Restack(ctx, &Request{
-		Branch:          branch,
+		Branch:          req.Branch,
 		ContinueCommand: []string{"branch", "restack"},
 		SkipConflicts:   opts.SkipConflicts,
 	})

--- a/internal/handler/restack/branch_test.go
+++ b/internal/handler/restack/branch_test.go
@@ -2,7 +2,6 @@ package restack
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"testing"
 
@@ -48,7 +47,7 @@ func TestHandler_RestackBranch(t *testing.T) {
 			Store:    statetest.NewMemoryStore(t, "main", "", log),
 			Service:  mockService,
 		}
-		require.NoError(t, handler.RestackBranch(context.Background(), "feature"))
+		require.NoError(t, handler.RestackBranch(t.Context(), "feature", nil))
 		assert.Contains(t, logBuffer.String(), "feature: restacked on main")
 	})
 
@@ -83,7 +82,7 @@ func TestHandler_RestackBranch(t *testing.T) {
 			Service:  mockService,
 		}
 
-		require.NoError(t, handler.RestackBranch(context.Background(), "feature"))
+		require.NoError(t, handler.RestackBranch(t.Context(), "feature", nil))
 	})
 
 	t.Run("UntrackedBranch", func(t *testing.T) {
@@ -114,7 +113,7 @@ func TestHandler_RestackBranch(t *testing.T) {
 			Service:  mockService,
 		}
 
-		err := handler.RestackBranch(context.Background(), "untracked")
+		err := handler.RestackBranch(t.Context(), "untracked", nil)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "untracked branch")
 		assert.Contains(t, logBuffer.String(), "untracked: branch not tracked: run '"+cli.Name()+" branch track")
@@ -147,7 +146,7 @@ func TestHandler_RestackBranch(t *testing.T) {
 			Store:    statetest.NewMemoryStore(t, "main", "", log),
 			Service:  mockService,
 		}
-		require.NoError(t, handler.RestackBranch(context.Background(), "already-restacked"))
+		require.NoError(t, handler.RestackBranch(t.Context(), "already-restacked", nil))
 		assert.Contains(t, logBuffer.String(), "already-restacked: branch does not need to be restacked.")
 	})
 
@@ -178,7 +177,7 @@ func TestHandler_RestackBranch(t *testing.T) {
 			Store:    statetest.NewMemoryStore(t, "main", "", log),
 			Service:  mockService,
 		}
-		err := handler.RestackBranch(context.Background(), "feature")
+		err := handler.RestackBranch(t.Context(), "feature", nil)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "restack branch")
 		assert.ErrorIs(t, err, unexpectedErr)

--- a/internal/handler/restack/branch_test.go
+++ b/internal/handler/restack/branch_test.go
@@ -47,7 +47,9 @@ func TestHandler_RestackBranch(t *testing.T) {
 			Store:    statetest.NewMemoryStore(t, "main", "", log),
 			Service:  mockService,
 		}
-		require.NoError(t, handler.RestackBranch(t.Context(), "feature", nil))
+		require.NoError(t, handler.RestackBranch(t.Context(), &BranchRequest{
+			Branch: "feature",
+		}))
 		assert.Contains(t, logBuffer.String(), "feature: restacked on main")
 	})
 
@@ -82,7 +84,53 @@ func TestHandler_RestackBranch(t *testing.T) {
 			Service:  mockService,
 		}
 
-		require.NoError(t, handler.RestackBranch(t.Context(), "feature", nil))
+		require.NoError(t, handler.RestackBranch(t.Context(), &BranchRequest{
+			Branch: "feature",
+		}))
+	})
+
+	t.Run("SkipConflicts", func(t *testing.T) {
+		var logBuffer bytes.Buffer
+		log := silog.New(&logBuffer, nil)
+		ctrl := gomock.NewController(t)
+
+		mockService := NewMockService(ctrl)
+		mockService.EXPECT().
+			BranchGraph(gomock.Any(), gomock.Any()).
+			Return(newBranchGraphBuilder("main").
+				Branch("feature", "main").
+				Build(t), nil)
+		mockService.EXPECT().
+			Restack(gomock.Any(), "feature").
+			Return(nil, &git.RebaseInterruptError{
+				Kind: git.RebaseInterruptConflict,
+			})
+
+		mockWorktree := NewMockGitWorktree(ctrl)
+		mockWorktree.EXPECT().
+			RootDir().
+			Return(t.TempDir())
+		mockWorktree.EXPECT().
+			RebaseAbort(gomock.Any()).
+			Return(nil)
+		mockWorktree.EXPECT().
+			CheckoutBranch(gomock.Any(), "feature").
+			Return(nil)
+
+		handler := &Handler{
+			Log:      log,
+			Worktree: mockWorktree,
+			Store:    statetest.NewMemoryStore(t, "main", "", log),
+			Service:  mockService,
+		}
+
+		require.NoError(t, handler.RestackBranch(t.Context(), &BranchRequest{
+			Branch: "feature",
+			Options: &Options{
+				SkipConflicts: true,
+			},
+		}))
+		assert.Contains(t, logBuffer.String(), "feature: conflict, skipping")
 	})
 
 	t.Run("UntrackedBranch", func(t *testing.T) {
@@ -113,7 +161,9 @@ func TestHandler_RestackBranch(t *testing.T) {
 			Service:  mockService,
 		}
 
-		err := handler.RestackBranch(t.Context(), "untracked", nil)
+		err := handler.RestackBranch(t.Context(), &BranchRequest{
+			Branch: "untracked",
+		})
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "untracked branch")
 		assert.Contains(t, logBuffer.String(), "untracked: branch not tracked: run '"+cli.Name()+" branch track")
@@ -146,7 +196,9 @@ func TestHandler_RestackBranch(t *testing.T) {
 			Store:    statetest.NewMemoryStore(t, "main", "", log),
 			Service:  mockService,
 		}
-		require.NoError(t, handler.RestackBranch(t.Context(), "already-restacked", nil))
+		require.NoError(t, handler.RestackBranch(t.Context(), &BranchRequest{
+			Branch: "already-restacked",
+		}))
 		assert.Contains(t, logBuffer.String(), "already-restacked: branch does not need to be restacked.")
 	})
 
@@ -177,7 +229,9 @@ func TestHandler_RestackBranch(t *testing.T) {
 			Store:    statetest.NewMemoryStore(t, "main", "", log),
 			Service:  mockService,
 		}
-		err := handler.RestackBranch(t.Context(), "feature", nil)
+		err := handler.RestackBranch(t.Context(), &BranchRequest{
+			Branch: "feature",
+		})
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "restack branch")
 		assert.ErrorIs(t, err, unexpectedErr)

--- a/internal/handler/restack/downstack.go
+++ b/internal/handler/restack/downstack.go
@@ -1,14 +1,25 @@
 package restack
 
-import "context"
+import (
+	"cmp"
+	"context"
+)
+
+// DownstackOptions holds options for restacking a downstack.
+type DownstackOptions struct {
+	// SkipConflicts indicates that conflicting branches should be skipped.
+	SkipConflicts bool `help:"Skip branches that cannot be rebased due to conflicts"`
+}
 
 // RestackDownstack restacks the downstack of the given branch.
 // This includes the branch itself.
-func (h *Handler) RestackDownstack(ctx context.Context, branch string) error {
+func (h *Handler) RestackDownstack(ctx context.Context, branch string, opts *DownstackOptions) error {
+	opts = cmp.Or(opts, &DownstackOptions{})
 	_, err := h.Restack(ctx, &Request{
 		Branch:          branch,
 		Scope:           ScopeDownstack,
 		ContinueCommand: []string{"downstack", "restack"},
+		SkipConflicts:   opts.SkipConflicts,
 	})
 	return err
 }

--- a/internal/handler/restack/downstack.go
+++ b/internal/handler/restack/downstack.go
@@ -5,18 +5,20 @@ import (
 	"context"
 )
 
-// DownstackOptions holds options for restacking a downstack.
-type DownstackOptions struct {
-	// SkipConflicts indicates that conflicting branches should be skipped.
-	SkipConflicts bool `help:"Skip branches that cannot be rebased due to conflicts"`
+// DownstackRequest is a request to restack a branch and its downstack.
+type DownstackRequest struct {
+	// Branch is the top of the downstack to restack.
+	Branch string // required
+
+	Options *Options // optional
 }
 
 // RestackDownstack restacks the downstack of the given branch.
 // This includes the branch itself.
-func (h *Handler) RestackDownstack(ctx context.Context, branch string, opts *DownstackOptions) error {
-	opts = cmp.Or(opts, &DownstackOptions{})
+func (h *Handler) RestackDownstack(ctx context.Context, req *DownstackRequest) error {
+	opts := cmp.Or(req.Options, &Options{})
 	_, err := h.Restack(ctx, &Request{
-		Branch:          branch,
+		Branch:          req.Branch,
 		Scope:           ScopeDownstack,
 		ContinueCommand: []string{"downstack", "restack"},
 		SkipConflicts:   opts.SkipConflicts,

--- a/internal/handler/restack/downstack_test.go
+++ b/internal/handler/restack/downstack_test.go
@@ -54,7 +54,7 @@ func TestHandler_RestackDownstack(t *testing.T) {
 			Service:  mockService,
 		}
 
-		require.NoError(t, handler.RestackDownstack(t.Context(), "feature3"))
+		require.NoError(t, handler.RestackDownstack(t.Context(), "feature3", nil))
 		assert.Contains(t, logBuffer.String(), "feature1: restacked on main")
 		assert.Contains(t, logBuffer.String(), "feature2: restacked on feature1")
 		assert.Contains(t, logBuffer.String(), "feature3: restacked on feature2")
@@ -99,6 +99,6 @@ func TestHandler_RestackDownstack(t *testing.T) {
 			Service:  mockService,
 		}
 
-		require.NoError(t, handler.RestackDownstack(t.Context(), "feature2"))
+		require.NoError(t, handler.RestackDownstack(t.Context(), "feature2", nil))
 	})
 }

--- a/internal/handler/restack/downstack_test.go
+++ b/internal/handler/restack/downstack_test.go
@@ -54,7 +54,9 @@ func TestHandler_RestackDownstack(t *testing.T) {
 			Service:  mockService,
 		}
 
-		require.NoError(t, handler.RestackDownstack(t.Context(), "feature3", nil))
+		require.NoError(t, handler.RestackDownstack(t.Context(), &DownstackRequest{
+			Branch: "feature3",
+		}))
 		assert.Contains(t, logBuffer.String(), "feature1: restacked on main")
 		assert.Contains(t, logBuffer.String(), "feature2: restacked on feature1")
 		assert.Contains(t, logBuffer.String(), "feature3: restacked on feature2")
@@ -99,6 +101,8 @@ func TestHandler_RestackDownstack(t *testing.T) {
 			Service:  mockService,
 		}
 
-		require.NoError(t, handler.RestackDownstack(t.Context(), "feature2", nil))
+		require.NoError(t, handler.RestackDownstack(t.Context(), &DownstackRequest{
+			Branch: "feature2",
+		}))
 	})
 }

--- a/internal/handler/restack/handler.go
+++ b/internal/handler/restack/handler.go
@@ -23,6 +23,7 @@ import (
 type GitWorktree interface {
 	CurrentBranch(ctx context.Context) (string, error)
 	CheckoutBranch(ctx context.Context, branch string) error
+	RebaseAbort(ctx context.Context) error
 	RootDir() string
 }
 
@@ -88,6 +89,13 @@ type Request struct {
 	// to resume this operation if it is interrupted
 	// due to a conflict.
 	ContinueCommand []string // required
+
+	// SkipConflicts indicates that branches which cannot be rebased
+	// cleanly due to a conflict should be skipped and logged
+	// instead of interrupting the operation for conflict resolution.
+	//
+	// Descendants of a skipped branch are also skipped.
+	SkipConflicts bool
 
 	// Scope specifies which branches are affected by the restack operation.
 	//
@@ -193,13 +201,40 @@ func (h *Handler) Restack(ctx context.Context, req *Request) (int, error) {
 	branchesToRestack = branchesToActuallyRestack
 
 	var restackCount int
+	var skipConflictCount int
 loop:
 	for _, branch := range branchesToRestack {
+		if req.SkipConflicts {
+			if info, ok := branchGraph.Lookup(branch); ok {
+				if _, baseSkipped := skipped[info.Base]; baseSkipped {
+					h.Log.Warnf(
+						"%v: base branch %v was not restacked, skipping",
+						branch,
+						info.Base,
+					)
+					skipped[branch] = struct{}{}
+					continue loop
+				}
+			}
+		}
+
 		res, err := h.Service.Restack(ctx, branch)
 		if err != nil {
 			var rebaseErr *git.RebaseInterruptError
 			switch {
 			case errors.As(err, &rebaseErr):
+				if req.SkipConflicts &&
+					rebaseErr.Kind == git.RebaseInterruptConflict {
+					if err := h.Worktree.RebaseAbort(ctx); err != nil {
+						return 0, fmt.Errorf("abort rebase: %w", err)
+					}
+
+					skipped[branch] = struct{}{}
+					skipConflictCount++
+					h.Log.Warnf("%v: conflict, skipping", branch)
+					continue loop
+				}
+
 				// If the rebase is interrupted by a conflict,
 				// we'll resume by re-running this command.
 				return 0, h.Service.RebaseRescue(ctx, spice.RebaseRescueRequest{
@@ -226,9 +261,18 @@ loop:
 		restackCount++
 	}
 
+	if req.SkipConflicts && skipConflictCount > 0 {
+		h.Log.Warnf("Skipped %d branch(es) due to conflicts", skipConflictCount)
+	}
+
 	if requestBranchWT != "" && requestBranchWT != currentWT {
 		h.Log.Warnf("%v: checked out in another worktree (%v), not checking out here", req.Branch, requestBranchWT)
-	} else if restackCount > 0 {
+	} else if restackCount > 0 || skipConflictCount > 0 {
+		// Restacking checks out each branch as it goes,
+		// and aborting a conflicted rebase leaves us on the branch
+		// that was being restacked.
+		// In both cases, return to the starting branch
+		// so the user is never stranded on an intermediate branch.
 		if err := h.Worktree.CheckoutBranch(ctx, req.Branch); err != nil {
 			return 0, fmt.Errorf("checkout branch %v: %w", req.Branch, err)
 		}

--- a/internal/handler/restack/handler.go
+++ b/internal/handler/restack/handler.go
@@ -76,6 +76,14 @@ const (
 	ScopeStack = ScopeUpstack | ScopeDownstack
 )
 
+// Options are optional parameters shared by the high-level restack
+// entry points ([Handler.RestackBranch], [Handler.RestackStack],
+// [Handler.RestackDownstack]).
+type Options struct {
+	// SkipConflicts indicates that conflicting branches should be skipped.
+	SkipConflicts bool `help:"Skip branches that cannot be rebased due to conflicts"`
+}
+
 // Request is a request to restack one or more branches.
 type Request struct {
 	// Branch is the starting point for the restack operation.

--- a/internal/handler/restack/handler_test.go
+++ b/internal/handler/restack/handler_test.go
@@ -473,6 +473,169 @@ func TestHandler_Restack(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 0, count)
 	})
+
+	t.Run("SkipConflicts", func(t *testing.T) {
+		t.Run("Conflict", func(t *testing.T) {
+			var logBuffer bytes.Buffer
+			log := silog.New(&logBuffer, nil)
+			ctrl := gomock.NewController(t)
+
+			rebaseErr := &git.RebaseInterruptError{
+				Kind: git.RebaseInterruptConflict,
+			}
+
+			mockService := NewMockService(ctrl)
+			mockService.EXPECT().
+				BranchGraph(gomock.Any(), gomock.Any()).
+				Return(newBranchGraphBuilder("main").
+					Branch("feature", "main").
+					Branch("feature2", "feature").
+					Branch("other", "main").
+					Build(t), nil)
+			mockService.EXPECT().
+				Restack(gomock.Any(), "feature").
+				Return(nil, rebaseErr)
+			mockService.EXPECT().
+				Restack(gomock.Any(), "other").
+				Return(&spice.RestackResponse{Base: "main"}, nil)
+
+			mockWorktree := NewMockGitWorktree(ctrl)
+			mockWorktree.EXPECT().
+				RootDir().
+				Return(t.TempDir())
+			mockWorktree.EXPECT().
+				RebaseAbort(gomock.Any()).
+				Return(nil)
+			mockWorktree.EXPECT().
+				CheckoutBranch(gomock.Any(), "main").
+				Return(nil)
+
+			handler := &Handler{
+				Log:      log,
+				Worktree: mockWorktree,
+				Store:    statetest.NewMemoryStore(t, "main", "", log),
+				Service:  mockService,
+			}
+
+			count, err := handler.Restack(t.Context(), &Request{
+				Branch:          "main",
+				ContinueCommand: []string{"false"},
+				Scope:           ScopeUpstackExclusive,
+				SkipConflicts:   true,
+			})
+
+			require.NoError(t, err)
+			assert.GreaterOrEqual(t, count, 1)
+			assert.Contains(t, logBuffer.String(), "feature: conflict, skipping")
+			assert.Contains(
+				t,
+				logBuffer.String(),
+				"feature2: base branch feature was not restacked, skipping",
+			)
+			assert.Contains(t, logBuffer.String(), "other: restacked on main")
+			assert.Contains(t, logBuffer.String(), "Skipped 1 branch(es) due to conflicts")
+		})
+
+		t.Run("AllConflict", func(t *testing.T) {
+			// When every branch conflicts and is skipped,
+			// the starting branch is still checked out
+			// so the user is not stranded on a conflicting branch.
+			var logBuffer bytes.Buffer
+			log := silog.New(&logBuffer, nil)
+			ctrl := gomock.NewController(t)
+
+			rebaseErr := &git.RebaseInterruptError{
+				Kind: git.RebaseInterruptConflict,
+			}
+
+			mockService := NewMockService(ctrl)
+			mockService.EXPECT().
+				BranchGraph(gomock.Any(), gomock.Any()).
+				Return(newBranchGraphBuilder("main").
+					Branch("feature", "main").
+					Build(t), nil)
+			mockService.EXPECT().
+				Restack(gomock.Any(), "feature").
+				Return(nil, rebaseErr)
+
+			mockWorktree := NewMockGitWorktree(ctrl)
+			mockWorktree.EXPECT().
+				RootDir().
+				Return(t.TempDir())
+			mockWorktree.EXPECT().
+				RebaseAbort(gomock.Any()).
+				Return(nil)
+			mockWorktree.EXPECT().
+				CheckoutBranch(gomock.Any(), "main").
+				Return(nil)
+
+			handler := &Handler{
+				Log:      log,
+				Worktree: mockWorktree,
+				Store:    statetest.NewMemoryStore(t, "main", "", log),
+				Service:  mockService,
+			}
+
+			count, err := handler.Restack(t.Context(), &Request{
+				Branch:          "main",
+				ContinueCommand: []string{"false"},
+				Scope:           ScopeUpstackExclusive,
+				SkipConflicts:   true,
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, 0, count)
+			assert.Contains(t, logBuffer.String(), "feature: conflict, skipping")
+			assert.Contains(t, logBuffer.String(), "Skipped 1 branch(es) due to conflicts")
+		})
+
+		t.Run("DeliberateInterrupt", func(t *testing.T) {
+			var logBuffer bytes.Buffer
+			log := silog.New(&logBuffer, nil)
+			ctrl := gomock.NewController(t)
+
+			rebaseErr := &git.RebaseInterruptError{
+				Kind: git.RebaseInterruptDeliberate,
+			}
+
+			mockService := NewMockService(ctrl)
+			mockService.EXPECT().
+				BranchGraph(gomock.Any(), gomock.Any()).
+				Return(newBranchGraphBuilder("main").
+					Branch("feature", "main").
+					Build(t), nil)
+			mockService.EXPECT().
+				Restack(gomock.Any(), "feature").
+				Return(nil, rebaseErr)
+			mockService.EXPECT().
+				RebaseRescue(gomock.Any(), gomock.Any()).
+				Return(nil)
+
+			mockWorktree := NewMockGitWorktree(ctrl)
+			mockWorktree.EXPECT().
+				RootDir().
+				Return(t.TempDir())
+
+			handler := &Handler{
+				Log:      log,
+				Worktree: mockWorktree,
+				Store:    statetest.NewMemoryStore(t, "main", "", log),
+				Service:  mockService,
+			}
+
+			count, err := handler.Restack(t.Context(), &Request{
+				Branch:          "feature",
+				ContinueCommand: []string{"false"},
+				Scope:           ScopeBranch,
+				SkipConflicts:   true,
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, 0, count)
+			assert.NotContains(t, logBuffer.String(), "conflict, skipping")
+			assert.NotContains(t, logBuffer.String(), "Skipped")
+		})
+	})
 }
 
 func TestHandler_Restack_trunk(t *testing.T) {

--- a/internal/handler/restack/mocks_test.go
+++ b/internal/handler/restack/mocks_test.go
@@ -70,6 +70,20 @@ func (mr *MockGitWorktreeMockRecorder) CurrentBranch(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentBranch", reflect.TypeOf((*MockGitWorktree)(nil).CurrentBranch), ctx)
 }
 
+// RebaseAbort mocks base method.
+func (m *MockGitWorktree) RebaseAbort(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RebaseAbort", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RebaseAbort indicates an expected call of RebaseAbort.
+func (mr *MockGitWorktreeMockRecorder) RebaseAbort(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RebaseAbort", reflect.TypeOf((*MockGitWorktree)(nil).RebaseAbort), ctx)
+}
+
 // RootDir mocks base method.
 func (m *MockGitWorktree) RootDir() string {
 	m.ctrl.T.Helper()

--- a/internal/handler/restack/stack.go
+++ b/internal/handler/restack/stack.go
@@ -1,15 +1,26 @@
 package restack
 
-import "context"
+import (
+	"cmp"
+	"context"
+)
+
+// StackOptions holds options for restacking a stack.
+type StackOptions struct {
+	// SkipConflicts indicates that conflicting branches should be skipped.
+	SkipConflicts bool `help:"Skip branches that cannot be rebased due to conflicts"`
+}
 
 // RestackStack restacks the stack of the given branch.
 // This includes all upstack and downtrack branches,
 // as well as the branch itself.
-func (h *Handler) RestackStack(ctx context.Context, branch string) error {
+func (h *Handler) RestackStack(ctx context.Context, branch string, opts *StackOptions) error {
+	opts = cmp.Or(opts, &StackOptions{})
 	_, err := h.Restack(ctx, &Request{
 		Branch:          branch,
 		Scope:           ScopeStack,
 		ContinueCommand: []string{"stack", "restack"},
+		SkipConflicts:   opts.SkipConflicts,
 	})
 	return err
 }

--- a/internal/handler/restack/stack.go
+++ b/internal/handler/restack/stack.go
@@ -5,19 +5,21 @@ import (
 	"context"
 )
 
-// StackOptions holds options for restacking a stack.
-type StackOptions struct {
-	// SkipConflicts indicates that conflicting branches should be skipped.
-	SkipConflicts bool `help:"Skip branches that cannot be rebased due to conflicts"`
+// StackRequest is a request to restack all branches in a stack.
+type StackRequest struct {
+	// Branch selects the stack to restack.
+	Branch string // required
+
+	Options *Options // optional
 }
 
 // RestackStack restacks the stack of the given branch.
 // This includes all upstack and downtrack branches,
 // as well as the branch itself.
-func (h *Handler) RestackStack(ctx context.Context, branch string, opts *StackOptions) error {
-	opts = cmp.Or(opts, &StackOptions{})
+func (h *Handler) RestackStack(ctx context.Context, req *StackRequest) error {
+	opts := cmp.Or(req.Options, &Options{})
 	_, err := h.Restack(ctx, &Request{
-		Branch:          branch,
+		Branch:          req.Branch,
 		Scope:           ScopeStack,
 		ContinueCommand: []string{"stack", "restack"},
 		SkipConflicts:   opts.SkipConflicts,

--- a/internal/handler/restack/upstack.go
+++ b/internal/handler/restack/upstack.go
@@ -9,6 +9,9 @@ import (
 type UpstackOptions struct {
 	// SkipStart indicates that the starting branch should not be restacked.
 	SkipStart bool `help:"Do not restack the starting branch"`
+
+	// SkipConflicts indicates that conflicting branches should be skipped.
+	SkipConflicts bool `help:"Skip branches that cannot be rebased due to conflicts"`
 }
 
 // RestackUpstack restacks the upstack of the given branch,
@@ -19,6 +22,7 @@ func (h *Handler) RestackUpstack(ctx context.Context, branch string, opts *Upsta
 		Branch:          branch,
 		Scope:           ScopeUpstack,
 		ContinueCommand: []string{"upstack", "restack"},
+		SkipConflicts:   opts.SkipConflicts,
 	}
 	if opts.SkipStart {
 		req.Scope = ScopeUpstackExclusive

--- a/internal/handler/restack/upstack.go
+++ b/internal/handler/restack/upstack.go
@@ -7,27 +7,34 @@ import (
 
 // UpstackOptions holds options for restacking the upstack of a branch.
 type UpstackOptions struct {
+	Options
+
 	// SkipStart indicates that the starting branch should not be restacked.
 	SkipStart bool `help:"Do not restack the starting branch"`
+}
 
-	// SkipConflicts indicates that conflicting branches should be skipped.
-	SkipConflicts bool `help:"Skip branches that cannot be rebased due to conflicts"`
+// UpstackRequest is a request to restack a branch and its upstack.
+type UpstackRequest struct {
+	// Branch is the bottom of the upstack to restack.
+	Branch string // required
+
+	Options *UpstackOptions // optional
 }
 
 // RestackUpstack restacks the upstack of the given branch,
 // including the branch itself, unless SkipStart is set.
-func (h *Handler) RestackUpstack(ctx context.Context, branch string, opts *UpstackOptions) error {
-	opts = cmp.Or(opts, &UpstackOptions{})
-	req := &Request{
-		Branch:          branch,
+func (h *Handler) RestackUpstack(ctx context.Context, req *UpstackRequest) error {
+	opts := cmp.Or(req.Options, &UpstackOptions{})
+	restackReq := &Request{
+		Branch:          req.Branch,
 		Scope:           ScopeUpstack,
 		ContinueCommand: []string{"upstack", "restack"},
 		SkipConflicts:   opts.SkipConflicts,
 	}
 	if opts.SkipStart {
-		req.Scope = ScopeUpstackExclusive
-		req.ContinueCommand = []string{"upstack", "restack", "--skip-start"}
+		restackReq.Scope = ScopeUpstackExclusive
+		restackReq.ContinueCommand = []string{"upstack", "restack", "--skip-start"}
 	}
-	_, err := h.Restack(ctx, req)
+	_, err := h.Restack(ctx, restackReq)
 	return err
 }

--- a/internal/handler/squash/handler.go
+++ b/internal/handler/squash/handler.go
@@ -54,7 +54,7 @@ var _ Service = (*spice.Service)(nil)
 
 // RestackHandler provides methods to restack branches.
 type RestackHandler interface {
-	RestackUpstack(ctx context.Context, branch string, opts *restack.UpstackOptions) error
+	RestackUpstack(ctx context.Context, req *restack.UpstackRequest) error
 }
 
 // Handler handles git-spice's squash commands.
@@ -186,7 +186,9 @@ func (h *Handler) SquashBranch(ctx context.Context, branchName string, opts *Opt
 	}
 	reattachedHead = true
 
-	return h.Restack.RestackUpstack(ctx, branchName, nil)
+	return h.Restack.RestackUpstack(ctx, &restack.UpstackRequest{
+		Branch: branchName,
+	})
 }
 
 func commitMessageTemplate(

--- a/internal/handler/squash/handler_test.go
+++ b/internal/handler/squash/handler_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/spice"
 	"go.uber.org/mock/gomock"
@@ -165,7 +166,9 @@ func TestHandler_SquashBranch(t *testing.T) {
 
 		mockRestack := NewMockRestackHandler(ctrl)
 		mockRestack.EXPECT().
-			RestackUpstack(t.Context(), branchName, nil).
+			RestackUpstack(t.Context(), &restack.UpstackRequest{
+				Branch: branchName,
+			}).
 			Return(nil)
 
 		handler := &Handler{
@@ -225,7 +228,9 @@ func TestHandler_SquashBranch(t *testing.T) {
 
 		mockRestack := NewMockRestackHandler(ctrl)
 		mockRestack.EXPECT().
-			RestackUpstack(t.Context(), branchName, nil).
+			RestackUpstack(t.Context(), &restack.UpstackRequest{
+				Branch: branchName,
+			}).
 			Return(nil)
 
 		handler := &Handler{
@@ -286,7 +291,9 @@ func TestHandler_SquashBranch(t *testing.T) {
 
 		mockRestack := NewMockRestackHandler(ctrl)
 		mockRestack.EXPECT().
-			RestackUpstack(t.Context(), branchName, nil).
+			RestackUpstack(t.Context(), &restack.UpstackRequest{
+				Branch: branchName,
+			}).
 			Return(nil)
 
 		handler := &Handler{
@@ -357,7 +364,9 @@ func TestHandler_SquashBranch(t *testing.T) {
 
 		mockRestack := NewMockRestackHandler(ctrl)
 		mockRestack.EXPECT().
-			RestackUpstack(t.Context(), branchName, nil).
+			RestackUpstack(t.Context(), &restack.UpstackRequest{
+				Branch: branchName,
+			}).
 			Return(nil)
 
 		handler := &Handler{

--- a/internal/handler/squash/mocks_test.go
+++ b/internal/handler/squash/mocks_test.go
@@ -283,15 +283,15 @@ func (m *MockRestackHandler) EXPECT() *MockRestackHandlerMockRecorder {
 }
 
 // RestackUpstack mocks base method.
-func (m *MockRestackHandler) RestackUpstack(ctx context.Context, branch string, opts *restack.UpstackOptions) error {
+func (m *MockRestackHandler) RestackUpstack(ctx context.Context, req *restack.UpstackRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestackUpstack", ctx, branch, opts)
+	ret := m.ctrl.Call(m, "RestackUpstack", ctx, req)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RestackUpstack indicates an expected call of RestackUpstack.
-func (mr *MockRestackHandlerMockRecorder) RestackUpstack(ctx, branch, opts any) *gomock.Call {
+func (mr *MockRestackHandlerMockRecorder) RestackUpstack(ctx, req any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackUpstack", reflect.TypeOf((*MockRestackHandler)(nil).RestackUpstack), ctx, branch, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackUpstack", reflect.TypeOf((*MockRestackHandler)(nil).RestackUpstack), ctx, req)
 }

--- a/internal/handler/sync/handler.go
+++ b/internal/handler/sync/handler.go
@@ -78,7 +78,7 @@ type DeleteHandler interface {
 // RestackHandler allows restacking branches after sync
 // has removed their downstack branches.
 type RestackHandler interface {
-	RestackBranch(ctx context.Context, branch string) error
+	RestackBranch(ctx context.Context, branch string, opts *restack.BranchOptions) error
 	RestackUpstack(ctx context.Context, branch string, opts *restack.UpstackOptions) error
 }
 
@@ -980,7 +980,7 @@ func (h *Handler) restackDeletedBranchUpstack(
 			return fmt.Errorf("restack upstack %q: %w", target, err)
 		}
 	case mode.Includes(spice.RestackAboves):
-		if err := h.Restack.RestackBranch(ctx, target); err != nil {
+		if err := h.Restack.RestackBranch(ctx, target, nil); err != nil {
 			return fmt.Errorf("restack branch %q: %w", target, err)
 		}
 	case mode.Includes(spice.RestackNone):

--- a/internal/handler/sync/handler.go
+++ b/internal/handler/sync/handler.go
@@ -78,8 +78,8 @@ type DeleteHandler interface {
 // RestackHandler allows restacking branches after sync
 // has removed their downstack branches.
 type RestackHandler interface {
-	RestackBranch(ctx context.Context, branch string, opts *restack.BranchOptions) error
-	RestackUpstack(ctx context.Context, branch string, opts *restack.UpstackOptions) error
+	RestackBranch(ctx context.Context, req *restack.BranchRequest) error
+	RestackUpstack(ctx context.Context, req *restack.UpstackRequest) error
 }
 
 // AutostashHandler is a subset of the autostash.Handler interface.
@@ -976,11 +976,15 @@ func (h *Handler) restackDeletedBranchUpstack(
 ) error {
 	switch {
 	case mode.Includes(spice.RestackUpstack):
-		if err := h.Restack.RestackUpstack(ctx, target, nil); err != nil {
+		if err := h.Restack.RestackUpstack(ctx, &restack.UpstackRequest{
+			Branch: target,
+		}); err != nil {
 			return fmt.Errorf("restack upstack %q: %w", target, err)
 		}
 	case mode.Includes(spice.RestackAboves):
-		if err := h.Restack.RestackBranch(ctx, target, nil); err != nil {
+		if err := h.Restack.RestackBranch(ctx, &restack.BranchRequest{
+			Branch: target,
+		}); err != nil {
 			return fmt.Errorf("restack branch %q: %w", target, err)
 		}
 	case mode.Includes(spice.RestackNone):

--- a/internal/handler/sync/handler_test.go
+++ b/internal/handler/sync/handler_test.go
@@ -368,7 +368,7 @@ func TestHandler_SyncTrunk_restackDeletedUpstacks(t *testing.T) {
 
 		mockRestack := NewMockRestackHandler(ctrl)
 		mockRestack.EXPECT().
-			RestackBranch(gomock.Any(), "child").
+			RestackBranch(gomock.Any(), "child", nil).
 			Return(nil)
 
 		mockAutostash := NewMockAutostashHandler(ctrl)

--- a/internal/handler/sync/handler_test.go
+++ b/internal/handler/sync/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/handler/autostash"
 	branchdel "go.abhg.dev/gs/internal/handler/delete"
+	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/silog/silogtest"
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/spicetest"
@@ -286,7 +287,9 @@ func TestHandler_SyncTrunk_autostashLazy(t *testing.T) {
 
 		mockRestack := NewMockRestackHandler(ctrl)
 		mockRestack.EXPECT().
-			RestackUpstack(gomock.Any(), "child", nil).
+			RestackUpstack(gomock.Any(), &restack.UpstackRequest{
+				Branch: "child",
+			}).
 			Return(nil)
 
 		handler := &Handler{
@@ -368,7 +371,9 @@ func TestHandler_SyncTrunk_restackDeletedUpstacks(t *testing.T) {
 
 		mockRestack := NewMockRestackHandler(ctrl)
 		mockRestack.EXPECT().
-			RestackBranch(gomock.Any(), "child", nil).
+			RestackBranch(gomock.Any(), &restack.BranchRequest{
+				Branch: "child",
+			}).
 			Return(nil)
 
 		mockAutostash := NewMockAutostashHandler(ctrl)
@@ -457,7 +462,9 @@ func TestHandler_SyncTrunk_restackDeletedUpstacks(t *testing.T) {
 
 		mockRestack := NewMockRestackHandler(ctrl)
 		mockRestack.EXPECT().
-			RestackUpstack(gomock.Any(), "child", nil).
+			RestackUpstack(gomock.Any(), &restack.UpstackRequest{
+				Branch: "child",
+			}).
 			Return(nil)
 
 		mockAutostash := NewMockAutostashHandler(ctrl)
@@ -551,7 +558,9 @@ func TestHandler_SyncTrunk_restackDeletedUpstacks(t *testing.T) {
 
 		mockRestack := NewMockRestackHandler(ctrl)
 		mockRestack.EXPECT().
-			RestackUpstack(gomock.Any(), "c", nil).
+			RestackUpstack(gomock.Any(), &restack.UpstackRequest{
+				Branch: "c",
+			}).
 			Return(nil)
 
 		mockAutostash := NewMockAutostashHandler(ctrl)

--- a/internal/handler/sync/mocks_test.go
+++ b/internal/handler/sync/mocks_test.go
@@ -782,17 +782,17 @@ func (m *MockRestackHandler) EXPECT() *MockRestackHandlerMockRecorder {
 }
 
 // RestackBranch mocks base method.
-func (m *MockRestackHandler) RestackBranch(ctx context.Context, branch string) error {
+func (m *MockRestackHandler) RestackBranch(ctx context.Context, branch string, opts *restack.BranchOptions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestackBranch", ctx, branch)
+	ret := m.ctrl.Call(m, "RestackBranch", ctx, branch, opts)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RestackBranch indicates an expected call of RestackBranch.
-func (mr *MockRestackHandlerMockRecorder) RestackBranch(ctx, branch any) *MockRestackHandlerRestackBranchCall {
+func (mr *MockRestackHandlerMockRecorder) RestackBranch(ctx, branch, opts any) *MockRestackHandlerRestackBranchCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackBranch", reflect.TypeOf((*MockRestackHandler)(nil).RestackBranch), ctx, branch)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackBranch", reflect.TypeOf((*MockRestackHandler)(nil).RestackBranch), ctx, branch, opts)
 	return &MockRestackHandlerRestackBranchCall{Call: call}
 }
 
@@ -808,13 +808,13 @@ func (c *MockRestackHandlerRestackBranchCall) Return(arg0 error) *MockRestackHan
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRestackHandlerRestackBranchCall) Do(f func(context.Context, string) error) *MockRestackHandlerRestackBranchCall {
+func (c *MockRestackHandlerRestackBranchCall) Do(f func(context.Context, string, *restack.BranchOptions) error) *MockRestackHandlerRestackBranchCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRestackHandlerRestackBranchCall) DoAndReturn(f func(context.Context, string) error) *MockRestackHandlerRestackBranchCall {
+func (c *MockRestackHandlerRestackBranchCall) DoAndReturn(f func(context.Context, string, *restack.BranchOptions) error) *MockRestackHandlerRestackBranchCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/handler/sync/mocks_test.go
+++ b/internal/handler/sync/mocks_test.go
@@ -782,17 +782,17 @@ func (m *MockRestackHandler) EXPECT() *MockRestackHandlerMockRecorder {
 }
 
 // RestackBranch mocks base method.
-func (m *MockRestackHandler) RestackBranch(ctx context.Context, branch string, opts *restack.BranchOptions) error {
+func (m *MockRestackHandler) RestackBranch(ctx context.Context, req *restack.BranchRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestackBranch", ctx, branch, opts)
+	ret := m.ctrl.Call(m, "RestackBranch", ctx, req)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RestackBranch indicates an expected call of RestackBranch.
-func (mr *MockRestackHandlerMockRecorder) RestackBranch(ctx, branch, opts any) *MockRestackHandlerRestackBranchCall {
+func (mr *MockRestackHandlerMockRecorder) RestackBranch(ctx, req any) *MockRestackHandlerRestackBranchCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackBranch", reflect.TypeOf((*MockRestackHandler)(nil).RestackBranch), ctx, branch, opts)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackBranch", reflect.TypeOf((*MockRestackHandler)(nil).RestackBranch), ctx, req)
 	return &MockRestackHandlerRestackBranchCall{Call: call}
 }
 
@@ -808,29 +808,29 @@ func (c *MockRestackHandlerRestackBranchCall) Return(arg0 error) *MockRestackHan
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRestackHandlerRestackBranchCall) Do(f func(context.Context, string, *restack.BranchOptions) error) *MockRestackHandlerRestackBranchCall {
+func (c *MockRestackHandlerRestackBranchCall) Do(f func(context.Context, *restack.BranchRequest) error) *MockRestackHandlerRestackBranchCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRestackHandlerRestackBranchCall) DoAndReturn(f func(context.Context, string, *restack.BranchOptions) error) *MockRestackHandlerRestackBranchCall {
+func (c *MockRestackHandlerRestackBranchCall) DoAndReturn(f func(context.Context, *restack.BranchRequest) error) *MockRestackHandlerRestackBranchCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // RestackUpstack mocks base method.
-func (m *MockRestackHandler) RestackUpstack(ctx context.Context, branch string, opts *restack.UpstackOptions) error {
+func (m *MockRestackHandler) RestackUpstack(ctx context.Context, req *restack.UpstackRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestackUpstack", ctx, branch, opts)
+	ret := m.ctrl.Call(m, "RestackUpstack", ctx, req)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RestackUpstack indicates an expected call of RestackUpstack.
-func (mr *MockRestackHandlerMockRecorder) RestackUpstack(ctx, branch, opts any) *MockRestackHandlerRestackUpstackCall {
+func (mr *MockRestackHandlerMockRecorder) RestackUpstack(ctx, req any) *MockRestackHandlerRestackUpstackCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackUpstack", reflect.TypeOf((*MockRestackHandler)(nil).RestackUpstack), ctx, branch, opts)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackUpstack", reflect.TypeOf((*MockRestackHandler)(nil).RestackUpstack), ctx, req)
 	return &MockRestackHandlerRestackUpstackCall{Call: call}
 }
 
@@ -846,13 +846,13 @@ func (c *MockRestackHandlerRestackUpstackCall) Return(arg0 error) *MockRestackHa
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRestackHandlerRestackUpstackCall) Do(f func(context.Context, string, *restack.UpstackOptions) error) *MockRestackHandlerRestackUpstackCall {
+func (c *MockRestackHandlerRestackUpstackCall) Do(f func(context.Context, *restack.UpstackRequest) error) *MockRestackHandlerRestackUpstackCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRestackHandlerRestackUpstackCall) DoAndReturn(f func(context.Context, string, *restack.UpstackOptions) error) *MockRestackHandlerRestackUpstackCall {
+func (c *MockRestackHandlerRestackUpstackCall) DoAndReturn(f func(context.Context, *restack.UpstackRequest) error) *MockRestackHandlerRestackUpstackCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/repo_restack.go
+++ b/repo_restack.go
@@ -12,16 +12,20 @@ import (
 	"go.abhg.dev/gs/internal/text"
 )
 
-type repoRestackCmd struct{}
+type repoRestackCmd struct {
+	SkipConflicts bool `help:"Skip branches that cannot be rebased due to conflicts"`
+}
 
 func (*repoRestackCmd) Help() string {
 	return text.Dedent(`
 		All tracked branches in the repository are rebased on top of their
 		respective bases in dependency order, ensuring a linear history.
+
+		Use --skip-conflicts to skip branches that cannot be rebased cleanly.
 	`)
 }
 
-func (*repoRestackCmd) Run(
+func (cmd *repoRestackCmd) Run(
 	ctx context.Context,
 	log *silog.Logger,
 	wt *git.Worktree,
@@ -48,6 +52,7 @@ func (*repoRestackCmd) Run(
 		Branch:          store.Trunk(),
 		Scope:           restack.ScopeUpstackExclusive,
 		ContinueCommand: []string{"repo", "restack"},
+		SkipConflicts:   cmd.SkipConflicts,
 	})
 	if err != nil {
 		return err

--- a/repo_restack.go
+++ b/repo_restack.go
@@ -58,13 +58,13 @@ func (cmd *repoRestackCmd) Run(
 		return err
 	}
 
+	if err := wt.CheckoutBranch(ctx, currentBranch); err != nil {
+		return fmt.Errorf("checkout %v: %w", currentBranch, err)
+	}
+
 	if count == 0 {
 		log.Infof("Nothing to restack: no tracked branches available")
 		return nil
-	}
-
-	if err := wt.CheckoutBranch(ctx, currentBranch); err != nil {
-		return fmt.Errorf("checkout %v: %w", currentBranch, err)
 	}
 
 	log.Infof("Restacked %d branches", count)

--- a/stack_restack.go
+++ b/stack_restack.go
@@ -7,6 +7,7 @@ import (
 
 	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
@@ -15,6 +16,8 @@ import (
 
 type stackRestackCmd struct {
 	Branch string `help:"Branch to restack the stack of" placeholder:"NAME" predictor:"trackedBranches"`
+
+	SkipConflicts bool `help:"Skip branches that cannot be rebased due to conflicts"`
 }
 
 func (*stackRestackCmd) Help() string {
@@ -23,6 +26,8 @@ func (*stackRestackCmd) Help() string {
 		respective bases, ensuring a linear history.
 
 		Use --branch to rebase the stack of a different branch.
+
+		Use --skip-conflicts to skip branches that cannot be rebased cleanly.
 	`)
 }
 
@@ -88,5 +93,7 @@ func (cmd *stackRestackCmd) Run(
 		return err
 	}
 
-	return handler.RestackStack(ctx, cmd.Branch)
+	return handler.RestackStack(ctx, cmd.Branch, &restack.StackOptions{
+		SkipConflicts: cmd.SkipConflicts,
+	})
 }

--- a/stack_restack.go
+++ b/stack_restack.go
@@ -93,7 +93,10 @@ func (cmd *stackRestackCmd) Run(
 		return err
 	}
 
-	return handler.RestackStack(ctx, cmd.Branch, &restack.StackOptions{
-		SkipConflicts: cmd.SkipConflicts,
+	return handler.RestackStack(ctx, &restack.StackRequest{
+		Branch: cmd.Branch,
+		Options: &restack.Options{
+			SkipConflicts: cmd.SkipConflicts,
+		},
 	})
 }

--- a/testdata/help/branch_restack.txt
+++ b/testdata/help/branch_restack.txt
@@ -6,7 +6,8 @@ The current branch will be rebased onto its base, ensuring a linear history.
 Use --branch to target a different branch.
 
 Flags:
-  --branch=NAME    Branch to restack
+  --branch=NAME       Branch to restack
+  --skip-conflicts    Skip branches that cannot be rebased due to conflicts
 
 Global Flags:
   -h, --help           Show help for the command

--- a/testdata/help/downstack_restack.txt
+++ b/testdata/help/downstack_restack.txt
@@ -8,7 +8,8 @@ their respective bases, ensuring a linear history.
 Use --branch to start at a different branch.
 
 Flags:
-  --branch=NAME    Branch to restack the downstack of
+  --branch=NAME       Branch to restack the downstack of
+  --skip-conflicts    Skip branches that cannot be rebased due to conflicts
 
 Global Flags:
   -h, --help           Show help for the command

--- a/testdata/help/repo_restack.txt
+++ b/testdata/help/repo_restack.txt
@@ -1,9 +1,14 @@
-Usage: gs repo (r) restack (r)
+Usage: gs repo (r) restack (r) [flags]
 
 Restack all tracked branches
 
 All tracked branches in the repository are rebased on top of their respective
 bases in dependency order, ensuring a linear history.
+
+Use --skip-conflicts to skip branches that cannot be rebased cleanly.
+
+Flags:
+  --skip-conflicts    Skip branches that cannot be rebased due to conflicts
 
 Global Flags:
   -h, --help           Show help for the command

--- a/testdata/help/stack_restack.txt
+++ b/testdata/help/stack_restack.txt
@@ -7,8 +7,11 @@ ensuring a linear history.
 
 Use --branch to rebase the stack of a different branch.
 
+Use --skip-conflicts to skip branches that cannot be rebased cleanly.
+
 Flags:
-  --branch=NAME    Branch to restack the stack of
+  --branch=NAME       Branch to restack the stack of
+  --skip-conflicts    Skip branches that cannot be rebased due to conflicts
 
 Global Flags:
   -h, --help           Show help for the command

--- a/testdata/help/upstack_restack.txt
+++ b/testdata/help/upstack_restack.txt
@@ -11,8 +11,9 @@ Use --skip-start to skip the starting branch, but still rebase all branches
 above it.
 
 Flags:
-  --skip-start     Do not restack the starting branch
-  --branch=NAME    Branch to restack the upstack of
+  --skip-start        Do not restack the starting branch
+  --skip-conflicts    Skip branches that cannot be rebased due to conflicts
+  --branch=NAME       Branch to restack the upstack of
 
 Global Flags:
   -h, --help           Show help for the command

--- a/testdata/script/restack_skip_conflicts.txt
+++ b/testdata/script/restack_skip_conflicts.txt
@@ -1,0 +1,61 @@
+# 'repo restack --skip-conflicts' skips conflicting branches
+# and continues restacking clean branches.
+
+as 'Test <test@example.com>'
+at '2026-06-09T12:00:00Z'
+
+mkdir repo
+cd repo
+git init
+git add init.txt
+git commit -m 'Initial commit'
+gs repo init
+
+# feature will conflict with the later trunk change.
+cp $WORK/extra/init.feature.txt init.txt
+git add init.txt
+gs branch create feature -m 'Feature changes init'
+
+# feature2 is upstack from feature and should be skipped.
+git add feature2.txt
+gs branch create feature2 -m 'Add feature2'
+
+# other is independent from feature and should restack cleanly.
+gs trunk
+git add other.txt
+gs branch create other -m 'Add other'
+
+# Advance trunk with a conflicting change.
+gs trunk
+cp $WORK/extra/init.main.txt init.txt
+git add init.txt
+git commit -m 'Main changes init'
+
+gs repo restack --skip-conflicts
+stderr 'feature: conflict, skipping'
+stderr 'feature2: base branch feature was not restacked, skipping'
+stderr 'other: restacked on main'
+stderr 'Skipped 1 branch\(es\) due to conflicts'
+stderr 'Restacked 1 branches'
+
+# The clean branch restacked, while the conflicting stack did not.
+git merge-base --is-ancestor main other
+! git merge-base --is-ancestor main feature
+git merge-base --is-ancestor feature feature2
+
+git branch --show-current
+stdout '^main$'
+
+git status --porcelain
+! stdout '.'
+
+-- repo/init.txt --
+initial init
+-- repo/feature2.txt --
+feature2
+-- repo/other.txt --
+other
+-- extra/init.feature.txt --
+feature init
+-- extra/init.main.txt --
+main init

--- a/testdata/script/restack_skip_conflicts.txt
+++ b/testdata/script/restack_skip_conflicts.txt
@@ -31,6 +31,10 @@ cp $WORK/extra/init.main.txt init.txt
 git add init.txt
 git commit -m 'Main changes init'
 
+# Start from a branch that will be skipped.
+# The command must restore it after processing the repository.
+git checkout feature2
+
 gs repo restack --skip-conflicts
 stderr 'feature: conflict, skipping'
 stderr 'feature2: base branch feature was not restacked, skipping'
@@ -44,7 +48,7 @@ git merge-base --is-ancestor main other
 git merge-base --is-ancestor feature feature2
 
 git branch --show-current
-stdout '^main$'
+stdout '^feature2$'
 
 git status --porcelain
 ! stdout '.'

--- a/upstack_restack.go
+++ b/upstack_restack.go
@@ -34,10 +34,10 @@ func (*upstackRestackCmd) Help() string {
 // RestackHandler implements high level restack operations.
 type RestackHandler interface {
 	RestackUpstack(ctx context.Context, branch string, opts *restack.UpstackOptions) error
-	RestackDownstack(ctx context.Context, branch string) error
+	RestackDownstack(ctx context.Context, branch string, opts *restack.DownstackOptions) error
 	Restack(context.Context, *restack.Request) (int, error)
-	RestackStack(ctx context.Context, branch string) error
-	RestackBranch(ctx context.Context, branch string) error
+	RestackStack(ctx context.Context, branch string, opts *restack.StackOptions) error
+	RestackBranch(ctx context.Context, branch string, opts *restack.BranchOptions) error
 }
 
 func (cmd *upstackRestackCmd) AfterApply(ctx context.Context, wt *git.Worktree) error {

--- a/upstack_restack.go
+++ b/upstack_restack.go
@@ -33,11 +33,11 @@ func (*upstackRestackCmd) Help() string {
 
 // RestackHandler implements high level restack operations.
 type RestackHandler interface {
-	RestackUpstack(ctx context.Context, branch string, opts *restack.UpstackOptions) error
-	RestackDownstack(ctx context.Context, branch string, opts *restack.DownstackOptions) error
+	RestackUpstack(ctx context.Context, req *restack.UpstackRequest) error
+	RestackDownstack(ctx context.Context, req *restack.DownstackRequest) error
 	Restack(context.Context, *restack.Request) (int, error)
-	RestackStack(ctx context.Context, branch string, opts *restack.StackOptions) error
-	RestackBranch(ctx context.Context, branch string, opts *restack.BranchOptions) error
+	RestackStack(ctx context.Context, req *restack.StackRequest) error
+	RestackBranch(ctx context.Context, req *restack.BranchRequest) error
 }
 
 func (cmd *upstackRestackCmd) AfterApply(ctx context.Context, wt *git.Worktree) error {
@@ -62,5 +62,8 @@ func (cmd *upstackRestackCmd) Run(
 		return err
 	}
 
-	return handler.RestackUpstack(ctx, cmd.Branch, &cmd.UpstackOptions)
+	return handler.RestackUpstack(ctx, &restack.UpstackRequest{
+		Branch:  cmd.Branch,
+		Options: &cmd.UpstackOptions,
+	})
 }


### PR DESCRIPTION
## Summary

Adds a `--skip-conflicts` flag to all restack commands (`gs repo restack`, `gs stack restack`, `gs upstack restack`, `gs downstack restack`, `gs branch restack`). When set, any branch that cannot be rebased cleanly due to a conflict is aborted and skipped (along with its upstack descendants) and logged, instead of dropping into the interactive conflict-resolution flow. The rest of the branches still restack, and the command exits successfully with a summary of how many branches were skipped.

## Why this matters (#116)

Today a single conflicting branch blocks an entire multi-branch restack such as `gs repo restack`. For stale stacks the user does not intend to work on, this forces them into a rescue/continue cycle just to get the rest of their branches restacked. As raised in #116, it is useful to opt into skipping conflicting branches and logging the un-rebased stacks (prior art: Graphite). The flag is off by default, so existing behavior is unchanged.

## Changes

- `restack.Request` gains a `SkipConflicts` field. In the restack loop, a `RebaseInterruptConflict` is aborted and skipped (warning `<branch>: conflict, skipping`) when the flag is set; descendants of a skipped branch are skipped consistently, and a final `Skipped N branch(es) due to conflicts` summary is logged.
- Deliberate (non-conflict) rebase interruptions still route to the existing rescue flow, regardless of the flag.
- After skipping conflicts, the starting branch is checked out at the end so the user is never left stranded on a conflicting branch (this also covers the all-conflicts case where nothing restacked).
- The flag is plumbed through the `RestackBranch`/`RestackStack`/`RestackUpstack`/`RestackDownstack` handler entrypoints (via small per-command options structs) and the corresponding CLI commands.
- Added a changelog entry, regenerated the CLI reference and command help fixtures.

## Testing

- New unit tests in `internal/handler/restack` covering: a conflicting branch plus its upstack being skipped while an independent branch restacks; the all-conflicts case still returning to the starting branch; and a deliberate interrupt still routing to rescue.
- New test script `testdata/script/restack_skip_conflicts.txt` exercising `gs repo restack --skip-conflicts` end to end (conflicting stack skipped, clean branch restacked, working tree clean, back on the starting branch, exit 0).
- `go build ./...`, `go vet`, the affected package tests, the command help fixtures, and the new test script all pass.

Fixes #116

AI was used for assistance.
