### PR TITLE
docs: Add shared protocol guide for script integrations

### DIFF
--- a/branch_restack.go
+++ b/branch_restack.go
@@ -32,5 +32,5 @@ func (cmd *branchRestackCmd) AfterApply(ctx context.Context, wt *git.Worktree) e
 }
 
 func (cmd *branchRestackCmd) Run(ctx context.Context, handler RestackHandler) error {
-	return handler.RestackBranch(ctx, cmd.Branch)
+	return handler.RestackBranch(ctx, cmd.Branch, nil)
 }

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
     - guide/concepts.md
     - guide/branch.md
     - guide/cr.md
+    - guide/scripts.md
     - guide/limits.md
     - guide/troubleshooting.md
     - guide/internals.md

--- a/doc/src/guide/scripts.md
+++ b/doc/src/guide/scripts.md
@@ -1,0 +1,257 @@
+---
+title: Script integrations
+icon: octicons/code-square-16
+description: >-
+  Shared protocol for the user-configured scripts that git-spice invokes
+  to generate commit messages and auto-resolve merge conflicts.
+---
+
+# Script integrations
+
+<!-- gs:version unreleased -->
+
+git-spice can hand off three operations to a user-configured script:
+
+| Feature | Trigger | Configured by |
+|---|---|---|
+| Message generation | $$gs commit create --fill$$ and friends | $$spice.message.generator$$ |
+| Restack auto-resolve | Rebase conflict during $$gs branch restack$$ et al. | $$spice.restack.resolver$$ |
+| Integration auto-resolve | Merge conflict during $$gs integration rebuild$$ | $$spice.integration.resolver$$ |
+
+All three speak the same protocol. This page documents the shared
+contract so that a single script can be reused across features, and so
+that wrapper tools (Claude Code, aider, custom shell scripts) only need
+to be written once.
+
+## How a script is invoked
+
+git-spice resolves the configured value as a shell command. The
+string may be either:
+
+- A self-contained shebang script (`#!/usr/bin/env bash`,
+  `#!/usr/bin/env python3`, etc.). git-spice writes it to a temporary
+  file with mode 0700 and executes the temp file directly. The
+  interpreter is whatever the shebang points to.
+- A plain command, in which case `sh -c '<command>'` runs it.
+
+In both cases:
+
+- The script's working directory is the repository root.
+- Parent environment is inherited, with `GIT_OPTIONAL_LOCKS=0`
+  appended so that long-running scripts don't contend with git's index
+  lock.
+- The remaining arguments to the gs command are forwarded as
+  positional parameters (`$1`, `$2`, ...). Most scripts ignore these.
+
+## Environment contract
+
+Every script receives at minimum:
+
+| Variable | When | Meaning |
+|---|---|---|
+| `GS_OPERATION` | always | High-level gs operation (table below) |
+| `GS_BRANCH` | when a branch is in scope | Branch being operated on |
+| `GS_BASE` | when applicable | Base branch (for restack and message contexts) |
+
+`GS_OPERATION` values:
+
+| Value | Source |
+|---|---|
+| `commit-create` | $$gs commit create --fill$$ |
+| `commit-amend` | $$gs commit amend --fill$$ |
+| `branch-create` | $$gs branch create --fill$$ |
+| `branch-submit` | $$gs branch submit --fill$$ (CR title/body) |
+| `branch-squash` | $$gs branch squash --fill$$ |
+| `branch-restack` | $$gs branch restack$$ auto-resolve |
+| `upstack-restack` | $$gs upstack restack$$ auto-resolve |
+| `downstack-restack` | $$gs downstack restack$$ auto-resolve |
+| `stack-restack` | $$gs stack restack$$ auto-resolve |
+| `repo-restack` | $$gs repo restack$$ auto-resolve |
+| `integration-rebuild` | $$gs integration rebuild$$ auto-resolve |
+
+Feature-specific extras layer on top of the shared minimum. For
+message-generation operations:
+
+| Variable | Meaning |
+|---|---|
+| `GS_MESSAGE_KIND` | `commit` or `branch` |
+| `GS_MESSAGE_UPDATE` | `true` (amend/update) or `false` (new) |
+| `GS_MESSAGE` | Existing commit message (commit amend, squash) |
+| `GS_TITLE` | Existing CR title (branch update) |
+| `GS_BODY` | Existing CR body (branch update) |
+
+Auto-resolve operations expose state through the worktree itself
+(`git status`, `git diff`, conflict markers) rather than via env vars.
+
+## Output contract
+
+Scripts emit a single JSON document on stdout. The schema is the union
+of all field uses; each feature reads the subset that applies.
+
+```json
+{
+  "title": "string",
+  "body": "string",
+  "assumptions": ["string", "..."],
+  "questions": ["string", "..."],
+  "unresolved_files": ["string", "..."]
+}
+```
+
+| Field | Read by | Meaning |
+|---|---|---|
+| `title` | Message generation | First-line commit message / CR title (required for message gen) |
+| `body` | Message generation | Body content (optional) |
+| `assumptions` | All features | Notes the script wants surfaced in the gs log so the user sees what was assumed |
+| `questions` | All features | Clarifying questions; trigger the interactive Q&A loop |
+| `unresolved_files` | Auto-resolve | Files the script could not resolve; treated as "not done" and re-invoked |
+
+Missing fields are valid (assumed empty / null). Extra fields are
+ignored. Anything written to stderr is captured and logged at debug
+level (or surfaced if the script exits non-zero).
+
+### Assumptions
+
+Each entry in `assumptions[]` is logged at info level prefixed with the
+feature name. This is how the script tells the user "I picked X
+because Y" without halting for confirmation.
+
+### Questions
+
+If `questions[]` is non-empty, git-spice prompts the user for each
+question in order. Answers are appended to the persistent resolution
+file (see below) and the script is re-invoked with the additional Q&A
+context available via the resolution file. The loop continues until
+the script returns an empty `questions[]` (a final answer), or
+the iteration cap is reached.
+
+### Termination
+
+A run is considered terminal when **all** of these are true:
+
+- The script exited zero.
+- `questions[]` is empty.
+- For auto-resolve operations, `unresolved_files[]` is empty.
+- For message-generation operations, `title` is non-empty.
+
+If termination conditions are not met but the iteration cap is
+reached, git-spice logs a warning and falls back to the manual path
+(open editor for messages; surface conflict for auto-resolve).
+
+## Persistent resolution files
+
+When a script returns `questions[]`, the prompts and the user's
+answers are recorded in
+`<repo-root>/.spice/resolutions/<feature>.json` (one file per feature:
+`message.json`, `restack.json`, `integration.json`). The next run on
+the same branch reads the file so a previously-answered question is
+not re-asked.
+
+The `.spice/` directory is created on first use. Whether to commit it
+is a project decision — share for team-wide reuse, ignore for purely
+local context.
+
+Entries are pruned when the associated branch is removed via
+$$gs branch delete$$ or $$gs branch untrack$$.
+
+## Iteration cap
+
+Each Q&A loop is bounded by $$spice.scriptResolve.maxIterations$$
+(default 10). Set per repo or globally:
+
+```freeze language="terminal"
+{green}${reset} git config {red}spice.scriptResolve.maxIterations{reset} {mag}20{reset}
+```
+
+The cap is a safety backstop — a script that always returns
+`questions[]` would otherwise loop forever.
+
+## Worked examples
+
+### Minimal commit-message generator
+
+A shebang script that reads the staged diff and emits a one-line
+title:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+diff=$(git diff --cached)
+title=$(echo "$diff" | head -1 | sed 's/^.*://' | head -c 60)
+
+cat <<JSON
+{
+  "title": "$title",
+  "assumptions": ["title derived from first diff line"]
+}
+JSON
+```
+
+### Auto-resolve via custom merge driver
+
+A resolver that delegates regeneration to a script bundle and reports
+each step as an assumption:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+conflicts=$(git diff --name-only --diff-filter=U)
+unresolved=()
+assumptions=()
+
+while read -r f; do
+  if [[ -z "$f" ]]; then continue; fi
+  if [[ -f "scripts/regen/$f.sh" ]]; then
+    "scripts/regen/$f.sh"
+    git add "$f"
+    assumptions+=("regenerated $f")
+  else
+    unresolved+=("$f")
+  fi
+done <<< "$conflicts"
+
+jq -n \
+  --argjson assumptions "$(printf '%s\n' "${assumptions[@]}" | jq -R . | jq -s .)" \
+  --argjson unresolved "$(printf '%s\n' "${unresolved[@]}" | jq -R . | jq -s .)" \
+  '{assumptions: $assumptions, unresolved_files: $unresolved}'
+```
+
+### LLM-backed wrapper
+
+Scripts that call out to an LLM follow the same protocol: marshal
+context into a prompt, call the LLM, parse the response into the JSON
+shape above. The LLM does not need to know it's behind gs — only the
+wrapper script does.
+
+## Error handling
+
+A script can fail at three layers:
+
+| Failure | gs behavior |
+|---|---|
+| Script not configured | $$gs commit create --fill$$ errors with a clear message pointing at $$spice.message.generator$$. Auto-resolve features silently skip if no resolver is configured. |
+| Script exits non-zero | Logged at warn level. Message generation falls back to the editor; auto-resolve falls back to surfacing the conflict for manual resolution. The exit code and a truncated stderr appear in the log. |
+| Script output is invalid JSON | Same as non-zero exit, with a "parse" stage marker in the log. |
+| `questions[]` keeps growing past the cap | Warn logged; fall back to manual path. |
+
+All failure paths are non-fatal — the script's misbehavior never
+strands the user in a half-finished state.
+
+## Configuration reference
+
+The full list of script-related config keys:
+
+| Key | Type | Default | Read by |
+|---|---|---|---|
+| `spice.message.generator` | string | "" | Message generation |
+| `spice.message.autoFill` | bool | false | Message generation |
+| `spice.restack.resolver` | string | "" | Restack auto-resolve |
+| `spice.restack.autoResolve` | bool | false | Restack auto-resolve |
+| `spice.integration.resolver` | string | "" | Integration auto-resolve |
+| `spice.integration.autoResolve` | bool | false | Integration auto-resolve |
+| `spice.scriptResolve.maxIterations` | int | 10 | All script-driven features |
+
+See the [configuration reference](../cli/config.md) for the full
+schema with link-anchored documentation.

