### PR TITLE
refactor(merge): Add merge queue scheduler

### DIFF
--- a/internal/graph/topo.go
+++ b/internal/graph/topo.go
@@ -1,39 +1,98 @@
 package graph
 
-import "go.abhg.dev/gs/internal/must"
+import (
+	"fmt"
+	"strings"
+
+	"go.abhg.dev/gs/internal/must"
+)
 
 // Toposort performs a topological sort of the given nodes.
 // parent returns the parent of a node, or false if the node doesn't have one.
 //
 // Values returned by parents MUST be in nodes.
-// The graph MUST NOT have a cycle.
+// If the graph has a cycle,
+// Toposort returns a CycleError.
 func Toposort[N comparable](
 	nodes []N,
 	parent func(N) (N, bool),
-) []N {
+) ([]N, error) {
 	topo := make([]N, 0, len(nodes))
-	seen := make(map[N]struct{})
-	var visit func(N)
-	visit = func(n N) {
-		if _, ok := seen[n]; ok {
-			return
+
+	// visitState tracks DFS progress:
+	// unseen nodes have not been explored,
+	// visiting nodes are on the current DFS path,
+	// and visited nodes already have a fixed position in topo.
+	type visitState uint8
+	const (
+		unseen visitState = iota
+		visiting
+		visited
+	)
+
+	seen := make(map[N]visitState, len(nodes))
+	var path []N
+	var visit func(N) error
+	visit = func(n N) error {
+		switch seen[n] {
+		case visiting:
+			for i, node := range path {
+				if node == n {
+					return &CycleError[N]{
+						Path: append(path[i:], n),
+					}
+				}
+			}
+			return &CycleError[N]{Path: []N{n, n}}
+		case visited:
+			return nil
 		}
-		seen[n] = struct{}{}
+
+		seen[n] = visiting
+		path = append(path, n)
 
 		if p, ok := parent(n); ok {
-			visit(p)
+			if err := visit(p); err != nil {
+				return err
+			}
 		}
 
+		path = path[:len(path)-1]
+		seen[n] = visited
 		topo = append(topo, n)
+		return nil
 	}
 
 	for _, n := range nodes {
-		visit(n)
+		if err := visit(n); err != nil {
+			return nil, err
+		}
 	}
 	must.BeEqualf(len(nodes), len(topo),
 		"topological sort produced incorrect number of elements:\n"+
 			"nodes: %v\n"+
 			"topo: %v", nodes, topo)
 
-	return topo
+	return topo, nil
+}
+
+// CycleError reports the cycle that prevented a topological sort.
+type CycleError[N comparable] struct {
+	Path []N
+}
+
+func (e *CycleError[N]) Error() string {
+	return "cycle: " + e.Format(" -> ")
+}
+
+// Format formats the cycle path with sep between each node.
+func (e *CycleError[N]) Format(sep string) string {
+	var out strings.Builder
+	for i, node := range e.Path {
+		if i > 0 {
+			out.WriteString(sep)
+		}
+		fmt.Fprint(&out, node)
+	}
+	return out.String()
 }

--- a/internal/graph/topo_test.go
+++ b/internal/graph/topo_test.go
@@ -1,11 +1,13 @@
 package graph_test
 
 import (
+	"errors"
 	"maps"
 	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.abhg.dev/gs/internal/graph"
 )
 
@@ -59,12 +61,35 @@ func TestToposort(t *testing.T) {
 			}
 
 			nodes := slices.Sorted(maps.Keys(nodeSet))
-			got := graph.Toposort(nodes, func(n string) (string, bool) {
+			got, err := graph.Toposort(nodes, func(n string) (string, bool) {
 				parent, ok := parents[n]
 				return parent, ok
 			})
+			require.NoError(t, err)
 
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestToposort_cycle(t *testing.T) {
+	_, err := graph.Toposort([]string{"a", "b", "c"},
+		func(n string) (string, bool) {
+			switch n {
+			case "a":
+				return "c", true
+			case "b":
+				return "a", true
+			case "c":
+				return "b", true
+			default:
+				return "", false
+			}
+		})
+	require.Error(t, err)
+
+	var cycleErr *graph.CycleError[string]
+	require.True(t, errors.As(err, &cycleErr))
+	assert.Equal(t, []string{"a", "c", "b", "a"}, cycleErr.Path)
+	assert.Equal(t, "cycle: a -> c -> b -> a", err.Error())
 }

--- a/internal/handler/delete/handler.go
+++ b/internal/handler/delete/handler.go
@@ -231,7 +231,7 @@ func (h *Handler) DeleteBranches(ctx context.Context, req *Request) error {
 
 	// Branches may have relationships with each other.
 	// Sort them in topological order: [close to trunk, ..., further from trunk].
-	topoBranches := graph.Toposort(slices.Sorted(maps.Keys(branchesToDelete)),
+	topoBranches, err := graph.Toposort(slices.Sorted(maps.Keys(branchesToDelete)),
 		func(branch string) (string, bool) {
 			info := branchesToDelete[branch]
 			// Branches affect each other's deletion order
@@ -239,6 +239,9 @@ func (h *Handler) DeleteBranches(ctx context.Context, req *Request) error {
 			_, ok := branchesToDelete[info.Base]
 			return info.Base, ok
 		})
+	if err != nil {
+		must.Failf("sort branches to delete: %v", err)
+	}
 
 	// Actual deletion will happen in the reverse of that order,
 	// deleting branches based on other branches first.

--- a/internal/handler/merge/handler.go
+++ b/internal/handler/merge/handler.go
@@ -589,8 +589,8 @@ func (e *mergePlanExecutor) awaitChangeHeadWithDelay(
 
 		if timeout == 0 {
 			return fmt.Errorf(
-				"change head for %q is still %s, want %s",
-				item.branch, statuses[0].HeadHash, item.headHash,
+				"change head is still %s, want %s",
+				statuses[0].HeadHash, item.headHash,
 			)
 		}
 		if attempt == 0 {
@@ -604,10 +604,7 @@ func (e *mergePlanExecutor) awaitChangeHeadWithDelay(
 			Item: item,
 		})
 		if err := sleep(ctx, delay); err != nil {
-			return fmt.Errorf(
-				"timed out waiting for forge head on %q",
-				item.branch,
-			)
+			return errors.New("timed out waiting for forge head")
 		}
 		delay = min(delay*2, maxDelay)
 	}
@@ -650,16 +647,11 @@ func (e *mergePlanExecutor) awaitChecksWithDelay(
 			return nil
 		}
 		if state == forge.ChecksFailed {
-			return fmt.Errorf(
-				"CI checks failed for %q", item.branch,
-			)
+			return errors.New("CI checks failed")
 		}
 
 		if timeout == 0 {
-			return fmt.Errorf(
-				"CI checks pending for %q (build-timeout=0)",
-				item.branch,
-			)
+			return errors.New("CI checks pending (build-timeout=0)")
 		}
 		if attempt == 0 {
 			var cancel context.CancelFunc
@@ -672,10 +664,7 @@ func (e *mergePlanExecutor) awaitChecksWithDelay(
 			Item: item,
 		})
 		if err := sleep(ctx, delay); err != nil {
-			return fmt.Errorf(
-				"timed out waiting for CI on %q",
-				item.branch,
-			)
+			return errors.New("timed out waiting for CI")
 		}
 		delay = min(delay*2, maxDelay)
 	}
@@ -691,9 +680,7 @@ func (e *mergePlanExecutor) ensureTargetsTrunk(
 		ctx, item.changeID,
 	)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"check base of %q: %w", item.branch, err,
-		)
+		return nil, fmt.Errorf("check base: %w", err)
 	}
 
 	if change.BaseName == e.Trunk {
@@ -742,10 +729,7 @@ func (e *mergePlanExecutor) awaitMerged(
 			Item: item,
 		})
 		if err := sleep(ctx, delay); err != nil {
-			return fmt.Errorf(
-				"timed out waiting for %q to merge",
-				item.branch,
-			)
+			return errors.New("timed out waiting for merge")
 		}
 
 		delay = min(delay*2, _maxDelay)
@@ -766,8 +750,7 @@ func (e *mergePlanExecutor) retargetChange(
 		forge.EditChangeOptions{Base: e.Trunk},
 	)
 	if err != nil {
-		return fmt.Errorf("retarget %q to %q: %w",
-			item.branch, e.Trunk, err)
+		return fmt.Errorf("retarget to %q: %w", e.Trunk, err)
 	}
 	return nil
 }

--- a/internal/handler/merge/handler.go
+++ b/internal/handler/merge/handler.go
@@ -180,12 +180,17 @@ func (h *Handler) MergeBranch(
 
 // mergeItem is one queue item in a downstack merge plan.
 //
-// buildPlan fills branch, changeID, and upstreamBranch from the branch graph.
-// validateSynced later fills headHash after it verifies the local branch
-// matches its upstream ref.
+// buildPlan fills branch, base, changeID, and upstreamBranch
+// from the branch graph.
+// validateSynced later fills headHash after it verifies
+// the local branch matches its upstream ref.
 type mergeItem struct {
 	// branch is the local branch to merge.
 	branch string
+
+	// base is the configured base branch observed
+	// when the plan was built.
+	base string
 
 	// changeID identifies the forge Change Request to merge.
 	changeID forge.ChangeID
@@ -236,6 +241,7 @@ func (h *Handler) buildPlan(
 
 		item := &mergeItem{
 			branch:         name,
+			base:           branch.Base,
 			changeID:       branch.Change.ChangeID(),
 			upstreamBranch: branch.UpstreamBranch,
 		}
@@ -448,150 +454,12 @@ func (h *Handler) executePlan(
 		BuildTimeout: opts.BuildTimeout,
 		Method:       opts.Method,
 		NoWait:       opts.NoWait,
-	}).execute(ctx, plan)
+	}).Execute(ctx, plan)
 	if err != nil {
 		return err
 	}
 
 	h.Log.Infof("All %d change(s) merged.", len(plan))
-	return nil
-}
-
-// mergePlanExecutor runs the merge loop after preflight checks complete.
-//
-// It intentionally has no logger.
-// Merge-loop status must be reported through progress events
-// so terminal and non-terminal output stay in one policy boundary.
-type mergePlanExecutor struct {
-	RemoteRepository forge.Repository // required
-	Repository       GitRepository    // required
-
-	Service Service        // required
-	Restack RestackHandler // required
-	Submit  SubmitHandler  // required
-	Sync    SyncHandler    // required
-
-	Progress mergeProgress // required
-
-	Trunk        string            // required
-	BuildTimeout time.Duration     // required
-	Method       forge.MergeMethod // required
-	NoWait       bool
-}
-
-func (e *mergePlanExecutor) execute(
-	ctx context.Context, plan []*mergeItem,
-) error {
-	for i, item := range plan {
-		// After each lower branch merges,
-		// prepare the next branch on top of updated trunk state.
-		if i > 0 {
-			e.Progress.Event(mergeProgressEvent{
-				Kind: mergeProgressPreparing,
-				Item: item,
-			})
-			if err := e.prepareForMerge(ctx, item); err != nil {
-				e.Progress.Event(mergeProgressEvent{
-					Kind: mergeProgressPrepareFailed,
-					Item: item,
-				})
-				return fmt.Errorf("prepare %q: %w", item.branch, err)
-			}
-		}
-
-		// The forge will only merge a change that targets trunk.
-		// Re-check immediately before each merge because prior queue items
-		// and repo sync may have changed the server-side base.
-		change, err := e.ensureTargetsTrunk(ctx, item)
-		if err != nil {
-			e.Progress.Event(mergeProgressEvent{
-				Kind: mergeProgressRetargetFailed,
-				Item: item,
-			})
-			return fmt.Errorf(
-				"ensure %q targets trunk: %w",
-				item.branch, err,
-			)
-		}
-
-		// CI is checked after retargeting and restacking
-		// so each merge waits on the exact change being merged.
-		if err := e.awaitChangeHead(ctx, item, change); err != nil {
-			e.Progress.Event(mergeProgressEvent{
-				Kind: mergeProgressChecksFailed,
-				Item: item,
-			})
-			return fmt.Errorf(
-				"wait for pushed head on %q: %w",
-				item.branch, err,
-			)
-		}
-		if err := e.awaitChecks(ctx, item); err != nil {
-			e.Progress.Event(mergeProgressEvent{
-				Kind: mergeProgressChecksFailed,
-				Item: item,
-			})
-			return fmt.Errorf(
-				"wait for checks on %q: %w",
-				item.branch, err,
-			)
-		}
-
-		e.Progress.Event(mergeProgressEvent{
-			Kind: mergeProgressMerging,
-			Item: item,
-			URL:  change.URL,
-		})
-		if err := e.RemoteRepository.MergeChange(
-			ctx, item.changeID,
-			forge.MergeChangeOptions{
-				Method:   e.Method,
-				HeadHash: item.headHash,
-			},
-		); err != nil {
-			e.Progress.Event(mergeProgressEvent{
-				Kind: mergeProgressMergeFailed,
-				Item: item,
-			})
-			return fmt.Errorf("merge %q: %w", item.branch, err)
-		}
-
-		if e.NoWait {
-			e.Progress.Event(mergeProgressEvent{
-				Kind: mergeProgressMergeRequested,
-				Item: item,
-			})
-			continue
-		}
-
-		// Wait until the forge reports the merge.
-		e.Progress.Event(mergeProgressEvent{
-			Kind: mergeProgressWaitingForMerge,
-			Item: item,
-		})
-		if err := e.awaitMerged(ctx, item); err != nil {
-			e.Progress.Event(mergeProgressEvent{
-				Kind: mergeProgressMergeIncomplete,
-				Item: item,
-			})
-			return fmt.Errorf("await merge of %q: %w",
-				item.branch, err)
-		}
-		e.Progress.Event(mergeProgressEvent{
-			Kind: mergeProgressMerged,
-			Item: item,
-		})
-
-		// SyncTrunk updates trunk,
-		// deletes merged branches,
-		// and retargets their upstacks.
-		if err := e.Sync.SyncTrunk(ctx, &sync.TrunkOptions{
-			ClosedChanges: sync.ClosedChangesIgnore,
-		}); err != nil {
-			return fmt.Errorf("sync trunk: %w", err)
-		}
-	}
-
 	return nil
 }
 

--- a/internal/handler/merge/handler_test.go
+++ b/internal/handler/merge/handler_test.go
@@ -296,11 +296,11 @@ func TestExecutePlan_retargets(t *testing.T) {
 		logBuffer: &logBuffer,
 	})
 
-	plan := []*mergeItem{
+	plan := testMergePlan([]*mergeItem{
 		{branch: "feat1", changeID: pr1},
 		{branch: "feat2", changeID: pr2},
 		{branch: "feat3", changeID: pr3},
-	}
+	})
 
 	err := h.executePlan(t.Context(), plan, mergeExecutionOptions{})
 	require.NoError(t, err)
@@ -391,10 +391,10 @@ func TestExecutePlan_waitsForPreparedChangeHeadBeforeChecks(t *testing.T) {
 		sync:      mockSync,
 	})
 
