### PR TITLE
bitbucket: Translate mergeability state

### DIFF
--- a/internal/forge/bitbucket/mergeability.go
+++ b/internal/forge/bitbucket/mergeability.go
@@ -7,12 +7,37 @@ import (
 )
 
 // ChangeMergeability reports whether the pull request can be merged.
-//
-// This compatibility implementation returns unknown until the Bitbucket-specific
-// mergeability translation is implemented.
 func (r *Repository) ChangeMergeability(
-	context.Context,
-	forge.ChangeID,
+	ctx context.Context,
+	id forge.ChangeID,
 ) (forge.ChangeMergeability, error) {
-	return forge.ChangeMergeability{}, nil
+	pr := mustPR(id)
+	pullRequest, err := r.getPullRequest(ctx, pr.Number)
+	if err != nil {
+		return forge.ChangeMergeability{}, err
+	}
+
+	return mergeabilityFromAPI(pullRequest.Mergeable, pullRequest.Queued), nil
+}
+
+func mergeabilityFromAPI(mergeable *bool, queued bool) forge.ChangeMergeability {
+	// Bitbucket Cloud reports the mergeability decision,
+	// but not the reason behind a blocked or waiting decision.
+	result := forge.ChangeMergeability{
+		Reason: forge.ChangeMergeabilityReasonUnknown,
+	}
+	switch {
+	case mergeable == nil && queued:
+		result.State = forge.ChangeMergeabilityWaiting
+	case mergeable == nil:
+		result.State = forge.ChangeMergeabilityUnknown
+	case queued:
+		result.State = forge.ChangeMergeabilityWaiting
+	case *mergeable:
+		result.State = forge.ChangeMergeabilityReady
+	default:
+		result.State = forge.ChangeMergeabilityBlocked
+	}
+
+	return result
 }

--- a/internal/forge/bitbucket/mergeability_test.go
+++ b/internal/forge/bitbucket/mergeability_test.go
@@ -1,0 +1,105 @@
+package bitbucket
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/gateway/bitbucket"
+)
+
+func TestChangeMergeability(t *testing.T) {
+	tests := []struct {
+		name string
+		pr   bitbucket.PullRequest
+		want forge.ChangeMergeability
+	}{
+		{
+			name: "Mergeable",
+			pr: bitbucket.PullRequest{
+				ID:        1,
+				Mergeable: new(true),
+			},
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityReady,
+				Reason: forge.ChangeMergeabilityReasonUnknown,
+			},
+		},
+		{
+			name: "Queued",
+			pr: bitbucket.PullRequest{
+				ID:        1,
+				Mergeable: new(false),
+				Queued:    true,
+			},
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityWaiting,
+				Reason: forge.ChangeMergeabilityReasonUnknown,
+			},
+		},
+		{
+			name: "QueuedMergeable",
+			pr: bitbucket.PullRequest{
+				ID:        1,
+				Mergeable: new(true),
+				Queued:    true,
+			},
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityWaiting,
+				Reason: forge.ChangeMergeabilityReasonUnknown,
+			},
+		},
+		{
+			name: "QueuedWithoutMergeable",
+			pr: bitbucket.PullRequest{
+				ID:     1,
+				Queued: true,
+			},
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityWaiting,
+				Reason: forge.ChangeMergeabilityReasonUnknown,
+			},
+		},
+		{
+			name: "NotMergeable",
+			pr: bitbucket.PullRequest{
+				ID:        1,
+				Mergeable: new(false),
+			},
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityBlocked,
+				Reason: forge.ChangeMergeabilityReasonUnknown,
+			},
+		},
+		{
+			name: "OmittedMergeable",
+			pr: bitbucket.PullRequest{
+				ID: 1,
+			},
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityUnknown,
+				Reason: forge.ChangeMergeabilityReasonUnknown,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "/repositories/workspace/repo/pullrequests/1", r.URL.Path)
+				require.NoError(t, json.NewEncoder(w).Encode(tt.pr))
+			}))
+			defer srv.Close()
+
+			repo := newTestRepository(srv.URL)
+			got, err := repo.ChangeMergeability(t.Context(), &PR{Number: 1})
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/gateway/bitbucket/api.go
+++ b/internal/gateway/bitbucket/api.go
@@ -31,6 +31,14 @@ type PullRequest struct {
 	Reviewers   []User           `json:"reviewers"`
 	Links       PullRequestLinks `json:"links"`
 	MergeCommit *Commit          `json:"merge_commit,omitempty"`
+
+	// Mergeable reports Bitbucket Cloud's current merge decision.
+	//
+	// It is nil when the response omits the field.
+	Mergeable *bool `json:"mergeable,omitempty"`
+
+	// Queued reports whether Bitbucket Cloud is still evaluating mergeability.
+	Queued bool `json:"queued,omitempty"`
 }
 
 // PullRequestCreateRequest is the request body for creating a pull request.

--- a/internal/gateway/bitbucket/api_test.go
+++ b/internal/gateway/bitbucket/api_test.go
@@ -1,6 +1,7 @@
 package bitbucket
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -90,6 +91,19 @@ func TestClient_PullRequestGet(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(55), pr.ID)
 	assert.Equal(t, "main", pr.Destination.Branch.Name)
+}
+
+func TestPullRequestMergeabilityFields(t *testing.T) {
+	var pr PullRequest
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"id": 55,
+		"mergeable": true,
+		"queued": true
+	}`), &pr))
+
+	require.NotNil(t, pr.Mergeable)
+	assert.True(t, *pr.Mergeable)
+	assert.True(t, pr.Queued)
 }
 
 func TestClient_PullRequestMerge(t *testing.T) {


### PR DESCRIPTION
Bitbucket reports merge readiness through pull request mergeability and
conflict fields.
Map those fields into the shared forge result.
Merge commands can then treat Bitbucket like other forges.

The shared mergeability integration scenario remains skipped for
Bitbucket with an explicit TODO.
The project does not currently have a recording account for those
fixtures, so unit coverage exercises the provider translation contract.