### PR TITLE
ui: Add scroll-region model runner

### DIFF
--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -10,6 +10,8 @@ import (
 
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
+	"go.abhg.dev/gs/internal/sigstack"
+	"go.abhg.dev/gs/internal/ui/scrollregion"
 )
 
 // FormKeyMap defines the key bindings for a form.
@@ -179,16 +181,49 @@ type RunOptions struct {
 
 	// WithoutSignals requests that the form not register signal handlers.
 	WithoutSignals bool
+
+	// Signals coordinates signal handling with the rest of the command.
+	Signals *sigstack.Stack
+
+	// ScrollRegionMinHeight and ScrollRegionMaxHeight reserve a bottom
+	// terminal region for the model.
+	//
+	// This is an experimental renderer mode. Ordinary terminal output scrolls
+	// above the reserved rows while the model is redrawn in the reserved rows.
+	// The reserved height follows the model's rendered line count.
+	// MinHeight prevents the region from bouncing when a model briefly renders
+	// fewer lines, and MaxHeight caps future detail sections.
+	ScrollRegionMinHeight int
+	ScrollRegionMaxHeight int
 }
 
 // FormRunOptions specifies options for [Form.Run].
 type FormRunOptions = RunOptions
 
 // RunModel runs the given Bubble Tea model.
