### PR TITLE
feat(merge): Add stack merge command

### DIFF
--- a/.changes/unreleased/Added-20260512-100847.yaml
+++ b/.changes/unreleased/Added-20260512-100847.yaml
@@ -1,3 +1,4 @@
 kind: Added
-body: Add 'gs downstack merge' (dsm) to merge a stacked PR series bottom-up with CI gating
+body: >-
+  Add 'gs downstack merge' command to merge CRs from trunk up to a specified branch.
 time: 2026-05-12T10:08:47.691277-04:00

--- a/.changes/unreleased/Added-20260613-220211.yaml
+++ b/.changes/unreleased/Added-20260613-220211.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add 'gs stack merge' command to merge all CRs in a stack.
+time: 2026-06-13T22:02:11.754091-07:00

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -286,6 +286,48 @@ only if there are multiple CRs in the stack.
 
 **Configuration**: [spice.submit.assignees](/cli/config.md#spicesubmitassignees), [spice.submit.draft](/cli/config.md#spicesubmitdraft), [spice.submit.labels](/cli/config.md#spicesubmitlabels), [spice.submit.labels.addWhen](/cli/config.md#spicesubmitlabelsaddwhen), [spice.submit.listTemplatesTimeout](/cli/config.md#spicesubmitlisttemplatestimeout), [spice.submit.navigationComment](/cli/config.md#spicesubmitnavigationcomment), [spice.submit.navigationComment.downstack](/cli/config.md#spicesubmitnavigationcommentdownstack), [spice.submit.navigationCommentStyle.marker](/cli/config.md#spicesubmitnavigationcommentstylemarker), [spice.submit.navigationCommentSync](/cli/config.md#spicesubmitnavigationcommentsync), [spice.submit.publish](/cli/config.md#spicesubmitpublish), [spice.submit.reviewers](/cli/config.md#spicesubmitreviewers), [spice.submit.reviewers.addWhen](/cli/config.md#spicesubmitreviewersaddwhen), [spice.submit.skipRestackCheck](/cli/config.md#spicesubmitskiprestackcheck), [spice.submit.template](/cli/config.md#spicesubmittemplate), [spice.submit.updateOnly](/cli/config.md#spicesubmitupdateonly), [spice.submit.web](/cli/config.md#spicesubmitweb)
 
+### git-spice stack merge {#gs-stack-merge}
+
+```
+gs stack (s) merge (m) [flags]
+```
+
+<span class="mdx-badge mdx-badge--experiment"><span class="mdx-badge__icon">:material-test-tube:{ title="Experimental" }</span><span class="mdx-badge__text">[merge](/cli/experiments.md#merge)</span></span>
+
+Merge a stack
+
+Merges the CRs for the current branch's stack into trunk.
+Use --branch to merge a different branch's stack.
+
+The stack includes the selected branch,
+its downstack branches down to trunk,
+and every upstack branch.
+
+Already-merged branches are skipped automatically.
+Branches must have an open Change Request to be merged.
+
+Before merging, the stack is checked for branches
+whose base PR was already merged on the forge.
+Use --no-branch-check to skip this validation.
+
+Before each merge, waits for CI checks to pass.
+Use --build-timeout to configure the maximum wait
+before failing if checks are not ready.
+
+By default, a branch failure skips that branch's upstack descendants,
+but independent sibling branches continue.
+Use --fail-fast to stop the queue after the first branch failure.
+
+**Flags**
+
+* `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
+* `--build-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.buildTimeout" }](/cli/config.md#spicemergebuildtimeout)): Max time to wait for CI checks before each merge. 0 means check once.
+* `--no-branch-check`: Skip stale base validation before merging.
+* `--fail-fast`: Stop the merge queue after the first branch failure.
+* `--branch=NAME`: Branch whose stack to merge
+
+**Configuration**: [spice.merge.buildTimeout](/cli/config.md#spicemergebuildtimeout), [spice.merge.method](/cli/config.md#spicemergemethod)
+
 ### git-spice stack restack {#gs-stack-restack}
 
 ```

--- a/doc/includes/cli-shorthands.md
+++ b/doc/includes/cli-shorthands.md
@@ -34,6 +34,7 @@
 | gs rs | [gs repo sync](/cli/reference.md#gs-repo-sync) |
 | gs sd | [gs stack delete](/cli/reference.md#gs-stack-delete) |
 | gs se | [gs stack edit](/cli/reference.md#gs-stack-edit) |
+| gs sm | [gs stack merge](/cli/reference.md#gs-stack-merge) |
 | gs sr | [gs stack restack](/cli/reference.md#gs-stack-restack) |
 | gs ss | [gs stack submit](/cli/reference.md#gs-stack-submit) |
 | gs usd | [gs upstack delete](/cli/reference.md#gs-upstack-delete) |

--- a/downstack_merge.go
+++ b/downstack_merge.go
@@ -64,6 +64,7 @@ func (*downstackMergeCmd) Help() string {
 type MergeHandler interface {
 	MergeDownstack(ctx context.Context, req *merge.DownstackMergeRequest) error
 	MergeBranch(ctx context.Context, req *merge.BranchMergeRequest) error
+	MergeStack(ctx context.Context, req *merge.StackMergeRequest) error
 }
 
 func (cmd *downstackMergeCmd) AfterApply(

--- a/internal/handler/merge/handler.go
+++ b/internal/handler/merge/handler.go
@@ -102,6 +102,26 @@ type BranchMergeRequest struct {
 	Options *Options // optional
 }
 
+// StackMergeOptions controls stack merge behavior.
+type StackMergeOptions struct {
+	Options
+
+	// NoBranchCheck skips stale base validation before merging.
+	NoBranchCheck bool `help:"Skip stale base validation before merging."`
+
+	// FailFast stops the merge queue after the first branch failure.
+	FailFast bool `help:"Stop the merge queue after the first branch failure."`
+}
+
+// StackMergeRequest asks Handler to merge a branch,
+// its downstack branches down to trunk,
+// and its upstack branches.
+type StackMergeRequest struct {
+	Branch string // required
+
+	Options *StackMergeOptions // optional
+}
+
 // Handler merges change requests via the forge API.
 type Handler struct {
 	Log              *silog.Logger    // required
@@ -134,7 +154,10 @@ func (h *Handler) MergeDownstack(
 		return nil
 	}
 
-	if err := h.confirm(plan); err != nil {
+	if err := h.confirm(
+		plan,
+		fmt.Sprintf("Merge %d change(s) bottom-up?", len(plan)),
+	); err != nil {
 		return err
 	}
 
@@ -178,10 +201,51 @@ func (h *Handler) MergeBranch(
 	})
 }
 
+// MergeStack merges the given branch,
+// its downstack branches down to trunk,
+// and its upstack branches.
+func (h *Handler) MergeStack(
+	ctx context.Context, req *StackMergeRequest,
+) error {
+	opts := cmp.Or(req.Options, &StackMergeOptions{})
+	graph, err := h.Service.BranchGraph(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("build branch graph: %w", err)
+	}
+
+	plan, err := h.buildPlanFromBranches(ctx, mergePlanRequest{
+		Graph:         graph,
+		Branches:      slices.Collect(graph.Stack(req.Branch)),
+		NoBranchCheck: opts.NoBranchCheck,
+	})
+	if err != nil {
+		return err
+	}
+
+	if len(plan) == 0 {
+		h.Log.Info("No open changes to merge.")
+		return nil
+	}
+
+	if err := h.confirm(
+		plan,
+		fmt.Sprintf("Merge %d change(s)?", len(plan)),
+	); err != nil {
+		return err
+	}
+
+	return h.executePlan(ctx, plan, mergeExecutionOptions{
+		Method:       opts.Method,
+		BuildTimeout: opts.BuildTimeout,
+		FailFast:     opts.FailFast,
+	})
+}
+
 // mergeItem is one queue item in a downstack merge plan.
 //
-// buildPlan fills branch, base, changeID, and upstreamBranch
-// from the branch graph.
+// buildPlanFromBranches fills branch, base, changeID, and upstreamBranch
+// from the branch graph for either a linear downstack
+// or a graph-shaped stack merge.
 // validateSynced later fills headHash after it verifies
 // the local branch matches its upstream ref.
 type mergeItem struct {
@@ -225,10 +289,34 @@ func (h *Handler) buildPlan(
 	downstack := slices.Collect(graph.Downstack(req.Branch))
 	slices.Reverse(downstack)
 
-	items := make([]*mergeItem, 0, len(downstack))
-	ids := make([]forge.ChangeID, 0, len(downstack))
-	for _, name := range downstack {
-		branch, ok := graph.Lookup(name)
+	return h.buildPlanFromBranches(ctx, mergePlanRequest{
+		Graph:         graph,
+		Branches:      downstack,
+		NoBranchCheck: opts.NoBranchCheck,
+		NoWait:        opts.NoWait,
+	})
+}
+
+// mergePlanRequest selects the local branches that become merge queue items.
+//
+// Branches provides the prompt order.
+// The merge queue still enforces base dependencies before execution.
+type mergePlanRequest struct {
+	Graph *spice.BranchGraph // required
+
+	Branches []string // required
+
+	NoBranchCheck bool
+	NoWait        bool
+}
+
+func (h *Handler) buildPlanFromBranches(
+	ctx context.Context, req mergePlanRequest,
+) ([]*mergeItem, error) {
+	items := make([]*mergeItem, 0, len(req.Branches))
+	ids := make([]forge.ChangeID, 0, len(req.Branches))
+	for _, name := range req.Branches {
+		branch, ok := req.Graph.Lookup(name)
 		if !ok {
 			return nil, fmt.Errorf("branch %q is not tracked", name)
 		}
@@ -248,6 +336,9 @@ func (h *Handler) buildPlan(
 		items = append(items, item)
 		ids = append(ids, item.changeID)
 	}
+	if len(items) == 0 {
+		return nil, nil
+	}
 
 	statuses, err := h.RemoteRepository.ChangeStatuses(ctx, ids)
 	if err != nil {
@@ -255,7 +346,7 @@ func (h *Handler) buildPlan(
 	}
 
 	// Drop already-merged changes from the queue,
-	// but stop if any downstack Change Request was closed without merging.
+	// but stop if any Change Request was closed without merging.
 	plan := items[:0]
 	for i, item := range items {
 		switch statuses[i].State {
@@ -272,7 +363,7 @@ func (h *Handler) buildPlan(
 		}
 	}
 
-	if opts.NoWait && len(plan) > 1 {
+	if req.NoWait && len(plan) > 1 {
 		return nil, fmt.Errorf(
 			"--no-wait can merge only one branch; "+
 				"got %d branches",
@@ -284,8 +375,10 @@ func (h *Handler) buildPlan(
 		return nil, fmt.Errorf("validate branch sync: %w", err)
 	}
 
-	if !opts.NoBranchCheck {
-		if err := h.validateFreshBases(ctx, graph, req.Branch); err != nil {
+	if !req.NoBranchCheck {
+		if err := h.validateFreshBases(
+			ctx, req.Graph, req.Branches,
+		); err != nil {
 			return nil, fmt.Errorf("validate stale bases: %w", err)
 		}
 	}
@@ -383,7 +476,7 @@ func (h *Handler) validateSynced(
 	return errors.New(msg.String())
 }
 
-func (h *Handler) confirm(plan []*mergeItem) error {
+func (h *Handler) confirm(plan []*mergeItem, title string) error {
 	if !ui.Interactive(h.View) {
 		return nil
 	}
@@ -396,12 +489,7 @@ func (h *Handler) confirm(plan []*mergeItem) error {
 
 	proceed := true
 	prompt := ui.NewConfirm().
-		WithTitle(
-			fmt.Sprintf(
-				"Merge %d change(s) bottom-up?",
-				len(plan),
-			),
-		).
+		WithTitle(title).
 		WithDescription(desc.String()).
 		WithValue(&proceed)
 	if err := ui.Run(h.View, prompt); err != nil {
@@ -418,6 +506,7 @@ type mergeExecutionOptions struct {
 	Method       forge.MergeMethod
 	BuildTimeout time.Duration
 	NoWait       bool
+	FailFast     bool
 }
 
 func (h *Handler) executePlan(
@@ -454,6 +543,7 @@ func (h *Handler) executePlan(
 		BuildTimeout: opts.BuildTimeout,
 		Method:       opts.Method,
 		NoWait:       opts.NoWait,
+		FailFast:     opts.FailFast,
 	}).Execute(ctx, plan)
 	if err != nil {
 		return err
@@ -466,12 +556,12 @@ func (h *Handler) executePlan(
 func (h *Handler) validateFreshBases(
 	ctx context.Context,
 	graph *spice.BranchGraph,
-	branch string,
+	branches []string,
 ) error {
 	staleBases, err := spice.FindStaleBases(ctx, graph,
 		func(context.Context) (forge.Repository, error) {
 			return h.RemoteRepository, nil
-		}, []string{branch})
+		}, branches)
 	if err != nil {
 		return fmt.Errorf("find stale bases: %w", err)
 	}

--- a/internal/handler/merge/handler_test.go
+++ b/internal/handler/merge/handler_test.go
@@ -548,6 +548,174 @@ func TestMergeBranch_rejectsBranchNotBasedOnTrunk(t *testing.T) {
 	assert.Contains(t, err.Error(), "gs downstack merge --branch feat2")
 }
 
+func TestMergeStack_includesUpstackDescendants(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockStore := NewMockStore(ctrl)
+	mockStore.EXPECT().Trunk().Return("main").AnyTimes()
+
+	pr1 := fakeChangeID("pr-1")
+	pr2 := fakeChangeID("pr-2")
+	pr3 := fakeChangeID("pr-3")
+	graph := testBranchGraph(t, []spice.LoadBranchItem{
+		testBranch("feat1", "main", pr1),
+		testBranch("feat2", "feat1", pr2),
+		testBranch("feat3", "feat1", pr3),
+	})
+
+	mockForge := forgetest.NewMockRepository(ctrl)
+	mockForge.EXPECT().
+		ChangeStatuses(gomock.Any(), []forge.ChangeID{pr1, pr2, pr3}).
+		Return([]forge.ChangeStatus{
+			{State: forge.ChangeOpen},
+			{State: forge.ChangeOpen},
+			{State: forge.ChangeOpen},
+		}, nil)
+	mockForge.EXPECT().
+		FindChangeByID(gomock.Any(), pr1).
+		Return(fakeFindResultWithHead("main", "head1"), nil)
+	expectMergeItem(mockForge, pr1)
+
+	mockService := NewMockService(ctrl)
+	mockService.EXPECT().
+		BranchGraph(gomock.Any(), gomock.Nil()).
+		Return(graph, nil)
+	mockService.EXPECT().
+		VerifyRestacked(gomock.Any(), "feat2").
+		Return(nil)
+	mockService.EXPECT().
+		VerifyRestacked(gomock.Any(), "feat3").
+		Return(nil)
+
+	mockGit := NewMockGitRepository(ctrl)
+	mockGit.EXPECT().
+		CommitAheadBehind(gomock.Any(), "origin/feat1", "feat1").
+		Return(0, 0, nil)
+	mockGit.EXPECT().
+		PeelToCommit(gomock.Any(), "feat1").
+		Return(git.Hash("head1"), nil)
+	mockGit.EXPECT().
+		CommitAheadBehind(gomock.Any(), "origin/feat2", "feat2").
+		Return(0, 0, nil)
+	mockGit.EXPECT().
+		PeelToCommit(gomock.Any(), "feat2").
+		Return(git.Hash("head2"), nil).
+		Times(2)
+	mockGit.EXPECT().
+		CommitAheadBehind(gomock.Any(), "origin/feat3", "feat3").
+		Return(0, 0, nil)
+	mockGit.EXPECT().
+		PeelToCommit(gomock.Any(), "feat3").
+		Return(git.Hash("head3"), nil).
+		Times(2)
+
+	mockForge.EXPECT().
+		FindChangeByID(gomock.Any(), pr2).
+		Return(fakeFindResultWithHead("main", "head2"), nil)
+	expectMergeItem(mockForge, pr2)
+	mockForge.EXPECT().
+		FindChangeByID(gomock.Any(), pr3).
+		Return(fakeFindResultWithHead("main", "head3"), nil)
+	expectMergeItem(mockForge, pr3)
+
+	h := newTestHandler(t, ctrl, testHandlerOpts{
+		forgeRepo: mockForge,
+		store:     mockStore,
+		service:   mockService,
+		gitRepo:   mockGit,
+	})
+
+	err := h.MergeStack(t.Context(), &StackMergeRequest{
+		Branch: "feat1",
+		Options: &StackMergeOptions{
+			NoBranchCheck: true,
+		},
+	})
+	require.NoError(t, err)
+}
+
+func TestMergeStack_passesFailFastToScheduler(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockStore := NewMockStore(ctrl)
+	mockStore.EXPECT().Trunk().Return("main").AnyTimes()
+
+	pr1 := fakeChangeID("pr-1")
+	pr2 := fakeChangeID("pr-2")
+	pr3 := fakeChangeID("pr-3")
+	graph := testBranchGraph(t, []spice.LoadBranchItem{
+		testBranch("feat1", "main", pr1),
+		testBranch("feat2", "feat1", pr2),
+		testBranch("feat3", "feat1", pr3),
+	})
+
+	mockForge := forgetest.NewMockRepository(ctrl)
+	mockForge.EXPECT().
+		ChangeStatuses(gomock.Any(), []forge.ChangeID{pr1, pr2, pr3}).
+		Return([]forge.ChangeStatus{
+			{State: forge.ChangeOpen},
+			{State: forge.ChangeOpen},
+			{State: forge.ChangeOpen},
+		}, nil)
+	mockForge.EXPECT().
+		FindChangeByID(gomock.Any(), pr1).
+		Return(fakeFindResultWithHead("main", "head1"), nil)
+	expectMergeItem(mockForge, pr1)
+
+	mockService := NewMockService(ctrl)
+	mockService.EXPECT().
+		BranchGraph(gomock.Any(), gomock.Nil()).
+		Return(graph, nil)
+	mockService.EXPECT().
+		VerifyRestacked(gomock.Any(), "feat2").
+		Return(nil)
+
+	mockGit := NewMockGitRepository(ctrl)
+	mockGit.EXPECT().
+		CommitAheadBehind(gomock.Any(), "origin/feat1", "feat1").
+		Return(0, 0, nil)
+	mockGit.EXPECT().
+		PeelToCommit(gomock.Any(), "feat1").
+		Return(git.Hash("head1"), nil)
+	mockGit.EXPECT().
+		CommitAheadBehind(gomock.Any(), "origin/feat2", "feat2").
+		Return(0, 0, nil)
+	mockGit.EXPECT().
+		PeelToCommit(gomock.Any(), "feat2").
+		Return(git.Hash("head2"), nil).
+		Times(2)
+	mockGit.EXPECT().
+		CommitAheadBehind(gomock.Any(), "origin/feat3", "feat3").
+		Return(0, 0, nil)
+	mockGit.EXPECT().
+		PeelToCommit(gomock.Any(), "feat3").
+		Return(git.Hash("head3"), nil)
+
+	mockForge.EXPECT().
+		FindChangeByID(gomock.Any(), pr2).
+		Return(fakeFindResultWithHead("main", "head2"), nil)
+	mockForge.EXPECT().
+		ChangeChecksState(gomock.Any(), pr2).
+		Return(forge.ChecksFailed, nil)
+
+	h := newTestHandler(t, ctrl, testHandlerOpts{
+		forgeRepo: mockForge,
+		store:     mockStore,
+		service:   mockService,
+		gitRepo:   mockGit,
+	})
+
+	err := h.MergeStack(t.Context(), &StackMergeRequest{
+		Branch: "feat1",
+		Options: &StackMergeOptions{
+			NoBranchCheck: true,
+			FailFast:      true,
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "CI checks failed")
+}
+
 func TestExecutePlan_syncTrunkFailureStopsLoop(t *testing.T) {
 	ctrl := gomock.NewController(t)
 

--- a/stack.go
+++ b/stack.go
@@ -2,6 +2,7 @@ package main
 
 type stackCmd struct {
 	Submit  stackSubmitCmd  `cmd:"" aliases:"s" help:"Submit a stack"`
+	Merge   stackMergeCmd   `cmd:"" aliases:"m" experiment:"merge" help:"Merge a stack"`
 	Restack stackRestackCmd `cmd:"" aliases:"r" help:"Restack a stack"`
 	Edit    stackEditCmd    `cmd:"" aliases:"e" help:"Edit the order of branches in a stack"`
 	Delete  stackDeleteCmd  `cmd:"" aliases:"d" released:"v0.16.0" help:"Delete all branches in a stack"`

--- a/stack_merge.go
+++ b/stack_merge.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/handler/merge"
+	"go.abhg.dev/gs/internal/spice/state"
+	"go.abhg.dev/gs/internal/text"
+)
+
+type stackMergeCmd struct {
+	merge.StackMergeOptions
+
+	Branch string `placeholder:"NAME" help:"Branch whose stack to merge" predictor:"trackedBranches"`
+}
+
+func (*stackMergeCmd) Help() string {
+	return text.Dedent(`
+		Merges the CRs for the current branch's stack into trunk.
+		Use --branch to merge a different branch's stack.
+
+		The stack includes the selected branch,
+		its downstack branches down to trunk,
+		and every upstack branch.
+
+		Already-merged branches are skipped automatically.
+		Branches must have an open Change Request to be merged.
+
+		Before merging, the stack is checked for branches
+		whose base PR was already merged on the forge.
+		Use --no-branch-check to skip this validation.
+
+		Before each merge, waits for CI checks to pass.
+		Use --build-timeout to configure the maximum wait
+		before failing if checks are not ready.
+
+		By default, a branch failure skips that branch's upstack descendants,
+		but independent sibling branches continue.
+		Use --fail-fast to stop the queue after the first branch failure.
+	`)
+}
+
+func (cmd *stackMergeCmd) AfterApply(
+	ctx context.Context,
+	wt *git.Worktree,
+) error {
+	if cmd.Branch != "" {
+		return nil
+	}
+	branch, err := wt.CurrentBranch(ctx)
+	if err != nil {
+		return fmt.Errorf("get current branch: %w", err)
+	}
+	cmd.Branch = branch
+	return nil
+}
+
+func (cmd *stackMergeCmd) Run(
+	ctx context.Context,
+	store *state.Store,
+	mergeHandler MergeHandler,
+) error {
+	if cmd.Branch == store.Trunk() {
+		return errors.New("cannot merge trunk")
+	}
+
+	return mergeHandler.MergeStack(ctx, &merge.StackMergeRequest{
+		Branch:  cmd.Branch,
+		Options: &cmd.StackMergeOptions,
+	})
+}

--- a/testdata/help/gs.txt
+++ b/testdata/help/gs.txt
@@ -31,6 +31,7 @@ Log
 
 Stack
   stack (s) submit (s)          Submit a stack
+  stack (s) merge (m)           Merge a stack
   stack (s) restack (r)         Restack a stack
   stack (s) edit (e)            Edit the order of branches in a stack
   stack (s) delete (d)          Delete all branches in a stack

--- a/testdata/help/stack_merge.txt
+++ b/testdata/help/stack_merge.txt
@@ -1,0 +1,38 @@
+Usage: gs stack (s) merge (m) [flags]
+
+Merge a stack
+
+Merges the CRs for the current branch's stack into trunk. Use --branch to merge
+a different branch's stack.
+
+The stack includes the selected branch, its downstack branches down to trunk,
+and every upstack branch.
+
+Already-merged branches are skipped automatically. Branches must have an open
+Change Request to be merged.
+
+Before merging, the stack is checked for branches whose base PR was already
+merged on the forge. Use --no-branch-check to skip this validation.
+
+Before each merge, waits for CI checks to pass. Use --build-timeout to configure
+the maximum wait before failing if checks are not ready.
+
+By default, a branch failure skips that branch's upstack descendants, but
+independent sibling branches continue. Use --fail-fast to stop the queue after
+the first branch failure.
+
+Flags:
+  --method=METHOD        Preferred merge method. One of 'merge', 'squash',
+                         and 'rebase'. (🔧 spice.merge.method)
+  --build-timeout=30m    Max time to wait for CI checks before each merge.
+                         0 means check once. (🔧 spice.merge.buildTimeout)
+  --no-branch-check      Skip stale base validation before merging.
+  --fail-fast            Stop the merge queue after the first branch failure.
+  --branch=NAME          Branch whose stack to merge
+
+Global Flags:
+  -h, --help           Show help for the command
+      --version        Print version information and quit
+  -v, --verbose        Enable verbose output ($GIT_SPICE_VERBOSE)
+  -C, --dir=DIR        Change to DIR before doing anything
+      --[no-]prompt    Whether to prompt for missing information

--- a/testdata/script/stack_merge_divergent.txt
+++ b/testdata/script/stack_merge_divergent.txt
@@ -1,0 +1,146 @@
+# 'stack merge' merges the selected branch and its divergent upstacks.
+
+as 'Test <test@example.com>'
+at '2026-06-14T09:35:00Z'
+
+# setup
+cd repo
+git init
+git config spice.experiment.merge true
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# create a divergent stack:
+# main -> feat1 -> feat2
+#              \-> feat3
+git add feat1.txt
+gs bc feat1 -m 'Add feat1'
+git add feat2.txt
+gs bc feat2 -m 'Add feat2'
+gs bco feat1
+git add feat3.txt
+gs bc feat3 -m 'Add feat3'
+
+# Submit from the branch whose stack includes both divergent upstacks.
+gs bco feat1
+gs stack submit --fill
+stderr 'Created #1'
+stderr 'Created #2'
+stderr 'Created #3'
+
+# Merge the stack from the shared branch.
+env ROBOT_INPUT=$WORK/robot-merge.golden ROBOT_OUTPUT=$WORK/robot-merge.actual
+gs stack merge
+cmp $WORK/robot-merge.actual $WORK/robot-merge.golden
+stderr 'feat1: merging #1:'
+stderr 'feat1: #1 was merged'
+stderr 'feat2: restacked on main'
+stderr 'Updated #2'
+stderr 'feat2: merging #2:'
+stderr 'feat2: #2 was merged'
+stderr 'feat3: restacked on main'
+stderr 'Updated #3'
+stderr 'feat3: merging #3:'
+stderr 'feat3: #3 was merged'
+stderr 'All 3 change.s. merged.'
+
+# verify all three changes are now merged
+shamhub dump changes
+cmpenvJSON stdout $WORK/golden/changes-merged.json
+
+-- repo/feat1.txt --
+feature 1
+-- repo/feat2.txt --
+feature 2
+-- repo/feat3.txt --
+feature 3
+-- robot-merge.golden --
+===
+> Merge 3 change(s)?: [Y/n]
+>   feat1 (#1)
+>   feat2 (#2)
+>   feat3 (#3)
+true
+-- golden/changes-merged.json --
+[
+  {
+    "number": 1,
+    "html_url": "$SHAMHUB_URL/alice/example/change/1",
+    "state": "closed",
+    "merged": true,
+    "title": "Add feat1",
+    "body": "",
+    "base": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "main",
+      "sha": "1a87435f94bc3fc823273410a223e31b9665dbdc"
+    },
+    "head": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "feat1",
+      "sha": "59bc50146899001ac5f7980229b6e2ac1b058448"
+    }
+  },
+  {
+    "number": 2,
+    "html_url": "$SHAMHUB_URL/alice/example/change/2",
+    "state": "closed",
+    "merged": true,
+    "title": "Add feat2",
+    "body": "",
+    "base": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "main",
+      "sha": "1a87435f94bc3fc823273410a223e31b9665dbdc"
+    },
+    "head": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "feat2",
+      "sha": "399f5d2acad8d9b9d72a7db340d9833468b33b1c"
+    }
+  },
+  {
+    "number": 3,
+    "html_url": "$SHAMHUB_URL/alice/example/change/3",
+    "state": "closed",
+    "merged": true,
+    "title": "Add feat3",
+    "body": "",
+    "base": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "main",
+      "sha": "1a87435f94bc3fc823273410a223e31b9665dbdc"
+    },
+    "head": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "feat3",
+      "sha": "a4b82177ae474989019f13f8651c97b97372ca15"
+    }
+  }
+]


### PR DESCRIPTION
Adds `gs stack merge` as the command that merges the selected branch stack scope: the selected branch, downstack branches down to trunk, and every upstack branch.

The command shares merge method, build timeout, and stale-base validation controls with other merge commands. It adds `--fail-fast`; by default, a failed branch skips that branch upstack while independent siblings continue through the scheduler.

Focused coverage exercises stack plan construction, fail-fast propagation, and a ShamHub-backed divergent stack merge.