-	err := h.executePlan(t.Context(), []*mergeItem{
+	err := h.executePlan(t.Context(), testMergePlan([]*mergeItem{
 		{branch: "feat1", changeID: pr1, headHash: git.Hash("head1")},
 		{branch: "feat2", changeID: pr2, headHash: git.Hash("old-head2")},
-	}, mergeExecutionOptions{})
+	}), mergeExecutionOptions{})
 	require.NoError(t, err)
 }
 
@@ -422,9 +422,9 @@ func TestExecutePlan_noWait(t *testing.T) {
 		logBuffer: &logBuffer,
 	})
 
-	plan := []*mergeItem{
+	plan := testMergePlan([]*mergeItem{
 		{branch: "feat1", changeID: pr1},
-	}
+	})
 
 	err := h.executePlan(t.Context(), plan, mergeExecutionOptions{
 		NoWait: true,
@@ -464,9 +464,9 @@ func TestExecutePlan_singleBranch(t *testing.T) {
 		sync:      mockSync,
 	})
 
-	err := h.executePlan(t.Context(), []*mergeItem{
+	err := h.executePlan(t.Context(), testMergePlan([]*mergeItem{
 		{branch: "feat1", changeID: pr1},
-	}, mergeExecutionOptions{})
+	}), mergeExecutionOptions{})
 	require.NoError(t, err)
 }
 
