### PR TITLE
restack: Use test context in handler tests

### DIFF
--- a/internal/handler/restack/branch_test.go
+++ b/internal/handler/restack/branch_test.go
@@ -2,7 +2,6 @@ package restack
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"testing"
 
@@ -48,7 +47,7 @@ func TestHandler_RestackBranch(t *testing.T) {
 			Store:    statetest.NewMemoryStore(t, "main", "", log),
 			Service:  mockService,
 		}
-		require.NoError(t, handler.RestackBranch(context.Background(), "feature"))
+		require.NoError(t, handler.RestackBranch(t.Context(), "feature"))
 		assert.Contains(t, logBuffer.String(), "feature: restacked on main")
 	})
 
@@ -83,7 +82,7 @@ func TestHandler_RestackBranch(t *testing.T) {
 			Service:  mockService,
 		}
 
-		require.NoError(t, handler.RestackBranch(context.Background(), "feature"))
+		require.NoError(t, handler.RestackBranch(t.Context(), "feature"))
 	})
 
 	t.Run("UntrackedBranch", func(t *testing.T) {
@@ -114,7 +113,7 @@ func TestHandler_RestackBranch(t *testing.T) {
 			Service:  mockService,
 		}
 
-		err := handler.RestackBranch(context.Background(), "untracked")
+		err := handler.RestackBranch(t.Context(), "untracked")
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "untracked branch")
 		assert.Contains(t, logBuffer.String(), "untracked: branch not tracked: run '"+cli.Name()+" branch track")
@@ -147,7 +146,7 @@ func TestHandler_RestackBranch(t *testing.T) {
 			Store:    statetest.NewMemoryStore(t, "main", "", log),
 			Service:  mockService,
 		}
-		require.NoError(t, handler.RestackBranch(context.Background(), "already-restacked"))
+		require.NoError(t, handler.RestackBranch(t.Context(), "already-restacked"))
 		assert.Contains(t, logBuffer.String(), "already-restacked: branch does not need to be restacked.")
 	})
 
@@ -178,7 +177,7 @@ func TestHandler_RestackBranch(t *testing.T) {
 			Store:    statetest.NewMemoryStore(t, "main", "", log),
 			Service:  mockService,
 		}
-		err := handler.RestackBranch(context.Background(), "feature")
+		err := handler.RestackBranch(t.Context(), "feature")
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "restack branch")
 		assert.ErrorIs(t, err, unexpectedErr)


### PR DESCRIPTION
Minor cleanup.

[skip changelog]: test-only