### PR TITLE
fix(mergeprogress): Avoid flickering between frames

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/buildkite/shellwords v1.0.1
 	github.com/charmbracelet/colorprofile v0.4.3
+	github.com/charmbracelet/ultraviolet v0.0.0-20260416155717-489999b90468
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/cli/browser v1.3.0
@@ -40,7 +41,6 @@ require (
 require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/charmbracelet/ultraviolet v0.0.0-20260416155717-489999b90468 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -214,6 +214,7 @@ func RunModel(model tea.Model, opts *RunOptions) (err error) {
 				Height:    opts.Height,
 				MinHeight: opts.ScrollRegionMinHeight,
 				MaxHeight: opts.ScrollRegionMaxHeight,
+				TERM:      opts.TERM,
 				Signals:   opts.Signals,
 			})
 		defer func() {

--- a/internal/ui/scrollregion/model.go
+++ b/internal/ui/scrollregion/model.go
@@ -47,6 +47,11 @@ type Options struct {
 	// This caps future model detail sections so log output keeps enough room.
 	MaxHeight int
 
+	// TERM overrides the terminal type used for capability detection.
+	//
+	// If empty, the renderer uses the process environment unchanged.
+	TERM string
+
 	// Signals receives terminal resize signals.
 	//
 	// If nil, a private stack is used for the lifetime of this model.
@@ -83,6 +88,7 @@ func New(model tea.Model, output io.Writer, opts *Options) *Model {
 		opts.Height,
 		opts.MinHeight,
 		opts.MaxHeight,
+		opts.TERM,
 	)
 	signals := opts.Signals
 	if signals == nil {

--- a/internal/ui/scrollregion/model_test.go
+++ b/internal/ui/scrollregion/model_test.go
@@ -28,13 +28,16 @@ func TestModel_RendersWithExplicitSize(t *testing.T) {
 	require.Nil(t, cmd)
 	_, cmd = model.Update(testStep{})
 	require.NotNil(t, cmd)
-	assert.NoError(t, model.Close())
 
 	got := visibleControl(buf.String())
-	assert.Contains(t, got, "<esc>[1;8r")                      // set scroll margins
-	assert.Contains(t, got, "<esc>[10;1H<esc>[2Kview: 0 40x2") // draw bottom row
-	assert.Contains(t, got, "<esc>[10;1H<esc>[2Kview: 1 40x2") // redraw bottom row
-	assert.Contains(t, got, "<esc>[r")                         // reset scroll margins
+	assert.Contains(t, got, "<esc>[1;8r")              // set scroll margins
+	assert.Contains(t, got, "<esc>[10;1Hview: 0 40x2") // draw bottom row
+	assert.Contains(t, got, "<esc>[10;7H1 ")           // diff changed cell
+	assert.NotContains(t, got, "<esc>[10;1H<esc>[2Kview: 1 40x2")
+
+	assert.NoError(t, model.Close())
+	got = visibleControl(buf.String())
+	assert.Contains(t, got, "<esc>[r") // reset scroll margins
 }
 
 func TestModel_GrowsToMax(t *testing.T) {
@@ -52,10 +55,10 @@ func TestModel_GrowsToMax(t *testing.T) {
 	require.NotNil(t, cmd)
 
 	got := visibleControl(buf.String())
-	assert.Contains(t, got, "<esc>[1;8r")                // reserve two bottom rows
-	assert.Contains(t, got, "<esc>[1;6r")                // grow to four bottom rows
-	assert.Contains(t, got, "<esc>[7;1H<esc>[2Kline 1")  // draw top reserved row
-	assert.Contains(t, got, "<esc>[10;1H<esc>[2Kline 4") // draw bottom reserved row
+	assert.Contains(t, got, "<esc>[1;8r")                 // reserve two bottom rows
+	assert.Contains(t, got, "<esc>[1;6r")                 // grow to four bottom rows
+	assert.Contains(t, got, "<esc>[7;1Hline 1")           // draw top reserved row
+	assert.Contains(t, got, "line 3\r\nline 4<esc>[6;1H") // draw bottom reserved row
 }
 
 func TestModel_RendersAfterFirstWindowSize(t *testing.T) {
@@ -71,7 +74,27 @@ func TestModel_RendersAfterFirstWindowSize(t *testing.T) {
 
 	got := visibleControl(buf.String())
 	assert.Contains(t, got, "<esc>[1;8r")
-	assert.Contains(t, got, "<esc>[10;1H<esc>[2Kwidget")
+	assert.Contains(t, got, "<esc>[10;1Hwidget")
+}
+
+func TestModel_PreservesStyledContent(t *testing.T) {
+	t.Setenv("TTY_FORCE", "1")
+	t.Setenv("NO_COLOR", "false")
+
+	var buf bytes.Buffer
+	model := New(&styledTestModel{}, &buf, &Options{
+		Width:     40,
+		Height:    10,
+		MinHeight: 2,
+		MaxHeight: 3,
+		TERM:      "xterm-256color",
+	})
+
+	_, cmd := model.Update(tea.WindowSizeMsg{Width: 40, Height: 10})
+	require.Nil(t, cmd)
+
+	got := visibleControl(buf.String())
+	assert.Contains(t, got, "<esc>[31mred")
 }
 
 func TestRenderer_LogsScrollAboveRegion(t *testing.T) {
@@ -167,6 +190,20 @@ func (m *staticTestModel) Update(tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m *staticTestModel) View() tea.View {
 	return tea.NewView("widget")
+}
+
+type styledTestModel struct{}
+
+func (m *styledTestModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m *styledTestModel) Update(tea.Msg) (tea.Model, tea.Cmd) {
+	return m, nil
+}
+
+func (m *styledTestModel) View() tea.View {
+	return tea.NewView("\x1b[31mred\x1b[0m")
 }
 
 type tallTestModel struct {

--- a/internal/ui/scrollregion/renderer.go
+++ b/internal/ui/scrollregion/renderer.go
@@ -2,10 +2,12 @@ package scrollregion
 
 import (
 	"io"
+	"os"
 	"strings"
 	"sync"
 
 	tea "charm.land/bubbletea/v2"
+	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/charmbracelet/x/term"
 	"go.abhg.dev/gs/internal/must"
@@ -18,11 +20,25 @@ type renderer struct {
 	// out is the same stream used by ordinary log output.
 	//
 	// If it exposes Fd, the renderer can discover terminal size from it.
-	out io.Writer // immutable
+	out  io.Writer // immutable
+	term string    // immutable
 
 	mu     sync.Mutex // guards mutable fields below
 	width  int
 	height int
+
+	// diffRenderer owns ultraviolet's view of the terminal.
+	//
+	// Ordinary log output bypasses it,
+	// so callers must resynchronize its cursor before each frame.
+	diffRenderer *uv.TerminalRenderer
+
+	// frame is a full-terminal buffer,
+	// but only the reserved rows are touched.
+	//
+	// Keeping full-terminal coordinates lets ultraviolet move the real cursor
+	// to absolute terminal rows without learning about DECSTBM.
+	frame uv.ScreenBuffer
 
 	minHeight int // immutable
 	maxHeight int // immutable
@@ -45,6 +61,7 @@ func newRenderer(
 	height int,
 	minHeight int,
 	maxHeight int,
+	term string,
 ) *renderer {
 	must.NotBeNilf(out, "scroll region output is required")
 	if minHeight <= 0 {
@@ -62,6 +79,7 @@ func newRenderer(
 
 	return &renderer{
 		out:           out,
+		term:          term,
 		width:         width,
 		height:        height,
 		minHeight:     minHeight,
@@ -98,7 +116,10 @@ func (r *renderer) Resize(width, height int) {
 	if !r.reserved {
 		return
 	}
+	// Resizing changes absolute row coordinates.
+	// Rebuild ultraviolet's coordinate space after the terminal margins move.
 	r.reserveLocked(0)
+	r.resetDiffLocked()
 }
 
 // Render draws view into the reserved rows.
@@ -113,36 +134,27 @@ func (r *renderer) Render(view tea.View) {
 		return
 	}
 
-	lines := viewLines(view.Content)
+	content := strings.TrimRight(view.Content, "\n")
+	lines := 0
+	if content != "" {
+		lines = strings.Count(content, "\n") + 1
+	}
 	oldHeight := r.currentHeight
-	r.currentHeight = r.heightForLines(len(lines))
+	r.currentHeight = r.heightForLines(lines)
 	if !r.reserved {
 		r.reserveInitial()
 	} else if oldHeight != r.currentHeight {
+		// Changing the reserved height moves the widget to different absolute
+		// rows, so ultraviolet's old screen coordinates are no longer valid.
 		r.reserveLocked(oldHeight)
+		r.resetDiffLocked()
 	}
-	if len(lines) > r.currentHeight {
-		lines = lines[:r.currentHeight]
+	if lines > r.currentHeight {
+		content = truncateViewLines(content, r.currentHeight)
+		lines = r.currentHeight
 	}
 
-	var b strings.Builder
-	renderStart := r.regionStart()
-	if len(lines) < r.currentHeight {
-		renderStart += r.currentHeight - len(lines)
-	}
-	for row := range r.currentHeight {
-		b.WriteString(ansi.CursorPosition(1, r.regionStart()+row))
-		b.WriteString(ansi.EraseLine(2))
-		lineIdx := row - (renderStart - r.regionStart())
-		if lineIdx >= 0 && lineIdx < len(lines) {
-			b.WriteString(lines[lineIdx])
-		}
-	}
-	// Park the cursor on the last scrollable row.
-	// Ordinary log writes should resume above the reserved rows,
-	// not inside the redrawn model region.
-	b.WriteString(ansi.CursorPosition(1, r.scrollBottom()))
-	_, _ = io.WriteString(r.out, b.String())
+	r.renderFrameLocked(content, lines)
 }
 
 // Close clears the reserved rows and restores normal scrolling.
@@ -235,6 +247,9 @@ func (r *renderer) reserveInitial() {
 	b.WriteString(ansi.CursorPosition(1, r.scrollBottom()))
 	_, _ = io.WriteString(r.out, b.String())
 	r.reserved = true
+	// The first frame must start from the terminal size and row coordinates
+	// established by the initial margin sequence.
+	r.resetDiffLocked()
 }
 
 func (r *renderer) reserveLocked(oldHeight int) {
@@ -256,6 +271,61 @@ func (r *renderer) reserveLocked(oldHeight int) {
 	_, _ = io.WriteString(r.out, b.String())
 }
 
+// resetDiffLocked rebuilds ultraviolet's terminal model.
+//
+// Ultraviolet tracks prior screen contents and cursor position internally.
+// When the terminal size or reserved region changes,
+// keeping that old model would make future diffs target stale rows.
+func (r *renderer) resetDiffLocked() {
+	if r.width <= 0 || r.height <= 0 {
+		r.diffRenderer = nil
+		r.frame = uv.ScreenBuffer{}
+		return
+	}
+
+	r.diffRenderer = uv.NewTerminalRenderer(r.out, r.rendererEnv())
+	r.frame = uv.NewScreenBuffer(r.width, r.height)
+}
+
+// renderFrameLocked draws content into the reserved rows
+// and lets ultraviolet emit a diff from the previous frame.
+func (r *renderer) renderFrameLocked(content string, lines int) {
+	if r.diffRenderer == nil || r.frame.Bounds().Empty() {
+		r.resetDiffLocked()
+	}
+	if r.diffRenderer == nil {
+		return
+	}
+
+	if missing := r.currentHeight - lines; missing > 0 {
+		content = strings.Repeat("\n", missing) + content
+	}
+
+	// This area maps the widget's local row zero to its absolute terminal row.
+	// The buffer still spans the whole terminal so cursor movement is absolute.
+	area := uv.Rect(0, r.regionStart()-1, r.width, r.currentHeight)
+	uv.NewStyledString(content).Draw(r.frame, area)
+
+	// Ordinary log writes happen outside ultraviolet,
+	// so the diff renderer's cursor position is stale by the next frame.
+	r.diffRenderer.SetPosition(-1, -1)
+	r.diffRenderer.Render(r.frame.RenderBuffer)
+	r.diffRenderer.MoveTo(0, r.scrollBottom()-1)
+	_ = r.diffRenderer.Flush()
+}
+
+// rendererEnv builds the environment used for terminal capability detection.
+//
+// TERM is supplied by callers that need Bubble Tea and ultraviolet
+// to use the same terminal profile in tests or controlled renderers.
+func (r *renderer) rendererEnv() []string {
+	env := os.Environ()
+	if r.term != "" {
+		env = append(env, "TERM="+r.term)
+	}
+	return env
+}
+
 func (r *renderer) marginSequence() string {
 	// DECSTBM keeps ordinary log output scrolling above the reserved rows.
 	return ansi.SetTopBottomMargins(1, r.scrollBottom())
@@ -275,10 +345,23 @@ func (r *renderer) heightForLines(lines int) int {
 	return min(height, r.height-1)
 }
 
-func viewLines(content string) []string {
-	content = strings.TrimRight(content, "\n")
-	if content == "" {
-		return nil
+// truncateViewLines drops rows beyond the reserved height.
+//
+// The wrapped model still renders as if it owns the full reserved viewport,
+// but the terminal region may be capped by MaxHeight.
+func truncateViewLines(content string, lines int) string {
+	if lines <= 0 {
+		return ""
 	}
-	return strings.Split(content, "\n")
+	newlines := 0
+	for idx, ch := range content {
+		if ch != '\n' {
+			continue
+		}
+		newlines++
+		if newlines == lines {
+			return content[:idx]
+		}
+	}
+	return content
 }


### PR DESCRIPTION
Animated merge progress updates
were redrawing every reserved row on each tick.
That made the widget prone to flicker
while ordinary merge output scrolled above it.

Use ultraviolet to render the reserved region
so unchanged cells are left alone between frames.
The scroll-region wrapper still owns most of the work;
ultraviolet only diffs the model rows inside that reserved region.

[skip changelog]: unreleased feature

<img width="920" height="520" alt="mergeprogress-widget" src="https://github.com/user-attachments/assets/157665e9-93ad-42ea-afc5-c1e3d2ba9350" />

