### PR TITLE
forge: Default integration merge helper

### DIFF
--- a/internal/forge/forgetest/integration.go
+++ b/internal/forge/forgetest/integration.go
@@ -207,8 +207,10 @@ func NewHTTPRecorder(
 }
 
 type (
-	// MergeChangeFunc merges a change.
-	// This functionality is not available on the forge interface.
+	// MergeChangeFunc merges a change with provider-specific test setup.
+	//
+	// Leave IntegrationConfig.MergeChange unset to use
+	// forge.Repository.MergeChange directly.
 	MergeChangeFunc func(
 		t *testing.T,
 		repo forge.Repository,
@@ -254,8 +256,10 @@ type IntegrationConfig struct {
 	// It receives an HTTP client to wrap as needed for the forge implementation.
 	OpenRepository func(*testing.T, *http.Client) forge.Repository // required
 
-	// MergeChange merges a change.
-	MergeChange MergeChangeFunc // required
+	// MergeChange merges a change with provider-specific test setup.
+	//
+	// If nil, the integration suite uses forge.Repository.MergeChange.
+	MergeChange MergeChangeFunc // optional
 
 	// CloseChange closes a change without merging.
 	CloseChange CloseChangeFunc // required
@@ -321,6 +325,19 @@ type IntegrationConfig struct {
 
 // RunIntegration runs integration tests with the given configuration.
 func RunIntegration(t *testing.T, config IntegrationConfig) {
+	mergeChange := config.MergeChange
+	if mergeChange == nil {
+		mergeChange = func(
+			t *testing.T,
+			repo forge.Repository,
+			changeID forge.ChangeID,
+		) {
+			require.NoError(t, repo.MergeChange(
+				t.Context(), changeID, forge.MergeChangeOptions{},
+			))
+		}
+	}
+
 	suite := &integrationSuite{
 		Forge: config.Forge,
 		Fixtures: fixturetest.Config{
@@ -329,7 +346,7 @@ func RunIntegration(t *testing.T, config IntegrationConfig) {
 		RemoteURL:             config.RemoteURL,
 		PushRemoteURL:         config.PushRemoteURL,
 		openRepository:        config.OpenRepository,
-		MergeChange:           config.MergeChange,
+		MergeChange:           mergeChange,
 		CloseChange:           config.CloseChange,
 		SetChangeChecksState:  config.SetChangeChecksState,
 		Reviewers:             config.Reviewers,

--- a/internal/forge/github/integration_test.go
+++ b/internal/forge/github/integration_test.go
@@ -119,9 +119,6 @@ func TestIntegration(t *testing.T) {
 			require.NoError(t, err)
 			return newRepo
 		},
-		MergeChange: func(t *testing.T, repo forge.Repository, change forge.ChangeID) {
-			require.NoError(t, github.MergeChange(t.Context(), repo.(*github.Repository), change.(*github.PR)))
-		},
 		CloseChange: func(t *testing.T, repo forge.Repository, change forge.ChangeID) {
 			require.NoError(t, github.CloseChange(t.Context(), repo.(*github.Repository), change.(*github.PR)))
 		},

--- a/internal/forge/github/repository_int_test.go
+++ b/internal/forge/github/repository_int_test.go
@@ -5,17 +5,11 @@ import (
 	"fmt"
 
 	"github.com/shurcooL/githubv4"
-	"go.abhg.dev/gs/internal/forge"
 )
 
 // NewRepository re-exports the private NewRepository function
 // for testing.
 var NewRepository = newRepository
-
-// MergeChange merges a pull request using the production method.
-func MergeChange(ctx context.Context, repo *Repository, id *PR) error {
-	return repo.MergeChange(ctx, id, forge.MergeChangeOptions{})
-}
 
 func CloseChange(ctx context.Context, repo *Repository, id *PR) error {
 	var m struct {

--- a/internal/forge/gitlab/integration_test.go
+++ b/internal/forge/gitlab/integration_test.go
@@ -114,9 +114,6 @@ func TestIntegration(t *testing.T) {
 			require.NoError(t, err)
 			return newRepo
 		},
-		MergeChange: func(t *testing.T, repo forge.Repository, change forge.ChangeID) {
-			require.NoError(t, gitlabforge.MergeChange(t.Context(), repo.(*gitlabforge.Repository), change.(*gitlabforge.MR)))
-		},
 		CloseChange: func(t *testing.T, repo forge.Repository, change forge.ChangeID) {
 			require.NoError(t, gitlabforge.CloseChange(t.Context(), repo.(*gitlabforge.Repository), change.(*gitlabforge.MR)))
 		},

--- a/internal/forge/gitlab/repository_int_test.go
+++ b/internal/forge/gitlab/repository_int_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/gateway/gitlab"
 )
 
@@ -17,11 +16,6 @@ type RepositoryOptions = repositoryOptions
 
 func RepositoryProjectID(repo *Repository) int64 {
 	return repo.repoID
-}
-
-// MergeChange merges a merge request using the production method.
-func MergeChange(ctx context.Context, repo *Repository, id *MR) error {
-	return repo.MergeChange(ctx, id, forge.MergeChangeOptions{})
 }
 
 func CloseChange(ctx context.Context, repo *Repository, id *MR) error {


### PR DESCRIPTION
Forge integration tests can use the shared Repository.MergeChange method
for providers that do not need extra test setup.

Keep the custom Bitbucket hook because it performs the approval step
needed before merging Bitbucket pull requests in integration tests.

[skip changelog]: test-only