### PR TITLE
fix(branch checkout): Allow dry-run worktree picks

### DIFF
--- a/.changes/unreleased/Fixed-20260620-072836.yaml
+++ b/.changes/unreleased/Fixed-20260620-072836.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'branch checkout: Branches checked out in other worktrees can now be selected with --dry-run.'
+time: 2026-06-20T07:28:36.784022-07:00

--- a/branch_checkout.go
+++ b/branch_checkout.go
@@ -115,10 +115,11 @@ func (cmd *branchCheckoutCmd) AfterApply(
 
 		cmd.Branch, err = branchPrompt.Prompt(ctx, &branchPromptRequest{
 			Disabled: func(b git.LocalBranch) bool {
-				// If detaching, allow selecting any branch,
+				// If detaching or printing the branch name,
+				// allow selecting any branch,
 				// including the current branch
 				// or branches checked out elsewhere.
-				if cmd.Detach {
+				if cmd.Detach || cmd.DryRun {
 					return false
 				}
 				return b.Name != currentBranch && b.Worktree != ""

--- a/testdata/script/branch_checkout_prompt_detach_worktrees.txt
+++ b/testdata/script/branch_checkout_prompt_detach_worktrees.txt
@@ -42,11 +42,26 @@ cmp $WORK/robot.actual $ROBOT_INPUT
 git rev-parse HEAD
 cmp stdout $WORK/golden/feat1-hash.txt
 
+# Attempt to print the selected branch name
+# from the other worktree.
+[unix] env ROBOT_INPUT=$WORK/robot-name-unix.golden
+[windows] env ROBOT_INPUT=$WORK/robot-name-windows.golden
+env ROBOT_OUTPUT=$WORK/robot-name.actual
+gs branch checkout -n
+cmp stdout $WORK/golden/feat1-name.txt
+cmp $WORK/robot-name.actual $ROBOT_INPUT
+
+# Verify dry-run did not change HEAD.
+git rev-parse HEAD
+cmp stdout $WORK/golden/feat1-hash.txt
+
 -- repo/feat1.txt --
 feature content
 
 -- golden/feat1-hash.txt --
 121498bab12f8ac31e38043ac0b475ccfdcf7769
+-- golden/feat1-name.txt --
+feat1
 -- robot-unix.golden --
 ===
 > Select a branch to checkout: 
@@ -58,4 +73,16 @@ feature content
 > Select a branch to checkout: 
 > ┏━□ feat1 [wt: ~\repo]
 > main ◀
+"feat1"
+-- robot-name-unix.golden --
+===
+> Select a branch to checkout: 
+> ┏━■ feat1 [wt: ~/repo] ◀
+> main
+"feat1"
+-- robot-name-windows.golden --
+===
+> Select a branch to checkout: 
+> ┏━■ feat1 [wt: ~\repo] ◀
+> main
 "feat1"


### PR DESCRIPTION
The interactive branch checkout prompt already lets `--detach` choose branches checked out in another worktree because no branch switch happens in the current worktree. `--dry-run` has the same no-switch contract: it only prints the selected branch name.

Before this change, `git-spice branch checkout -n` displayed those branches but rejected the selection as `unknown branch` because the prompt item was disabled. Dry-run mode now leaves those items selectable and still returns before mutating the worktree.

The worktree prompt regression covers selecting a checked-out branch with `--dry-run` and verifies that HEAD is unchanged.

Verification:

- `mise run test:script --run branch_checkout_prompt_detach_worktrees`
- `go test ./internal/handler/checkout`
- `mise run lint`
- `mise run build`