@@ -574,9 +574,9 @@ func TestExecutePlan_syncTrunkFailureStopsLoop(t *testing.T) {
 		sync:      mockSync,
 	})
 
-	err := h.executePlan(t.Context(), []*mergeItem{
+	err := h.executePlan(t.Context(), testMergePlan([]*mergeItem{
 		{branch: "feat1", changeID: pr1},
-	}, mergeExecutionOptions{})
+	}), mergeExecutionOptions{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "sync trunk")
 }
@@ -608,13 +608,13 @@ func TestExecutePlan_mergeMethod(t *testing.T) {
 		store:     mockStore,
 	})
 
-	err := h.executePlan(t.Context(), []*mergeItem{
+	err := h.executePlan(t.Context(), testMergePlan([]*mergeItem{
 		{
 			branch:   "feat1",
 			changeID: pr1,
 			headHash: git.Hash("head1"),
 		},
-	}, mergeExecutionOptions{
+	}), mergeExecutionOptions{
 		Method: forge.MergeMethodSquash,
 		NoWait: true,
 	})
@@ -656,9 +656,9 @@ func TestExecutePlan_retargetsStaleFirstItem(t *testing.T) {
 		logBuffer: &logBuffer,
 	})
 
-	err := h.executePlan(t.Context(), []*mergeItem{
+	err := h.executePlan(t.Context(), testMergePlan([]*mergeItem{
 		{branch: "feat1", changeID: pr1},
-	}, mergeExecutionOptions{})
+	}), mergeExecutionOptions{})
 	require.NoError(t, err)
 
 	output := logBuffer.String()
@@ -695,9 +695,9 @@ func TestExecutePlan_firstItemAlreadyOnTrunk(t *testing.T) {
 		logBuffer: &logBuffer,
 	})
 
-	err := h.executePlan(t.Context(), []*mergeItem{
+	err := h.executePlan(t.Context(), testMergePlan([]*mergeItem{
 		{branch: "feat1", changeID: pr1},
-	}, mergeExecutionOptions{})
+	}), mergeExecutionOptions{})
 	require.NoError(t, err)
 
 	assert.NotContains(t,
@@ -1004,6 +1004,16 @@ func newTestMergePlanExecutor(
 		BuildTimeout: 30 * time.Minute,
 		Method:       forge.MergeMethodDefault,
 	}
+}
+
+func testMergePlan(items []*mergeItem) []*mergeItem {
+	for idx, item := range items {
+		item.base = "main"
+		if idx > 0 {
+			item.base = items[idx-1].branch
+		}
+	}
+	return items
 }
 
 func testForgeRepo(

--- a/internal/handler/merge/progress.go
+++ b/internal/handler/merge/progress.go
@@ -49,6 +49,9 @@ const (
 	mergeProgressWaitingForMerge                                // waiting for merged state
 	mergeProgressMergeIncomplete                                // merged state did not appear
 	mergeProgressMerged                                         // merged state observed
+	mergeProgressSyncFailed                                     // trunk sync failed
+	mergeProgressFailed                                         // branch failed by scheduler policy
+	mergeProgressSkipped                                        // branch skipped by scheduler policy
 )
 
 // logMergeProgress reports merge progress through sparse log messages.
@@ -83,6 +86,8 @@ func (p *logMergeProgress) Event(event mergeProgressEvent) {
 			event.Item.branch, event.Item.changeID, event.URL)
 	case mergeProgressWaitingForMerge:
 		p.log.Debugf("%s: waiting for merge", event.Item.branch)
+	case mergeProgressSkipped:
+		p.log.Infof("%s: skipped", event.Item.branch)
 	}
 }
 