--- a/downstack_restack.go
+++ b/downstack_restack.go
@@ -44,5 +44,5 @@ func (cmd *downstackRestackCmd) Run(
 		return errors.New("nothing to restack below trunk")
 	}
 
-	return handler.RestackDownstack(ctx, cmd.Branch)
+	return handler.RestackDownstack(ctx, cmd.Branch, nil)
 }

--- a/internal/handler/merge/handler.go
+++ b/internal/handler/merge/handler.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/handler/submit"
 	"go.abhg.dev/gs/internal/handler/sync"
 
@@ -36,7 +37,7 @@ type Service interface {
 
 // RestackHandler restacks branches after their bases are merged.
 type RestackHandler interface {
-	RestackBranch(context.Context, string) error
+	RestackBranch(ctx context.Context, branch string, opts *restack.Options) error
 }
 
 // SubmitHandler updates change requests after branch restacks.
@@ -599,7 +600,7 @@ func (e *mergePlanExecutor) prepareForMerge(
 			return fmt.Errorf("verify restacked: %w", err)
 		}
 
-		if err := e.Restack.RestackBranch(ctx, item.branch); err != nil {
+		if err := e.Restack.RestackBranch(ctx, item.branch, nil); err != nil {
 			return fmt.Errorf("restack branch: %w", err)
 		}
 

--- a/internal/handler/merge/handler_test.go
+++ b/internal/handler/merge/handler_test.go
@@ -317,10 +317,10 @@ func TestExecutePlan_retargets(t *testing.T) {
 
 	mockRestack := NewMockRestackHandler(ctrl)
 	mockRestack.EXPECT().
-		RestackBranch(gomock.Any(), "feat2").
+		RestackBranch(gomock.Any(), "feat2", gomock.Nil()).
 		Return(nil)
 	mockRestack.EXPECT().
-		RestackBranch(gomock.Any(), "feat3").
+		RestackBranch(gomock.Any(), "feat3", gomock.Nil()).
 		Return(nil)
 
 	mockSubmit := NewMockSubmitHandler(ctrl)
@@ -396,7 +396,7 @@ func TestExecutePlan_waitsForPreparedChangeHeadBeforeChecks(t *testing.T) {
 
 	mockRestack := NewMockRestackHandler(ctrl)
 	mockRestack.EXPECT().
-		RestackBranch(gomock.Any(), "feat2").
+		RestackBranch(gomock.Any(), "feat2", gomock.Nil()).
 		Return(nil)
 
 	mockSubmit := NewMockSubmitHandler(ctrl)

--- a/internal/handler/merge/mocks_test.go
+++ b/internal/handler/merge/mocks_test.go
@@ -13,6 +13,7 @@ import (
 	reflect "reflect"
 
 	git "go.abhg.dev/gs/internal/git"
+	restack "go.abhg.dev/gs/internal/handler/restack"
 	submit "go.abhg.dev/gs/internal/handler/submit"
 	sync "go.abhg.dev/gs/internal/handler/sync"
 	spice "go.abhg.dev/gs/internal/spice"
@@ -207,17 +208,17 @@ func (m *MockRestackHandler) EXPECT() *MockRestackHandlerMockRecorder {
 }
 
 // RestackBranch mocks base method.
-func (m *MockRestackHandler) RestackBranch(arg0 context.Context, arg1 string) error {
+func (m *MockRestackHandler) RestackBranch(ctx context.Context, branch string, opts *restack.Options) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestackBranch", arg0, arg1)
+	ret := m.ctrl.Call(m, "RestackBranch", ctx, branch, opts)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RestackBranch indicates an expected call of RestackBranch.
-func (mr *MockRestackHandlerMockRecorder) RestackBranch(arg0, arg1 any) *MockRestackHandlerRestackBranchCall {
+func (mr *MockRestackHandlerMockRecorder) RestackBranch(ctx, branch, opts any) *MockRestackHandlerRestackBranchCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackBranch", reflect.TypeOf((*MockRestackHandler)(nil).RestackBranch), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackBranch", reflect.TypeOf((*MockRestackHandler)(nil).RestackBranch), ctx, branch, opts)
 	return &MockRestackHandlerRestackBranchCall{Call: call}
 }
 
@@ -233,13 +234,13 @@ func (c *MockRestackHandlerRestackBranchCall) Return(arg0 error) *MockRestackHan
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRestackHandlerRestackBranchCall) Do(f func(context.Context, string) error) *MockRestackHandlerRestackBranchCall {
+func (c *MockRestackHandlerRestackBranchCall) Do(f func(context.Context, string, *restack.Options) error) *MockRestackHandlerRestackBranchCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRestackHandlerRestackBranchCall) DoAndReturn(f func(context.Context, string) error) *MockRestackHandlerRestackBranchCall {
+func (c *MockRestackHandlerRestackBranchCall) DoAndReturn(f func(context.Context, string, *restack.Options) error) *MockRestackHandlerRestackBranchCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/handler/restack/branch.go
+++ b/internal/handler/restack/branch.go
@@ -3,10 +3,13 @@ package restack
 import "context"
 
 // RestackBranch restacks the given branch onto its base.
-func (h *Handler) RestackBranch(ctx context.Context, branch string) error {
+func (h *Handler) RestackBranch(
+	ctx context.Context, branch string, opts *Options,
+) error {
 	_, err := h.Restack(ctx, &Request{
 		Branch:          branch,
 		ContinueCommand: []string{"branch", "restack"},
+		AutoResolve:     opts.autoResolvePtr(),
 	})
 	return err
 }

--- a/internal/handler/restack/branch_test.go
+++ b/internal/handler/restack/branch_test.go
@@ -47,7 +47,7 @@ func TestHandler_RestackBranch(t *testing.T) {
 			Store:    statetest.NewMemoryStore(t, "main", "", log),
 			Service:  mockService,
 		}
-		require.NoError(t, handler.RestackBranch(t.Context(), "feature"))
+		require.NoError(t, handler.RestackBranch(t.Context(), "feature", nil))
 		assert.Contains(t, logBuffer.String(), "feature: restacked on main")
 	})
 
@@ -82,7 +82,7 @@ func TestHandler_RestackBranch(t *testing.T) {
 			Service:  mockService,
 		}
 
-		require.NoError(t, handler.RestackBranch(t.Context(), "feature"))
+		require.NoError(t, handler.RestackBranch(t.Context(), "feature", nil))
 	})
 
 	t.Run("UntrackedBranch", func(t *testing.T) {
@@ -113,7 +113,7 @@ func TestHandler_RestackBranch(t *testing.T) {
 			Service:  mockService,
 		}
 
-		err := handler.RestackBranch(t.Context(), "untracked")
+		err := handler.RestackBranch(t.Context(), "untracked", nil)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "untracked branch")
 		assert.Contains(t, logBuffer.String(), "untracked: branch not tracked: run '"+cli.Name()+" branch track")
@@ -146,7 +146,7 @@ func TestHandler_RestackBranch(t *testing.T) {
 			Store:    statetest.NewMemoryStore(t, "main", "", log),
 			Service:  mockService,
 		}
-		require.NoError(t, handler.RestackBranch(t.Context(), "already-restacked"))
+		require.NoError(t, handler.RestackBranch(t.Context(), "already-restacked", nil))
 		assert.Contains(t, logBuffer.String(), "already-restacked: branch does not need to be restacked.")
 	})
 
@@ -177,7 +177,7 @@ func TestHandler_RestackBranch(t *testing.T) {
 			Store:    statetest.NewMemoryStore(t, "main", "", log),
 			Service:  mockService,
 		}
-		err := handler.RestackBranch(t.Context(), "feature")
+		err := handler.RestackBranch(t.Context(), "feature", nil)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "restack branch")
 		assert.ErrorIs(t, err, unexpectedErr)

