### PR TITLE
forge: Add mergeability API

### DIFF
--- a/internal/forge/bitbucket/mergeability.go
+++ b/internal/forge/bitbucket/mergeability.go
@@ -1,0 +1,18 @@
+package bitbucket
+
+import (
+	"context"
+
+	"go.abhg.dev/gs/internal/forge"
+)
+
+// ChangeMergeability reports whether the pull request can be merged.
+//
+// This compatibility implementation returns unknown until the Bitbucket-specific
+// mergeability translation is implemented.
+func (r *Repository) ChangeMergeability(
+	context.Context,
+	forge.ChangeID,
+) (forge.ChangeMergeability, error) {
+	return forge.ChangeMergeability{}, nil
+}

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -290,6 +290,14 @@ type Repository interface {
 	// MergeChange merges an open change into its base branch.
 	MergeChange(ctx context.Context, id ChangeID, opts MergeChangeOptions) error
 
+	// ChangeMergeability reports whether the forge currently considers
+	// the change mergeable.
+	//
+	// This reports the forge's merge decision,
+	// not the detailed status of individual CI/checks signals.
+	// Use ChangeChecks for check display and required-check inspection.
+	ChangeMergeability(ctx context.Context, id ChangeID) (ChangeMergeability, error)
+
 	FindChangesByBranch(ctx context.Context, branch string, opts FindChangesOptions) ([]*FindChangeItem, error)
 	FindChangeByID(ctx context.Context, id ChangeID) (*FindChangeItem, error)
 	ChangeStatuses(ctx context.Context, ids []ChangeID) ([]ChangeStatus, error)
@@ -577,6 +585,169 @@ func (m MergeMethod) String() string {
 		return fmt.Sprintf("MergeMethod(%d)", int(m))
 	}
 	return string(bs)
+}
+
+// ChangeMergeability is a forge-independent summary of whether a change
+// can be merged under the forge's current policy.
+type ChangeMergeability struct {
+	// State reports the forge's current mergeability decision.
+	State ChangeMergeabilityState
+
+	// Reason reports why the state is waiting or blocked.
+	//
+	// Ready, unknown, and unsupported states must use
+	// ChangeMergeabilityReasonUnknown.
+	// Waiting and blocked states should use the most specific reason the forge
+	// exposes, or ChangeMergeabilityReasonUnknown if the forge exposes no
+	// forge-neutral reason.
+	Reason ChangeMergeabilityReason
+}
+
+// ChangeMergeabilityState describes the forge's current mergeability decision.
+type ChangeMergeabilityState int
+
+const (
+	// ChangeMergeabilityUnknown indicates that the forge returned no usable
+	// mergeability state for this request.
+	//
+	// This is not a waiting state.
+	// Callers should not assume retrying will produce a more specific answer.
+	ChangeMergeabilityUnknown ChangeMergeabilityState = iota
+
+	// ChangeMergeabilityUnsupported indicates that the forge implementation
+	// does not support mergeability.
+	ChangeMergeabilityUnsupported
+
+	// ChangeMergeabilityReady indicates that the forge currently allows
+	// the change to be merged.
+	ChangeMergeabilityReady
+
+	// ChangeMergeabilityWaiting indicates that the forge has not reached
+	// a final mergeability decision yet.
+	ChangeMergeabilityWaiting
+
+	// ChangeMergeabilityBlocked indicates that the forge currently rejects
+	// merging the change.
+	ChangeMergeabilityBlocked
+)
+
+func (s ChangeMergeabilityState) String() string {
+	switch s {
+	case ChangeMergeabilityUnknown:
+		return "unknown"
+	case ChangeMergeabilityUnsupported:
+		return "unsupported"
+	case ChangeMergeabilityReady:
+		return "ready"
+	case ChangeMergeabilityWaiting:
+		return "waiting"
+	case ChangeMergeabilityBlocked:
+		return "blocked"
+	default:
+		return fmt.Sprintf("ChangeMergeabilityState(%d)", int(s))
+	}
+}
+
+// GoString returns a Go-syntax representation of the mergeability state.
+func (s ChangeMergeabilityState) GoString() string {
+	switch s {
+	case ChangeMergeabilityUnknown:
+		return "ChangeMergeabilityUnknown"
+	case ChangeMergeabilityUnsupported:
+		return "ChangeMergeabilityUnsupported"
+	case ChangeMergeabilityReady:
+		return "ChangeMergeabilityReady"
+	case ChangeMergeabilityWaiting:
+		return "ChangeMergeabilityWaiting"
+	case ChangeMergeabilityBlocked:
+		return "ChangeMergeabilityBlocked"
+	default:
+		return fmt.Sprintf("ChangeMergeabilityState(%d)", int(s))
+	}
+}
+
+// ChangeMergeabilityReason gives the primary forge-neutral reason why
+// mergeability is waiting or blocked.
+type ChangeMergeabilityReason int
+
+const (
+	// ChangeMergeabilityReasonUnknown indicates that no more specific reason
+	// is available.
+	ChangeMergeabilityReasonUnknown ChangeMergeabilityReason = iota
+
+	// ChangeMergeabilityReasonChecks indicates that CI or status checks
+	// are preventing a ready mergeability decision.
+	ChangeMergeabilityReasonChecks
+
+	// ChangeMergeabilityReasonReview indicates that review or approval policy
+	// determines mergeability.
+	ChangeMergeabilityReasonReview
+
+	// ChangeMergeabilityReasonDraft indicates that the change is still a draft.
+	ChangeMergeabilityReasonDraft
+
+	// ChangeMergeabilityReasonConflicts indicates that merge conflicts
+	// determine mergeability.
+	ChangeMergeabilityReasonConflicts
+
+	// ChangeMergeabilityReasonBehind indicates that the change must be updated
+	// with its base branch before merging.
+	ChangeMergeabilityReasonBehind
+
+	// ChangeMergeabilityReasonDiscussions indicates that unresolved
+	// discussions or comments determine mergeability.
+	ChangeMergeabilityReasonDiscussions
+
+	// ChangeMergeabilityReasonPolicy indicates that a forge or repository
+	// policy determines mergeability.
+	ChangeMergeabilityReasonPolicy
+)
+
+func (r ChangeMergeabilityReason) String() string {
+	switch r {
+	case ChangeMergeabilityReasonUnknown:
+		return "unknown"
+	case ChangeMergeabilityReasonChecks:
+		return "checks"
+	case ChangeMergeabilityReasonReview:
+		return "review"
+	case ChangeMergeabilityReasonDraft:
+		return "draft"
+	case ChangeMergeabilityReasonConflicts:
+		return "conflicts"
+	case ChangeMergeabilityReasonBehind:
+		return "behind"
+	case ChangeMergeabilityReasonDiscussions:
+		return "discussions"
+	case ChangeMergeabilityReasonPolicy:
+		return "policy"
+	default:
+		return fmt.Sprintf("ChangeMergeabilityReason(%d)", int(r))
+	}
+}
+
+// GoString returns a Go-syntax representation of the mergeability reason.
+func (r ChangeMergeabilityReason) GoString() string {
+	switch r {
+	case ChangeMergeabilityReasonUnknown:
+		return "ChangeMergeabilityReasonUnknown"
+	case ChangeMergeabilityReasonChecks:
+		return "ChangeMergeabilityReasonChecks"
+	case ChangeMergeabilityReasonReview:
+		return "ChangeMergeabilityReasonReview"
+	case ChangeMergeabilityReasonDraft:
+		return "ChangeMergeabilityReasonDraft"
+	case ChangeMergeabilityReasonConflicts:
+		return "ChangeMergeabilityReasonConflicts"
+	case ChangeMergeabilityReasonBehind:
+		return "ChangeMergeabilityReasonBehind"
+	case ChangeMergeabilityReasonDiscussions:
+		return "ChangeMergeabilityReasonDiscussions"
+	case ChangeMergeabilityReasonPolicy:
+		return "ChangeMergeabilityReasonPolicy"
+	default:
+		return fmt.Sprintf("ChangeMergeabilityReason(%d)", int(r))
+	}
 }
 
 // FindChangeItem is a single result from searching for changes in the

