### PR TITLE
test(forgetest): Add mergeability scenarios

### DIFF
--- a/internal/forge/bitbucket/integration_test.go
+++ b/internal/forge/bitbucket/integration_test.go
@@ -120,6 +120,10 @@ func TestIntegration(t *testing.T) {
 		// 			check.State,
 		// 		))
 		// },
+		// TODO: Remove SkipMergeability after Bitbucket fixtures can be
+		// recorded for real ready, draft, and conflicting pull requests.
+		// The current Bitbucket integration setup cannot record new fixtures
+		// because no working test account is available.
 		SetCommentsPageSize: bitbucket.SetListChangeCommentsPageSize,
 		Reviewers:           []string{cfg.Reviewer},
 		Assignees:           []string{},
@@ -128,6 +132,7 @@ func TestIntegration(t *testing.T) {
 		SkipAssignees:         true, // no PR assignees
 		SkipTemplates:         true, // limited template support
 		ShortHeadHash:         true, // API returns 12-char hashes
+		SkipMergeability:      true, // no working account for recording
 		SkipMerge:             true, // requires branch permissions
 		SkipCommentPagination: true, // 403 with small pages
 	})

--- a/internal/forge/forgetest/integration.go
+++ b/internal/forge/forgetest/integration.go
@@ -15,6 +15,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -266,6 +267,13 @@ type IntegrationConfig struct {
 	// SetChangeCheck sets a synthetic check for a change.
 	SetChangeCheck SetChangeCheckFunc // optional
 
+	// SkipMergeability skips shared mergeability integration tests.
+	//
+	// The tests are enabled by default.
+	// Set to true while a provider branch is still adding mergeability support
+	// or cannot record the required fixtures.
+	SkipMergeability bool // optional
+
 	// Reviewers is a list of usernames that can be added as reviewers to changes.
 	Reviewers []string // required
 
@@ -394,6 +402,14 @@ func RunIntegration(t *testing.T, config IntegrationConfig) {
 			t.Parallel()
 
 			suite.TestChangeChecks(t)
+		})
+	}
+
+	if !config.SkipMergeability {
+		t.Run("ChangeMergeability", func(t *testing.T) {
+			t.Parallel()
+
+			suite.TestChangeMergeability(t, !config.SkipDraft)
 		})
 	}
 
@@ -913,6 +929,206 @@ func (s *integrationSuite) TestChangeChecks(t *testing.T) {
 			assert.Equal(t, []forge.ChangeCheck{tt.want}, got)
 		})
 	}
