### PR TITLE
merge: Wait for pushed head before CI

### DIFF
--- a/internal/handler/merge/handler.go
+++ b/internal/handler/merge/handler.go
@@ -442,6 +442,16 @@ func (e *mergePlanExecutor) execute(
 
 		// CI is checked after retargeting and restacking
 		// so each merge waits on the exact change being merged.
+		if err := e.awaitChangeHead(ctx, item, change); err != nil {
+			e.Progress.Event(mergeProgressEvent{
+				Kind: mergeProgressChecksFailed,
+				Item: item,
+			})
+			return fmt.Errorf(
+				"wait for pushed head on %q: %w",
+				item.branch, err,
+			)
+		}
 		if err := e.awaitChecks(ctx, item); err != nil {
 			e.Progress.Event(mergeProgressEvent{
 				Kind: mergeProgressChecksFailed,
@@ -581,6 +591,84 @@ func (e *mergePlanExecutor) prepareForMerge(
 	}
 	item.headHash = head
 	return nil
+}
+
+// awaitChangeHead waits until the forge reports the same change head
+// that the merge loop is about to merge.
+func (e *mergePlanExecutor) awaitChangeHead(
+	ctx context.Context,
+	item *mergeItem,
+	change *forge.FindChangeItem,
+) error {
+	const (
+		_baseDelay = 10 * time.Second
+		_maxDelay  = 30 * time.Second
+	)
+
+	return e.awaitChangeHeadWithDelay(
+		ctx, item, change, e.BuildTimeout, _baseDelay, _maxDelay,
+	)
+}
+
+func (e *mergePlanExecutor) awaitChangeHeadWithDelay(
+	ctx context.Context,
+	item *mergeItem,
+	change *forge.FindChangeItem,
+	timeout, baseDelay, maxDelay time.Duration,
+) error {
+	if item.headHash == "" {
+		return nil
+	}
+	hashMatches := func(got git.Hash) bool {
+		return got != "" &&
+			(item.headHash == got ||
+				strings.HasPrefix(item.headHash.String(), got.String()) ||
+				strings.HasPrefix(got.String(), item.headHash.String()))
+	}
+
+	if hashMatches(change.HeadHash) {
+		return nil
+	}
+
+	delay := baseDelay
+	for attempt := 0; ; attempt++ {
+		statuses, err := e.RemoteRepository.ChangeStatuses(
+			ctx, []forge.ChangeID{item.changeID},
+		)
+		if err != nil {
+			return fmt.Errorf("query change head: %w", err)
+		}
+		if len(statuses) == 0 {
+			return errors.New("forge returned no change status")
+		}
+		if hashMatches(statuses[0].HeadHash) {
+			return nil
+		}
+
+		if timeout == 0 {
+			return fmt.Errorf(
+				"change head for %q is still %s, want %s",
+				item.branch, statuses[0].HeadHash, item.headHash,
+			)
+		}
+		if attempt == 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, timeout)
+			defer cancel()
+		}
+
+		e.Progress.Event(mergeProgressEvent{
+			Kind: mergeProgressWaitingForChecks,
+			Item: item,
+		})
+		if err := sleep(ctx, delay); err != nil {
+			return fmt.Errorf(
+				"timed out waiting for forge head on %q",
+				item.branch,
+			)
+		}
+		delay = min(delay*2, maxDelay)
+	}
 }
 
 // awaitChecks polls until CI checks pass for the given change.

--- a/internal/handler/merge/handler_test.go
+++ b/internal/handler/merge/handler_test.go
@@ -238,13 +238,13 @@ func TestExecutePlan_retargets(t *testing.T) {
 	// Pre-check: pr-1 already targets main.
 	mockForge.EXPECT().
 		FindChangeByID(gomock.Any(), pr1).
-		Return(fakeFindResult("main"), nil)
+		Return(fakeFindResultWithHead("main", "head1"), nil)
 	mockForge.EXPECT().
 		FindChangeByID(gomock.Any(), pr2).
-		Return(fakeFindResult("main"), nil)
+		Return(fakeFindResultWithHead("main", "head2"), nil)
 	mockForge.EXPECT().
 		FindChangeByID(gomock.Any(), pr3).
-		Return(fakeFindResult("main"), nil)
+		Return(fakeFindResultWithHead("main", "head3"), nil)
 
 	// Each merge: checks -> merge -> awaitMerged -> sync
 	// -> prepare next (except last).
@@ -315,6 +315,90 @@ func TestExecutePlan_retargets(t *testing.T) {
 	assert.NotContains(t, output, "Restacking feat3 after merge")
 }
 
+func TestExecutePlan_waitsForPreparedChangeHeadBeforeChecks(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockForge := forgetest.NewMockRepository(ctrl)
+	mockStore := NewMockStore(ctrl)
+	mockStore.EXPECT().Trunk().Return("main").AnyTimes()
+
+	mockService := NewMockService(ctrl)
+	mockService.EXPECT().
+		VerifyRestacked(gomock.Any(), "feat2").
+		Return(&spice.BranchNeedsRestackError{Base: "main"})
+
+	pr1 := fakeChangeID("pr-1")
+	pr2 := fakeChangeID("pr-2")
+
+	mockForge.EXPECT().
+		FindChangeByID(gomock.Any(), pr1).
+		Return(fakeFindResultWithHead("main", "head1"), nil)
+	expectMergeItem(mockForge, pr1)
+
+	mockRestack := NewMockRestackHandler(ctrl)
+	mockRestack.EXPECT().
+		RestackBranch(gomock.Any(), "feat2").
+		Return(nil)
+
+	mockSubmit := NewMockSubmitHandler(ctrl)
+	mockSubmit.EXPECT().
+		Submit(gomock.Any(), gomock.Any()).
+		DoAndReturn(assertSubmitUpdate(t, "feat2"))
+
+	mockGit := NewMockGitRepository(ctrl)
+	mockGit.EXPECT().
+		PeelToCommit(gomock.Any(), "feat2").
+		Return(git.Hash("new-head2"), nil)
+
+	// The submit call can return before the forge's change view catches up
+	// to the pushed branch head.
+	// A stale ChecksPassed value at this point belongs to the old head,
+	// so the merge loop must wait until the forge reports new-head2
+	// before asking whether checks passed.
+	mockForge.EXPECT().
+		FindChangeByID(gomock.Any(), pr2).
+		Return(fakeFindResultWithHead("main", "old-head2"), nil)
+	status := mockForge.EXPECT().
+		ChangeStatuses(gomock.Any(), []forge.ChangeID{pr2}).
+		Return([]forge.ChangeStatus{{
+			State:    forge.ChangeOpen,
+			HeadHash: git.Hash("new-head2"),
+		}}, nil)
+	mockForge.EXPECT().
+		ChangeChecksState(gomock.Any(), pr2).
+		Return(forge.ChecksPassed, nil).
+		After(status.Call)
+	mockForge.EXPECT().
+		MergeChange(gomock.Any(), pr2, forge.MergeChangeOptions{
+			Method:   forge.MergeMethodDefault,
+			HeadHash: git.Hash("new-head2"),
+		}).
+		Return(nil)
+	expectMerged(mockForge, pr2)
+
+	mockSync := NewMockSyncHandler(ctrl)
+	mockSync.EXPECT().
+		SyncTrunk(gomock.Any(), syncTrunkOptions()).
+		Return(nil).
+		Times(2)
+
+	h := newTestHandler(t, ctrl, testHandlerOpts{
+		forgeRepo: mockForge,
+		store:     mockStore,
+		service:   mockService,
+		gitRepo:   mockGit,
+		restack:   mockRestack,
+		submit:    mockSubmit,
+		sync:      mockSync,
+	})
+
+	err := h.executePlan(t.Context(), []*mergeItem{
+		{branch: "feat1", changeID: pr1, headHash: git.Hash("head1")},
+		{branch: "feat2", changeID: pr2, headHash: git.Hash("old-head2")},
+	}, &Request{Branch: "feat2"})
+	require.NoError(t, err)
+}
+
 func TestExecutePlan_noWait(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	var logBuffer bytes.Buffer
@@ -328,7 +412,7 @@ func TestExecutePlan_noWait(t *testing.T) {
 	// Pre-check: pr-1 already targets main.
 	mockForge.EXPECT().
 		FindChangeByID(gomock.Any(), pr1).
-		Return(fakeFindResult("main"), nil)
+		Return(fakeFindResultWithHead("main", "head1"), nil)
 
 	expectChecksAndMerge(mockForge, pr1)
 	// No ChangesStates polling (awaitMerged skipped).
@@ -432,7 +516,7 @@ func TestExecutePlan_mergeMethod(t *testing.T) {
 
 	mockForge.EXPECT().
 		FindChangeByID(gomock.Any(), pr1).
-		Return(fakeFindResult("main"), nil)
+		Return(fakeFindResultWithHead("main", "head1"), nil)
 	mockForge.EXPECT().
 		ChangeChecksState(gomock.Any(), pr1).
 		Return(forge.ChecksPassed, nil)
@@ -904,12 +988,19 @@ func testGitRepo(
 func fakeFindResult(
 	base string,
 ) *forge.FindChangeItem {
+	return fakeFindResultWithHead(base, "abc123")
+}
+
+func fakeFindResultWithHead(
+	base string,
+	head git.Hash,
+) *forge.FindChangeItem {
 	return &forge.FindChangeItem{
 		ID:       fakeChangeID("find-id"),
 		URL:      "http://example.com/1",
 		State:    forge.ChangeOpen,
 		Subject:  "test change",
-		HeadHash: "abc123",
+		HeadHash: head,
 		BaseName: base,
 		Draft:    false,
 	}


### PR DESCRIPTION
After a downstack merge restacks and submits an upstack branch,
the forge can lag behind the local branch state.
The existing merge loop asked for the aggregate check state immediately.
That allowed stale passing checks from the previous change head,
or a temporary no-rollup state,
to satisfy the wait before CI for the pushed head had run.

Wait until the forge reports the same change head
that the merge loop will pass to `MergeChange`.
Only after that head is visible do we ask whether checks passed.
This keeps `gs downstack merge` from merging a restacked branch
based on check state that belonged to an older head.

The regression covers the stale-head ordering directly:
checks are not queried until the forge reports the newly pushed head.