### PR TITLE
github: Cache user ID lookups

### DIFF
--- a/.changes/unreleased/Fixed-20260609-201333.yaml
+++ b/.changes/unreleased/Fixed-20260609-201333.yaml
@@ -1,0 +1,4 @@
+kind: Fixed
+body: >-
+  github: GitHub user ID lookups during the same operation are now reused.
+time: 2026-06-09T20:13:33.204033-07:00

--- a/internal/forge/github/repository.go
+++ b/internal/forge/github/repository.go
@@ -3,10 +3,12 @@ package github
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/shurcooL/githubv4"
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/silog"
+	"golang.org/x/sync/singleflight"
 )
 
 // Repository is a GitHub repository.
@@ -16,6 +18,15 @@ type Repository struct {
 	log         *silog.Logger
 	client      *githubv4.Client
 	forge       *Forge
+
+	userIDsMu sync.Mutex // guards userIDs
+	// userIDs caches successful login lookups for this repository.
+	//
+	// Pull request metadata operations can resolve the same login
+	// through reviewers, assignees, or follow-up edits in one command.
+	userIDs map[string]githubv4.ID
+	// userIDGroup coalesces concurrent misses for the same login.
+	userIDGroup singleflight.Group
 }
 
 var _ forge.Repository = (*Repository)(nil)
@@ -38,12 +49,13 @@ func newRepository(
 	}
 
 	return &Repository{
-		owner:  owner,
-		repo:   repo,
-		log:    log,
-		client: client,
-		repoID: repoID,
-		forge:  forge,
+		owner:   owner,
+		repo:    repo,
+		log:     log,
+		client:  client,
+		repoID:  repoID,
+		forge:   forge,
+		userIDs: make(map[string]githubv4.ID),
 	}, nil
 }
 