+}
+
+// TestChangeMergeability verifies that forges report mergeability
+// independently from the CI/check status surface.
+func (s *integrationSuite) TestChangeMergeability(
+	t *testing.T,
+	includeDraft bool,
+) {
+	t.Run("Ready", func(t *testing.T) {
+		t.Parallel()
+
+		s.testChangeMergeabilityReady(t)
+	})
+
+	t.Run("Conflicts", func(t *testing.T) {
+		t.Parallel()
+
+		s.testChangeMergeabilityConflicts(t)
+	})
+
+	if includeDraft {
+		t.Run("Draft", func(t *testing.T) {
+			t.Parallel()
+
+			s.testChangeMergeabilityDraft(t)
+		})
+	}
+}
+
+func (s *integrationSuite) testChangeMergeabilityReady(t *testing.T) {
+	baseName := fixturetest.New(s.Fixtures, "base", func() string {
+		return "ready-base-" + randomString(8)
+	}).Get(t)
+	headName := fixturetest.New(s.Fixtures, "head", func() string {
+		return "ready-head-" + randomString(8)
+	}).Get(t)
+
+	if Update() {
+		testRepo := newTestRepository(t, s.RemoteURL)
+		testRepo.CheckoutBranch("main")
+		testRepo.Push("main:" + baseName)
+		t.Cleanup(func() {
+			testRepo.DeleteRemoteBranch(baseName)
+		})
+
+		testRepo.CreateBranch(headName)
+		testRepo.CheckoutBranch(headName)
+		testRepo.WriteFile(headName+".txt", randomString(32))
+		testRepo.AddAllAndCommit("commit for mergeability ready")
+		testRepo.Push(headName)
+		t.Cleanup(func() {
+			testRepo.DeleteRemoteBranch(headName)
+		})
+	}
+
+	repo := s.OpenRepository(t)
+
+	change, err := repo.SubmitChange(
+		t.Context(),
+		forge.SubmitChangeRequest{
+			Subject: "Mergeability " + headName,
+			Body:    "Mergeability scenario test",
+			Base:    baseName,
+			Head:    headName,
+		},
+	)
+	require.NoError(t, err, "error creating change")
+	if Update() {
+		t.Cleanup(func() {
+			s.CloseChange(t, repo, change.ID)
+		})
+	}
+
+	var got forge.ChangeMergeability
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		var err error
+		got, err = repo.ChangeMergeability(t.Context(), change.ID)
+		require.NoError(c, err, "error fetching mergeability")
+		assert.Equal(c, forge.ChangeMergeability{
+			State: forge.ChangeMergeabilityReady,
+		}, got)
+	}, 30*time.Second, 500*time.Millisecond)
+}
+
+func (s *integrationSuite) testChangeMergeabilityConflicts(t *testing.T) {
+	baseName := fixturetest.New(s.Fixtures, "base", func() string {
+		return "conflict-base-" + randomString(8)
+	}).Get(t)
+	headName := fixturetest.New(s.Fixtures, "head", func() string {
+		return "conflict-head-" + randomString(8)
+	}).Get(t)
+
+	if Update() {
+		testRepo := newTestRepository(t, s.RemoteURL)
+		testRepo.CheckoutBranch("main")
+		testRepo.Push("main:" + baseName)
+		t.Cleanup(func() {
+			testRepo.DeleteRemoteBranch(baseName)
+		})
+
+		testRepo.CreateBranch(headName)
+		testRepo.CheckoutBranch(headName)
+		testRepo.WriteFile("mergeability-conflict.txt", "head "+randomString(32))
+		testRepo.AddAllAndCommit("commit conflicting head")
+		testRepo.Push(headName)
+		t.Cleanup(func() {
+			testRepo.DeleteRemoteBranch(headName)
+		})
+
+		testRepo.CheckoutBranch("main")
+		testRepo.WriteFile("mergeability-conflict.txt", "base "+randomString(32))
+		testRepo.AddAllAndCommit("commit conflicting base")
+		testRepo.Push("HEAD:" + baseName)
+	}
+
+	repo := s.OpenRepository(t)
+
+	change, err := repo.SubmitChange(
+		t.Context(),
+		forge.SubmitChangeRequest{
+			Subject: "Mergeability " + headName,
+			Body:    "Mergeability scenario test",
+			Base:    baseName,
+			Head:    headName,
+		},
+	)
+	require.NoError(t, err, "error creating change")
+	if Update() {
+		t.Cleanup(func() {
+			s.CloseChange(t, repo, change.ID)
+		})
+	}
+
+	var got forge.ChangeMergeability
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		var err error
+		got, err = repo.ChangeMergeability(t.Context(), change.ID)
+		require.NoError(c, err, "error fetching mergeability")
+		assert.Equal(c, forge.ChangeMergeability{
+			State:  forge.ChangeMergeabilityBlocked,
+			Reason: forge.ChangeMergeabilityReasonConflicts,
+		}, got)
+	}, 30*time.Second, 500*time.Millisecond)
+}
+
+func (s *integrationSuite) testChangeMergeabilityDraft(t *testing.T) {
+	baseName := fixturetest.New(s.Fixtures, "base", func() string {
+		return "draft-base-" + randomString(8)
+	}).Get(t)
+	headName := fixturetest.New(s.Fixtures, "head", func() string {
+		return "draft-head-" + randomString(8)
+	}).Get(t)
+
+	if Update() {
+		testRepo := newTestRepository(t, s.RemoteURL)
+		testRepo.CheckoutBranch("main")
+		testRepo.Push("main:" + baseName)
+		t.Cleanup(func() {
+			testRepo.DeleteRemoteBranch(baseName)
+		})
+
+		testRepo.CreateBranch(headName)
+		testRepo.CheckoutBranch(headName)
+		testRepo.WriteFile(headName+".txt", randomString(32))
+		testRepo.AddAllAndCommit("commit for mergeability draft")
+		testRepo.Push(headName)
+		t.Cleanup(func() {
+			testRepo.DeleteRemoteBranch(headName)
+		})
+	}
+
+	repo := s.OpenRepository(t)
+
+	change, err := repo.SubmitChange(
+		t.Context(),
+		forge.SubmitChangeRequest{
+			Subject: "Mergeability " + headName,
+			Body:    "Mergeability scenario test",
+			Base:    baseName,
+			Head:    headName,
+			Draft:   true,
+		},
+	)
+	require.NoError(t, err, "error creating change")
+	if Update() {
+		t.Cleanup(func() {
+			s.CloseChange(t, repo, change.ID)
+		})
+	}
+
+	var got forge.ChangeMergeability
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		var err error
+		got, err = repo.ChangeMergeability(t.Context(), change.ID)
+		require.NoError(c, err, "error fetching mergeability")
+		assert.Equal(c, forge.ChangeMergeability{
+			State:  forge.ChangeMergeabilityBlocked,
+			Reason: forge.ChangeMergeabilityReasonDraft,
+		}, got)
+	}, 30*time.Second, 500*time.Millisecond)
 }
 
 // FindChangesByBranch returns no error, and an empty slice