--- a/internal/forge/forge_test.go
+++ b/internal/forge/forge_test.go
@@ -361,3 +361,127 @@ func TestMergeMethod(t *testing.T) {
 		assert.Equal(t, forge.MergeMethodDefault, got)
 	})
 }
+
+func TestChangeMergeabilityState(t *testing.T) {
+	tests := []struct {
+		name   string
+		give   forge.ChangeMergeabilityState
+		want   string
+		wantGo string
+	}{
+		{
+			name:   "Unknown",
+			give:   forge.ChangeMergeabilityUnknown,
+			want:   "unknown",
+			wantGo: "ChangeMergeabilityUnknown",
+		},
+		{
+			name:   "Unsupported",
+			give:   forge.ChangeMergeabilityUnsupported,
+			want:   "unsupported",
+			wantGo: "ChangeMergeabilityUnsupported",
+		},
+		{
+			name:   "Ready",
+			give:   forge.ChangeMergeabilityReady,
+			want:   "ready",
+			wantGo: "ChangeMergeabilityReady",
+		},
+		{
+			name:   "Waiting",
+			give:   forge.ChangeMergeabilityWaiting,
+			want:   "waiting",
+			wantGo: "ChangeMergeabilityWaiting",
+		},
+		{
+			name:   "Blocked",
+			give:   forge.ChangeMergeabilityBlocked,
+			want:   "blocked",
+			wantGo: "ChangeMergeabilityBlocked",
+		},
+		{
+			name:   "Unrecognized",
+			give:   forge.ChangeMergeabilityState(42),
+			want:   "ChangeMergeabilityState(42)",
+			wantGo: "ChangeMergeabilityState(42)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.give.String())
+			assert.Equal(t, tt.wantGo, tt.give.GoString())
+		})
+	}
+}
+
+func TestChangeMergeabilityReason(t *testing.T) {
+	tests := []struct {
+		name   string
+		give   forge.ChangeMergeabilityReason
+		want   string
+		wantGo string
+	}{
+		{
+			name:   "Unknown",
+			give:   forge.ChangeMergeabilityReasonUnknown,
+			want:   "unknown",
+			wantGo: "ChangeMergeabilityReasonUnknown",
+		},
+		{
+			name:   "Checks",
+			give:   forge.ChangeMergeabilityReasonChecks,
+			want:   "checks",
+			wantGo: "ChangeMergeabilityReasonChecks",
+		},
+		{
+			name:   "Review",
+			give:   forge.ChangeMergeabilityReasonReview,
+			want:   "review",
+			wantGo: "ChangeMergeabilityReasonReview",
+		},
+		{
+			name:   "Draft",
+			give:   forge.ChangeMergeabilityReasonDraft,
+			want:   "draft",
+			wantGo: "ChangeMergeabilityReasonDraft",
+		},
+		{
+			name:   "Conflicts",
+			give:   forge.ChangeMergeabilityReasonConflicts,
+			want:   "conflicts",
+			wantGo: "ChangeMergeabilityReasonConflicts",
+		},
+		{
+			name:   "Behind",
+			give:   forge.ChangeMergeabilityReasonBehind,
+			want:   "behind",
+			wantGo: "ChangeMergeabilityReasonBehind",
+		},
+		{
+			name:   "Discussions",
+			give:   forge.ChangeMergeabilityReasonDiscussions,
+			want:   "discussions",
+			wantGo: "ChangeMergeabilityReasonDiscussions",
+		},
+		{
+			name:   "Policy",
+			give:   forge.ChangeMergeabilityReasonPolicy,
+			want:   "policy",
+			wantGo: "ChangeMergeabilityReasonPolicy",
+		},
+		{
+			name:   "Unrecognized",
+			give:   forge.ChangeMergeabilityReason(42),
+			want:   "ChangeMergeabilityReason(42)",
+			wantGo: "ChangeMergeabilityReason(42)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.give.String())
+			assert.Equal(t, tt.wantGo, tt.give.GoString())
+		})
+	}
+}