-func RunModel(model tea.Model, opts *RunOptions) error {
+func RunModel(model tea.Model, opts *RunOptions) (err error) {
 	opts = cmp.Or(opts, &RunOptions{})
 
 	var teaOpts []tea.ProgramOption
+	startScrollRegion := func(*tea.Program) {}
+	if opts.ScrollRegionMinHeight > 0 || opts.ScrollRegionMaxHeight > 0 {
+		scrollRegion := scrollregion.New(model,
+			cmp.Or(opts.Output, io.Writer(os.Stderr)),
+			&scrollregion.Options{
+				Width:     opts.Width,
+				Height:    opts.Height,
+				MinHeight: opts.ScrollRegionMinHeight,
+				MaxHeight: opts.ScrollRegionMaxHeight,
+				Signals:   opts.Signals,
+			})
+		defer func() {
+			err = errors.Join(err, scrollRegion.Close())
+		}()
+		model = scrollRegion
+		teaOpts = append(teaOpts, tea.WithoutRenderer())
+		startScrollRegion = scrollRegion.Start
+	}
+
 	if i := opts.Input; i != nil {
 		teaOpts = append(teaOpts, tea.WithInput(i))
 	}
@@ -205,12 +240,12 @@ func RunModel(model tea.Model, opts *RunOptions) error {
 	if opts.WithoutSignals {
 		teaOpts = append(teaOpts, tea.WithoutSignals())
 	}
-
 	program := tea.NewProgram(model, teaOpts...)
+	startScrollRegion(program)
 	if msg := opts.SendMsg; msg != nil {
 		go program.Send(msg)
 	}
-	_, err := program.Run()
+	_, err = program.Run()
 	return err
 }
 

--- a/internal/ui/scrollregion/model.go
+++ b/internal/ui/scrollregion/model.go
@@ -1,0 +1,167 @@
+// Package scrollregion runs a Bubble Tea model in a reserved terminal region.
+//
+// The package is motivated by command progress widgets,
+// but it can wrap any Bubble Tea model that has a compact view
+// and needs to coexist with ordinary terminal output.
+// It disables Bubble Tea's renderer,
+// draws the model itself into a bottom scroll region,
+// and leaves normal writes to the output stream alone
+// so logs can continue to print above the region.
+//
+// This is terminal-control code.
+// It assumes an ANSI-compatible terminal with DECSTBM scrolling margins.
+// When the output does not expose a file descriptor,
+// callers must provide an explicit initial size
+// or the model will wait until a size is available.
+package scrollregion
+
+import (
+	"cmp"
+	"context"
+	"io"
+	"sync"
+
+	tea "charm.land/bubbletea/v2"
+	"go.abhg.dev/gs/internal/sigstack"
+)
+
+// Options configures optional reserved-region behavior.
+type Options struct {
+	// Width and Height are the initial terminal size.
+	//
+	// If either value is zero
+	// and output exposes an Fd method,
+	// the missing value is detected from the terminal.
+	Width, Height int
+
+	// MinHeight is the minimum number of rows reserved for the model.
+	//
+	// Defaults to 1.
+	// This prevents the reserved region from bouncing when a model
+	// temporarily renders fewer rows.
+	MinHeight int
+
+	// MaxHeight is the maximum number of rows reserved for the model.
+	//
+	// Defaults to MinHeight.
+	// This caps future model detail sections so log output keeps enough room.
+	MaxHeight int
+
+	// Signals receives terminal resize signals.
+	//
+	// If nil, a private stack is used for the lifetime of this model.
+	Signals *sigstack.Stack
+}
+
+// Model wraps a Bubble Tea model with reserved-region rendering.
+//
+// Model is still a Bubble Tea model.
+// Callers should pass it to tea.NewProgram with tea.WithoutRenderer,
+// then call Start with that program before Run.
+type Model struct {
+	model    tea.Model
+	renderer *renderer
+	signals  *sigstack.Stack
+
+	resizeMu     sync.Mutex
+	cancelResize context.CancelFunc
+	resizeDone   <-chan struct{}
+}
+
+var _ tea.Model = (*Model)(nil)
+
+// New wraps model so it renders in a reserved terminal region.
+//
+// The output writer is the stream that receives both the wrapped model
+// and any ordinary terminal output that should scroll above it.
+// If opts is nil, defaults are used for all optional fields.
+func New(model tea.Model, output io.Writer, opts *Options) *Model {
+	opts = cmp.Or(opts, &Options{})
+	r := newRenderer(
+		output,
+		opts.Width,
+		opts.Height,
+		opts.MinHeight,
+		opts.MaxHeight,
+	)
+	signals := opts.Signals
+	if signals == nil {
+		signals = new(sigstack.Stack)
+	}
+	return &Model{
+		model:    model,
+		renderer: r,
+		signals:  signals,
+	}
+}
+
+// Close restores terminal margins and clears the reserved region.
+func (m *Model) Close() error {
+	m.stopResize()
+	return m.renderer.Close()
+}
+
+// Start begins sending WindowSizeMsg values when the terminal resizes.
+//
+// Bubble Tea does not initialize terminal output
+// while WithoutRenderer is in use,
+// so this model owns resize watching for the reserved-region mode.
+// Start is idempotent.
+// Close stops the resize watcher before restoring the terminal.
+func (m *Model) Start(program *tea.Program) {
+	m.resizeMu.Lock()
+	defer m.resizeMu.Unlock()
+
+	if m.cancelResize != nil {
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	m.cancelResize = cancel
+	m.resizeDone = m.watchResize(ctx, program)
+}
+
+// Init initializes the wrapped model and sends the startup terminal size.
+func (m *Model) Init() tea.Cmd {
+	return tea.Batch(
+		m.renderer.initialWindowSize,
+		m.model.Init(),
+	)
+}
+
+// Update forwards messages to the wrapped model and renders the result.
+func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if size, ok := msg.(tea.WindowSizeMsg); ok {
+		m.renderer.Resize(size.Width, size.Height)
+		// The wrapped model should lay itself out within the reserved region,
+		// not the full terminal height that log output uses above it.
+		msg = tea.WindowSizeMsg{
+			Width:  size.Width,
+			Height: m.renderer.ModelHeight(),
+		}
+	}
+
+	model, cmd := m.model.Update(msg)
+	m.model = model
+	m.renderer.Render(m.model.View())
+	return m, cmd
+}
+
+// View returns an empty view because this model renders itself.
+func (m *Model) View() tea.View {
+	return tea.NewView("")
+}
+
+func (m *Model) stopResize() {
+	m.resizeMu.Lock()
+	cancel := m.cancelResize
+	done := m.resizeDone
+	m.cancelResize = nil
+	m.resizeDone = nil
+	m.resizeMu.Unlock()
+
+	if cancel == nil {
+		return
+	}
+	cancel()
+	<-done
+}

--- a/internal/ui/scrollregion/model_test.go
+++ b/internal/ui/scrollregion/model_test.go
@@ -1,0 +1,263 @@
+package scrollregion
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/hexops/autogold/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vito/midterm"
+)
+
+func TestModel_RendersWithExplicitSize(t *testing.T) {
+	var buf bytes.Buffer
+	model := New(&testModel{}, &buf, &Options{
+		Width:     40,
+		Height:    10,
+		MinHeight: 2,
+		MaxHeight: 3,
+	})
+
+	_, cmd := model.Update(tea.WindowSizeMsg{Width: 40, Height: 10})
+	require.Nil(t, cmd)
+	_, cmd = model.Update(testStep{})
+	require.NotNil(t, cmd)
+	assert.NoError(t, model.Close())
+
+	got := visibleControl(buf.String())
+	assert.Contains(t, got, "<esc>[1;8r")                      // set scroll margins
+	assert.Contains(t, got, "<esc>[10;1H<esc>[2Kview: 0 40x2") // draw bottom row
+	assert.Contains(t, got, "<esc>[10;1H<esc>[2Kview: 1 40x2") // redraw bottom row
+	assert.Contains(t, got, "<esc>[r")                         // reset scroll margins
+}
+
+func TestModel_GrowsToMax(t *testing.T) {
+	var buf bytes.Buffer
+	model := New(&tallTestModel{}, &buf, &Options{
+		Width:     40,
+		Height:    10,
+		MinHeight: 2,
+		MaxHeight: 4,
+	})
+
+	_, cmd := model.Update(tea.WindowSizeMsg{Width: 40, Height: 10})
+	require.Nil(t, cmd)
+	_, cmd = model.Update(testStep{})
+	require.NotNil(t, cmd)
+
+	got := visibleControl(buf.String())
+	assert.Contains(t, got, "<esc>[1;8r")                // reserve two bottom rows
+	assert.Contains(t, got, "<esc>[1;6r")                // grow to four bottom rows
+	assert.Contains(t, got, "<esc>[7;1H<esc>[2Kline 1")  // draw top reserved row
+	assert.Contains(t, got, "<esc>[10;1H<esc>[2Kline 4") // draw bottom reserved row
+}
+
+func TestModel_RendersAfterFirstWindowSize(t *testing.T) {
+	var buf bytes.Buffer
+	model := New(&staticTestModel{}, &buf, &Options{
+		Width:     40,
+		MinHeight: 2,
+		MaxHeight: 3,
+	})
+
+	_, cmd := model.Update(tea.WindowSizeMsg{Width: 40, Height: 10})
+	require.Nil(t, cmd)
+
+	got := visibleControl(buf.String())
+	assert.Contains(t, got, "<esc>[1;8r")
+	assert.Contains(t, got, "<esc>[10;1H<esc>[2Kwidget")
+}
+
+func TestRenderer_LogsScrollAboveRegion(t *testing.T) {
+	term := midterm.NewTerminal(10, 40)
+	term.Raw = true
+
+	model := New(&staticTestModel{}, term, &Options{
+		Width:     40,
+		Height:    10,
+		MinHeight: 3,
+		MaxHeight: 3,
+	})
+	_, _ = model.Update(tea.WindowSizeMsg{Width: 40, Height: 10})
+
+	_, err := io.WriteString(term, "log 1\r\nlog 2\r\nlog 3\r\nlog 4\r\n")
+	require.NoError(t, err)
+
+	rows := renderedRows(term)
+	assert.True(t, rowContains(rows[:7], "log 4"), rows[:7])
+	assert.Equal(t, "widget", rows[9])
+
+	require.NoError(t, model.Close())
+}
+
+func TestRenderer_RenderedRows(t *testing.T) {
+	term := midterm.NewTerminal(10, 40)
+	term.Raw = true
+
+	model := New(&rectangleTestModel{}, term, &Options{
+		Width:     40,
+		Height:    10,
+		MinHeight: 4,
+		MaxHeight: 6,
+	})
+	_, _ = model.Update(tea.WindowSizeMsg{Width: 40, Height: 10})
+
+	_, err := io.WriteString(term, "pulled 1 commit\r\nupdated #123\r\n")
+	require.NoError(t, err)
+
+	autogold.Expect([]string{
+		"",
+		"",
+		"",
+		"pulled 1 commit",
+		"updated #123",
+		"",
+		"+--------------+",
+		"|              |",
+		"|              |",
+		"+--------------+",
+	}).Equal(t, renderedRows(term))
+
+	require.NoError(t, model.Close())
+}
+
+type testModel struct {
+	step   int
+	width  int
+	height int
+}
+
+func (m *testModel) Init() tea.Cmd {
+	return func() tea.Msg { return testStep{} }
+}
+
+func (m *testModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+	case testStep:
+		m.step++
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m *testModel) View() tea.View {
+	return tea.NewView(fmt.Sprintf("view: %d %dx%d", m.step, m.width, m.height))
+}
+
+type testStep struct{}
+
+type staticTestModel struct{}
+
+func (m *staticTestModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m *staticTestModel) Update(tea.Msg) (tea.Model, tea.Cmd) {
+	return m, nil
+}
+
+func (m *staticTestModel) View() tea.View {
+	return tea.NewView("widget")
+}
+
+type tallTestModel struct {
+	tall bool
+}
+
+func (m *tallTestModel) Init() tea.Cmd {
+	return func() tea.Msg { return testStep{} }
+}
+
+func (m *tallTestModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if _, ok := msg.(testStep); ok {
+		m.tall = true
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m *tallTestModel) View() tea.View {
+	if !m.tall {
+		return tea.NewView("short")
+	}
+	return tea.NewView("line 1\nline 2\nline 3\nline 4\nline 5")
+}
+
+type rectangleTestModel struct {
+	width  int
+	height int
+}
+
+func (m *rectangleTestModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m *rectangleTestModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if size, ok := msg.(tea.WindowSizeMsg); ok {
+		m.width = min(size.Width, 16)
+		m.height = size.Height
+	}
+	return m, nil
+}
+
+func (m *rectangleTestModel) View() tea.View {
+	width := max(2, m.width)
+	height := max(2, m.height)
+	top := "+" + strings.Repeat("-", width-2) + "+"
+	middle := "|" + strings.Repeat(" ", width-2) + "|"
+
+	lines := make([]string, height)
+	lines[0] = top
+	for i := 1; i < height-1; i++ {
+		lines[i] = middle
+	}
+	lines[height-1] = top
+	return tea.NewView(strings.Join(lines, "\n"))
+}
+
+func visibleControl(s string) string {
+	return strings.ReplaceAll(s, "\x1b", "<esc>")
+}
+
+func renderedRows(term *midterm.Terminal) []string {
+	rows := make([]string, len(term.Content))
+	for i, row := range term.Content {
+		rows[i] = string(trimRightWS(row))
+	}
+	return rows
+}
+
+func rowContains(rows []string, want string) bool {
+	return slices.ContainsFunc(rows, func(row string) bool {
+		return strings.Contains(row, want)
+	})
+}
+
+func trimRightWS(rs []rune) []rune {
+	for i, v := range slices.Backward(rs) {
+		switch v {
+		case 0, ' ', '\t', '\n':
+		default:
+			rs = rs[:i+1]
+			if j := slices.Index(rs, 0); j >= 0 {
+				rs = slices.Clone(rs)
+				for k := j; k < len(rs); k++ {
+					if rs[k] == 0 {
+						rs[k] = ' '
+					}
+				}
+			}
+			return rs
+		}
+	}
+	return nil
+}

--- a/internal/ui/scrollregion/renderer.go
+++ b/internal/ui/scrollregion/renderer.go
@@ -1,0 +1,284 @@
+package scrollregion
+
+import (
+	"io"
+	"strings"
+	"sync"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/charmbracelet/x/term"
+	"go.abhg.dev/gs/internal/must"
+)
+
+const defaultWidth = 80
+
+// renderer owns the terminal scroll margins and reserved-region frames.
+type renderer struct {
+	// out is the same stream used by ordinary log output.
+	//
+	// If it exposes Fd, the renderer can discover terminal size from it.
+	out io.Writer // immutable
+
+	mu     sync.Mutex // guards mutable fields below
+	width  int
+	height int
+
+	minHeight int // immutable
+	maxHeight int // immutable
+
+	// currentHeight is recalculated from the rendered view within the configured
+	// bounds so a compact model does not permanently claim MaxHeight rows.
+	currentHeight int
+
+	// reserved is true after DECSTBM has been installed.
+	//
+	// The first reservation waits until Render sees real content so the
+	// terminal does not flicker through a min-height region and then grow.
+	reserved bool
+	closed   bool
+}
+
+func newRenderer(
+	out io.Writer,
+	width int,
+	height int,
+	minHeight int,
+	maxHeight int,
+) *renderer {
+	must.NotBeNilf(out, "scroll region output is required")
+	if minHeight <= 0 {
+		minHeight = 1
+	}
+	if maxHeight <= 0 {
+		maxHeight = minHeight
+	}
+	must.Bef(minHeight <= maxHeight,
+		"scroll region minimum height %d exceeds maximum height %d",
+		minHeight, maxHeight)
+	must.Bef(height <= 0 || minHeight < height,
+		"scroll region minimum height %d must be less than terminal height %d",
+		minHeight, height)
+
+	return &renderer{
+		out:           out,
+		width:         width,
+		height:        height,
+		minHeight:     minHeight,
+		maxHeight:     maxHeight,
+		currentHeight: minHeight,
+	}
+}
+
+// Resize updates the terminal dimensions used for the scroll margins.
+//
+// Resize may run before the first render. In that case it records the size
+// but waits for Render to install the margins at the rendered content height.
+func (r *renderer) Resize(width, height int) {
+	if width <= 0 || height <= 0 {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.closed {
+		return
+	}
+
+	if r.reserved && r.width == width && r.height == height {
+		return
+	}
+
+	r.width = width
+	r.height = height
+	if r.currentHeight >= r.height {
+		r.currentHeight = r.height - 1
+	}
+	if !r.reserved {
+		return
+	}
+	r.reserveLocked(0)
+}
+
+// Render draws view into the reserved rows.
+func (r *renderer) Render(view tea.View) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.closed {
+		return
+	}
+	if r.height <= 0 {
+		return
+	}
+
+	lines := viewLines(view.Content)
+	oldHeight := r.currentHeight
+	r.currentHeight = r.heightForLines(len(lines))
+	if !r.reserved {
+		r.reserveInitial()
+	} else if oldHeight != r.currentHeight {
+		r.reserveLocked(oldHeight)
+	}
+	if len(lines) > r.currentHeight {
+		lines = lines[:r.currentHeight]
+	}
+
+	var b strings.Builder
+	renderStart := r.regionStart()
+	if len(lines) < r.currentHeight {
+		renderStart += r.currentHeight - len(lines)
+	}
+	for row := range r.currentHeight {
+		b.WriteString(ansi.CursorPosition(1, r.regionStart()+row))
+		b.WriteString(ansi.EraseLine(2))
+		lineIdx := row - (renderStart - r.regionStart())
+		if lineIdx >= 0 && lineIdx < len(lines) {
+			b.WriteString(lines[lineIdx])
+		}
+	}
+	// Park the cursor on the last scrollable row.
+	// Ordinary log writes should resume above the reserved rows,
+	// not inside the redrawn model region.
+	b.WriteString(ansi.CursorPosition(1, r.scrollBottom()))
+	_, _ = io.WriteString(r.out, b.String())
+}
+
+// Close clears the reserved rows and restores normal scrolling.
+func (r *renderer) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.closed {
+		return nil
+	}
+	r.closed = true
+	if !r.reserved {
+		return nil
+	}
+
+	var b strings.Builder
+	for row := range r.currentHeight {
+		b.WriteString(ansi.CursorPosition(1, r.regionStart()+row))
+		b.WriteString(ansi.EraseLine(2))
+	}
+	// Reset DECSTBM by omitting top and bottom margins.
+	// github.com/charmbracelet/x/ansi provides SetScrollingRegion
+	// but no reset helper in the version used by this module.
+	b.WriteString("\x1b[r")
+	b.WriteString(ansi.ShowCursor)
+	b.WriteString(ansi.CursorPosition(1, r.height))
+	_, err := io.WriteString(r.out, b.String())
+	return err
+}
+
+// ModelHeight reports the current height presented to the wrapped model.
+func (r *renderer) ModelHeight() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.currentHeight
+}
+
+// initialWindowSize builds the startup WindowSizeMsg for the wrapped model.
+//
+// Bubble Tea normally sends this message after initializing its renderer.
+// Reserved-region mode disables that renderer, so the model synthesizes the
+// same message from explicit options or the output file descriptor.
+func (r *renderer) initialWindowSize() tea.Msg {
+	width, height := r.size()
+
+	if termWidth, termHeight, ok := r.latestWindowSize(); ok {
+		if width <= 0 {
+			width = termWidth
+		}
+		if height <= 0 {
+			height = termHeight
+		}
+	}
+	if width <= 0 {
+		width = defaultWidth
+	}
+	if height <= 0 {
+		return nil
+	}
+	return tea.WindowSizeMsg{Width: width, Height: height}
+}
+
+// latestWindowSize reads the current terminal size from the output stream.
+func (r *renderer) latestWindowSize() (width, height int, ok bool) {
+	fdOut, ok := r.out.(interface{ Fd() uintptr })
+	if !ok {
+		return 0, 0, false
+	}
+
+	width, height, err := term.GetSize(fdOut.Fd())
+	if err != nil {
+		return 0, 0, false
+	}
+	return width, height, true
+}
+
+func (r *renderer) size() (int, int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.width, r.height
+}
+
+func (r *renderer) reserveInitial() {
+	var b strings.Builder
+	// Print blank rows before installing DECSTBM so the terminal has physical
+	// rows available for the reserved region at the bottom of the viewport.
+	b.WriteString(strings.Repeat("\n", r.currentHeight))
+	b.WriteString(r.marginSequence())
+	b.WriteString(ansi.HideCursor)
+	b.WriteString(ansi.CursorPosition(1, r.scrollBottom()))
+	_, _ = io.WriteString(r.out, b.String())
+	r.reserved = true
+}
+
+func (r *renderer) reserveLocked(oldHeight int) {
+	clearHeight := max(oldHeight, r.currentHeight)
+	var b strings.Builder
+	b.WriteString(r.marginSequence())
+	b.WriteString(ansi.HideCursor)
+	if clearHeight > 0 {
+		start := r.height - clearHeight + 1
+		for row := range clearHeight {
+			b.WriteString(ansi.CursorPosition(1, start+row))
+			b.WriteString(ansi.EraseLine(2))
+		}
+	}
+	// Park the cursor on the last scrollable row.
+	// The next ordinary write should occur above the reserved rows,
+	// not inside the redrawn model region.
+	b.WriteString(ansi.CursorPosition(1, r.scrollBottom()))
+	_, _ = io.WriteString(r.out, b.String())
+}
+
+func (r *renderer) marginSequence() string {
+	// DECSTBM keeps ordinary log output scrolling above the reserved rows.
+	return ansi.SetTopBottomMargins(1, r.scrollBottom())
+}
+
+func (r *renderer) scrollBottom() int {
+	return r.height - r.currentHeight
+}
+
+func (r *renderer) regionStart() int {
+	return r.scrollBottom() + 1
+}
+
+func (r *renderer) heightForLines(lines int) int {
+	height := max(lines, r.minHeight)
+	height = min(height, r.maxHeight)
+	return min(height, r.height-1)
+}
+
+func viewLines(content string) []string {
+	content = strings.TrimRight(content, "\n")
+	if content == "" {
+		return nil
+	}
+	return strings.Split(content, "\n")
+}