--- a/internal/handler/restack/downstack.go
+++ b/internal/handler/restack/downstack.go
@@ -4,11 +4,14 @@ import "context"
 
 // RestackDownstack restacks the downstack of the given branch.
 // This includes the branch itself.
-func (h *Handler) RestackDownstack(ctx context.Context, branch string) error {
+func (h *Handler) RestackDownstack(
+	ctx context.Context, branch string, opts *Options,
+) error {
 	_, err := h.Restack(ctx, &Request{
 		Branch:          branch,
 		Scope:           ScopeDownstack,
 		ContinueCommand: []string{"downstack", "restack"},
+		AutoResolve:     opts.autoResolvePtr(),
 	})
 	return err
 }

--- a/internal/handler/restack/downstack_test.go
+++ b/internal/handler/restack/downstack_test.go
@@ -54,7 +54,7 @@ func TestHandler_RestackDownstack(t *testing.T) {
 			Service:  mockService,
 		}
 
-		require.NoError(t, handler.RestackDownstack(t.Context(), "feature3"))
+		require.NoError(t, handler.RestackDownstack(t.Context(), "feature3", nil))
 		assert.Contains(t, logBuffer.String(), "feature1: restacked on main")
 		assert.Contains(t, logBuffer.String(), "feature2: restacked on feature1")
 		assert.Contains(t, logBuffer.String(), "feature3: restacked on feature2")
@@ -99,6 +99,6 @@ func TestHandler_RestackDownstack(t *testing.T) {
 			Service:  mockService,
 		}
 
-		require.NoError(t, handler.RestackDownstack(t.Context(), "feature2"))
+		require.NoError(t, handler.RestackDownstack(t.Context(), "feature2", nil))
 	})
 }

