### PR TITLE
fix: Forward stdin to shell aliases

### DIFF
--- a/.changes/unreleased/Fixed-20260619-181803.yaml
+++ b/.changes/unreleased/Fixed-20260619-181803.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'Standard input is now forwarded to configured shell command aliases.'
+time: 2026-06-19T18:18:03.930828-07:00

--- a/doc/src/community/recipes.md
+++ b/doc/src/community/recipes.md
@@ -110,6 +110,33 @@ and track the branch with git-spice if it is not already tracked.
 
 ## Workflows
 
+### Create a worktree from the branch prompt
+
+<!-- gs:version unreleased -->
+
+git-spice supports custom shorthands,
+including shell command aliases
+that run commands outside git-spice.
+See [Shell command aliases](../cli/shorthand.md#shell-command-aliases)
+for the syntax and argument handling rules.
+
+This adds `gs wtadd <path>`,
+which asks you to choose a branch from the git-spice branch prompt,
+then creates a Git worktree at the requested path for that branch.
+
+```bash
+git config --global spice.shorthand.wtadd \
+    '!branch=$(git-spice bco -n) &&
+      git worktree add "${1:?worktree path required}" "$branch"'
+```
+
+**How it works:**
+
+- `git-spice bco -n` opens the $$gs branch checkout$$ branch prompt
+  and prints the selected branch name instead of checking it out.
+- `${1:?worktree path required}` makes the shell command fail
+  if no path argument was supplied.
+
 ### Create branches without committing
 
 <!-- gs:version v0.5.0 -->

--- a/main.go
+++ b/main.go
@@ -240,6 +240,7 @@ func main() {
 		}
 
 		if err := xec.Command(ctx, logger, "sh", shArgs...).
+			WithStdin(os.Stdin).
 			WithStdout(os.Stdout).
 			WithStderr(os.Stderr).
 			AppendEnv(fmt.Sprintf("%v=%d", recursionDepthEnvVar, depth+1)).

--- a/testdata/script/shell_aliases.txt
+++ b/testdata/script/shell_aliases.txt
@@ -63,7 +63,17 @@ git config spice.shorthand.echo-args '!echo "arg1=$1 arg2=$2"'
 gs echo-args hello world
 stdout 'arg1=hello arg2=world'
 
+# Test shell alias stdin forwarding.
+git config spice.shorthand.echo-stdin '!cat'
+stdin stdin.txt
+exec gs echo-stdin
+stdout 'line one'
+stdout 'line two'
+
 -- repo/foo.txt --
 foo content
 -- repo/bar.txt --
 bar content
+-- repo/stdin.txt --
+line one
+line two


### PR DESCRIPTION
Shell command aliases can wrap interactive git-spice commands
or commands that read piped input,
but the alias subprocess previously inherited stdout and stderr only.
That left commands such as `git-spice bco -n`
with no input stream when the alias was invoked through git-spice.

Forward stdin to the shell command subprocess
so configured shell aliases behave like ordinary shell commands.