### PR TITLE
feat(branch): Add branch merge command

### DIFF
--- a/.changes/unreleased/Added-20260613-171037.yaml
+++ b/.changes/unreleased/Added-20260613-171037.yaml
@@ -1,0 +1,4 @@
+kind: Added
+body: >-
+  Add 'gs branch merge' command to merge a single trunk-based branch.
+time: 2026-06-13T17:10:37.930835-07:00

--- a/branch.go
+++ b/branch.go
@@ -36,6 +36,7 @@ type branchCmd struct {
 	Diff branchDiffCmd `cmd:"" aliases:"di" help:"Show diff between a branch and its base"`
 
 	// Pull request management
+	Merge  branchMergeCmd  `cmd:"" aliases:"m" experiment:"merge" help:"Merge a branch into trunk"`
 	Submit branchSubmitCmd `cmd:"" aliases:"s" help:"Submit a branch"`
 }
 

--- a/branch_merge.go
+++ b/branch_merge.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/handler/merge"
+	"go.abhg.dev/gs/internal/spice/state"
+	"go.abhg.dev/gs/internal/text"
+)
+
+type branchMergeCmd struct {
+	merge.Options
+
+	Branch string `placeholder:"NAME" help:"Branch to merge" predictor:"trackedBranches"`
+}
+
+func (*branchMergeCmd) Help() string {
+	return text.Dedent(`
+		Merges the CR for the current branch into trunk.
+		Use --branch to merge a different branch.
+
+		The branch must be based directly on trunk.
+		To merge a stacked branch, use 'gs downstack merge'.
+
+		Before merging, waits for CI checks to pass.
+		Use --build-timeout to configure the maximum wait.
+	`)
+}
+
+func (cmd *branchMergeCmd) AfterApply(
+	ctx context.Context,
+	wt *git.Worktree,
+) error {
+	if cmd.Branch != "" {
+		return nil
+	}
+	branch, err := wt.CurrentBranch(ctx)
+	if err != nil {
+		return fmt.Errorf("get current branch: %w", err)
+	}
+	cmd.Branch = branch
+	return nil
+}
+
+func (cmd *branchMergeCmd) Run(
+	ctx context.Context,
+	store *state.Store,
+	mergeHandler MergeHandler,
+) error {
+	if cmd.Branch == store.Trunk() {
+		return errors.New("cannot merge trunk")
+	}
+
+	return mergeHandler.MergeBranch(ctx, &merge.BranchMergeRequest{
+		Branch:  cmd.Branch,
+		Options: &cmd.Options,
+	})
+}

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -615,11 +615,11 @@ when you don't want to wait for the merge to propagate.
 
 **Flags**
 
-* `--branch=NAME`: Branch to start merging from
-* `--no-wait`: Skip polling for a single branch merge to propagate.
-* `--no-branch-check`: Skip stale base validation before merging.
 * `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
 * `--build-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.buildTimeout" }](/cli/config.md#spicemergebuildtimeout)): Max time to wait for CI checks before each merge. 0 means check once.