--- a/internal/ui/scrollregion/resize_other.go
+++ b/internal/ui/scrollregion/resize_other.go
@@ -1,0 +1,19 @@
+//go:build !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris && !aix && !zos
+
+package scrollregion
+
+import (
+	"context"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func (m *Model) watchResize(
+	context.Context,
+	*tea.Program,
+) <-chan struct{} {
+	// Bubble Tea does not provide SIGWINCH resize watching on these targets.
+	done := make(chan struct{})
+	close(done)
+	return done
+}

--- a/internal/ui/scrollregion/resize_unix.go
+++ b/internal/ui/scrollregion/resize_unix.go
@@ -1,0 +1,49 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || aix || zos
+
+package scrollregion
+
+import (
+	"context"
+	"syscall"
+
+	tea "charm.land/bubbletea/v2"
+	"go.abhg.dev/gs/internal/sigstack"
+)
+
+func (m *Model) watchResize(
+	ctx context.Context,
+	program *tea.Program,
+) <-chan struct{} {
+	done := make(chan struct{})
+	if _, _, ok := m.renderer.latestWindowSize(); !ok {
+		close(done)
+		return done
+	}
+
+	signals := make(chan sigstack.Signal, 1)
+	// Register through sigstack so other terminal components can share
+	// SIGWINCH without replacing each other's signal handlers.
+	m.signals.Notify(signals, syscall.SIGWINCH)
+	go func() {
+		defer close(done)
+		defer m.signals.Stop(signals)
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-signals:
+				// SIGWINCH means the terminal may have changed size.
+				// Read the size from the same output stream used for rendering,
+				// then forward the Bubble Tea size message into the wrapped model.
+				if width, height, ok := m.renderer.latestWindowSize(); ok {
+					program.Send(tea.WindowSizeMsg{
+						Width:  width,
+						Height: height,
+					})
+				}
+			}
+		}
+	}()
+	return done
+}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -9,6 +9,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/colorprofile"
+	"go.abhg.dev/gs/internal/sigstack"
 )
 
 // ErrPrompt indicates that we're not running in interactive mode.
