### PR TITLE
test: Use test contexts in tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,6 +72,9 @@ linters:
         - (*go.abhg.dev/gs/internal/log.Logger).Log
         - (*go.abhg.dev/gs/internal/log.Logger).With
 
+    usetesting:
+      context-background: true
+
   exclusions:
     generated: lax
     rules:

--- a/internal/forge/shamhub/fork_test.go
+++ b/internal/forge/shamhub/fork_test.go
@@ -2,7 +2,6 @@ package shamhub
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"net/http"
 	"os"
@@ -25,7 +24,7 @@ func TestForkWorkflow(t *testing.T) {
 	t.Setenv("GIT_COMMITTER_NAME", "Test")
 	t.Setenv("GIT_COMMITTER_EMAIL", "test@example.com")
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Setup ShamHub server
 	sh, err := New(Config{

--- a/internal/git/gitedit/signal_test.go
+++ b/internal/git/gitedit/signal_test.go
@@ -58,7 +58,7 @@ import (
 //	  └─ asserts: exit 0, correct message on stdout
 func TestIntegrationEditor_signalAbsorbed(t *testing.T) {
 	if os.Getenv("_GITEDIT_SIGNAL_TEST") == "1" {
-		os.Exit(signalTestSubprocess())
+		os.Exit(signalTestSubprocess(t.Context()))
 		return
 	}
 
@@ -154,7 +154,7 @@ func TestIntegrationEditor_signalAbsorbed(t *testing.T) {
 // signalTestSubprocess runs inside the re-exec'd test binary.
 // It creates a real git repo, configures an Editor
 // with a real sigstack.Stack, and prints the resulting message.
-func signalTestSubprocess() (exitCode int) {
+func signalTestSubprocess(ctx context.Context) (exitCode int) {
 	fixture, err := gittest.LoadFixtureScript(
 		[]byte(os.Getenv("_GITEDIT_FIXTURE")),
 	)
@@ -164,7 +164,6 @@ func signalTestSubprocess() (exitCode int) {
 	}
 	defer fixture.Cleanup()
 
-	ctx := context.Background()
 	repo, err := git.Open(
 		ctx, fixture.Dir(),
 		git.OpenOptions{Log: silog.Nop()},


### PR DESCRIPTION
Enable `usetesting.context-background` to guard
against `context.Background()` versus `t.Context()` in tests.

[skip changelog]: not user-facing