@@ -301,6 +306,23 @@ func widgetProgressEvent(event mergeProgressEvent) mergeprogress.Event {
 			ItemID:  item.branch,
 			State:   mergeprogress.StateMerged,
 			Message: item.branch + ": merged",
+		}
+	case mergeProgressSyncFailed:
+		return mergeprogress.Event{
+			ItemID:  item.branch,
+			State:   mergeprogress.StateFailed,
+			Message: item.branch + ": sync failed",
+		}
+	case mergeProgressFailed:
+		return mergeprogress.Event{
+			ItemID: item.branch,
+			State:  mergeprogress.StateFailed,
+		}
+	case mergeProgressSkipped:
+		return mergeprogress.Event{
+			ItemID:  item.branch,
+			State:   mergeprogress.StateSkipped,
+			Message: item.branch + ": skipped",
 		}
 	default:
 		panic(fmt.Sprintf("unknown merge progress event kind: %d",

--- a/internal/handler/merge/scheduler.go
+++ b/internal/handler/merge/scheduler.go
@@ -1,0 +1,217 @@
+package merge
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/handler/sync"
+	"go.abhg.dev/gs/internal/mergequeue"
+)
+
+var _ mergequeue.Executor[*mergeItem] = (*mergePlanExecutor)(nil)
+
+// mergePlanExecutor runs the merge loop after preflight checks complete.
+//
+// It intentionally has no logger.
+// Merge-loop status must be reported through progress events
+// so terminal and non-terminal output stay in one policy boundary.
+type mergePlanExecutor struct {
+	RemoteRepository forge.Repository // required
+	Repository       GitRepository    // required
+
+	Service Service        // required
+	Restack RestackHandler // required
+	Submit  SubmitHandler  // required
+	Sync    SyncHandler    // required
+
+	Progress mergeProgress // required
+
+	Trunk        string            // required
+	BuildTimeout time.Duration     // required
+	Method       forge.MergeMethod // required
+	NoWait       bool
+	FailFast     bool
+}
+
+// Execute runs the merge queue over the supplied plan items.
+//
+// Execute is the boundary between preflight planning
+// and the merge-loop scheduler.
+// It adapts merge items into queue items,
+// then lets mergequeue.Scheduler decide readiness,
+// failure propagation,
+// and skip propagation.
+func (e *mergePlanExecutor) Execute(
+	ctx context.Context,
+	plan []*mergeItem,
+) error {
+	items := make([]mergequeue.Item[*mergeItem], 0, len(plan))
+	for _, item := range plan {
+		items = append(items, mergequeue.Item[*mergeItem]{
+			ID:     item.branch,
+			BaseID: item.base,
+			Value:  item,
+		})
+	}
+
+	scheduler, err := mergequeue.New(items, &mergequeue.Options[*mergeItem]{
+		FailFast: e.FailFast,
+		Observer: &mergeQueueObserver{
+			progress: e.Progress,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("build merge queue: %w", err)
+	}
+	return scheduler.Run(ctx, e)
+}
+
+// Merge implements mergequeue.Executor.
+func (e *mergePlanExecutor) Merge(ctx context.Context, item *mergeItem) error {
+	if item.base != e.Trunk {
+		// Non-trunk items were based on another item in this queue
+		// when the plan was built.
+		// After that base merges,
+		// the item must be restacked,
+		// submitted,
+		// and resolved to its new head before the forge merge request.
+		e.Progress.Event(mergeProgressEvent{
+			Kind: mergeProgressPreparing,
+			Item: item,
+		})
+		if err := e.prepareForMerge(ctx, item); err != nil {
+			e.Progress.Event(mergeProgressEvent{
+				Kind: mergeProgressPrepareFailed,
+				Item: item,
+			})
+			return fmt.Errorf("prepare %q: %w", item.branch, err)
+		}
+	}
+	return e.mergeOne(ctx, item)
+}
+
+func (e *mergePlanExecutor) mergeOne(
+	ctx context.Context,
+	item *mergeItem,
+) error {
+	// The forge will only merge a change that targets trunk.
+	// Re-check immediately before each merge because prior queue items
+	// and repo sync may have changed the server-side base.
+	change, err := e.ensureTargetsTrunk(ctx, item)
+	if err != nil {
+		e.Progress.Event(mergeProgressEvent{
+			Kind: mergeProgressRetargetFailed,
+			Item: item,
+		})
+		return fmt.Errorf(
+			"ensure %q targets trunk: %w",
+			item.branch, err,
+		)
+	}
+
+	// CI is checked after retargeting and restacking
+	// so each merge waits on the exact change being merged.
+	if err := e.awaitChangeHead(ctx, item, change); err != nil {
+		e.Progress.Event(mergeProgressEvent{
+			Kind: mergeProgressChecksFailed,
+			Item: item,
+		})
+		return fmt.Errorf(
+			"wait for pushed head on %q: %w",
+			item.branch, err,
+		)
+	}
+	if err := e.awaitChecks(ctx, item); err != nil {
+		e.Progress.Event(mergeProgressEvent{
+			Kind: mergeProgressChecksFailed,
+			Item: item,
+		})
+		return fmt.Errorf(
+			"wait for checks on %q: %w",
+			item.branch, err,
+		)
+	}
+
+	e.Progress.Event(mergeProgressEvent{
+		Kind: mergeProgressMerging,
+		Item: item,
+		URL:  change.URL,
+	})
+	if err := e.RemoteRepository.MergeChange(
+		ctx, item.changeID,
+		forge.MergeChangeOptions{
+			Method:   e.Method,
+			HeadHash: item.headHash,
+		},
+	); err != nil {
+		e.Progress.Event(mergeProgressEvent{
+			Kind: mergeProgressMergeFailed,
+			Item: item,
+		})
+		return fmt.Errorf("merge %q: %w", item.branch, err)
+	}
+
+	if e.NoWait {
+		e.Progress.Event(mergeProgressEvent{
+			Kind: mergeProgressMergeRequested,
+			Item: item,
+		})
+		return nil
+	}
+
+	// Wait until the forge reports the merge.
+	e.Progress.Event(mergeProgressEvent{
+		Kind: mergeProgressWaitingForMerge,
+		Item: item,
+	})
+	if err := e.awaitMerged(ctx, item); err != nil {
+		e.Progress.Event(mergeProgressEvent{
+			Kind: mergeProgressMergeIncomplete,
+			Item: item,
+		})
+		return fmt.Errorf("await merge of %q: %w", item.branch, err)
+	}
+	e.Progress.Event(mergeProgressEvent{
+		Kind: mergeProgressMerged,
+		Item: item,
+	})
+
+	// SyncTrunk updates trunk,
+	// deletes merged branches,
+	// and retargets their upstacks.
+	if err := e.Sync.SyncTrunk(ctx, &sync.TrunkOptions{
+		ClosedChanges: sync.ClosedChangesIgnore,
+	}); err != nil {
+		e.Progress.Event(mergeProgressEvent{
+			Kind: mergeProgressSyncFailed,
+			Item: item,
+		})
+		return fmt.Errorf("sync trunk: %w", err)
+	}
+	return nil
+}
+
+// mergeQueueObserver adapts scheduler decisions
+// back into merge progress events.
+type mergeQueueObserver struct {
+	progress mergeProgress
+}
+
+func (o *mergeQueueObserver) Failed(item *mergeItem, _ error) {
+	o.progress.Event(mergeProgressEvent{
+		Kind: mergeProgressFailed,
+		Item: item,
+	})
+}
+
+func (o *mergeQueueObserver) Skipped(
+	item *mergeItem,
+	_ mergequeue.SkipReason,
+) {
+	o.progress.Event(mergeProgressEvent{
+		Kind: mergeProgressSkipped,
+		Item: item,
+	})
+}

--- a/internal/handler/merge/scheduler.go
+++ b/internal/handler/merge/scheduler.go
@@ -86,7 +86,7 @@ func (e *mergePlanExecutor) Merge(ctx context.Context, item *mergeItem) error {
 				Kind: mergeProgressPrepareFailed,
 				Item: item,
 			})
-			return fmt.Errorf("prepare %q: %w", item.branch, err)
+			return fmt.Errorf("prepare: %w", err)
 		}
 	}
 	return e.mergeOne(ctx, item)
@@ -105,10 +105,7 @@ func (e *mergePlanExecutor) mergeOne(
 			Kind: mergeProgressRetargetFailed,
 			Item: item,
 		})
-		return fmt.Errorf(
-			"ensure %q targets trunk: %w",
-			item.branch, err,
-		)
+		return fmt.Errorf("ensure targets trunk: %w", err)
 	}
 
 	// CI is checked after retargeting and restacking
@@ -118,20 +115,14 @@ func (e *mergePlanExecutor) mergeOne(
 			Kind: mergeProgressChecksFailed,
 			Item: item,
 		})
-		return fmt.Errorf(
-			"wait for pushed head on %q: %w",
-			item.branch, err,
-		)
+		return fmt.Errorf("wait for pushed head: %w", err)
 	}
 	if err := e.awaitChecks(ctx, item); err != nil {
 		e.Progress.Event(mergeProgressEvent{
 			Kind: mergeProgressChecksFailed,
 			Item: item,
 		})
-		return fmt.Errorf(
-			"wait for checks on %q: %w",
-			item.branch, err,
-		)
+		return fmt.Errorf("wait for checks: %w", err)
 	}
 
 	e.Progress.Event(mergeProgressEvent{
@@ -150,7 +141,7 @@ func (e *mergePlanExecutor) mergeOne(
 			Kind: mergeProgressMergeFailed,
 			Item: item,
 		})
-		return fmt.Errorf("merge %q: %w", item.branch, err)
+		return fmt.Errorf("merge: %w", err)
 	}
 
 	if e.NoWait {
@@ -171,7 +162,7 @@ func (e *mergePlanExecutor) mergeOne(
 			Kind: mergeProgressMergeIncomplete,
 			Item: item,
 		})