--- a/internal/handler/restack/handler.go
+++ b/internal/handler/restack/handler.go
@@ -93,6 +93,33 @@ type Request struct {
 	//
 	// Defaults to ScopeBranch.
 	Scope Scope
+
+	// AutoResolve, if non-nil, overrides
+	// [Handler.DefaultAutoResolve] for this invocation. A true
+	// value enables the configured resolver; a false value disables
+	// it even when configured.
+	AutoResolve *bool
+}
+
+// Options are optional parameters shared by the high-level restack
+// entry points ([Handler.RestackBranch], [Handler.RestackStack],
+// [Handler.RestackDownstack]).
+type Options struct {
+	// AutoResolve, if non-nil, overrides
+	// [Handler.DefaultAutoResolve] for this invocation. A true
+	// value enables the configured resolver; a false value disables
+	// it even when configured.
+	AutoResolve *bool
+}
+
+// autoResolvePtr returns the AutoResolve pointer if opts is
+// non-nil, or nil. Callers pass the result through to
+// [Request.AutoResolve].
+func (o *Options) autoResolvePtr() *bool {
+	if o == nil {
+		return nil
+	}
+	return o.AutoResolve
 }
 
 // Restack restacks one or more branches according to the request.

--- a/internal/handler/restack/stack.go
+++ b/internal/handler/restack/stack.go
@@ -5,11 +5,14 @@ import "context"
 // RestackStack restacks the stack of the given branch.
 // This includes all upstack and downtrack branches,
 // as well as the branch itself.