@@ -1739,6 +1955,16 @@ func newTestRepository(t *testing.T, remoteURL string) *testRepository {
 		WithStdout(output).
 		WithStderr(output)
 	require.NoError(t, cmd.Run(), "failed to clone repository")
+
+	require.NoError(t, xec.Command(
+		t.Context(),
+		silogtest.New(t),
+		"git", "config", "commit.gpgsign", "false",
+	).
+		WithDir(repoDir).
+		WithStdout(output).
+		WithStderr(output).
+		Run(), "disable commit signing")
 
 	ctx := t.Context()
 	work, err := git.OpenWorktree(ctx, repoDir, git.OpenOptions{

--- a/internal/forge/github/integration_test.go
+++ b/internal/forge/github/integration_test.go
@@ -139,6 +139,9 @@ func TestIntegration(t *testing.T) {
 				check,
 			))
 		},
+		// TODO: Remove SkipMergeability after the GitHub provider branch
+		// records scenario fixtures.
+		SkipMergeability:    true,
 		SetCommentsPageSize: github.SetListChangeCommentsPageSize,
 		Reviewers:           []string{cfg.Reviewer},
 		Assignees:           []string{cfg.Assignee},

--- a/internal/forge/gitlab/integration_test.go
+++ b/internal/forge/gitlab/integration_test.go
@@ -158,8 +158,11 @@ func TestIntegration(t *testing.T) {
 				time.Sleep(2 * time.Second)
 			}
 		},
+		// TODO: Remove SkipMergeability after the GitLab provider branch
+		// records scenario fixtures.
 		SetCommentsPageSize:   gitlabforge.SetListChangeCommentsPageSize,
 		BaseBranchMayBeAbsent: true,
+		SkipMergeability:      true,
 		SkipMerge:             true, // Merge requires MR approval settings to be disabled
 		Reviewers:             []string{cfg.Reviewer},
 		Assignees:             []string{cfg.Assignee},

--- a/internal/forge/shamhub/integration_test.go
+++ b/internal/forge/shamhub/integration_test.go
@@ -193,7 +193,9 @@ func TestIntegration(t *testing.T) {
 				))
 		},
 		SetCommentsPageSize: SetListChangeCommentsPageSize,
-		Reviewers:           []string{"reviewer1", "reviewer2"},
-		Assignees:           []string{"assignee1", "assignee2"},
+		// TODO: Remove SkipMergeability on the ShamHub provider branch.
+		SkipMergeability: true,
+		Reviewers:        []string{"reviewer1", "reviewer2"},
+		Assignees:        []string{"assignee1", "assignee2"},
 	})
 }


### PR DESCRIPTION
Mergeability integration coverage needs to prove the forge-reported
state that real changes produce.

Test against Ready, Draft, and Conflicts scenarios
that the shared suite can create and inspect across providers.

We're holding off on testing CI failures
as that requires much more machinery to set up,
and the API calls are still the same.