### PR TITLE
WIP: go.abhg.dev/{gs => git-spice}

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,8 +42,8 @@ linters:
         - charm.land/lipgloss/v2.Fprintln
 
         # This is always a strings.Builder, and can't fail.
-        - (go.abhg.dev/gs/internal/ui.Writer).WriteString
-        - (go.abhg.dev/gs/internal/ui.Writer).Write
+        - (go.abhg.dev/git-spice/internal/ui.Writer).WriteString
+        - (go.abhg.dev/git-spice/internal/ui.Writer).Write
 
     depguard:
       rules:
@@ -63,14 +63,14 @@ linters:
 
     loggercheck:
       rules:
-        - (*go.abhg.dev/gs/internal/log.Logger).Trace
-        - (*go.abhg.dev/gs/internal/log.Logger).Debug
-        - (*go.abhg.dev/gs/internal/log.Logger).Info
-        - (*go.abhg.dev/gs/internal/log.Logger).Warn
-        - (*go.abhg.dev/gs/internal/log.Logger).Error
-        - (*go.abhg.dev/gs/internal/log.Logger).Fatal
-        - (*go.abhg.dev/gs/internal/log.Logger).Log
-        - (*go.abhg.dev/gs/internal/log.Logger).With
+        - (*go.abhg.dev/git-spice/internal/log.Logger).Trace
+        - (*go.abhg.dev/git-spice/internal/log.Logger).Debug
+        - (*go.abhg.dev/git-spice/internal/log.Logger).Info
+        - (*go.abhg.dev/git-spice/internal/log.Logger).Warn
+        - (*go.abhg.dev/git-spice/internal/log.Logger).Error
+        - (*go.abhg.dev/git-spice/internal/log.Logger).Fatal
+        - (*go.abhg.dev/git-spice/internal/log.Logger).Log
+        - (*go.abhg.dev/git-spice/internal/log.Logger).With
 
   exclusions:
     generated: lax

--- a/doc/go.mod
+++ b/doc/go.mod
@@ -1,4 +1,4 @@
-module go.abhg.dev/gs/doc
+module go.abhg.dev/git-spice/doc
 
 go 1.24.0
 

--- a/doc/src/start/install.md
+++ b/doc/src/start/install.md
@@ -146,7 +146,7 @@ To **build from source**, follow these steps:
 2. Run the following command:
 
     ```bash
-    go install go.abhg.dev/gs@latest
+    go install go.abhg.dev/git-spice@latest
     ```
 
 ## Recommended: add a `gs` alias

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go.abhg.dev/gs
+module go.abhg.dev/git-spice
 
 go 1.26.0
 

--- a/mise.toml
+++ b/mise.toml
@@ -157,7 +157,7 @@ go build -o bin/git-spice -tags="
   {%- if usage.pprof -%}
     profile
   {%- endif -%}
-" go.abhg.dev/gs
+" go.abhg.dev/git-spice
 ln -sf git-spice {{ config_root }}/bin/gs
 """
 wait_for = ["generate"]

--- a/tools/ci/launchpad-ppa/debian.txtar
+++ b/tools/ci/launchpad-ppa/debian.txtar
@@ -71,7 +71,7 @@ override_dh_auto_build:
 	CGO_ENABLED=0 go build \
 		-o _build/git-spice \
 		-ldflags "-s -w -X main._version=$(VERSION)" \
-		go.abhg.dev/gs
+		go.abhg.dev/git-spice
 
 override_dh_auto_test:
 	@echo "Skipping upstream tests during package build."


### PR DESCRIPTION
Rename the module path to `go.abhg.dev/git-spice`.

Source code has been left unchanged until closer to the release.
Use the following command to update all source code:

    git grep -l go.abhg.dev/gs -- ':!README*' ':!doc/**' ':!go.mod' \
        | xargs perl -0pi -e \
            's#go\.abhg\.dev/gs#go.abhg.dev/git-spice#g'

Resolves #1238