-func (h *Handler) RestackStack(ctx context.Context, branch string) error {
+func (h *Handler) RestackStack(
+	ctx context.Context, branch string, opts *Options,
+) error {
 	_, err := h.Restack(ctx, &Request{
 		Branch:          branch,
 		Scope:           ScopeStack,
 		ContinueCommand: []string{"stack", "restack"},
+		AutoResolve:     opts.autoResolvePtr(),
 	})
 	return err
 }

--- a/internal/handler/sync/handler.go
+++ b/internal/handler/sync/handler.go
@@ -78,7 +78,7 @@ type DeleteHandler interface {
 // RestackHandler allows restacking branches after sync
 // has removed their downstack branches.
 type RestackHandler interface {
-	RestackBranch(ctx context.Context, branch string) error
+	RestackBranch(ctx context.Context, branch string, opts *restack.Options) error
 	RestackUpstack(ctx context.Context, branch string, opts *restack.UpstackOptions) error
 }
 
@@ -983,7 +983,7 @@ func (h *Handler) restackDeletedBranchUpstack(
 			return fmt.Errorf("restack upstack %q: %w", target, err)
 		}
 	case mode.Includes(spice.RestackAboves):
-		if err := h.Restack.RestackBranch(ctx, target); err != nil {
+		if err := h.Restack.RestackBranch(ctx, target, nil); err != nil {
 			return fmt.Errorf("restack branch %q: %w", target, err)
 		}
 	case mode.Includes(spice.RestackNone):

--- a/internal/handler/sync/handler_test.go
+++ b/internal/handler/sync/handler_test.go
@@ -368,7 +368,7 @@ func TestHandler_SyncTrunk_restackDeletedUpstacks(t *testing.T) {
 
 		mockRestack := NewMockRestackHandler(ctrl)
 		mockRestack.EXPECT().
-			RestackBranch(gomock.Any(), "child").
+			RestackBranch(gomock.Any(), "child", gomock.Nil()).
 			Return(nil)
 
 		mockAutostash := NewMockAutostashHandler(ctrl)

--- a/internal/handler/sync/mocks_test.go
+++ b/internal/handler/sync/mocks_test.go
@@ -782,17 +782,17 @@ func (m *MockRestackHandler) EXPECT() *MockRestackHandlerMockRecorder {
 }
 
 // RestackBranch mocks base method.
-func (m *MockRestackHandler) RestackBranch(ctx context.Context, branch string) error {
+func (m *MockRestackHandler) RestackBranch(ctx context.Context, branch string, opts *restack.Options) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestackBranch", ctx, branch)
+	ret := m.ctrl.Call(m, "RestackBranch", ctx, branch, opts)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RestackBranch indicates an expected call of RestackBranch.
-func (mr *MockRestackHandlerMockRecorder) RestackBranch(ctx, branch any) *MockRestackHandlerRestackBranchCall {
+func (mr *MockRestackHandlerMockRecorder) RestackBranch(ctx, branch, opts any) *MockRestackHandlerRestackBranchCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackBranch", reflect.TypeOf((*MockRestackHandler)(nil).RestackBranch), ctx, branch)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackBranch", reflect.TypeOf((*MockRestackHandler)(nil).RestackBranch), ctx, branch, opts)
 	return &MockRestackHandlerRestackBranchCall{Call: call}
 }
 
@@ -808,13 +808,13 @@ func (c *MockRestackHandlerRestackBranchCall) Return(arg0 error) *MockRestackHan
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRestackHandlerRestackBranchCall) Do(f func(context.Context, string) error) *MockRestackHandlerRestackBranchCall {
+func (c *MockRestackHandlerRestackBranchCall) Do(f func(context.Context, string, *restack.Options) error) *MockRestackHandlerRestackBranchCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRestackHandlerRestackBranchCall) DoAndReturn(f func(context.Context, string) error) *MockRestackHandlerRestackBranchCall {
+func (c *MockRestackHandlerRestackBranchCall) DoAndReturn(f func(context.Context, string, *restack.Options) error) *MockRestackHandlerRestackBranchCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/stack_restack.go
+++ b/stack_restack.go
@@ -88,5 +88,5 @@ func (cmd *stackRestackCmd) Run(
 		return err
 	}
 
-	return handler.RestackStack(ctx, cmd.Branch)
+	return handler.RestackStack(ctx, cmd.Branch, nil)
 }

--- a/upstack_restack.go
+++ b/upstack_restack.go
@@ -34,10 +34,10 @@ func (*upstackRestackCmd) Help() string {
 // RestackHandler implements high level restack operations.
 type RestackHandler interface {
 	RestackUpstack(ctx context.Context, branch string, opts *restack.UpstackOptions) error
-	RestackDownstack(ctx context.Context, branch string) error
+	RestackDownstack(ctx context.Context, branch string, opts *restack.Options) error
 	Restack(context.Context, *restack.Request) (int, error)
-	RestackStack(ctx context.Context, branch string) error
-	RestackBranch(ctx context.Context, branch string) error
+	RestackStack(ctx context.Context, branch string, opts *restack.Options) error
+	RestackBranch(ctx context.Context, branch string, opts *restack.Options) error
 }
 
 func (cmd *upstackRestackCmd) AfterApply(ctx context.Context, wt *git.Worktree) error {


### PR DESCRIPTION
Adds doc/src/guide/scripts.md as the single source of truth for the
shared protocol that ties together three soon-to-be-aligned features:

  - spice.message.generator (commit message generation)
  - spice.restack.resolver  (restack auto-resolve)
  - spice.integration.resolver (integration-rebuild auto-resolve)

Documents:

  - Invocation shape (shebang vs sh -c, working dir, args forwarding).
  - Shared env contract: GS_OPERATION, GS_BRANCH, GS_BASE, plus the
    table of all GS_OPERATION values across the three features. Lists
    message-feature-specific extras (GS_MESSAGE_*, GS_TITLE, GS_BODY).
  - JSON output schema (the union of fields across all three features).
  - Assumptions logging, the questions Q&A loop, and termination rules.
  - .spice/resolutions/<feature>.json layout for persistent Q&A.
  - spice.scriptResolve.maxIterations cap.
  - Worked examples and error-handling expectations.

This commit is a prerequisite for the implementation work landing on
ed-irl/scriptrun and the three feature branches above it. Registering
the page in doc/mkdocs.yml's User Guide section.