-		return fmt.Errorf("await merge of %q: %w", item.branch, err)
+		return fmt.Errorf("await merge: %w", err)
 	}
 	e.Progress.Event(mergeProgressEvent{
 		Kind: mergeProgressMerged,

--- a/internal/handler/merge/scheduler_test.go
+++ b/internal/handler/merge/scheduler_test.go
@@ -1,0 +1,331 @@
+package merge
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/forge/forgetest"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/handler/sync"
+)
+
+func TestMergeScheduler_parentMergeUnlocksIndependentChildren(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockForge := forgetest.NewMockRepository(ctrl)
+	mockStore := NewMockStore(ctrl)
+	mockStore.EXPECT().Trunk().Return("main")
+
+	pr1 := fakeChangeID("pr-1")
+	pr2 := fakeChangeID("pr-2")
+	pr3 := fakeChangeID("pr-3")
+	var operations []string
+
+	mockForge.EXPECT().
+		FindChangeByID(gomock.Any(), pr1).
+		Return(fakeFindResult("main"), nil)
+	expectMergeWithRecord(mockForge, pr1, &operations)
+
+	mockService := NewMockService(ctrl)
+	mockService.EXPECT().
+		VerifyRestacked(gomock.Any(), "feat2").
+		Return(nil)
+	mockService.EXPECT().
+		VerifyRestacked(gomock.Any(), "feat3").
+		Return(nil)
+
+	mockGit := NewMockGitRepository(ctrl)
+	mockGit.EXPECT().
+		PeelToCommit(gomock.Any(), "feat2").
+		Return(git.Hash("head2"), nil)
+	mockGit.EXPECT().
+		PeelToCommit(gomock.Any(), "feat3").
+		Return(git.Hash("head3"), nil)
+
+	mockForge.EXPECT().
+		FindChangeByID(gomock.Any(), pr2).
+		Return(fakeFindResultWithHead("main", "head2"), nil)
+	expectMergeWithRecord(mockForge, pr2, &operations)
+	mockForge.EXPECT().
+		FindChangeByID(gomock.Any(), pr3).
+		Return(fakeFindResultWithHead("main", "head3"), nil)
+	expectMergeWithRecord(mockForge, pr3, &operations)
+
+	syncHandler := &recordingSyncHandler{operations: &operations}
+	h := newTestHandler(t, ctrl, testHandlerOpts{
+		forgeRepo: mockForge,
+		store:     mockStore,
+		service:   mockService,
+		gitRepo:   mockGit,
+		sync:      syncHandler,
+	})
+
+	err := h.executePlan(t.Context(), testMergePlanWithBases(
+		testPlanEntry("feat1", "main", pr1),
+		testPlanEntry("feat2", "feat1", pr2),
+		testPlanEntry("feat3", "feat1", pr3),
+	), mergeExecutionOptions{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, syncHandler.calls)
+	assert.Equal(t, []string{
+		"merge pr-1",
+		"sync",
+		"merge pr-2",
+		"sync",
+		"merge pr-3",
+		"sync",
+	}, operations)
+}
+
+func TestMergeScheduler_siblingContinuesAfterSubtreeFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockForge := forgetest.NewMockRepository(ctrl)
+
+	pr1 := fakeChangeID("pr-1")
+	pr2 := fakeChangeID("pr-2")
+	pr3 := fakeChangeID("pr-3")
+	pr4 := fakeChangeID("pr-4")
+
+	mockForge.EXPECT().
+		FindChangeByID(gomock.Any(), pr1).
+		Return(fakeFindResult("main"), nil)
+	expectMergeItem(mockForge, pr1)
+
+	mockService := NewMockService(ctrl)
+	mockService.EXPECT().
+		VerifyRestacked(gomock.Any(), "feat2").
+		Return(nil)
+	mockService.EXPECT().
+		VerifyRestacked(gomock.Any(), "feat3").
+		Return(nil)
+
+	mockGit := NewMockGitRepository(ctrl)
+	mockGit.EXPECT().
+		PeelToCommit(gomock.Any(), "feat2").
+		Return(git.Hash("head2"), nil)
+	mockGit.EXPECT().
+		PeelToCommit(gomock.Any(), "feat3").
+		Return(git.Hash("head3"), nil)
+
+	mockForge.EXPECT().
+		FindChangeByID(gomock.Any(), pr2).
+		Return(fakeFindResultWithHead("main", "head2"), nil)
+	mockForge.EXPECT().
+		ChangeChecksState(gomock.Any(), pr2).
+		Return(forge.ChecksFailed, nil)
+
+	mockForge.EXPECT().
+		FindChangeByID(gomock.Any(), pr3).
+		Return(fakeFindResultWithHead("main", "head3"), nil)
+	expectMergeItem(mockForge, pr3)
+
+	progress := &recordingMergeProgress{}
+	err := newTestMergePlanExecutor(
+		newTestHandler(t, ctrl, testHandlerOpts{
+			forgeRepo: mockForge,
+			service:   mockService,
+			gitRepo:   mockGit,
+		}),
+		progress,
+	).Execute(t.Context(), testMergePlanWithBases(
+		testPlanEntry("feat1", "main", pr1),
+		testPlanEntry("feat2", "feat1", pr2),
+		testPlanEntry("feat4", "feat2", pr4),
+		testPlanEntry("feat3", "feat1", pr3),
+	))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "CI checks failed")
+	assert.True(t, progress.seen(mergeProgressFailed, "feat2"))
+	assert.True(t, progress.seen(mergeProgressSkipped, "feat4"))
+	assert.True(t, progress.seen(mergeProgressMerging, "feat3"))
+}
+
+func TestMergeScheduler_restackFailureSkipsSubtree(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockForge := forgetest.NewMockRepository(ctrl)
+
+	pr1 := fakeChangeID("pr-1")
+	pr2 := fakeChangeID("pr-2")
+	pr3 := fakeChangeID("pr-3")
+	pr4 := fakeChangeID("pr-4")
+
+	mockForge.EXPECT().
+		FindChangeByID(gomock.Any(), pr1).
+		Return(fakeFindResult("main"), nil)
+	expectMergeItem(mockForge, pr1)
+
+	mockService := NewMockService(ctrl)
+	mockService.EXPECT().
+		VerifyRestacked(gomock.Any(), "feat2").
+		Return(errors.New("restack check failed"))
+	mockService.EXPECT().
+		VerifyRestacked(gomock.Any(), "feat3").
+		Return(nil)
+
+	mockGit := NewMockGitRepository(ctrl)
+	mockGit.EXPECT().
+		PeelToCommit(gomock.Any(), "feat3").
+		Return(git.Hash("head3"), nil)
+
+	mockForge.EXPECT().
+		FindChangeByID(gomock.Any(), pr3).
+		Return(fakeFindResultWithHead("main", "head3"), nil)
+	expectMergeItem(mockForge, pr3)
+
+	progress := &recordingMergeProgress{}
+	err := newTestMergePlanExecutor(
+		newTestHandler(t, ctrl, testHandlerOpts{
+			forgeRepo: mockForge,
+			service:   mockService,
+			gitRepo:   mockGit,
+		}),
+		progress,
+	).Execute(t.Context(), testMergePlanWithBases(
+		testPlanEntry("feat1", "main", pr1),
+		testPlanEntry("feat2", "feat1", pr2),
+		testPlanEntry("feat4", "feat2", pr4),
+		testPlanEntry("feat3", "feat1", pr3),
+	))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "restack check failed")
+	assert.True(t, progress.seen(mergeProgressPrepareFailed, "feat2"))
+	assert.True(t, progress.seen(mergeProgressFailed, "feat2"))
+	assert.True(t, progress.seen(mergeProgressSkipped, "feat4"))
+	assert.True(t, progress.seen(mergeProgressMerging, "feat3"))
+}
+
+func TestMergeScheduler_failFastStopsOnFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockForge := forgetest.NewMockRepository(ctrl)
+
+	pr1 := fakeChangeID("pr-1")
+	pr2 := fakeChangeID("pr-2")
+	pr3 := fakeChangeID("pr-3")
+
+	mockForge.EXPECT().
+		FindChangeByID(gomock.Any(), pr1).
+		Return(fakeFindResult("main"), nil)
+	expectMergeItem(mockForge, pr1)
+
+	mockService := NewMockService(ctrl)
+	mockService.EXPECT().
+		VerifyRestacked(gomock.Any(), "feat2").
+		Return(nil)
+
+	mockGit := NewMockGitRepository(ctrl)
+	mockGit.EXPECT().
+		PeelToCommit(gomock.Any(), "feat2").
+		Return(git.Hash("head2"), nil)
+
+	mockForge.EXPECT().
+		FindChangeByID(gomock.Any(), pr2).
+		Return(fakeFindResultWithHead("main", "head2"), nil)
+	mockForge.EXPECT().
+		ChangeChecksState(gomock.Any(), pr2).
+		Return(forge.ChecksFailed, nil)
+
+	progress := &recordingMergeProgress{}
+	executor := newTestMergePlanExecutor(
+		newTestHandler(t, ctrl, testHandlerOpts{
+			forgeRepo: mockForge,
+			service:   mockService,
+			gitRepo:   mockGit,
+		}),
+		progress,
+	)
+	executor.FailFast = true
+
+	err := executor.Execute(t.Context(), testMergePlanWithBases(
+		testPlanEntry("feat1", "main", pr1),
+		testPlanEntry("feat2", "feat1", pr2),
+		testPlanEntry("feat3", "feat1", pr3),
+	))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "CI checks failed")
+	assert.False(t, progress.seen(mergeProgressMerging, "feat3"))
+}
+
+type recordingSyncHandler struct {
+	calls      int
+	operations *[]string
+}
+
+func (h *recordingSyncHandler) SyncTrunk(
+	context.Context,
+	*sync.TrunkOptions,
+) error {
+	h.calls++
+	if h.operations != nil {
+		*h.operations = append(*h.operations, "sync")
+	}
+	return nil
+}
+
+type recordingMergeProgress struct {
+	events []mergeProgressEvent
+}
+
+func (p *recordingMergeProgress) Event(event mergeProgressEvent) {
+	p.events = append(p.events, event)
+}
+
+func (p *recordingMergeProgress) seen(
+	kind mergeProgressEventKind,
+	branch string,
+) bool {
+	for _, event := range p.events {
+		if event.Kind == kind && event.Item.branch == branch {
+			return true
+		}
+	}
+	return false
+}
+
+func testPlanEntry(
+	branch string,
+	base string,
+	changeID fakeChangeID,
+) *mergeItem {
+	return &mergeItem{
+		branch:   branch,
+		base:     base,
+		changeID: changeID,
+	}
+}
+
+func testMergePlanWithBases(items ...*mergeItem) []*mergeItem {
+	return items
+}
+
+func expectMergeWithRecord(
+	mockForge *forgetest.MockRepository,
+	id fakeChangeID,
+	operations *[]string,
+) {
+	mockForge.EXPECT().
+		ChangeChecksState(gomock.Any(), id).
+		Return(forge.ChecksPassed, nil)
+
+	mockForge.EXPECT().
+		MergeChange(gomock.Any(), id, gomock.Any()).
+		DoAndReturn(func(
+			context.Context,
+			forge.ChangeID,
+			forge.MergeChangeOptions,
+		) error {
+			*operations = append(*operations, "merge "+id.String())
+			return nil
+		})
+
+	expectMerged(mockForge, id)
+}