@@ -71,6 +83,46 @@ func repositoryGQLID(
 
 // userID looks up a user's GraphQL ID by login.
 func (r *Repository) userID(ctx context.Context, login string) (githubv4.ID, error) {
+	r.userIDsMu.Lock()
+	id, ok := r.userIDs[login]
+	r.userIDsMu.Unlock()
+	if ok {
+		// Another goroutine resolved this login
+		// while the singleflight call was waiting for the lock.
+		return id, nil
+	}
+
+	idAny, err, _ := r.userIDGroup.Do(login, func() (any, error) {
+		r.userIDsMu.Lock()
+		id, ok := r.userIDs[login]
+		r.userIDsMu.Unlock()
+		if ok {
+			// Another goroutine resolved this login
+			// while the singleflight call was waiting for the lock.
+			return id, nil
+		}
+
+		id, err := r.queryUserID(ctx, login)
+		if err != nil {
+			return "", err
+		}
+
+		r.userIDsMu.Lock()
+		if r.userIDs == nil {
+			r.userIDs = make(map[string]githubv4.ID)
+		}
+		r.userIDs[login] = id
+		r.userIDsMu.Unlock()
+
+		return id, nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return idAny.(githubv4.ID), nil
+}
+
+func (r *Repository) queryUserID(ctx context.Context, login string) (githubv4.ID, error) {
 	var query struct {
 		User struct {
 			ID githubv4.ID `graphql:"id"`

--- a/internal/forge/github/submit_test.go
+++ b/internal/forge/github/submit_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/shurcooL/githubv4"
@@ -90,4 +92,167 @@ func TestRepository_SubmitChange_fromPushRepository(t *testing.T) {
 	assert.Equal(t,
 		"https://github.com/test-owner/test-repo/pull/55",
 		change.URL)
+}
+
+func TestRepository_prMetadataCachesUserIDs(t *testing.T) {
+	var userQueries int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+
+		var body struct {
+			Query     string `json:"query"`
+			Variables struct {
+				Login string         `json:"login"`
+				Input map[string]any `json:"input"`
+			} `json:"variables"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+
+		switch {
+		case strings.Contains(body.Query, "user(login: $login)"):
+			userQueries++
+			assert.Equal(t, "alice", body.Variables.Login)
+
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"user": map[string]any{
+						"id": "aliceID",
+					},
+				},
+			}))
+
+		case strings.Contains(body.Query, "requestReviews(input:"):
+			assert.Equal(t, "prID", body.Variables.Input["pullRequestId"])
+			assert.Equal(t, []any{"aliceID"}, body.Variables.Input["userIds"])
+
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"requestReviews": map[string]any{
+						"clientMutationId": "reviewMutation",
+					},
+				},
+			}))
+
+		case strings.Contains(body.Query, "addAssigneesToAssignable(input:"):
+			assert.Equal(t, "prID", body.Variables.Input["assignableId"])
+			assert.Equal(t, []any{"aliceID"}, body.Variables.Input["assigneeIds"])
+
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"addAssigneesToAssignable": map[string]any{
+						"clientMutationId": "assigneeMutation",
+					},
+				},
+			}))
+
+		default:
+			t.Fatalf("unexpected query: %s", body.Query)
+		}
+	}))
+	defer srv.Close()
+
+	repo, err := newRepository(
+		t.Context(), new(Forge),
+		"test-owner", "test-repo",
+		silogtest.New(t),
+		githubv4.NewEnterpriseClient(srv.URL, nil),
+		"repoID",
+	)
+	require.NoError(t, err)
+
+	err = repo.addReviewersToPullRequest(
+		t.Context(),
+		[]string{"alice"},
+		githubv4.ID("prID"),
+	)
+	require.NoError(t, err)
+
+	err = repo.addAssigneesToPullRequest(
+		t.Context(),
+		[]string{"alice"},
+		githubv4.ID("prID"),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, userQueries)
+}
+
+func TestRepository_userIDCoalescesConcurrentMisses(t *testing.T) {
+	var userQueries atomic.Int32
+	firstQueryStarted := make(chan struct{})
+	releaseQuery := make(chan struct{})
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() { close(releaseQuery) })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+
+		var body struct {
+			Query     string `json:"query"`
+			Variables struct {
+				Login string `json:"login"`
+			} `json:"variables"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		require.Contains(t, body.Query, "user(login: $login)")
+		assert.Equal(t, "alice", body.Variables.Login)
+
+		if userQueries.Add(1) == 1 {
+			close(firstQueryStarted)
+		}
+
+		// Hold the first request open
+		// so the second goroutine must join the in-flight lookup
+		// instead of reading from a warmed cache.
+		<-releaseQuery
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"id": "aliceID",
+				},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	repo, err := newRepository(
+		t.Context(), new(Forge),
+		"test-owner", "test-repo",
+		silogtest.New(t),
+		githubv4.NewEnterpriseClient(srv.URL, nil),
+		"repoID",
+	)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+
+	wg.Go(func() {
+		id, err := repo.userID(t.Context(), "alice")
+		if err == nil {
+			assert.Equal(t, githubv4.ID("aliceID"), id)
+		}
+		errs <- err
+	})
+
+	<-firstQueryStarted
+
+	wg.Go(func() {
+		id, err := repo.userID(t.Context(), "alice")
+		if err == nil {
+			assert.Equal(t, githubv4.ID("aliceID"), id)
+		}
+		errs <- err
+	})
+
+	// The second lookup starts while the first request is still blocked,
+	// so a second GraphQL request would mean the miss was not coalesced.
+	releaseOnce.Do(func() { close(releaseQuery) })
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	assert.Equal(t, int32(1), userQueries.Load())
 }


### PR DESCRIPTION
GitHub pull request metadata can resolve the same login
while applying reviewers, assignees, or follow-up edits.
Cache successful user ID lookups on the repository object
so repeated metadata operations can reuse one GraphQL result.

Concurrent cache misses for the same login are coalesced
so parallel callers do not send duplicate `user(login:)` queries.
Tests cover both sequential reviewer-to-assignee reuse
and concurrent lookup reuse against a local HTTP server.