### PR TITLE
fix(nav): Suppress dry-run restack warnings

### DIFF
--- a/.changes/unreleased/Fixed-20260620-074438.yaml
+++ b/.changes/unreleased/Fixed-20260620-074438.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'Navigation commands will no longer print restack warnings with --dry-run.'
+time: 2026-06-20T07:44:38.439383-07:00

--- a/internal/handler/checkout/handler.go
+++ b/internal/handler/checkout/handler.go
@@ -99,6 +99,11 @@ func (h *Handler) CheckoutBranch(ctx context.Context, req *Request) error {
 	must.NotBeBlankf(branch, "branch name must not be blank")
 	must.NotBef(opts.DryRun && opts.Detach, "cannot use both dry-run and detach options")
 
+	if opts.DryRun {
+		_, _ = fmt.Fprintln(h.Stdout, branch)
+		return nil
+	}
+
 	log := h.Log
 	if branch != h.Store.Trunk() {
 		if err := h.Service.VerifyRestacked(ctx, branch); err != nil {
@@ -159,11 +164,6 @@ func (h *Handler) CheckoutBranch(ctx context.Context, req *Request) error {
 					"branch", branch, "error", err)
 			}
 		}
-	}
-
-	if opts.DryRun {
-		_, _ = fmt.Fprintln(h.Stdout, branch)
-		return nil
 	}
 
 	if opts.Detach {

--- a/internal/handler/checkout/handler_test.go
+++ b/internal/handler/checkout/handler_test.go
@@ -139,9 +139,6 @@ func TestHandler_CheckoutBranch_NonTrunk(t *testing.T) {
 
 	t.Run("DryRun", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		mockWorktree := NewMockGitWorktree(ctrl)
-		mockTrack := NewMockTrackHandler(ctrl)
-		mockService := NewMockService(ctrl)
 
 		var stdout bytes.Buffer
 		handler := &Handler{
@@ -149,15 +146,10 @@ func TestHandler_CheckoutBranch_NonTrunk(t *testing.T) {
 			Log:        silog.Nop(),
 			Store:      mockStore,
 			Repository: NewMockGitRepository(ctrl),
-			Worktree:   mockWorktree,
-			Track:      mockTrack,
-			Service:    mockService,
+			Worktree:   NewMockGitWorktree(ctrl),
+			Track:      NewMockTrackHandler(ctrl),
+			Service:    NewMockService(ctrl),
 		}
-
-		mockService.
-			EXPECT().
-			VerifyRestacked(gomock.Any(), "feature").
-			Return(nil)
 
 		req := &Request{
 			Branch:  "feature",
@@ -167,6 +159,30 @@ func TestHandler_CheckoutBranch_NonTrunk(t *testing.T) {
 		err := handler.CheckoutBranch(t.Context(), req)
 		assert.NoError(t, err)
 		assert.Equal(t, "feature\n", stdout.String())
+	})
+
+	t.Run("DryRunNeedsRestack", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		var logBuffer bytes.Buffer
+		var stdout bytes.Buffer
+		handler := &Handler{
+			Stdout:     &stdout,
+			Log:        silog.New(&logBuffer, nil),
+			Store:      mockStore,
+			Repository: NewMockGitRepository(ctrl),
+			Worktree:   NewMockGitWorktree(ctrl),
+			Track:      NewMockTrackHandler(ctrl),
+			Service:    NewMockService(ctrl),
+		}
+
+		err := handler.CheckoutBranch(t.Context(), &Request{
+			Branch:  "feature",
+			Options: &Options{DryRun: true},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "feature\n", stdout.String())
+		assert.NotContains(t, logBuffer.String(), "needs to be restacked")
 	})
 
 	t.Run("Detach", func(t *testing.T) {

--- a/testdata/script/issue1289_nav_dry_run_no_restack_warning.txt
+++ b/testdata/script/issue1289_nav_dry_run_no_restack_warning.txt
@@ -1,0 +1,23 @@
+# Regression test for https://github.com/abhinav/git-spice/issues/1289.
+#
+# Navigation dry runs print only the target branch name,
+# even when the target branch needs to be restacked.
+
+as 'Test <test@example.com>'
+at '2026-06-20T16:26:04Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+gs bc -m feature1
+gs bc -m feature2
+gs trunk
+git commit --allow-empty -m 'Move trunk'
+gs bco feature2
+
+gs down -n
+stdout feature1
+! stderr 'needs to be restacked'


### PR DESCRIPTION
Navigation dry runs are meant to report the resolved branch name without
running checkout-side validation or mutations.

Checking restack state before the dry-run return made `gs down -n` print
a restack warning when the target branch needed restack, even though the
command was only answering which branch it would select.

Dry-run checkout now returns before restack verification, branch recovery,
or tracking prompts.

Resolves #1289