@@ -90,7 +91,8 @@ type TerminalView struct {
 	r io.Reader
 	w io.Writer
 
-	theme func() Theme
+	theme   func() Theme
+	signals *sigstack.Stack
 }
 
 var _ InteractiveView = (*TerminalView)(nil)
@@ -106,6 +108,15 @@ func NewTerminalView(r io.Reader, w io.Writer) *TerminalView {
 	}
 }
 
+// WithSignals sets the signal stack used by terminal UI components.
+//
+// If WithSignals is not called,
+// components that need signal handling create private stacks.
+func (tv *TerminalView) WithSignals(signals *sigstack.Stack) *TerminalView {
+	tv.signals = signals
+	return tv
+}
+
 func (tv *TerminalView) Write(p []byte) (int, error) {
 	return tv.w.Write(p)
 }
@@ -118,9 +129,10 @@ func (tv *TerminalView) Theme() Theme {
 // Prompt prompts the user for input with the given interactive fields.
 func (tv *TerminalView) Prompt(fields ...Field) error {
 	return NewForm(fields...).Run(&FormRunOptions{
-		Input:  tv.r,
-		Output: tv.w,
-		Theme:  tv.theme(),
+		Input:   tv.r,
+		Output:  tv.w,
+		Theme:   tv.theme(),
+		Signals: tv.signals,
 	})
 }
 
@@ -138,6 +150,9 @@ func (tv *TerminalView) RunModel(
 	}
 	if opts.Theme == (Theme{}) {
 		opts.Theme = tv.theme()
+	}
+	if opts.Signals == nil {
+		opts.Signals = tv.signals
 	}
 	return RunModel(model, opts)
 }

