### PR TITLE
merge: Run progress widget in scroll region

### DIFF
--- a/internal/handler/merge/handler.go
+++ b/internal/handler/merge/handler.go
@@ -344,16 +344,83 @@ func (h *Handler) confirm(plan []*mergeItem) error {
 
 func (h *Handler) executePlan(
 	ctx context.Context, plan []*mergeItem, req *Request,
+) (err error) {
+	var progress mergeProgress
+	if runner, ok := h.View.(ui.ModelView); ok {
+		widgetProgress := newWidgetMergeProgress(
+			runner, h.View.Theme(),
+		)
+		progress = widgetProgress
+		ctx = widgetProgress.Start(ctx, plan)
+		defer func() {
+			err = errors.Join(err, widgetProgress.Finish())
+		}()
+	} else {
+		progress = newLogMergeProgress(h.Log)
+	}
+
+	err = (&mergePlanExecutor{
+		RemoteRepository: h.RemoteRepository,
+		Repository:       h.Repository,
+
+		Service: h.Service,
+		Restack: h.Restack,
+		Submit:  h.Submit,
+		Sync:    h.Sync,
+
+		Progress: progress,
+
+		Trunk:        h.Store.Trunk(),
+		BuildTimeout: req.BuildTimeout,
+		Method:       req.Method,
+		NoWait:       req.NoWait,
+	}).execute(ctx, plan)
+	if err != nil {
+		return err
+	}
+
+	h.Log.Infof("All %d change(s) merged.", len(plan))
+	return nil
+}
+
+// mergePlanExecutor runs the merge loop after preflight checks complete.
+//
+// It intentionally has no logger.
+// Merge-loop status must be reported through progress events
+// so terminal and non-terminal output stay in one policy boundary.
+type mergePlanExecutor struct {
+	RemoteRepository forge.Repository // required
+	Repository       GitRepository    // required
+
+	Service Service        // required
+	Restack RestackHandler // required
+	Submit  SubmitHandler  // required
+	Sync    SyncHandler    // required
+
+	Progress mergeProgress // required
+
+	Trunk        string            // required
+	BuildTimeout time.Duration     // required
+	Method       forge.MergeMethod // required
+	NoWait       bool
+}
+
+func (e *mergePlanExecutor) execute(
+	ctx context.Context, plan []*mergeItem,
 ) error {
-	trunk := h.Store.Trunk()
-
 	for i, item := range plan {
-		lastItem := i == len(plan)-1
-
 		// After each lower branch merges,
 		// prepare the next branch on top of updated trunk state.
 		if i > 0 {
-			if err := h.prepareForMerge(ctx, item); err != nil {
+			e.Progress.Event(mergeProgressEvent{
+				Kind: mergeProgressPreparing,
+				Item: item,
+			})
+			if err := e.prepareForMerge(ctx, item); err != nil {
+				e.Progress.Event(mergeProgressEvent{
+					Kind: mergeProgressPrepareFailed,
+					Item: item,
+				})
 				return fmt.Errorf("prepare %q: %w", item.branch, err)
 			}
 		}
@@ -361,10 +428,12 @@ func (h *Handler) executePlan(
 		// The forge will only merge a change that targets trunk.
 		// Re-check immediately before each merge because prior queue items
 		// and repo sync may have changed the server-side base.
-		change, err := h.ensureTargetsTrunk(
-			ctx, item, trunk,
-		)
+		change, err := e.ensureTargetsTrunk(ctx, item)
 		if err != nil {
+			e.Progress.Event(mergeProgressEvent{
+				Kind: mergeProgressRetargetFailed,
+				Item: item,
+			})
 			return fmt.Errorf(
 				"ensure %q targets trunk: %w",
 				item.branch, err,
@@ -373,54 +442,72 @@ func (h *Handler) executePlan(
 
 		// CI is checked after retargeting and restacking
 		// so each merge waits on the exact change being merged.
-		if err := h.awaitChecks(
-			ctx, item, req.BuildTimeout,
-		); err != nil {
+		if err := e.awaitChecks(ctx, item); err != nil {
+			e.Progress.Event(mergeProgressEvent{
+				Kind: mergeProgressChecksFailed,
+				Item: item,
+			})
 			return fmt.Errorf(
 				"wait for checks on %q: %w",
 				item.branch, err,
 			)
 		}
 
-		h.Log.Infof(
-			"%s: merging %v: %s",
-			item.branch, item.changeID, change.URL,
-		)
-		if err := h.RemoteRepository.MergeChange(
+		e.Progress.Event(mergeProgressEvent{
+			Kind: mergeProgressMerging,
+			Item: item,
+			URL:  change.URL,
+		})
+		if err := e.RemoteRepository.MergeChange(
 			ctx, item.changeID,
 			forge.MergeChangeOptions{
-				Method:   req.Method,
+				Method:   e.Method,
 				HeadHash: item.headHash,
 			},
 		); err != nil {
+			e.Progress.Event(mergeProgressEvent{
+				Kind: mergeProgressMergeFailed,
+				Item: item,
+			})
 			return fmt.Errorf("merge %q: %w", item.branch, err)
 		}
 
-		if req.NoWait {
+		if e.NoWait {
+			e.Progress.Event(mergeProgressEvent{
+				Kind: mergeProgressMergeRequested,
+				Item: item,
+			})
 			continue
 		}
 
 		// Wait until the forge reports the merge.
-		if err := h.awaitMerged(ctx, item); err != nil {
+		e.Progress.Event(mergeProgressEvent{
+			Kind: mergeProgressWaitingForMerge,
+			Item: item,
+		})
+		if err := e.awaitMerged(ctx, item); err != nil {
+			e.Progress.Event(mergeProgressEvent{
+				Kind: mergeProgressMergeIncomplete,
+				Item: item,
+			})
 			return fmt.Errorf("await merge of %q: %w",
 				item.branch, err)
 		}
+		e.Progress.Event(mergeProgressEvent{
+			Kind: mergeProgressMerged,
+			Item: item,
+		})
 
 		// SyncTrunk updates trunk,
 		// deletes merged branches,
 		// and retargets their upstacks.
-		if err := h.Sync.SyncTrunk(ctx, &sync.TrunkOptions{
+		if err := e.Sync.SyncTrunk(ctx, &sync.TrunkOptions{
 			ClosedChanges: sync.ClosedChangesIgnore,
 		}); err != nil {
-			if !lastItem {
-				return fmt.Errorf("sync trunk: %w", err)
-			}
-			h.Log.Warn("Unable to sync trunk after merge",
-				"error", err)
+			return fmt.Errorf("sync trunk: %w", err)
 		}
 	}
 
-	h.Log.Infof("All %d change(s) merged.", len(plan))
 	return nil
 }
 
@@ -460,21 +547,21 @@ func (h *Handler) validateFreshBases(
 // This is intentionally outside delete cleanup:
 // the merge queue owns the user-visible restack and submit
 // needed before the branch can be merged.
-func (h *Handler) prepareForMerge(
+func (e *mergePlanExecutor) prepareForMerge(
 	ctx context.Context,
 	item *mergeItem,
 ) error {
-	if err := h.Service.VerifyRestacked(ctx, item.branch); err != nil {
+	if err := e.Service.VerifyRestacked(ctx, item.branch); err != nil {
 		var restackErr *spice.BranchNeedsRestackError
 		if !errors.As(err, &restackErr) {
 			return fmt.Errorf("verify restacked: %w", err)
 		}
 
-		if err := h.Restack.RestackBranch(ctx, item.branch); err != nil {
+		if err := e.Restack.RestackBranch(ctx, item.branch); err != nil {
 			return fmt.Errorf("restack branch: %w", err)
 		}
 
-		if err := h.Submit.Submit(ctx, &submit.Request{
+		if err := e.Submit.Submit(ctx, &submit.Request{
 			Branch: item.branch,
 			Options: &submit.Options{
 				// Publish keeps this on the normal Change Request update path.
@@ -488,7 +575,7 @@ func (h *Handler) prepareForMerge(
 		}
 	}
 
-	head, err := h.Repository.PeelToCommit(ctx, item.branch)
+	head, err := e.Repository.PeelToCommit(ctx, item.branch)
 	if err != nil {
 		return fmt.Errorf("resolve updated head: %w", err)
 	}
@@ -498,35 +585,38 @@ func (h *Handler) prepareForMerge(
 
 // awaitChecks polls until CI checks pass for the given change.
 // Uses truncated exponential backoff.
-func (h *Handler) awaitChecks(
+func (e *mergePlanExecutor) awaitChecks(
 	ctx context.Context,
 	item *mergeItem,
-	timeout time.Duration,
 ) error {
 	const (
 		_baseDelay = 10 * time.Second
 		_maxDelay  = 30 * time.Second
 	)
 
-	return h.awaitChecksWithDelay(
-		ctx, item, timeout, _baseDelay, _maxDelay,
+	return e.awaitChecksWithDelay(
+		ctx, item, e.BuildTimeout, _baseDelay, _maxDelay,
 	)
 }
 
-func (h *Handler) awaitChecksWithDelay(
+func (e *mergePlanExecutor) awaitChecksWithDelay(
 	ctx context.Context,
 	item *mergeItem,
 	timeout, baseDelay, maxDelay time.Duration,
 ) error {
 	delay := baseDelay
 	for attempt := 0; ; attempt++ {
-		state, err := h.RemoteRepository.ChangeChecksState(
+		state, err := e.RemoteRepository.ChangeChecksState(
 			ctx, item.changeID,
 		)
 		if err != nil {
 			return fmt.Errorf("query checks: %w", err)
 		}
 		if state == forge.ChecksPassed {
+			e.Progress.Event(mergeProgressEvent{
+				Kind: mergeProgressChecksPassed,
+				Item: item,
+			})
 			return nil
 		}
 		if state == forge.ChecksFailed {
@@ -547,7 +637,10 @@ func (h *Handler) awaitChecksWithDelay(
 			defer cancel()
 		}
 
-		h.Log.Infof("%s: waiting for CI checks", item.branch)
+		e.Progress.Event(mergeProgressEvent{
+			Kind: mergeProgressWaitingForChecks,
+			Item: item,
+		})
 		if err := sleep(ctx, delay); err != nil {
 			return fmt.Errorf(
 				"timed out waiting for CI on %q",
@@ -560,12 +653,11 @@ func (h *Handler) awaitChecksWithDelay(
 
 // ensureTargetsTrunk verifies a change targets trunk
 // on the forge, retargeting if needed.
-func (h *Handler) ensureTargetsTrunk(
+func (e *mergePlanExecutor) ensureTargetsTrunk(
 	ctx context.Context,
 	item *mergeItem,
-	trunk string,
 ) (*forge.FindChangeItem, error) {
-	change, err := h.RemoteRepository.FindChangeByID(
+	change, err := e.RemoteRepository.FindChangeByID(
 		ctx, item.changeID,
 	)
 	if err != nil {
@@ -574,11 +666,11 @@ func (h *Handler) ensureTargetsTrunk(
 		)
 	}
 
-	if change.BaseName == trunk {
+	if change.BaseName == e.Trunk {
 		return change, nil
 	}
 
-	if err := h.retargetChange(ctx, item, trunk); err != nil {
+	if err := e.retargetChange(ctx, item); err != nil {
 		return nil, err
 	}
 	return change, nil
@@ -586,7 +678,7 @@ func (h *Handler) ensureTargetsTrunk(
 
 // awaitMerged polls until the given change shows as merged.
 // Uses exponential backoff starting at 500ms, capped at 8s.
-func (h *Handler) awaitMerged(
+func (e *mergePlanExecutor) awaitMerged(
 	ctx context.Context, item *mergeItem,
 ) error {
 	const (
@@ -604,7 +696,7 @@ func (h *Handler) awaitMerged(
 	// need a more expressive wait state.
 	delay := _initialDelay
 	for {
-		statuses, err := h.RemoteRepository.ChangeStatuses(
+		statuses, err := e.RemoteRepository.ChangeStatuses(
 			ctx, []forge.ChangeID{item.changeID},
 		)
 		if err != nil {
@@ -615,8 +707,10 @@ func (h *Handler) awaitMerged(
 			return nil
 		}
 
-		h.Log.Debugf("%s: waiting for merge to settle",
-			item.branch)
+		e.Progress.Event(mergeProgressEvent{
+			Kind: mergeProgressWaitingForMerge,
+			Item: item,
+		})
 		if err := sleep(ctx, delay); err != nil {
 			return fmt.Errorf(
 				"timed out waiting for %q to merge",
@@ -629,18 +723,21 @@ func (h *Handler) awaitMerged(
 }
 
 // retargetChange updates a change's base to trunk.
-func (h *Handler) retargetChange(
-	ctx context.Context, item *mergeItem, trunk string,
+func (e *mergePlanExecutor) retargetChange(
+	ctx context.Context, item *mergeItem,
 ) error {
-	h.Log.Infof("%s: retargeting %v onto %s",
-		item.branch, item.changeID, trunk)
-	err := h.RemoteRepository.EditChange(
+	e.Progress.Event(mergeProgressEvent{
+		Kind: mergeProgressRetargeting,
+		Item: item,
+		Base: e.Trunk,
+	})
+	err := e.RemoteRepository.EditChange(
 		ctx, item.changeID,
-		forge.EditChangeOptions{Base: trunk},
+		forge.EditChangeOptions{Base: e.Trunk},
 	)
 	if err != nil {
 		return fmt.Errorf("retarget %q to %q: %w",
-			item.branch, trunk, err)
+			item.branch, e.Trunk, err)
 	}
 	return nil
 }

--- a/internal/handler/merge/handler_test.go
+++ b/internal/handler/merge/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -48,10 +49,14 @@ func TestAwaitMerged_immediate(t *testing.T) {
 		logBuffer: nil,
 	})
 
-	err := h.awaitMerged(t.Context(), &mergeItem{
+	item := &mergeItem{
 		branch:   "feat1",
 		changeID: fakeChangeID("pr-1"),
-	})
+	}
+	progress := newLogMergeProgress(silog.Nop())
+	executor := newTestMergePlanExecutor(h, progress)
+
+	err := executor.awaitMerged(t.Context(), item)
 	require.NoError(t, err)
 }
 
@@ -79,10 +84,14 @@ func TestAwaitMerged_afterPolling(t *testing.T) {
 		logBuffer: nil,
 	})
 
-	err := h.awaitMerged(t.Context(), &mergeItem{
+	item := &mergeItem{
 		branch:   "feat1",
 		changeID: fakeChangeID("pr-1"),
-	})
+	}
+	progress := newLogMergeProgress(silog.Nop())
+	executor := newTestMergePlanExecutor(h, progress)
+
+	err := executor.awaitMerged(t.Context(), item)
 	require.NoError(t, err)
 }
 
@@ -101,10 +110,14 @@ func TestAwaitChecks_passed(t *testing.T) {
 		logBuffer: nil,
 	})
 
-	err := h.awaitChecks(t.Context(), &mergeItem{
+	item := &mergeItem{
 		branch:   "feat1",
 		changeID: fakeChangeID("pr-1"),
-	}, 30*time.Minute)
+	}
+	progress := newLogMergeProgress(silog.Nop())
+	executor := newTestMergePlanExecutor(h, progress)
+
+	err := executor.awaitChecks(t.Context(), item)
 	require.NoError(t, err)
 }
 
@@ -123,10 +136,14 @@ func TestAwaitChecks_failed(t *testing.T) {
 		logBuffer: nil,
 	})
 
-	err := h.awaitChecks(t.Context(), &mergeItem{
+	item := &mergeItem{
 		branch:   "feat1",
 		changeID: fakeChangeID("pr-1"),
-	}, 30*time.Minute)
+	}
+	progress := newLogMergeProgress(silog.Nop())
+	executor := newTestMergePlanExecutor(h, progress)
+
+	err := executor.awaitChecks(t.Context(), item)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "CI checks failed")
 }
@@ -147,10 +164,15 @@ func TestAwaitChecks_pendingZeroTimeout(t *testing.T) {
 	})
 
 	// timeout=0 means fail immediately if pending.
-	err := h.awaitChecks(t.Context(), &mergeItem{
+	item := &mergeItem{
 		branch:   "feat1",
 		changeID: fakeChangeID("pr-1"),
-	}, 0)
+	}
+	progress := newLogMergeProgress(silog.Nop())
+	executor := newTestMergePlanExecutor(h, progress)
+
+	executor.BuildTimeout = 0
+	err := executor.awaitChecks(t.Context(), item)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "CI checks pending")
 }
@@ -176,12 +198,16 @@ func TestAwaitChecks_pendingThenPassed(t *testing.T) {
 		logBuffer: nil,
 	})
 
-	err := h.awaitChecksWithDelay(
+	item := &mergeItem{
+		branch:   "feat1",
+		changeID: fakeChangeID("pr-1"),
+	}
+	progress := newLogMergeProgress(silog.Nop())
+	executor := newTestMergePlanExecutor(h, progress)
+
+	err := executor.awaitChecksWithDelay(
 		t.Context(),
-		&mergeItem{
-			branch:   "feat1",
-			changeID: fakeChangeID("pr-1"),
-		},
+		item,
 		5*time.Second,      // timeout
 		1*time.Millisecond, // base delay (fast for test)
 		2*time.Millisecond, // max delay
@@ -362,6 +388,39 @@ func TestExecutePlan_singleBranch(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestExecutePlan_syncTrunkFailureStopsLoop(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockForge := forgetest.NewMockRepository(ctrl)
+	mockStore := NewMockStore(ctrl)
+	mockStore.EXPECT().Trunk().Return("main")
+
+	pr1 := fakeChangeID("pr-1")
+
+	mockForge.EXPECT().
+		FindChangeByID(gomock.Any(), pr1).
+		Return(fakeFindResult("main"), nil)
+
+	expectMergeItem(mockForge, pr1)
+
+	mockSync := NewMockSyncHandler(ctrl)
+	mockSync.EXPECT().
+		SyncTrunk(gomock.Any(), syncTrunkOptions()).
+		Return(errors.New("sync failed"))
+
+	h := newTestHandler(t, ctrl, testHandlerOpts{
+		forgeRepo: mockForge,
+		store:     mockStore,
+		sync:      mockSync,
+	})
+
+	err := h.executePlan(t.Context(), []*mergeItem{
+		{branch: "feat1", changeID: pr1},
+	}, &Request{Branch: "feat1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sync trunk")
+}
+
 func TestExecutePlan_mergeMethod(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
@@ -484,6 +543,81 @@ func TestExecutePlan_firstItemAlreadyOnTrunk(t *testing.T) {
 
 	assert.NotContains(t,
 		logBuffer.String(), "retargeting")
+}
+
+func TestLogMergeProgress_deduplicatesRepeatedState(t *testing.T) {
+	var logBuffer bytes.Buffer
+	progress := newLogMergeProgress(silog.New(&logBuffer, nil))
+	item := &mergeItem{
+		branch:   "feat1",
+		changeID: fakeChangeID("pr-1"),
+	}
+
+	progress.Event(mergeProgressEvent{
+		Kind: mergeProgressRetargeting,
+		Item: item,
+		Base: "main",
+	})
+	progress.Event(mergeProgressEvent{
+		Kind: mergeProgressRetargeting,
+		Item: item,
+		Base: "main",
+	})
+	progress.Event(mergeProgressEvent{
+		Kind: mergeProgressWaitingForChecks,
+		Item: item,
+	})
+	progress.Event(mergeProgressEvent{
+		Kind: mergeProgressWaitingForChecks,
+		Item: item,
+	})
+	progress.Event(mergeProgressEvent{
+		Kind: mergeProgressMerging,
+		Item: item,
+		URL:  "http://example.com/1",
+	})
+	progress.Event(mergeProgressEvent{
+		Kind: mergeProgressMerging,
+		Item: item,
+		URL:  "http://example.com/1",
+	})
+
+	output := logBuffer.String()
+	assert.Equal(t, 1, strings.Count(output,
+		"feat1: retargeting pr-1 onto main"))
+	assert.Equal(t, 1, strings.Count(output,
+		"feat1: waiting for CI checks"))
+	assert.Equal(t, 1, strings.Count(output,
+		"feat1: merging pr-1: http://example.com/1"))
+}
+
+func TestLogMergeProgress_waitingForMergeIsDebug(t *testing.T) {
+	item := &mergeItem{
+		branch:   "feat1",
+		changeID: fakeChangeID("pr-1"),
+	}
+
+	var infoBuffer bytes.Buffer
+	infoProgress := newLogMergeProgress(silog.New(&infoBuffer, nil))
+	infoProgress.Event(mergeProgressEvent{
+		Kind: mergeProgressWaitingForMerge,
+		Item: item,
+	})
+	assert.NotContains(t, infoBuffer.String(),
+		"feat1: waiting for merge")
+
+	var debugBuffer bytes.Buffer
+	debugProgress := newLogMergeProgress(
+		silog.New(&debugBuffer, &silog.Options{
+			Level: silog.LevelDebug,
+		}),
+	)
+	debugProgress.Event(mergeProgressEvent{
+		Kind: mergeProgressWaitingForMerge,
+		Item: item,
+	})
+	assert.Contains(t, debugBuffer.String(),
+		"feat1: waiting for merge")
 }
 
 func TestValidateSynced_allInSync(t *testing.T) {
@@ -672,6 +806,27 @@ func testLog(buf *bytes.Buffer) *silog.Logger {
 		return silog.New(buf, nil)
 	}
 	return silog.Nop()
+}
+
+func newTestMergePlanExecutor(
+	h *Handler,
+	progress mergeProgress,
+) *mergePlanExecutor {
+	return &mergePlanExecutor{
+		RemoteRepository: h.RemoteRepository,
+		Repository:       h.Repository,
+
+		Service: h.Service,
+		Restack: h.Restack,
+		Submit:  h.Submit,
+		Sync:    h.Sync,
+
+		Progress: progress,
+
+		Trunk:        "main",
+		BuildTimeout: 30 * time.Minute,
+		Method:       forge.MergeMethodDefault,
+	}
 }
 
 func testForgeRepo(

--- a/internal/handler/merge/progress.go
+++ b/internal/handler/merge/progress.go
@@ -1,0 +1,298 @@
+package merge
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	tea "charm.land/bubbletea/v2"
+	"go.abhg.dev/gs/internal/silog"
+	"go.abhg.dev/gs/internal/ui"
+	"go.abhg.dev/gs/internal/ui/widget/mergeprogress"
+)
+
+// mergeProgress reports merge-loop progress to either the terminal widget
+// or the non-interactive log stream.
+type mergeProgress interface {
+	Event(mergeProgressEvent)
+}
+
+// mergeProgressEvent is one progress event emitted by the merge loop.
+type mergeProgressEvent struct {
+	// Kind identifies the merge-loop state being reported.
+	Kind mergeProgressEventKind
+
+	// Item identifies the branch and change being updated.
+	Item *mergeItem
+
+	// URL is the forge URL associated with merge request events.
+	URL string
+
+	// Base is the target branch associated with retargeting events.
+	Base string
+}
+
+// mergeProgressEventKind identifies the operation state being reported.
+type mergeProgressEventKind uint8
+
+const (
+	mergeProgressPreparing        mergeProgressEventKind = iota // branch preparation started
+	mergeProgressPrepareFailed                                  // local preparation failed
+	mergeProgressRetargeting                                    // retargeting to trunk started
+	mergeProgressRetargetFailed                                 // retargeting to trunk failed
+	mergeProgressWaitingForChecks                               // CI checks still pending
+	mergeProgressChecksPassed                                   // CI checks passed
+	mergeProgressChecksFailed                                   // CI checks failed or timed out
+	mergeProgressMerging                                        // forge merge request started
+	mergeProgressMergeFailed                                    // forge merge request failed
+	mergeProgressMergeRequested                                 // merge requested without waiting
+	mergeProgressWaitingForMerge                                // waiting for merged state
+	mergeProgressMergeIncomplete                                // merged state did not appear
+	mergeProgressMerged                                         // merged state observed
+)
+
+// logMergeProgress reports merge progress through sparse log messages.
+type logMergeProgress struct {
+	log *silog.Logger
+
+	last map[string]mergeProgressEvent
+}
+
+func newLogMergeProgress(log *silog.Logger) *logMergeProgress {
+	return &logMergeProgress{
+		log:  log,
+		last: make(map[string]mergeProgressEvent),
+	}
+}
+
+func (p *logMergeProgress) Event(event mergeProgressEvent) {
+	item := event.Item
+	if p.last[item.branch] == event {
+		return
+	}
+	p.last[item.branch] = event
+
+	switch event.Kind {
+	case mergeProgressRetargeting:
+		p.log.Infof("%s: retargeting %v onto %s",
+			event.Item.branch, event.Item.changeID, event.Base)
+	case mergeProgressWaitingForChecks:
+		p.log.Infof("%s: waiting for CI checks", event.Item.branch)
+	case mergeProgressMerging:
+		p.log.Infof("%s: merging %v: %s",
+			event.Item.branch, event.Item.changeID, event.URL)
+	case mergeProgressWaitingForMerge:
+		p.log.Debugf("%s: waiting for merge", event.Item.branch)
+	}
+}
+
+// widgetMergeProgress reports merge progress through a Bubble Tea model.
+type widgetMergeProgress struct {
+	runner ui.ModelView
+	theme  ui.Theme
+
+	events chan tea.Msg
+	// err is written before stopped is closed
+	// and read only after receiving from stopped.
+	// Closing stopped synchronizes the write with the read.
+	err error
+
+	stopped chan struct{}
+	cancel  context.CancelFunc
+}
+
+func newWidgetMergeProgress(
+	runner ui.ModelView,
+	theme ui.Theme,
+) *widgetMergeProgress {
+	return &widgetMergeProgress{
+		runner: runner,
+		theme:  theme,
+	}
+}
+
+// Start launches the Bubble Tea progress model
+// and returns a context canceled when the user cancels the widget.
+//
+// The caller must call Finish after the merge loop exits
+// so the model goroutine can stop and report renderer errors.
+func (p *widgetMergeProgress) Start(
+	ctx context.Context,
+	items []*mergeItem,
+) context.Context {
+	ctx, p.cancel = context.WithCancel(ctx)
+	p.events = make(chan tea.Msg, 1)
+	p.stopped = make(chan struct{})
+
+	progressItems := make([]mergeprogress.Item, len(items))
+	for idx, item := range items {
+		progressItems[idx] = mergeprogress.Item{
+			ID:    item.branch,
+			State: mergeprogress.StatePending,
+		}
+	}
+
+	model := &mergeProgressModel{
+		Widget: mergeprogress.New(progressItems...).
+			WithTheme(p.theme),
+		events: p.events,
+	}
+	go func() {
+		p.err = p.runner.RunModel(model, nil)
+		if errors.Is(model.Err(), mergeprogress.ErrCanceled) {
+			p.cancel()
+		}
+		close(p.stopped)
+	}()
+	return ctx
+}
+
+func (p *widgetMergeProgress) Event(event mergeProgressEvent) {
+	if p.events == nil {
+		return
+	}
+
+	select {
+	case p.events <- widgetProgressEvent(event):
+	case <-p.stopped:
+	}
+}
+
+func (p *widgetMergeProgress) Finish() error {
+	if p.events == nil {
+		return nil
+	}
+
+	select {
+	case p.events <- mergeProgressDone{}:
+	case <-p.stopped:
+	}
+	<-p.stopped
+	if p.err != nil {
+		return fmt.Errorf("run merge progress: %w", p.err)
+	}
+	return nil
+}
+
+type mergeProgressModel struct {
+	*mergeprogress.Widget
+
+	events <-chan tea.Msg
+}
+
+func (m *mergeProgressModel) Init() tea.Cmd {
+	return waitMergeProgressEvent(m.events)
+}
+
+func (m *mergeProgressModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if _, ok := msg.(mergeProgressDone); ok {
+		return m, tea.Quit
+	}
+
+	model, cmd := m.Widget.Update(msg)
+	if widget, ok := model.(*mergeprogress.Widget); ok {
+		m.Widget = widget
+	}
+	return m, tea.Batch(cmd, waitMergeProgressEvent(m.events))
+}
+
+// mergeProgressDone tells the Bubble Tea model
+// that the merge loop has stopped publishing events.
+type mergeProgressDone struct{}
+
+// waitMergeProgressEvent blocks the Bubble Tea update loop
+// until the merge loop publishes the next progress message.
+func waitMergeProgressEvent(events <-chan tea.Msg) tea.Cmd {
+	return func() tea.Msg {
+		return <-events
+	}
+}
+
+func widgetProgressEvent(event mergeProgressEvent) mergeprogress.Event {
+	item := event.Item
+	switch event.Kind {
+	case mergeProgressPreparing:
+		return mergeprogress.Event{
+			ItemID:  item.branch,
+			State:   mergeprogress.StateActive,
+			Message: fmt.Sprintf("%s: preparing %v", item.branch, item.changeID),
+		}
+	case mergeProgressPrepareFailed:
+		return mergeprogress.Event{
+			ItemID:  item.branch,
+			State:   mergeprogress.StateFailed,
+			Message: item.branch + ": prepare failed",
+		}
+	case mergeProgressRetargeting:
+		return mergeprogress.Event{
+			ItemID: item.branch,
+			State:  mergeprogress.StateActive,
+			Message: fmt.Sprintf("%s: retargeting %v onto %s",
+				item.branch, item.changeID, event.Base),
+		}
+	case mergeProgressRetargetFailed:
+		return mergeprogress.Event{
+			ItemID:  item.branch,
+			State:   mergeprogress.StateFailed,
+			Message: item.branch + ": retarget failed",
+		}
+	case mergeProgressWaitingForChecks:
+		return mergeprogress.Event{
+			ItemID:  item.branch,
+			State:   mergeprogress.StateActive,
+			Message: item.branch + ": waiting for CI checks",
+		}
+	case mergeProgressChecksPassed:
+		return mergeprogress.Event{
+			ItemID:  item.branch,
+			State:   mergeprogress.StateActive,
+			Message: item.branch + ": CI checks passed",
+		}
+	case mergeProgressChecksFailed:
+		return mergeprogress.Event{
+			ItemID:  item.branch,
+			State:   mergeprogress.StateFailed,
+			Message: item.branch + ": CI checks failed",
+		}
+	case mergeProgressMerging:
+		return mergeprogress.Event{
+			ItemID: item.branch,
+			State:  mergeprogress.StateActive,
+			Message: fmt.Sprintf("%s: merging %v: %s",
+				item.branch, item.changeID, event.URL),
+		}
+	case mergeProgressMergeFailed:
+		return mergeprogress.Event{
+			ItemID:  item.branch,
+			State:   mergeprogress.StateFailed,
+			Message: item.branch + ": merge failed",
+		}
+	case mergeProgressMergeRequested:
+		return mergeprogress.Event{
+			ItemID:  item.branch,
+			State:   mergeprogress.StateMerged,
+			Message: item.branch + ": merge requested",
+		}
+	case mergeProgressWaitingForMerge:
+		return mergeprogress.Event{
+			ItemID:  item.branch,
+			State:   mergeprogress.StateActive,
+			Message: item.branch + ": waiting for merge",
+		}
+	case mergeProgressMergeIncomplete:
+		return mergeprogress.Event{
+			ItemID:  item.branch,
+			State:   mergeprogress.StateFailed,
+			Message: item.branch + ": merge did not complete",
+		}
+	case mergeProgressMerged:
+		return mergeprogress.Event{
+			ItemID:  item.branch,
+			State:   mergeprogress.StateMerged,
+			Message: item.branch + ": merged",
+		}
+	default:
+		panic(fmt.Sprintf("unknown merge progress event kind: %d",
+			event.Kind))
+	}
+}

--- a/internal/handler/merge/progress.go
+++ b/internal/handler/merge/progress.go
@@ -101,6 +101,14 @@ type widgetMergeProgress struct {
 	cancel  context.CancelFunc
 }
 
+const (
+	// The merge progress widget needs enough room for the bar,
+	// the summary row,
+	// and one or two status lines without consuming the terminal.
+	mergeProgressScrollRegionMinHeight = 4
+	mergeProgressScrollRegionMaxHeight = 8
+)
+
 func newWidgetMergeProgress(
 	runner ui.ModelView,
 	theme ui.Theme,
@@ -138,7 +146,10 @@ func (p *widgetMergeProgress) Start(
 		events: p.events,
 	}
 	go func() {
-		p.err = p.runner.RunModel(model, nil)
+		p.err = p.runner.RunModel(model, &ui.RunOptions{
+			ScrollRegionMinHeight: mergeProgressScrollRegionMinHeight,
+			ScrollRegionMaxHeight: mergeProgressScrollRegionMaxHeight,
+		})
 		if errors.Is(model.Err(), mergeprogress.ErrCanceled) {
 			p.cancel()
 		}

--- a/internal/handler/merge/progress_test.go
+++ b/internal/handler/merge/progress_test.go
@@ -12,10 +12,8 @@ import (
 )
 
 func TestWidgetMergeProgress_FinishAfterRunnerExit(t *testing.T) {
-	progress := newWidgetMergeProgress(
-		earlyExitModelView{},
-		ui.DefaultThemeLight(),
-	)
+	view := new(earlyExitModelView)
+	progress := newWidgetMergeProgress(view, ui.DefaultThemeLight())
 	progress.Start(t.Context(), []*mergeItem{{
 		branch: "feat1",
 	}})
@@ -25,6 +23,13 @@ func TestWidgetMergeProgress_FinishAfterRunnerExit(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("progress model did not exit")
 	}
+	require.NotNil(t, view.opts)
+	require.Equal(t,
+		mergeProgressScrollRegionMinHeight,
+		view.opts.ScrollRegionMinHeight)
+	require.Equal(t,
+		mergeProgressScrollRegionMaxHeight,
+		view.opts.ScrollRegionMaxHeight)
 
 	done := make(chan error, 1)
 	go func() {
@@ -45,16 +50,19 @@ func TestWidgetMergeProgress_FinishAfterRunnerExit(t *testing.T) {
 	}
 }
 
-type earlyExitModelView struct{}
-
-func (earlyExitModelView) Write(p []byte) (int, error) {
+func (*earlyExitModelView) Write(p []byte) (int, error) {
 	return io.Discard.Write(p)
 }
 
-func (earlyExitModelView) Theme() ui.Theme {
+func (*earlyExitModelView) Theme() ui.Theme {
 	return ui.DefaultThemeLight()
 }
 
-func (earlyExitModelView) RunModel(tea.Model, *ui.RunOptions) error {
+func (v *earlyExitModelView) RunModel(_ tea.Model, opts *ui.RunOptions) error {
+	v.opts = opts
 	return nil
+}
+
+type earlyExitModelView struct {
+	opts *ui.RunOptions
 }

--- a/internal/handler/merge/progress_test.go
+++ b/internal/handler/merge/progress_test.go
@@ -1,0 +1,60 @@
+package merge
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/require"
+
+	"go.abhg.dev/gs/internal/ui"
+)
+
+func TestWidgetMergeProgress_FinishAfterRunnerExit(t *testing.T) {
+	progress := newWidgetMergeProgress(
+		earlyExitModelView{},
+		ui.DefaultThemeLight(),
+	)
+	progress.Start(t.Context(), []*mergeItem{{
+		branch: "feat1",
+	}})
+
+	select {
+	case <-progress.stopped:
+	case <-time.After(time.Second):
+		t.Fatal("progress model did not exit")
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		progress.Event(mergeProgressEvent{
+			Kind: mergeProgressChecksFailed,
+			Item: &mergeItem{
+				branch: "feat1",
+			},
+		})
+		done <- progress.Finish()
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Finish blocked after progress model exited")
+	}
+}
+
+type earlyExitModelView struct{}
+
+func (earlyExitModelView) Write(p []byte) (int, error) {
+	return io.Discard.Write(p)
+}
+
+func (earlyExitModelView) Theme() ui.Theme {
+	return ui.DefaultThemeLight()
+}
+
+func (earlyExitModelView) RunModel(tea.Model, *ui.RunOptions) error {
+	return nil
+}

--- a/internal/ui/widget/mergeprogress/cmd/demo/main.go
+++ b/internal/ui/widget/mergeprogress/cmd/demo/main.go
@@ -4,10 +4,13 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/colorprofile"
+	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/ui"
 	"go.abhg.dev/gs/internal/ui/widget/mergeprogress"
 )
@@ -23,8 +26,15 @@ func main() {
 		"feat1: waiting for CI checks",
 		"detail message")
 	flag.BoolVar(&req.animate, "animate", false, "animate progress")
+	flag.BoolVar(&req.logs, "logs", false,
+		"emit synthetic logs while the widget is active")
 	flag.DurationVar(&req.tick, "tick", 750*time.Millisecond, "animation tick")
 	flag.IntVar(&req.width, "width", 0, "initial widget width")
+	flag.IntVar(&req.height, "height", 0, "initial terminal height")
+	flag.IntVar(&req.regionMinHeight, "region-min-height", 4,
+		"minimum bottom rows reserved for the widget")
+	flag.IntVar(&req.regionMaxHeight, "region-max-height", 8,
+		"maximum bottom rows reserved for the widget")
 	flag.BoolVar(&req.dark, "dark", true, "use the dark theme")
 	flag.Parse()
 
@@ -44,9 +54,14 @@ type request struct {
 
 	message string
 	animate bool
+	logs    bool
 	tick    time.Duration
 	width   int
-	dark    bool
+	height  int
+
+	regionMinHeight int
+	regionMaxHeight int
+	dark            bool
 }
 
 func (r *request) run() error {
@@ -64,14 +79,24 @@ func (r *request) run() error {
 			Widget: widget,
 			states: r.states(),
 			tick:   r.tick,
+			log: silog.New(&colorprofile.Writer{
+				Forward: crlfWriter{os.Stdout},
+				Profile: colorprofile.Detect(os.Stdout, os.Environ()),
+			}, &silog.Options{
+				Level: silog.LevelDebug,
+			}),
+			logs: r.logs,
 		}
 	}
 
-	_, err := tea.NewProgram(model,
-		tea.WithInput(os.Stdin),
-		tea.WithOutput(os.Stdout),
-		tea.WithWindowSize(r.width, 20)).Run()
-	if err != nil {
+	if err := ui.RunModel(model, &ui.RunOptions{
+		Input:                 os.Stdin,
+		Output:                os.Stdout,
+		Width:                 r.width,
+		Height:                r.height,
+		ScrollRegionMinHeight: r.regionMinHeight,
+		ScrollRegionMaxHeight: r.regionMaxHeight,
+	}); err != nil {
 		return fmt.Errorf("run program: %w", err)
 	}
 	return nil
@@ -124,6 +149,8 @@ type demoModel struct {
 
 	states []mergeprogress.State
 	tick   time.Duration
+	log    *silog.Logger
+	logs   bool
 }
 
 type tickMsg struct{}
@@ -149,11 +176,13 @@ func (m *demoModel) advance() tea.Cmd {
 		if state == mergeprogress.StateActive {
 			m.states[idx] = mergeprogress.StateMerged
 			itemID := itemID(idx)
+			m.logf("%s: pulled 1 new commit(s)", itemID)
 			_, _ = m.Widget.Update(mergeprogress.Event{
 				ItemID:  itemID,
 				State:   mergeprogress.StateMerged,
 				Message: itemID + ": merged",
 			})
+			m.logf("%s: deleted (was %s)", itemID, fakeHash(idx))
 			return m.nextTick()
 		}
 	}
@@ -162,11 +191,15 @@ func (m *demoModel) advance() tea.Cmd {
 		if state == mergeprogress.StatePending {
 			m.states[idx] = mergeprogress.StateActive
 			itemID := itemID(idx)
+			m.logf("%s: retargeting #%d onto main...",
+				itemID, changeNumber(idx))
 			_, _ = m.Widget.Update(mergeprogress.Event{
 				ItemID:  itemID,
 				State:   mergeprogress.StateActive,
 				Message: itemID + ": waiting for CI checks",
 			})
+			m.logf("%s: updated #%d: https://example.test/pull/%d",
+				itemID, changeNumber(idx), changeNumber(idx))
 			return m.nextTick()
 		}
 	}
@@ -180,6 +213,39 @@ func (m *demoModel) nextTick() tea.Cmd {
 	})
 }
 
+func (m *demoModel) logf(format string, args ...any) {
+	if m.logs {
+		m.log.Infof(format, args...)
+	}
+}
+
 func itemID(idx int) string {
 	return fmt.Sprintf("feat%d", idx+1)
+}
+
+func changeNumber(idx int) int {
+	return 1200 + idx + 1
+}
+
+func fakeHash(idx int) string {
+	return fmt.Sprintf("%06x", 0xabc000+idx)
+}
+
+type crlfWriter struct {
+	w io.Writer
+}
+
+func (w crlfWriter) Write(p []byte) (int, error) {
+	for _, b := range p {
+		if b == '\n' {
+			if _, err := w.w.Write([]byte{'\r', '\n'}); err != nil {
+				return 0, err
+			}
+			continue
+		}
+		if _, err := w.w.Write([]byte{b}); err != nil {
+			return 0, err
+		}
+	}
+	return len(p), nil
 }


### PR DESCRIPTION
We had to revert #1234 because the widget used Bubble Tea's standard rendering,
which conflicted with the command log output.

This takes advantage of #1273, which added scroll-region reservation.
When `gs downstack merge` uses the terminal widget now,
ordinary logs continue to print above the reserved region
while the widget redraws in the bottom rows.

The configured height range is four to eight rows,
which fits the current compact status view and leaves room
for short future detail sections.

https://github.com/user-attachments/assets/8da855a9-8f95-406a-aeb9-814834b88138

Reapply #1234
Reverts eb0f912a239eaf271a189823b21d9b6ae80e8252