+* `--no-wait`: Skip polling for a single branch merge to propagate.
+* `--no-branch-check`: Skip stale base validation before merging.
+* `--branch=NAME`: Branch to start merging from
 
 **Configuration**: [spice.merge.buildTimeout](/cli/config.md#spicemergebuildtimeout), [spice.merge.method](/cli/config.md#spicemergemethod)
 
@@ -1074,6 +1074,33 @@ Use --branch to target a different branch.
 **Flags**
 
 * `--branch=NAME`: Branch to diff
+
+### git-spice branch merge {#gs-branch-merge}
+
+```
+gs branch (b) merge (m) [flags]
+```
+
+<span class="mdx-badge mdx-badge--experiment"><span class="mdx-badge__icon">:material-test-tube:{ title="Experimental" }</span><span class="mdx-badge__text">[merge](/cli/experiments.md#merge)</span></span>
+
+Merge a branch into trunk
+
+Merges the CR for the current branch into trunk.
+Use --branch to merge a different branch.
+
+The branch must be based directly on trunk.
+To merge a stacked branch, use 'gs downstack merge'.
+
+Before merging, waits for CI checks to pass.
+Use --build-timeout to configure the maximum wait.
+
+**Flags**
+
+* `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
+* `--build-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.buildTimeout" }](/cli/config.md#spicemergebuildtimeout)): Max time to wait for CI checks before each merge. 0 means check once.
+* `--branch=NAME`: Branch to merge
+
+**Configuration**: [spice.merge.buildTimeout](/cli/config.md#spicemergebuildtimeout), [spice.merge.method](/cli/config.md#spicemergemethod)
 
 ### git-spice branch submit {#gs-branch-submit}
 

--- a/doc/includes/cli-shorthands.md
+++ b/doc/includes/cli-shorthands.md
@@ -6,6 +6,7 @@
 | gs bdi | [gs branch diff](/cli/reference.md#gs-branch-diff) |
 | gs be | [gs branch edit](/cli/reference.md#gs-branch-edit) |
 | gs bfo | [gs branch fold](/cli/reference.md#gs-branch-fold) |
+| gs bm | [gs branch merge](/cli/reference.md#gs-branch-merge) |
 | gs bon | [gs branch onto](/cli/reference.md#gs-branch-onto) |
 | gs br | [gs branch restack](/cli/reference.md#gs-branch-restack) |
 | gs brn | [gs branch rename](/cli/reference.md#gs-branch-rename) |

--- a/downstack_merge.go
+++ b/downstack_merge.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
-	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/handler/merge"
 	"go.abhg.dev/gs/internal/spice/state"
@@ -14,11 +12,9 @@ import (
 )
 
 type downstackMergeCmd struct {
-	Branch        string            `placeholder:"NAME" help:"Branch to start merging from" predictor:"trackedBranches"`
-	NoWait        bool              `help:"Skip polling for a single branch merge to propagate."`
-	NoBranchCheck bool              `help:"Skip stale base validation before merging."`
-	Method        forge.MergeMethod `placeholder:"METHOD" config:"merge.method" help:"Preferred merge method. One of 'merge', 'squash', and 'rebase'."`
-	BuildTimeout  time.Duration     `config:"merge.buildTimeout" default:"30m" help:"Max time to wait for CI checks before each merge. 0 means check once."`
+	merge.DownstackMergeOptions
+
+	Branch string `placeholder:"NAME" help:"Branch to start merging from" predictor:"trackedBranches"`
 }
 
 func (*downstackMergeCmd) Help() string {
@@ -66,7 +62,8 @@ func (*downstackMergeCmd) Help() string {
 
 // MergeHandler merges change requests via a forge.
 type MergeHandler interface {
-	MergeDownstack(ctx context.Context, req *merge.Request) error
+	MergeDownstack(ctx context.Context, req *merge.DownstackMergeRequest) error
+	MergeBranch(ctx context.Context, req *merge.BranchMergeRequest) error
 }
 
 func (cmd *downstackMergeCmd) AfterApply(
@@ -93,11 +90,8 @@ func (cmd *downstackMergeCmd) Run(
 		return errors.New("cannot merge trunk")
 	}
 
-	return mergeHandler.MergeDownstack(ctx, &merge.Request{
-		Branch:        cmd.Branch,
-		NoWait:        cmd.NoWait,
-		NoBranchCheck: cmd.NoBranchCheck,
-		Method:        cmd.Method,
-		BuildTimeout:  cmd.BuildTimeout,
+	return mergeHandler.MergeDownstack(ctx, &merge.DownstackMergeRequest{
+		Branch:  cmd.Branch,
+		Options: &cmd.DownstackMergeOptions,
 	})
 }

--- a/internal/handler/merge/handler.go
+++ b/internal/handler/merge/handler.go
@@ -1,7 +1,8 @@
-// Package merge implements the downstack merge command.
+// Package merge implements forge-backed merge commands.
 package merge
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -58,25 +59,47 @@ type GitRepository interface {
 	) (ahead, behind int, err error)
 }
 
-// Request is a request to merge a branch and its downstack.
-type Request struct {
-	Branch string // required
-
-	// NoWait skips polling for the merge to propagate.
-	// Server-dependent cleanup is left to a later sync.
-	NoWait bool
-
-	// NoBranchCheck skips stale base validation.
-	NoBranchCheck bool
-
+// Options controls behavior shared by forge-backed merge commands.
+type Options struct {
 	// Method selects the forge merge strategy.
-	// Empty means use the forge default.
-	Method forge.MergeMethod
+	// Empty means use the configured or forge default.
+	Method forge.MergeMethod `placeholder:"METHOD" config:"merge.method" help:"Preferred merge method. One of 'merge', 'squash', and 'rebase'."`
 
 	// BuildTimeout is the maximum time to wait
-	// for CI checks to pass before each merge.
-	// Zero means check once and fail if not ready.
-	BuildTimeout time.Duration
+	// for CI checks before each merge attempt.
+	// Zero means check once and fail if CI is not ready.
+	BuildTimeout time.Duration `config:"merge.buildTimeout" default:"30m" help:"Max time to wait for CI checks before each merge. 0 means check once."`
+}
+
+// DownstackMergeOptions controls downstack merge behavior.
+type DownstackMergeOptions struct {
+	Options
+
+	// NoWait skips polling for a single merge to propagate.
+	// Server-dependent cleanup is left to a later sync.
+	NoWait bool `help:"Skip polling for a single branch merge to propagate."`
+
+	// NoBranchCheck skips stale base validation before merging.
+	NoBranchCheck bool `help:"Skip stale base validation before merging."`
+}
+
+// DownstackMergeRequest asks Handler to merge a branch
+// and its downstack ancestors bottom-up.
+type DownstackMergeRequest struct {
+	Branch string // required
+
+	Options *DownstackMergeOptions // optional
+
+	// BranchGraph reuses branch graph data already loaded by the caller.
+	BranchGraph *spice.BranchGraph // optional
+}
+
+// BranchMergeRequest asks Handler to merge one branch
+// that is configured directly on trunk.
+type BranchMergeRequest struct {
+	Branch string // required
+
+	Options *Options // optional
 }
 
 // Handler merges change requests via the forge API.
@@ -98,8 +121,9 @@ type Handler struct {
 // MergeDownstack merges the given branch
 // and all its downstack ancestors bottom-up.
 func (h *Handler) MergeDownstack(
-	ctx context.Context, req *Request,
+	ctx context.Context, req *DownstackMergeRequest,
 ) error {
+	opts := cmp.Or(req.Options, &DownstackMergeOptions{})
 	plan, err := h.buildPlan(ctx, req)
 	if err != nil {
 		return err
@@ -114,7 +138,44 @@ func (h *Handler) MergeDownstack(
 		return err
 	}
 
-	return h.executePlan(ctx, plan, req)
+	return h.executePlan(ctx, plan, mergeExecutionOptions{
+		Method:       opts.Method,
+		BuildTimeout: opts.BuildTimeout,
+		NoWait:       opts.NoWait,
+	})
+}
+
+// MergeBranch merges one branch that is configured directly on trunk.
+func (h *Handler) MergeBranch(
+	ctx context.Context, req *BranchMergeRequest,
+) error {
+	opts := cmp.Or(req.Options, &Options{})
+	graph, err := h.Service.BranchGraph(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("build branch graph: %w", err)
+	}
+
+	branch, ok := graph.Lookup(req.Branch)
+	if !ok {
+		return fmt.Errorf("branch %q is not tracked", req.Branch)
+	}
+	trunk := h.Store.Trunk()
+	if branch.Base != trunk {
+		return fmt.Errorf(
+			"branch %q is based on %q, not trunk; "+
+				"use 'gs downstack merge --branch %s' "+
+				"to merge stack branches bottom-up",
+			req.Branch, branch.Base, req.Branch,
+		)
+	}
+
+	return h.MergeDownstack(ctx, &DownstackMergeRequest{
+		Branch: req.Branch,
+		Options: &DownstackMergeOptions{
+			Options: *opts,
+		},
+		BranchGraph: graph,
+	})
 }
 
 // mergeItem is one queue item in a downstack merge plan.
@@ -142,11 +203,16 @@ type mergeItem struct {
 // contains only open Change Requests,
 // and has local push-safety metadata ready for execution.
 func (h *Handler) buildPlan(
-	ctx context.Context, req *Request,
+	ctx context.Context, req *DownstackMergeRequest,
 ) ([]*mergeItem, error) {
-	graph, err := h.Service.BranchGraph(ctx, nil)
-	if err != nil {
-		return nil, fmt.Errorf("build branch graph: %w", err)
+	opts := cmp.Or(req.Options, &DownstackMergeOptions{})
+	graph := req.BranchGraph
+	if graph == nil {
+		var err error
+		graph, err = h.Service.BranchGraph(ctx, nil)
+		if err != nil {
+			return nil, fmt.Errorf("build branch graph: %w", err)
+		}
 	}
 
 	// Build the queue bottom-up because each merge changes
@@ -200,7 +266,7 @@ func (h *Handler) buildPlan(
 		}
 	}
 
-	if req.NoWait && len(plan) > 1 {
+	if opts.NoWait && len(plan) > 1 {
 		return nil, fmt.Errorf(
 			"--no-wait can merge only one branch; "+
 				"got %d branches",
@@ -212,7 +278,7 @@ func (h *Handler) buildPlan(
 		return nil, fmt.Errorf("validate branch sync: %w", err)
 	}
 
-	if !req.NoBranchCheck {
+	if !opts.NoBranchCheck {
 		if err := h.validateFreshBases(ctx, graph, req.Branch); err != nil {
 			return nil, fmt.Errorf("validate stale bases: %w", err)
 		}
@@ -342,8 +408,16 @@ func (h *Handler) confirm(plan []*mergeItem) error {
 	return nil
 }
 
+type mergeExecutionOptions struct {
+	Method       forge.MergeMethod
+	BuildTimeout time.Duration
+	NoWait       bool
+}
+
 func (h *Handler) executePlan(
-	ctx context.Context, plan []*mergeItem, req *Request,
+	ctx context.Context,
+	plan []*mergeItem,
+	opts mergeExecutionOptions,
 ) (err error) {
 	var progress mergeProgress
 	if runner, ok := h.View.(ui.ModelView); ok {
@@ -371,9 +445,9 @@ func (h *Handler) executePlan(
 		Progress: progress,
 
 		Trunk:        h.Store.Trunk(),
-		BuildTimeout: req.BuildTimeout,
-		Method:       req.Method,
-		NoWait:       req.NoWait,
+		BuildTimeout: opts.BuildTimeout,
+		Method:       opts.Method,
+		NoWait:       opts.NoWait,
 	}).execute(ctx, plan)
 	if err != nil {
 		return err

--- a/internal/handler/merge/handler_test.go
+++ b/internal/handler/merge/handler_test.go
@@ -21,6 +21,7 @@ import (
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/spicetest"
 	"go.abhg.dev/gs/internal/ui"
 )
 
@@ -301,9 +302,7 @@ func TestExecutePlan_retargets(t *testing.T) {
 		{branch: "feat3", changeID: pr3},
 	}
 
-	err := h.executePlan(t.Context(), plan, &Request{
-		Branch: "feat3",
-	})
+	err := h.executePlan(t.Context(), plan, mergeExecutionOptions{})
 	require.NoError(t, err)
 
 	output := logBuffer.String()
@@ -395,7 +394,7 @@ func TestExecutePlan_waitsForPreparedChangeHeadBeforeChecks(t *testing.T) {
 	err := h.executePlan(t.Context(), []*mergeItem{
 		{branch: "feat1", changeID: pr1, headHash: git.Hash("head1")},
 		{branch: "feat2", changeID: pr2, headHash: git.Hash("old-head2")},
-	}, &Request{Branch: "feat2"})
+	}, mergeExecutionOptions{})
 	require.NoError(t, err)
 }
 
@@ -427,8 +426,7 @@ func TestExecutePlan_noWait(t *testing.T) {
 		{branch: "feat1", changeID: pr1},
 	}
 
-	err := h.executePlan(t.Context(), plan, &Request{
-		Branch: "feat1",
+	err := h.executePlan(t.Context(), plan, mergeExecutionOptions{
 		NoWait: true,
 	})
 	require.NoError(t, err)
@@ -468,8 +466,86 @@ func TestExecutePlan_singleBranch(t *testing.T) {
 
 	err := h.executePlan(t.Context(), []*mergeItem{
 		{branch: "feat1", changeID: pr1},
-	}, &Request{Branch: "feat1"})
+	}, mergeExecutionOptions{})
 	require.NoError(t, err)
+}
+
+func TestMergeBranch_delegatesToDownstackMerge(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockStore := NewMockStore(ctrl)
+	mockStore.EXPECT().Trunk().Return("main").AnyTimes()
+
+	mockForge := forgetest.NewMockRepository(ctrl)
+	pr1 := fakeChangeID("pr-1")
+	mockForge.EXPECT().
+		ChangeStatuses(gomock.Any(), []forge.ChangeID{pr1}).
+		Return([]forge.ChangeStatus{{State: forge.ChangeOpen}}, nil)
+	mockForge.EXPECT().
+		FindChangeByID(gomock.Any(), pr1).
+		Return(fakeFindResultWithHead("main", "head1"), nil)
+	expectMergeItem(mockForge, pr1)
+
+	mockGit := NewMockGitRepository(ctrl)
+	mockGit.EXPECT().
+		CommitAheadBehind(
+			gomock.Any(), "origin/feat1", "feat1",
+		).
+		Return(0, 0, nil)
+	mockGit.EXPECT().
+		PeelToCommit(gomock.Any(), "feat1").
+		Return(git.Hash("head1"), nil)
+
+	graph := testBranchGraph(t, []spice.LoadBranchItem{
+		testBranch("feat1", "main", pr1),
+	})
+	mockService := NewMockService(ctrl)
+	mockService.EXPECT().
+		BranchGraph(gomock.Any(), gomock.Nil()).
+		Return(graph, nil)
+
+	mockSync := NewMockSyncHandler(ctrl)
+	mockSync.EXPECT().
+		SyncTrunk(gomock.Any(), syncTrunkOptions()).
+		Return(nil)
+
+	h := newTestHandler(t, ctrl, testHandlerOpts{
+		forgeRepo: mockForge,
+		store:     mockStore,
+		service:   mockService,
+		gitRepo:   mockGit,
+		sync:      mockSync,
+	})
+
+	err := h.MergeBranch(t.Context(), &BranchMergeRequest{
+		Branch: "feat1",
+	})
+	require.NoError(t, err)
+}
+
+func TestMergeBranch_rejectsBranchNotBasedOnTrunk(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockStore := NewMockStore(ctrl)
+	mockStore.EXPECT().Trunk().Return("main")
+
+	h := newTestHandler(t, ctrl, testHandlerOpts{
+		store: mockStore,
+		service: testBranchGraphService(ctrl,
+			testBranchGraph(t, []spice.LoadBranchItem{
+				testBranch("feat1", "main", fakeChangeID("pr-1")),
+				testBranch("feat2", "feat1", fakeChangeID("pr-2")),
+			}),
+		),
+	})
+
+	err := h.MergeBranch(t.Context(), &BranchMergeRequest{
+		Branch: "feat2",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(),
+		"branch \"feat2\" is based on \"feat1\", not trunk")
+	assert.Contains(t, err.Error(), "gs downstack merge --branch feat2")
 }
 
 func TestExecutePlan_syncTrunkFailureStopsLoop(t *testing.T) {
@@ -500,7 +576,7 @@ func TestExecutePlan_syncTrunkFailureStopsLoop(t *testing.T) {
 
 	err := h.executePlan(t.Context(), []*mergeItem{
 		{branch: "feat1", changeID: pr1},
-	}, &Request{Branch: "feat1"})
+	}, mergeExecutionOptions{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "sync trunk")
 }
@@ -538,8 +614,7 @@ func TestExecutePlan_mergeMethod(t *testing.T) {
 			changeID: pr1,
 			headHash: git.Hash("head1"),
 		},
-	}, &Request{
-		Branch: "feat1",
+	}, mergeExecutionOptions{
 		Method: forge.MergeMethodSquash,
 		NoWait: true,
 	})
@@ -583,7 +658,7 @@ func TestExecutePlan_retargetsStaleFirstItem(t *testing.T) {
 
 	err := h.executePlan(t.Context(), []*mergeItem{
 		{branch: "feat1", changeID: pr1},
-	}, &Request{Branch: "feat1"})
+	}, mergeExecutionOptions{})
 	require.NoError(t, err)
 
 	output := logBuffer.String()
@@ -622,7 +697,7 @@ func TestExecutePlan_firstItemAlreadyOnTrunk(t *testing.T) {
 
 	err := h.executePlan(t.Context(), []*mergeItem{
 		{branch: "feat1", changeID: pr1},
-	}, &Request{Branch: "feat1"})
+	}, mergeExecutionOptions{})
 	require.NoError(t, err)
 
 	assert.NotContains(t,
@@ -857,6 +932,24 @@ type testHandlerOpts struct {
 	logBuffer *bytes.Buffer
 }
 
+type testChangeMetadata fakeChangeID
+
+var _ forge.ChangeMetadata = testChangeMetadata("")
+
+func (c testChangeMetadata) ForgeID() string {
+	return "fake"
+}
+
+func (c testChangeMetadata) ChangeID() forge.ChangeID {
+	return fakeChangeID(c)
+}
+
+func (c testChangeMetadata) NavigationCommentID() forge.ChangeCommentID {
+	return nil
+}
+
+func (c testChangeMetadata) SetNavigationCommentID(forge.ChangeCommentID) {}
+
 // newTestHandler builds a Handler with sensible defaults
 // for any fields not provided in opts.
 func newTestHandler(
@@ -981,6 +1074,42 @@ func testGitRepo(
 		return mock
 	}
 	return NewMockGitRepository(ctrl)
+}
+
+func testBranchGraph(
+	t *testing.T,
+	branches []spice.LoadBranchItem,
+) *spice.BranchGraph {
+	t.Helper()
+
+	return spicetest.NewBranchGraph(t, spicetest.BranchGraphConfig{
+		Trunk:    "main",
+		Branches: branches,
+	})
+}
+
+func testBranch(
+	name string,
+	base string,
+	changeID fakeChangeID,
+) spice.LoadBranchItem {
+	return spice.LoadBranchItem{
+		Name:           name,
+		Base:           base,
+		Change:         testChangeMetadata(changeID),
+		UpstreamBranch: name,
+	}
+}
+
+func testBranchGraphService(
+	ctrl *gomock.Controller,
+	graph *spice.BranchGraph,
+) *MockService {
+	mockService := NewMockService(ctrl)
+	mockService.EXPECT().
+		BranchGraph(gomock.Any(), gomock.Nil()).
+		Return(graph, nil)
+	return mockService
 }
 
 // fakeFindResult returns a minimal FindChangeItem

--- a/testdata/help/branch_merge.txt
+++ b/testdata/help/branch_merge.txt
@@ -1,0 +1,26 @@
+Usage: gs branch (b) merge (m) [flags]
+
+Merge a branch into trunk
+
+Merges the CR for the current branch into trunk. Use --branch to merge a
+different branch.
+
+The branch must be based directly on trunk. To merge a stacked branch, use 'gs
+downstack merge'.
+
+Before merging, waits for CI checks to pass. Use --build-timeout to configure
+the maximum wait.
+
+Flags:
+  --method=METHOD        Preferred merge method. One of 'merge', 'squash',
+                         and 'rebase'. (🔧 spice.merge.method)
+  --build-timeout=30m    Max time to wait for CI checks before each merge.
+                         0 means check once. (🔧 spice.merge.buildTimeout)
+  --branch=NAME          Branch to merge
+
+Global Flags:
+  -h, --help           Show help for the command
+      --version        Print version information and quit
+  -v, --verbose        Enable verbose output ($GIT_SPICE_VERBOSE)
+  -C, --dir=DIR        Change to DIR before doing anything
+      --[no-]prompt    Whether to prompt for missing information

--- a/testdata/help/downstack_merge.txt
+++ b/testdata/help/downstack_merge.txt
@@ -34,13 +34,13 @@ Use --no-wait for single branch merging when you don't want to wait for the
 merge to propagate. --no-wait is rejected for multi-branch merges.
 
 Flags:
-  --branch=NAME          Branch to start merging from
-  --no-wait              Skip polling for a single branch merge to propagate.
-  --no-branch-check      Skip stale base validation before merging.
   --method=METHOD        Preferred merge method. One of 'merge', 'squash',
                          and 'rebase'. (🔧 spice.merge.method)
   --build-timeout=30m    Max time to wait for CI checks before each merge.
                          0 means check once. (🔧 spice.merge.buildTimeout)
+  --no-wait              Skip polling for a single branch merge to propagate.
+  --no-branch-check      Skip stale base validation before merging.
+  --branch=NAME          Branch to start merging from
 
 Global Flags:
   -h, --help           Show help for the command

--- a/testdata/help/gs.txt
+++ b/testdata/help/gs.txt
@@ -58,6 +58,7 @@ Branch
   branch (b) restack (r)       Restack a branch
   branch (b) onto (on)         Move a branch onto another branch
   branch (b) diff (di)         Show diff between a branch and its base
+  branch (b) merge (m)         Merge a branch into trunk
   branch (b) submit (s)        Submit a branch
 
 Commit

--- a/testdata/script/branch_merge_current.txt
+++ b/testdata/script/branch_merge_current.txt
@@ -1,0 +1,48 @@
+# 'branch merge' merges the current branch into trunk.
+
+as 'Test <test@example.com>'
+at '2026-06-13T18:29:00Z'
+
+# setup
+cd repo
+git init
+git config spice.experiment.merge true
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# create a branch directly on trunk
+git add feature1.txt
+gs bc feature1 -m 'Add feature 1'
+
+# submit the branch
+gs branch submit --fill
+stderr 'Created #1'
+
+# merge the current branch
+env ROBOT_INPUT=$WORK/robot-merge.golden ROBOT_OUTPUT=$WORK/robot-merge.actual
+gs branch merge
+cmp $WORK/robot-merge.actual $WORK/robot-merge.golden
+stderr 'feature1: merging #1:'
+stderr 'feature1: #1 was merged'
+stderr 'All 1 change.s. merged.'
+
+# verify the change is now merged
+shamhub dump changes
+stdout '"merged": true'
+! stdout '"state": "open"'
+
+-- repo/feature1.txt --
+This is feature 1
+-- robot-merge.golden --
+===
+> Merge 1 change(s) bottom-up?: [Y/n]
+>   feature1 (#1)
+true

--- a/testdata/script/branch_merge_explicit_branch.txt
+++ b/testdata/script/branch_merge_explicit_branch.txt
@@ -1,0 +1,73 @@
+# 'branch merge --branch' refuses to merge when CI checks failed.
+
+as 'Test <test@example.com>'
+at '2026-06-13T18:29:00Z'
+
+# setup
+cd repo
+git init
+git config spice.experiment.merge true
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# create a branch directly on trunk
+git add feature1.txt
+gs bc feature1 -m 'Add feature 1'
+
+# submit the branch and mark its checks failed
+gs branch submit --fill
+stderr 'Created #1'
+shamhub set-status alice/example 1 failed
+
+# branch merge should stop before sending the merge request.
+gs trunk
+env ROBOT_INPUT=$WORK/robot-merge.golden ROBOT_OUTPUT=$WORK/robot-merge.actual
+! gs branch merge --branch feature1
+cmp $WORK/robot-merge.actual $WORK/robot-merge.golden
+cmp stderr $WORK/golden/merge-stderr.txt
+
+# The change remains open because it was never merged.
+shamhub dump change 1
+cmpenvJSON stdout $WORK/golden/change-1.json
+
+-- repo/feature1.txt --
+This is feature 1
+-- robot-merge.golden --
+===
+> Merge 1 change(s) bottom-up?: [Y/n]
+>   feature1 (#1)
+true
+-- golden/merge-stderr.txt --
+FTL gs: wait for checks on "feature1": CI checks failed for "feature1"
+-- golden/change-1.json --
+{
+  "number": 1,
+  "html_url": "$SHAMHUB_URL/alice/example/change/1",
+  "state": "open",
+  "title": "Add feature 1",
+  "body": "",
+  "base": {
+    "repository": {
+      "owner": "alice",
+      "name": "example"
+    },
+    "ref": "main",
+    "sha": "fd0c8194fd8dbdd59644d28e87c4be2550429197"
+  },
+  "head": {
+    "repository": {
+      "owner": "alice",
+      "name": "example"
+    },
+    "ref": "feature1",
+    "sha": "62c3c4e12506afae52cd50383886ea7a815700c3"
+  }
+}

--- a/testdata/script/branch_merge_stacked_branch.txt
+++ b/testdata/script/branch_merge_stacked_branch.txt
@@ -1,0 +1,45 @@
+# 'branch merge' rejects branches that are configured on another branch.
+
+as 'Test <test@example.com>'
+at '2026-06-13T18:29:00Z'
+
+# setup
+cd repo
+git init
+git config spice.experiment.merge true
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# create a stack: main -> feature1 -> feature2
+git add feature1.txt
+gs bc feature1 -m 'Add feature 1'
+git add feature2.txt
+gs bc feature2 -m 'Add feature 2'
+
+# submit the stack
+gs downstack submit --fill
+stderr 'Created #1'
+stderr 'Created #2'
+
+# branch merge is only for branches configured directly on trunk.
+! gs branch merge --branch feature2
+stderr 'branch "feature2" is based on "feature1", not trunk'
+stderr 'gs downstack merge --branch feature2'
+
+# verify both changes are still open
+shamhub dump changes
+stdout '"state": "open"'
+! stdout '"merged": true'
+
+-- repo/feature1.txt --
+This is feature 1
+-- repo/feature2.txt --
+This is feature 2


### PR DESCRIPTION
Users can merge one branch that is configured directly on trunk:

    gs branch merge
    gs branch merge --branch feature

The command uses the existing forge-backed merge loop for the selected branch. That keeps merge confirmation, CI waiting, merge method selection, build timeout handling, and one-item progress reporting consistent with downstack merge.

Branches configured on another branch are rejected with guidance to use `gs downstack merge --branch <name>` for stack-level merge behavior. The branch command deliberately exposes only the shared merge options, so downstack-only behavior such as `--no-wait` and stale-base bypass stays off this command.

Focused scripts cover current-branch defaulting, explicit branch selection with failed CI, confirmation, and configured-base rejection.