### PR TITLE
mergeprogress: Animate active segments

### DIFF
--- a/internal/handler/merge/progress.go
+++ b/internal/handler/merge/progress.go
@@ -192,7 +192,7 @@ type mergeProgressModel struct {
 }
 
 func (m *mergeProgressModel) Init() tea.Cmd {
-	return waitMergeProgressEvent(m.events)
+	return tea.Batch(m.Widget.Init(), waitMergeProgressEvent(m.events))
 }
 
 func (m *mergeProgressModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {

--- a/internal/ui/widget/mergeprogress/animation.go
+++ b/internal/ui/widget/mergeprogress/animation.go
@@ -1,0 +1,103 @@
+package mergeprogress
+
+import (
+	"math"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+const (
+	_animationTick             = 80 * time.Millisecond
+	_animationMinCycle         = 1400 * time.Millisecond
+	_animationMaxCellsPerFrame = 2
+)
+
+// animationTickMsg carries the elapsed animation time for the next frame.
+type animationTickMsg time.Duration
+
+// animationState owns the active-segment animation clock.
+//
+// It keeps the timing policy together with the state Bubble Tea mutates
+// as ticks are scheduled and delivered.
+type animationState struct {
+	enabled bool // whether animation may schedule ticks
+
+	elapsed time.Duration // elapsed animation time
+
+	// tickScheduled prevents ordinary progress events from starting
+	// overlapping animation clocks while an earlier tick is still pending.
+	tickScheduled bool
+}
+
+func (a animationState) marker(width int) (position int, glyph string, ok bool) {
+	if !a.enabled || width <= 0 {
+		return 0, "", false
+	}
+
+	cycle := a.cycleForWidth(width)
+	phase := float64(a.elapsed%cycle) / float64(cycle)
+	// A cosine wave maps one cycle into a smooth ping-pong path:
+	// 0 at the start,
+	// 1 halfway through,
+	// and 0 again at the end.
+	eased := (1 - math.Cos(2*math.Pi*phase)) / 2
+	position = int(math.Round(eased * float64(width-1)))
+
+	if phase < 0.05 || phase >= 0.95 {
+		return position, "╺", true
+	}
+	if phase > 0.45 && phase < 0.55 {
+		return position, "╸", true
+	}
+
+	speed := math.Abs(math.Sin(2 * math.Pi * phase))
+	switch {
+	case speed > 0.85:
+		return position, "—", true
+	case speed > 0.45:
+		return position, "–", true
+	default:
+		return position, "-", true
+	}
+}
+
+func (a *animationState) resetSchedule() {
+	a.tickScheduled = false
+}
+
+func (a *animationState) advance(msg animationTickMsg) {
+	a.tickScheduled = false
+	a.elapsed = time.Duration(msg)
+}
+
+func (a *animationState) scheduleTick(hasActiveItem bool) tea.Cmd {
+	// Only one timer may be outstanding,
+	// or progress events can start competing animation clocks.
+	if !a.enabled || !hasActiveItem || a.tickScheduled {
+		return nil
+	}
+
+	nextElapsed := a.elapsed + _animationTick
+	a.tickScheduled = true
+	return tea.Tick(_animationTick, func(time.Time) tea.Msg {
+		return animationTickMsg(nextElapsed)
+	})
+}
+
+func (animationState) cycleForWidth(width int) time.Duration {
+	if width <= 1 {
+		return _animationMinCycle
+	}
+
+	// The cosine easing moves fastest at the center of the segment.
+	// Size the cycle for that peak speed instead of the average speed
+	// so wide segments do not jump too many cells between frames.
+	cycle := time.Duration(math.Ceil(
+		float64(width-1) *
+			math.Pi *
+			float64(_animationTick) /
+			float64(_animationMaxCellsPerFrame),
+	))
+	return max(_animationMinCycle, cycle)
+}

--- a/internal/ui/widget/mergeprogress/cmd/demo/main.go
+++ b/internal/ui/widget/mergeprogress/cmd/demo/main.go
@@ -156,7 +156,7 @@ type demoModel struct {
 type tickMsg struct{}
 
 func (m *demoModel) Init() tea.Cmd {
-	return m.nextTick()
+	return tea.Batch(m.Widget.Init(), m.nextTick())
 }
 
 func (m *demoModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -177,13 +177,13 @@ func (m *demoModel) advance() tea.Cmd {
 			m.states[idx] = mergeprogress.StateMerged
 			itemID := itemID(idx)
 			m.logf("%s: pulled 1 new commit(s)", itemID)
-			_, _ = m.Widget.Update(mergeprogress.Event{
+			_, cmd := m.Widget.Update(mergeprogress.Event{
 				ItemID:  itemID,
 				State:   mergeprogress.StateMerged,
 				Message: itemID + ": merged",
 			})
 			m.logf("%s: deleted (was %s)", itemID, fakeHash(idx))
-			return m.nextTick()
+			return tea.Batch(cmd, m.nextTick())
 		}
 	}
 
@@ -193,14 +193,14 @@ func (m *demoModel) advance() tea.Cmd {
 			itemID := itemID(idx)
 			m.logf("%s: retargeting #%d onto main...",
 				itemID, changeNumber(idx))
-			_, _ = m.Widget.Update(mergeprogress.Event{
+			_, cmd := m.Widget.Update(mergeprogress.Event{
 				ItemID:  itemID,
 				State:   mergeprogress.StateActive,
 				Message: itemID + ": waiting for CI checks",
 			})
 			m.logf("%s: updated #%d: https://example.test/pull/%d",
 				itemID, changeNumber(idx), changeNumber(idx))
-			return m.nextTick()
+			return tea.Batch(cmd, m.nextTick())
 		}
 	}
 

--- a/internal/ui/widget/mergeprogress/progress.go
+++ b/internal/ui/widget/mergeprogress/progress.go
@@ -136,12 +136,13 @@ type Widget struct {
 	KeyMap KeyMap
 	Style  Style
 
-	items   []Item
-	index   map[string]int // item ID => items index
-	message string
-	err     error
-	width   int
-	theme   ui.Theme
+	items     []Item
+	index     map[string]int // item ID => items index
+	message   string
+	err       error
+	width     int
+	theme     ui.Theme
+	animation animationState
 }
 
 var _ tea.Model = (*Widget)(nil)
@@ -151,6 +152,9 @@ func New(items ...Item) *Widget {
 	w := &Widget{
 		KeyMap: DefaultKeyMap,
 		Style:  DefaultStyle,
+		animation: animationState{
+			enabled: true,
+		},
 	}
 	w.setItems(items...)
 	return w
@@ -181,6 +185,17 @@ func (w *Widget) WithTheme(theme ui.Theme) *Widget {
 	return w
 }
 
+// WithAnimation enables or disables frame-driven active-state animation.
+//
+// Animation is enabled by default.
+//
+// This is intended for code-level rendering contexts such as stable snapshots,
+// not for user-facing configuration.
+func (w *Widget) WithAnimation(enabled bool) *Widget {
+	w.animation.enabled = enabled
+	return w
+}
+
 // Err reports cancellation or another rendering error.
 func (w *Widget) Err() error {
 	return w.err
@@ -188,7 +203,8 @@ func (w *Widget) Err() error {
 
 // Init initializes the Bubble Tea model.
 func (w *Widget) Init() tea.Cmd {
-	return nil
+	w.animation.resetSchedule()
+	return w.scheduleAnimationTick()
 }
 
 // Update updates the Bubble Tea model.
@@ -198,6 +214,10 @@ func (w *Widget) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		w.width = msg.Width
 	case Event:
 		w.apply(msg)
+		return w, w.scheduleAnimationTick()
+	case animationTickMsg:
+		w.animation.advance(msg)
+		return w, w.scheduleAnimationTick()
 	case tea.KeyMsg:
 		if key.Matches(msg, w.KeyMap.Cancel) {
 			w.err = ErrCanceled
@@ -274,11 +294,31 @@ func (w *Widget) renderBar(out ui.Writer, theme ui.Theme) {
 
 	segmentWidths := distribute(width, len(w.items))
 	for idx, item := range w.items {
-		out.WriteString(strings.Repeat(
-			w.styleFor(item.State).String(theme),
-			segmentWidths[idx],
-		))
+		w.renderSegment(out, theme, item.State, segmentWidths[idx])
 	}
+}
+
+func (w *Widget) renderSegment(
+	out ui.Writer,
+	theme ui.Theme,
+	state State,
+	width int,
+) {
+	if state == StateActive {
+		position, glyph, ok := w.animation.marker(width)
+		if ok {
+			active := w.Style.Active.String(theme)
+			out.WriteString(strings.Repeat(active, position))
+			out.WriteString(w.Style.Active.SetString(glyph).String(theme))
+			out.WriteString(strings.Repeat(active, width-position-1))
+			return
+		}
+	}
+
+	out.WriteString(strings.Repeat(
+		w.styleFor(state).String(theme),
+		width,
+	))
 }
 
 func (w *Widget) styleFor(state State) ui.Style {
@@ -294,6 +334,19 @@ func (w *Widget) styleFor(state State) ui.Style {
 	default:
 		return w.Style.Pending
 	}
+}
+
+func (w *Widget) scheduleAnimationTick() tea.Cmd {
+	return w.animation.scheduleTick(w.hasActiveItem())
+}
+
+func (w *Widget) hasActiveItem() bool {
+	for _, item := range w.items {
+		if item.State == StateActive {
+			return true
+		}
+	}
+	return false
 }
 
 // distribute divides a bar width into contiguous item segment widths.

--- a/internal/ui/widget/mergeprogress/progress_test.go
+++ b/internal/ui/widget/mergeprogress/progress_test.go
@@ -15,7 +15,9 @@ import (
 )
 
 func TestWidget_RenderProgression(t *testing.T) {
-	widget := New(makeItems(10)...).WithTheme(ui.DefaultThemeDark())
+	widget := New(makeItems(10)...).
+		WithTheme(ui.DefaultThemeDark()).
+		WithAnimation(false)
 	mustUpdate(t, widget, tea.WindowSizeMsg{Width: 40})
 
 	autogold.Expect(`Merging: 0 of 10 changes
@@ -95,14 +97,18 @@ func TestWidget_Render_scalingKeepsShape(t *testing.T) {
 	}
 	items[7].State = StateActive
 
-	wideWidget := New(items...).WithTheme(ui.DefaultThemeDark())
+	wideWidget := New(items...).
+		WithTheme(ui.DefaultThemeDark()).
+		WithAnimation(false)
 	mustUpdate(t, wideWidget, tea.WindowSizeMsg{Width: 72})
 	mustUpdate(t, wideWidget, Event{
 		Message: "Waiting for CI checks on feature-08 (#108).",
 	})
 	wide := renderPlain(wideWidget)
 
-	narrowWidget := New(items...).WithTheme(ui.DefaultThemeDark())
+	narrowWidget := New(items...).
+		WithTheme(ui.DefaultThemeDark()).
+		WithAnimation(false)
 	mustUpdate(t, narrowWidget, tea.WindowSizeMsg{Width: 24})
 	mustUpdate(t, narrowWidget, Event{
 		Message: "Waiting for CI checks on feature-08 (#108).",
@@ -129,7 +135,9 @@ func TestWidget_Render_failedAndSkipped(t *testing.T) {
 	items[2].State = StateActive
 	items[3].State = StateFailed
 
-	widget := New(items...).WithTheme(ui.DefaultThemeDark())
+	widget := New(items...).
+		WithTheme(ui.DefaultThemeDark()).
+		WithAnimation(false)
 	mustUpdate(t, widget, tea.WindowSizeMsg{Width: 20})
 	mustUpdate(t, widget, Event{
 		Message: "CI checks failed for feature-04 (#104).",


### PR DESCRIPTION
Active merge progress segments now show a small moving marker
so long-running merge waits have visible progress without changing
merge state updates or forge behavior.

The marker stays inside the active segment and falls back to the
existing static glyph when the segment is too narrow.
Widget callers can disable animation for deterministic snapshots.

[skip changelog]: feature unreleased