--- a/internal/forge/forgetest/mocks.go
+++ b/internal/forge/forgetest/mocks.go
@@ -748,6 +748,45 @@ func (c *MockRepositoryChangeChecksCall) DoAndReturn(f func(context.Context, for
 	return c
 }
 
+// ChangeMergeability mocks base method.
+func (m *MockRepository) ChangeMergeability(ctx context.Context, id forge.ChangeID) (forge.ChangeMergeability, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ChangeMergeability", ctx, id)
+	ret0, _ := ret[0].(forge.ChangeMergeability)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ChangeMergeability indicates an expected call of ChangeMergeability.
+func (mr *MockRepositoryMockRecorder) ChangeMergeability(ctx, id any) *MockRepositoryChangeMergeabilityCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeMergeability", reflect.TypeOf((*MockRepository)(nil).ChangeMergeability), ctx, id)
+	return &MockRepositoryChangeMergeabilityCall{Call: call}
+}
+
+// MockRepositoryChangeMergeabilityCall wrap *gomock.Call
+type MockRepositoryChangeMergeabilityCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockRepositoryChangeMergeabilityCall) Return(arg0 forge.ChangeMergeability, arg1 error) *MockRepositoryChangeMergeabilityCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockRepositoryChangeMergeabilityCall) Do(f func(context.Context, forge.ChangeID) (forge.ChangeMergeability, error)) *MockRepositoryChangeMergeabilityCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockRepositoryChangeMergeabilityCall) DoAndReturn(f func(context.Context, forge.ChangeID) (forge.ChangeMergeability, error)) *MockRepositoryChangeMergeabilityCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ChangeStatuses mocks base method.
 func (m *MockRepository) ChangeStatuses(ctx context.Context, ids []forge.ChangeID) ([]forge.ChangeStatus, error) {
 	m.ctrl.T.Helper()

--- a/internal/forge/github/mergeability.go
+++ b/internal/forge/github/mergeability.go
@@ -1,0 +1,18 @@
+package github
+
+import (
+	"context"
+
+	"go.abhg.dev/gs/internal/forge"
+)
+
+// ChangeMergeability reports whether the pull request can be merged.
+//
+// This compatibility implementation returns unknown until the GitHub-specific
+// mergeability translation is implemented.
+func (r *Repository) ChangeMergeability(
+	context.Context,
+	forge.ChangeID,
+) (forge.ChangeMergeability, error) {
+	return forge.ChangeMergeability{}, nil
+}

--- a/internal/forge/gitlab/mergeability.go
+++ b/internal/forge/gitlab/mergeability.go
@@ -1,0 +1,18 @@
+package gitlab
+
+import (
+	"context"
+
+	"go.abhg.dev/gs/internal/forge"
+)
+
+// ChangeMergeability reports whether the merge request can be merged.
+//
+// This compatibility implementation returns unknown until the GitLab-specific
+// mergeability translation is implemented.
+func (r *Repository) ChangeMergeability(
+	context.Context,
+	forge.ChangeID,
+) (forge.ChangeMergeability, error) {
+	return forge.ChangeMergeability{}, nil
+}

--- a/internal/forge/shamhub/mergeability.go
+++ b/internal/forge/shamhub/mergeability.go
@@ -1,0 +1,18 @@
+package shamhub
+
+import (
+	"context"
+
+	"go.abhg.dev/gs/internal/forge"
+)
+
+// ChangeMergeability reports whether the change can be merged.
+//
+// This compatibility implementation returns unknown until the ShamHub-specific
+// mergeability simulation is implemented.
+func (r *forgeRepository) ChangeMergeability(
+	context.Context,
+	forge.ChangeID,
+) (forge.ChangeMergeability, error) {
+	return forge.ChangeMergeability{}, nil
+}


### PR DESCRIPTION
## Summary

- Add `ChangeMergeability` to the forge repository contract.
- Keep CI/check details under `ChangeChecks` instead of overloading check status as merge readiness.
- Provide initial provider implementations that return the zero-value unknown result so provider translation branches can define their own policies separately.

## Testing

- Worker validation previously covered focused forge tests and review repairs for this branch.

[skip changelog]: internal forge API boundary for unreleased merge work.