--- a/main.go
+++ b/main.go
@@ -331,7 +331,12 @@ type forgeOptions struct {
 	Kind string `name:"forge-kind" hidden:"" config:"forge.kind" env:"GIT_SPICE_FORGE_KIND" configHelp:"-" help:"Forge kind to use when remote URLs do not identify a supported Git host."`
 }
 
-func (cmd *mainCmd) AfterApply(ctx context.Context, kctx *kong.Context, logger *silog.Logger) error {
+func (cmd *mainCmd) AfterApply(
+	ctx context.Context,
+	kctx *kong.Context,
+	logger *silog.Logger,
+	signals *sigstack.Stack,
+) error {
 	if cmd.Globals.Verbose {
 		logger.SetLevel(silog.LevelDebug)
 	}
@@ -347,7 +352,7 @@ func (cmd *mainCmd) AfterApply(ctx context.Context, kctx *kong.Context, logger *
 		}
 	}
 
-	view, err := _buildView(os.Stdin, kctx.Stderr, cmd.Globals.Prompt)
+	view, err := _buildView(os.Stdin, kctx.Stderr, cmd.Globals.Prompt, signals)
 	if err != nil {
 		return fmt.Errorf("build view: %w", err)
 	}
@@ -692,9 +697,14 @@ type AutostashHandler interface {
 
 var _ AutostashHandler = (*autostash.Handler)(nil)
 
-var _buildView = func(stdin io.Reader, stderr io.Writer, interactive bool) (ui.View, error) {
+var _buildView = func(
+	stdin io.Reader,
+	stderr io.Writer,
+	interactive bool,
+	signals *sigstack.Stack,
+) (ui.View, error) {
 	if interactive {
-		return ui.NewTerminalView(stdin, stderr), nil
+		return ui.NewTerminalView(stdin, stderr).WithSignals(signals), nil
 	}
 	return ui.NewFileView(stderr), nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -13,6 +13,7 @@ import (
 	"go.abhg.dev/gs/internal/mockedit"
 	"go.abhg.dev/gs/internal/secret"
 	"go.abhg.dev/gs/internal/secret/secrettest"
+	"go.abhg.dev/gs/internal/sigstack"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/termtest"
 	"go.abhg.dev/gs/internal/ui"
@@ -50,7 +51,12 @@ func TestMain(m *testing.M) {
 			// If ROBOT_INPUT is set, install a uitest.RobotView
 			// instead of the normal view. This will always be interactive.
 			if fixtureFile := os.Getenv("ROBOT_INPUT"); fixtureFile != "" {
-				_buildView = func(_ io.Reader, stderr io.Writer, _ bool) (ui.View, error) {
+				_buildView = func(
+					_ io.Reader,
+					stderr io.Writer,
+					_ bool,
+					_ *sigstack.Stack,
+				) (ui.View, error) {
 					return uitest.NewRobotView(
 						fixtureFile,
 						&uitest.RobotViewOptions{


### PR DESCRIPTION
Merge progress needs a terminal mode where a Bubble Tea model can keep
redrawing while ordinary command output continues to write to the same
stream. That mode must preserve resize behavior without using the
alternate screen and without turning progress into repeated log lines.

The standard Bubble Tea renderer owns cursor movement and resize setup.
That works for full-screen programs,
but it collides with command logs when both write to the terminal.
Disabling the renderer avoids that contention,
but it also means the command must supply the startup size
and resize events itself.

Add a scroll-region runner to the shared UI layer.
The runner wraps any compact Bubble Tea model,
draws it into reserved bottom rows with DECSTBM margins,
and leaves normal writes to scroll above those rows.
The wrapped model still receives `tea.WindowSizeMsg` values,
but the terminal-size source now belongs to the runner.

`TerminalView` also carries the command `sigstack.Stack`.
That lets the scroll-region resize watcher share signal handling
with the rest of the command instead of registering a separate
`os/signal` handler.

The reserved height is a min/max range.
The minimum prevents the reserved region from bouncing
when a model briefly renders fewer rows.
The maximum leaves space for log output
as future widgets grow more detailed.