--- a/internal/handler/sync/handler.go
+++ b/internal/handler/sync/handler.go
@@ -754,13 +754,16 @@ func (h *Handler) findForgeFinishedBranches(
 		}
 	}
 	sort.Strings(mergedBranchNames)
-	topoBranches := graph.Toposort(mergedBranchNames,
+	topoBranches, err := graph.Toposort(mergedBranchNames,
 		func(name string) (string, bool) {
 			base := finishedBranches[name].Base
 			// Ordering matters only if the base was also merged.
 			baseBranch, ok := finishedBranches[base]
 			return base, ok && baseBranch.Merged
 		})
+	if err != nil {
+		must.Failf("sort merged branches: %v", err)
+	}
 
 	// For each merged branch, bubble up merged downstacks
 	// to their direct upstacks.

--- a/internal/mergequeue/scheduler.go
+++ b/internal/mergequeue/scheduler.go
@@ -1,0 +1,274 @@
+// Package mergequeue schedules dependent items for sequential merging.
+//
+// The package knows only opaque item IDs and base IDs.
+// Callers own domain-specific work such as forge calls,
+// local repository updates,
+// logging,
+// and progress rendering.
+package mergequeue
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.abhg.dev/container/ring"
+	"go.abhg.dev/gs/internal/graph"
+	"go.abhg.dev/gs/internal/must"
+)
+
+// Item is one mergeable item in a dependency queue.
+type Item[T any] struct {
+	// ID uniquely identifies this item inside one queue.
+	ID string // required
+
+	// BaseID identifies the item that must merge before this item.
+	// Empty and unknown bases make the item ready at queue start.
+	BaseID string
+
+	// Value is passed unchanged to the Executor.
+	Value T
+}
+
+// Options configures Scheduler behavior.
+type Options[T any] struct {
+	// FailFast stops scheduling after the first item failure.
+	// By default, independent items continue after failures.
+	FailFast bool
+
+	// Observer receives scheduler-level state transitions.
+	Observer Observer[T]
+}
+
+// Executor merges one queue item.
+//
+// Scheduler calls Merge sequentially.
+// A nil error marks the item complete
+// and unlocks items based directly on it.
+type Executor[T any] interface {
+	Merge(context.Context, T) error
+}
+
+// Observer receives scheduler-level events.
+//
+// The observer is for scheduler decisions only,
+// such as items failed by Executor
+// or skipped without calling Executor.
+// Per-item merge progress belongs inside the caller's Executor.
+type Observer[T any] interface {
+	Failed(T, error)
+	Skipped(T, SkipReason)
+}
+
+// SkipReason explains why a pending item became ineligible.
+type SkipReason int
+
+const (
+	// SkipBecauseBelowFailed means a dependency below this item failed.
+	SkipBecauseBelowFailed SkipReason = iota
+
+	// SkipBecauseFailFast means fail-fast stopped the remaining queue.
+	SkipBecauseFailFast
+)
+
+// ItemError wraps an error returned for a specific queue item.
+type ItemError struct {
+	ID  string // required
+	Err error  // required
+}
+
+func (e *ItemError) Error() string {
+	return fmt.Sprintf("merge queue item %q: %v", e.ID, e.Err)
+}
+
+func (e *ItemError) Unwrap() error {
+	return e.Err
+}
+
+// Scheduler runs mergeable items in dependency order.
+type Scheduler[T any] struct {
+	// nodes indexes every queued item by Item.ID.
+	nodes map[string]*node[T]
+
+	// order stores nodes in topological order.
+	// Scheduler uses it for deterministic ready initialization
+	// and fail-fast skip reporting.
+	order []*node[T]
+
+	// ready contains pending nodes whose queued base has already merged
+	// or whose base is not part of this queue.
+	ready ring.Q[*node[T]]
+
+	failFast bool
+
+	observer Observer[T]
+}
+
+// New validates items and prepares a Scheduler.
+//
+// Duplicate IDs,
+// empty IDs,
+// and cycles among queued items are rejected.
+// Items may appear in any order:
+// an item may appear before or after its base.
+// Items with an empty or unknown BaseID are ready at queue start.
+// Among ready siblings,
+// input order determines execution order.
+func New[T any](
+	items []Item[T],
+	opts *Options[T],
+) (*Scheduler[T], error) {
+	if opts == nil {
+		opts = &Options[T]{}
+	}
+	observer := opts.Observer
+	if observer == nil {
+		observer = &nopObserver[T]{}
+	}
+
+	scheduler := &Scheduler[T]{
+		nodes:    make(map[string]*node[T], len(items)),
+		order:    make([]*node[T], 0, len(items)),
+		failFast: opts.FailFast,
+		observer: observer,
+	}
+
+	ids := make([]string, 0, len(items))
+	for i, item := range items {
+		must.NotBeBlankf(item.ID, "item at index %d has empty ID", i)
+		if _, ok := scheduler.nodes[item.ID]; ok {
+			return nil, fmt.Errorf("duplicate item ID %q", item.ID)
+		}
+
+		n := &node[T]{item: item}
+		scheduler.nodes[item.ID] = n
+		ids = append(ids, item.ID)
+	}
+
+	topoIDs, err := graph.Toposort(ids, func(id string) (string, bool) {
+		baseID := scheduler.nodes[id].item.BaseID
+		_, ok := scheduler.nodes[baseID]
+		return baseID, ok
+	})
+	if err != nil {
+		var cycleErr *graph.CycleError[string]
+		if errors.As(err, &cycleErr) {
+			return nil, fmt.Errorf(
+				"cycle includes items: %s",
+				cycleErr.Format(" -> "),
+			)
+		}
+		return nil, fmt.Errorf("sort items: %w", err)
+	}
+	for _, id := range topoIDs {
+		scheduler.order = append(scheduler.order, scheduler.nodes[id])
+	}
+
+	for _, n := range scheduler.order {
+		base := scheduler.nodes[n.item.BaseID]
+		if base == nil {
+			scheduler.ready.Push(n)
+			continue
+		}
+		base.aboves = append(base.aboves, n)
+	}
+
+	return scheduler, nil
+}
+
+// Run executes ready items until the queue completes or fail-fast stops it.
+//
+// Run mutates scheduler state,
+// so a Scheduler should be used for one run only.
+// Item failures are wrapped in ItemError and returned with errors.Join.
+func (s *Scheduler[T]) Run(
+	ctx context.Context,
+	exec Executor[T],
+) error {
+	must.NotBeNilf(exec, "merge queue executor is required")
+
+	var errs []error
+	for !s.ready.Empty() {
+		n := s.ready.Pop()
+		if n.state != nodePending {
+			continue
+		}
+
+		if err := exec.Merge(ctx, n.item.Value); err != nil {
+			n.state = nodeFailed
+			s.observer.Failed(n.item.Value, err)
+			errs = append(errs, &ItemError{
+				ID:  n.item.ID,
+				Err: err,
+			})
+			s.skipAboves(n)
+			if s.failFast {
+				s.skipRemaining()
+				return errors.Join(errs...)
+			}
+			continue
+		}
+
+		n.state = nodeMerged
+		for _, above := range n.aboves {
+			s.ready.Push(above)
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *Scheduler[T]) skipAboves(n *node[T]) {
+	for _, above := range n.aboves {
+		if above.state != nodePending {
+			continue
+		}
+		above.state = nodeSkipped
+		s.observer.Skipped(
+			above.item.Value,
+			SkipBecauseBelowFailed,
+		)
+		s.skipAboves(above)
+	}
+}
+
+func (s *Scheduler[T]) skipRemaining() {
+	for _, n := range s.order {
+		if n.state != nodePending {
+			continue
+		}
+		n.state = nodeSkipped
+		s.observer.Skipped(
+			n.item.Value,
+			SkipBecauseFailFast,
+		)
+	}
+}
+
+// node is the scheduler's mutable state for one input item.
+type node[T any] struct {
+	item Item[T]
+
+	// aboves are items based directly on this item.
+	aboves []*node[T]
+
+	state nodeState
+}
+
+// nodeState records whether a queued item is still eligible.
+type nodeState uint8
+
+const (
+	nodePending nodeState = iota
+	nodeMerged
+	nodeFailed
+	nodeSkipped
+)
+
+// nopObserver is the default observer used when callers do not need
+// scheduler events.
+type nopObserver[T any] struct{}
+
+func (*nopObserver[T]) Failed(T, error) {}
+
+func (*nopObserver[T]) Skipped(T, SkipReason) {}

--- a/internal/mergequeue/scheduler_test.go
+++ b/internal/mergequeue/scheduler_test.go
@@ -1,0 +1,183 @@
+package mergequeue
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScheduler_Run_parentUnlocksReadySiblingsInInputOrder(
+	t *testing.T,
+) {
+	scheduler, err := New([]Item[string]{
+		{ID: "root", Value: "root"},
+		{ID: "first", BaseID: "root", Value: "first"},
+		{ID: "second", BaseID: "root", Value: "second"},
+	}, nil)
+	require.NoError(t, err)
+
+	exec := &recordingExecutor{}
+	require.NoError(t, scheduler.Run(t.Context(), exec))
+
+	assert.Equal(t, []string{"root", "first", "second"}, exec.items)
+}
+
+func TestScheduler_Run_topoSortsOutOfOrderInput(t *testing.T) {
+	scheduler, err := New([]Item[string]{
+		{ID: "feature", BaseID: "base", Value: "feature"},
+		{ID: "base", Value: "base"},
+	}, nil)
+	require.NoError(t, err)
+
+	exec := &recordingExecutor{}
+	require.NoError(t, scheduler.Run(t.Context(), exec))
+
+	assert.Equal(t, []string{"base", "feature"}, exec.items)
+}
+
+func TestScheduler_Run_missingBaseStartsReady(t *testing.T) {
+	scheduler, err := New([]Item[string]{
+		{ID: "child", BaseID: "external", Value: "child"},
+		{ID: "root", Value: "root"},
+	}, nil)
+	require.NoError(t, err)
+
+	exec := &recordingExecutor{}
+	require.NoError(t, scheduler.Run(t.Context(), exec))
+
+	assert.Equal(t, []string{"child", "root"}, exec.items)
+}
+
+func TestScheduler_Run_independentBranchContinuesAfterFailure(
+	t *testing.T,
+) {
+	failErr := errors.New("merge failed")
+	observer := &recordingObserver[string]{}
+	scheduler, err := New([]Item[string]{
+		{ID: "root", Value: "root"},
+		{ID: "broken", BaseID: "root", Value: "broken"},
+		{ID: "blocked", BaseID: "broken", Value: "blocked"},
+		{ID: "independent", BaseID: "root", Value: "independent"},
+	}, &Options[string]{
+		Observer: observer,
+	})
+	require.NoError(t, err)
+
+	err = scheduler.Run(t.Context(), &recordingExecutor{
+		fail: map[string]error{"broken": failErr},
+	})
+	require.Error(t, err)
+
+	var itemErr *ItemError
+	require.ErrorAs(t, err, &itemErr)
+	assert.Equal(t, "broken", itemErr.ID)
+	assert.ErrorIs(t, err, failErr)
+	assert.Equal(t, []string{"broken"}, observer.failed)
+	assert.Equal(t, []skipRecord[string]{
+		{item: "blocked", reason: SkipBecauseBelowFailed},
+	}, observer.skipped)
+}
+
+func TestScheduler_Run_failFastSkipsRemainingPending(t *testing.T) {
+	observer := &recordingObserver[string]{}
+	scheduler, err := New([]Item[string]{
+		{ID: "root", Value: "root"},
+		{ID: "broken", BaseID: "root", Value: "broken"},
+		{ID: "blocked", BaseID: "broken", Value: "blocked"},
+		{ID: "other", BaseID: "root", Value: "other"},
+	}, &Options[string]{
+		FailFast: true,
+		Observer: observer,
+	})
+	require.NoError(t, err)
+
+	err = scheduler.Run(t.Context(), &recordingExecutor{
+		fail: map[string]error{"broken": errors.New("merge failed")},
+	})
+	require.Error(t, err)
+
+	assert.Equal(t, []skipRecord[string]{
+		{item: "blocked", reason: SkipBecauseBelowFailed},
+		{item: "other", reason: SkipBecauseFailFast},
+	}, observer.skipped)
+}
+
+func TestScheduler_Run_returnsItemError(t *testing.T) {
+	failErr := errors.New("merge failed")
+	scheduler, err := New([]Item[string]{
+		{ID: "broken", Value: "broken"},
+	}, nil)
+	require.NoError(t, err)
+
+	err = scheduler.Run(t.Context(), &recordingExecutor{
+		fail: map[string]error{"broken": failErr},
+	})
+	require.Error(t, err)
+
+	var itemErr *ItemError
+	require.ErrorAs(t, err, &itemErr)
+	assert.Equal(t, "broken", itemErr.ID)
+	assert.ErrorIs(t, err, failErr)
+}
+
+func TestNew_rejectsDuplicateID(t *testing.T) {
+	_, err := New([]Item[string]{
+		{ID: "same", Value: "one"},
+		{ID: "same", Value: "two"},
+	}, nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `duplicate item ID "same"`)
+}
+
+func TestNew_rejectsCycle(t *testing.T) {
+	_, err := New([]Item[string]{
+		{ID: "one", BaseID: "two", Value: "one"},
+		{ID: "two", BaseID: "three", Value: "two"},
+		{ID: "three", BaseID: "one", Value: "three"},
+	}, nil)
+
+	require.Error(t, err)
+	assert.Contains(
+		t,
+		err.Error(),
+		"cycle includes items: one -> two -> three -> one",
+	)
+}
+
+type recordingExecutor struct {
+	items []string
+	fail  map[string]error
+}
+
+func (e *recordingExecutor) Merge(
+	_ context.Context,
+	item string,
+) error {
+	e.items = append(e.items, item)
+	return e.fail[item]
+}
+
+type recordingObserver[T comparable] struct {
+	failed  []T
+	skipped []skipRecord[T]
+}
+
+func (o *recordingObserver[T]) Failed(item T, _ error) {
+	o.failed = append(o.failed, item)
+}
+
+func (o *recordingObserver[T]) Skipped(item T, reason SkipReason) {
+	o.skipped = append(o.skipped, skipRecord[T]{
+		item:   item,
+		reason: reason,
+	})
+}
+
+type skipRecord[T comparable] struct {
+	item   T
+	reason SkipReason
+}

--- a/testdata/script/branch_merge_explicit_branch.txt
+++ b/testdata/script/branch_merge_explicit_branch.txt
@@ -46,7 +46,7 @@ This is feature 1
 >   feature1 (#1)
 true
 -- golden/merge-stderr.txt --
-FTL gs: wait for checks on "feature1": CI checks failed for "feature1"
+FTL gs: merge queue item "feature1": wait for checks: CI checks failed
 -- golden/change-1.json --
 {
   "number": 1,

--- a/testdata/script/downstack_merge_checks_fail_next.txt
+++ b/testdata/script/downstack_merge_checks_fail_next.txt
@@ -63,7 +63,7 @@ INF feature1: deleted (was dc8aa3d)
 INF feature2: retargeting #2 onto main...
 INF feature2: restacked on main
 INF Updated #2: $SHAMHUB_URL/alice/example/change/2
-FTL gs: wait for checks on "feature2": CI checks failed for "feature2"
+FTL gs: merge queue item "feature2": wait for checks: CI checks failed
 -- golden/change-1.json --
 {
   "number": 1,

--- a/testdata/script/downstack_merge_checks_failed.txt
+++ b/testdata/script/downstack_merge_checks_failed.txt
@@ -45,7 +45,7 @@ This is feature 1
 >   feature1 (#1)
 true
 -- golden/merge-stderr.txt --
-FTL gs: wait for checks on "feature1": CI checks failed for "feature1"
+FTL gs: merge queue item "feature1": wait for checks: CI checks failed
 -- golden/change-1.json --
 {
   "number": 1,

--- a/testdata/script/downstack_merge_checks_pending.txt
+++ b/testdata/script/downstack_merge_checks_pending.txt
@@ -45,7 +45,7 @@ This is feature 1
 >   feature1 (#1)
 true
 -- golden/merge-stderr.txt --
-FTL gs: wait for checks on "feature1": CI checks pending for "feature1" (build-timeout=0)
+FTL gs: merge queue item "feature1": wait for checks: CI checks pending (build-timeout=0)
 -- golden/change-1.json --
 {
   "number": 1,


### PR DESCRIPTION
Stack-level merge commands need to schedule branch graphs
where multiple branches can become eligible
after a shared base merges.
That scheduling policy should be testable
without depending on forge APIs,
local Git state,
logging,
or terminal rendering.

Teach `internal/graph.Toposort` to return cycle errors
that preserve the cycle path.
`internal/mergequeue` uses that topological order
as its scheduling baseline,
so queued bases become eligible before their upstacks
even when callers provide items out of dependency order.

Introduce `internal/mergequeue` as the generic queue boundary.
The scheduler accepts opaque item IDs and base IDs,
rejects duplicate IDs and cycles,
and reports item failures with `ItemError`.
Non-fail-fast execution skips only the failed item upstack
and continues independent branches;
fail-fast execution skips all remaining pending work.

The merge handler now adapts `mergeItem` values into queue items
and lets `mergePlanExecutor` implement the queue executor directly.
Preparation,
CI waits,
forge merge calls,
and trunk sync stay in the existing merge executor
so merge-loop output still flows through progress events
instead of direct logging.

Queue observers report both failed and skipped items.
The progress bridge uses that to mark failed branches in the widget
while preserving the more specific failure message
emitted by the merge step that returned the error.