### PR TITLE
fix(branch track): Reject non-branch operands

### DIFF
--- a/.changes/unreleased/Fixed-20260620-071743.yaml
+++ b/.changes/unreleased/Fixed-20260620-071743.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'branch track: Reject revision names such as HEAD when tracking a branch.'
+time: 2026-06-20T07:17:43.281689-07:00

--- a/internal/handler/track/branch.go
+++ b/internal/handler/track/branch.go
@@ -15,7 +15,7 @@ import (
 
 // BranchRequest is the request for tracking a branch.
 type BranchRequest struct {
-	// Branch is the name of the branch to track.
+	// Branch is the name of the local branch to track.
 	Branch string // required
 
 	// Base is the name of the base branch this branch merges into.
@@ -30,6 +30,9 @@ func (h *Handler) TrackBranch(ctx context.Context, req *BranchRequest) error {
 	log, store := h.Log, h.Store
 	if req.Branch == store.Trunk() {
 		return errors.New("cannot track trunk branch")
+	}
+	if !h.Repository.BranchExists(ctx, req.Branch) {
+		return fmt.Errorf("branch %q does not exist", req.Branch)
 	}
 
 	if req.Base == "" {

--- a/internal/handler/track/branch_test.go
+++ b/internal/handler/track/branch_test.go
@@ -61,6 +61,9 @@ func TestHandler_TrackBranch(t *testing.T) {
 
 		mockRepo := NewMockGitRepository(ctrl)
 		mockRepo.EXPECT().
+			BranchExists(t.Context(), "feature").
+			Return(true)
+		mockRepo.EXPECT().
 			PeelToCommit(t.Context(), "develop").
 			Return(git.Hash("def456"), nil)
 
@@ -92,6 +95,9 @@ func TestHandler_TrackBranch(t *testing.T) {
 		ctrl := gomock.NewController(t)
 
 		mockRepo := NewMockGitRepository(ctrl)
+		mockRepo.EXPECT().
+			BranchExists(t.Context(), "feature").
+			Return(true)
 		mockRepo.EXPECT().
 			PeelToCommit(t.Context(), "main").
 			Return(git.Hash("def456"), nil)
@@ -137,6 +143,9 @@ func TestHandler_TrackBranch(t *testing.T) {
 
 		mockRepo := NewMockGitRepository(ctrl)
 		mockRepo.EXPECT().
+			BranchExists(ctx, "new-feature").
+			Return(true)
+		mockRepo.EXPECT().
 			PeelToCommit(ctx, "new-feature").
 			Return("", assert.AnError)
 		mockRepo.EXPECT().
@@ -172,6 +181,9 @@ func TestHandler_TrackBranch(t *testing.T) {
 		ctrl := gomock.NewController(t)
 
 		mockRepo := NewMockGitRepository(ctrl)
+		mockRepo.EXPECT().
+			BranchExists(t.Context(), "feature").
+			Return(true)
 		mockRepo.EXPECT().
 			PeelToCommit(t.Context(), "main").
 			Return(git.Hash("main123"), nil)
@@ -209,6 +221,9 @@ func TestHandler_TrackBranch(t *testing.T) {
 
 		mockRepo := NewMockGitRepository(ctrl)
 		mockRepo.EXPECT().
+			BranchExists(t.Context(), "feature").
+			Return(true)
+		mockRepo.EXPECT().
 			PeelToCommit(t.Context(), "main").
 			Return(git.Hash("main123"), nil)
 
@@ -231,6 +246,32 @@ func TestHandler_TrackBranch(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.Contains(t, logBuffer.String(), "stack state verification failed")
+	})
+
+	t.Run("CannotTrackNonBranch", func(t *testing.T) {
+		log := silog.Nop()
+		store := statetest.NewMemoryStore(t, "main", "", log)
+
+		ctrl := gomock.NewController(t)
+
+		mockRepo := NewMockGitRepository(ctrl)
+		mockRepo.EXPECT().
+			BranchExists(t.Context(), "HEAD").
+			Return(false)
+
+		handler := &Handler{
+			Log:        log,
+			Repository: mockRepo,
+			Store:      store,
+			Service:    NewMockService(ctrl),
+			View:       ui.NewFileView(t.Output()),
+		}
+
+		err := handler.TrackBranch(t.Context(), &BranchRequest{
+			Branch: "HEAD",
+			Base:   "main",
+		})
+		assert.EqualError(t, err, `branch "HEAD" does not exist`)
 	})
 }
 

--- a/internal/handler/track/handler.go
+++ b/internal/handler/track/handler.go
@@ -16,6 +16,7 @@ import (
 
 // GitRepository provides read access to the Git repository's state.
 type GitRepository interface {
+	BranchExists(ctx context.Context, branch string) bool
 	PeelToCommit(ctx context.Context, ref string) (git.Hash, error)
 	ListCommits(ctx context.Context, commits git.CommitRange) iter.Seq2[git.Hash, error]
 	LocalBranches(ctx context.Context, opts *git.LocalBranchesOptions) iter.Seq2[git.LocalBranch, error]

--- a/internal/handler/track/mocks_test.go
+++ b/internal/handler/track/mocks_test.go
@@ -42,6 +42,44 @@ func (m *MockGitRepository) EXPECT() *MockGitRepositoryMockRecorder {
 	return m.recorder
 }
 
+// BranchExists mocks base method.
+func (m *MockGitRepository) BranchExists(ctx context.Context, branch string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BranchExists", ctx, branch)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// BranchExists indicates an expected call of BranchExists.
+func (mr *MockGitRepositoryMockRecorder) BranchExists(ctx, branch any) *MockGitRepositoryBranchExistsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BranchExists", reflect.TypeOf((*MockGitRepository)(nil).BranchExists), ctx, branch)
+	return &MockGitRepositoryBranchExistsCall{Call: call}
+}
+
+// MockGitRepositoryBranchExistsCall wrap *gomock.Call
+type MockGitRepositoryBranchExistsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockGitRepositoryBranchExistsCall) Return(arg0 bool) *MockGitRepositoryBranchExistsCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockGitRepositoryBranchExistsCall) Do(f func(context.Context, string) bool) *MockGitRepositoryBranchExistsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockGitRepositoryBranchExistsCall) DoAndReturn(f func(context.Context, string) bool) *MockGitRepositoryBranchExistsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ListCommits mocks base method.
 func (m *MockGitRepository) ListCommits(ctx context.Context, commits git.CommitRange) iter.Seq2[git.Hash, error] {
 	m.ctrl.T.Helper()

--- a/testdata/script/branch_track_head_err.txt
+++ b/testdata/script/branch_track_head_err.txt
@@ -1,0 +1,23 @@
+# 'branch track' rejects HEAD as an explicit branch operand.
+
+as 'Test <test@example.com>'
+at '2026-06-20T21:28:29Z'
+
+mkdir repo
+cd repo
+
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git checkout -b feature
+git commit --allow-empty -m 'feature 1'
+
+! gs branch track HEAD
+stderr 'branch "HEAD" does not exist'
+
+gs ls
+cmp stderr $WORK/golden/ls.txt
+
+-- golden/ls.txt --
+main


### PR DESCRIPTION
`gs branch track HEAD` previously accepted `HEAD` because branch tracking peeled the operand as a revision and wrote a `HEAD` branch record.

Branch tracking now checks that the requested name exists as a local branch before base inference or state updates. Revision names that do not name local branches are rejected instead.

Regression coverage verifies that `HEAD` is rejected and leaves only the trunk branch tracked.
