### PR TITLE
github: Translate mergeability state

### DIFF
--- a/internal/forge/github/integration_test.go
+++ b/internal/forge/github/integration_test.go
@@ -139,9 +139,6 @@ func TestIntegration(t *testing.T) {
 				check,
 			))
 		},
-		// TODO: Remove SkipMergeability after the GitHub provider branch
-		// records scenario fixtures.
-		SkipMergeability:    true,
 		SetCommentsPageSize: github.SetListChangeCommentsPageSize,
 		Reviewers:           []string{cfg.Reviewer},
 		Assignees:           []string{cfg.Assignee},

--- a/internal/forge/github/mergeability.go
+++ b/internal/forge/github/mergeability.go
@@ -83,7 +83,7 @@ func changeMergeabilityFromGitHub(
 		}
 	case githubv4.MergeStateStatusBlocked:
 		return forge.ChangeMergeability{
-			State:  forge.ChangeMergeabilityBlocked,
+			State:  forge.ChangeMergeabilityWaiting,
 			Reason: forge.ChangeMergeabilityReasonUnknown,
 		}
 	}

--- a/internal/forge/github/mergeability.go
+++ b/internal/forge/github/mergeability.go
@@ -2,17 +2,111 @@ package github
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/shurcooL/githubv4"
 	"go.abhg.dev/gs/internal/forge"
 )
 
 // ChangeMergeability reports whether the pull request can be merged.
-//
-// This compatibility implementation returns unknown until the GitHub-specific
-// mergeability translation is implemented.
 func (r *Repository) ChangeMergeability(
-	context.Context,
-	forge.ChangeID,
+	ctx context.Context,
+	fid forge.ChangeID,
 ) (forge.ChangeMergeability, error) {
-	return forge.ChangeMergeability{}, nil
+	pr := mustPR(fid)
+	gqlID, err := r.graphQLID(ctx, pr)
+	if err != nil {
+		return forge.ChangeMergeability{},
+			fmt.Errorf("resolve PR ID: %w", err)
+	}
+
+	var q struct {
+		Node struct {
+			PullRequest struct {
+				Mergeable        githubv4.MergeableState   `graphql:"mergeable"`
+				MergeStateStatus githubv4.MergeStateStatus `graphql:"mergeStateStatus"`
+				IsDraft          githubv4.Boolean          `graphql:"isDraft"`
+			} `graphql:"... on PullRequest"`
+		} `graphql:"node(id: $id)"`
+	}
+	if err := r.client.Query(ctx, &q, map[string]any{
+		"id": gqlID,
+	}); err != nil {
+		return forge.ChangeMergeability{},
+			fmt.Errorf("query mergeability: %w", err)
+	}
+
+	return changeMergeabilityFromGitHub(
+		q.Node.PullRequest.Mergeable,
+		q.Node.PullRequest.MergeStateStatus,
+		bool(q.Node.PullRequest.IsDraft),
+	), nil
+}
+
+func changeMergeabilityFromGitHub(
+	mergeable githubv4.MergeableState,
+	mergeState githubv4.MergeStateStatus,
+	isDraft bool,
+) forge.ChangeMergeability {
+	if isDraft {
+		// GitHub can report UNKNOWN merge state for drafts while its
+		// mergeability calculation is still settling.
+		// Use isDraft directly so drafts do not look like generic waiting.
+		return forge.ChangeMergeability{
+			State:  forge.ChangeMergeabilityBlocked,
+			Reason: forge.ChangeMergeabilityReasonDraft,
+		}
+	}
+
+	switch mergeState {
+	case githubv4.MergeStateStatusClean,
+		githubv4.MergeStateStatusHasHooks,
+		githubv4.MergeStateStatusUnstable:
+		return forge.ChangeMergeability{
+			State:  forge.ChangeMergeabilityReady,
+			Reason: forge.ChangeMergeabilityReasonUnknown,
+		}
+	case githubv4.MergeStateStatusDirty:
+		return forge.ChangeMergeability{
+			State:  forge.ChangeMergeabilityBlocked,
+			Reason: forge.ChangeMergeabilityReasonConflicts,
+		}
+	case githubv4.MergeStateStatusBehind:
+		return forge.ChangeMergeability{
+			State:  forge.ChangeMergeabilityBlocked,
+			Reason: forge.ChangeMergeabilityReasonBehind,
+		}
+	case githubv4.MergeStateStatusDraft:
+		return forge.ChangeMergeability{
+			State:  forge.ChangeMergeabilityBlocked,
+			Reason: forge.ChangeMergeabilityReasonDraft,
+		}
+	case githubv4.MergeStateStatusBlocked:
+		return forge.ChangeMergeability{
+			State:  forge.ChangeMergeabilityBlocked,
+			Reason: forge.ChangeMergeabilityReasonUnknown,
+		}
+	}
+
+	switch mergeable {
+	case githubv4.MergeableStateConflicting:
+		return forge.ChangeMergeability{
+			State:  forge.ChangeMergeabilityBlocked,
+			Reason: forge.ChangeMergeabilityReasonConflicts,
+		}
+	case githubv4.MergeableStateMergeable,
+		githubv4.MergeableStateUnknown:
+		// PullRequest.mergeable only reports the conflict calculation.
+		// When mergeStateStatus is UNKNOWN or unsupported,
+		// MERGEABLE does not prove that branch protection is satisfied.
+		return forge.ChangeMergeability{
+			State:  forge.ChangeMergeabilityWaiting,
+			Reason: forge.ChangeMergeabilityReasonUnknown,
+		}
+	default:
+		return forge.ChangeMergeability{
+			State:  forge.ChangeMergeabilityUnknown,
+			Reason: forge.ChangeMergeabilityReasonUnknown,
+		}
+	}
 }

--- a/internal/forge/github/mergeability_test.go
+++ b/internal/forge/github/mergeability_test.go
@@ -160,11 +160,11 @@ func TestChangeMergeabilityFromGitHub(t *testing.T) {
 			},
 		},
 		{
-			name:           "Blocked",
+			name:           "BlockedWaits",
 			giveMergeable:  githubv4.MergeableStateMergeable,
 			giveMergeState: githubv4.MergeStateStatusBlocked,
 			want: forge.ChangeMergeability{
-				State:  forge.ChangeMergeabilityBlocked,
+				State:  forge.ChangeMergeabilityWaiting,
 				Reason: forge.ChangeMergeabilityReasonUnknown,
 			},
 		},

--- a/internal/forge/github/mergeability_test.go
+++ b/internal/forge/github/mergeability_test.go
@@ -1,0 +1,218 @@
+package github
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/shurcooL/githubv4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/silog/silogtest"
+)
+
+func TestRepository_ChangeMergeability(t *testing.T) {
+	var queried bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+
+		var body struct {
+			Query     string `json:"query"`
+			Variables struct {
+				ID string `json:"id"`
+			} `json:"variables"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "prID", body.Variables.ID)
+		assert.Contains(t, body.Query, "mergeable")
+		assert.Contains(t, body.Query, "mergeStateStatus")
+		assert.Contains(t, body.Query, "isDraft")
+		queried = true
+
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"node": map[string]any{
+					"mergeable":        "MERGEABLE",
+					"mergeStateStatus": "CLEAN",
+					"isDraft":          false,
+				},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	repo, err := newRepository(
+		t.Context(), new(Forge),
+		"owner", "repo",
+		silogtest.New(t),
+		githubv4.NewEnterpriseClient(srv.URL, nil),
+		"repoID",
+	)
+	require.NoError(t, err)
+
+	got, err := repo.ChangeMergeability(
+		t.Context(),
+		&PR{Number: 1, GQLID: "prID"},
+	)
+	require.NoError(t, err)
+	assert.True(t, queried)
+	assert.Equal(t, forge.ChangeMergeability{
+		State:  forge.ChangeMergeabilityReady,
+		Reason: forge.ChangeMergeabilityReasonUnknown,
+	}, got)
+}
+
+func TestRepository_ChangeMergeability_wrapsQueryError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "offline", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	repo, err := newRepository(
+		t.Context(), new(Forge),
+		"owner", "repo",
+		silogtest.New(t),
+		githubv4.NewEnterpriseClient(srv.URL, nil),
+		"repoID",
+	)
+	require.NoError(t, err)
+
+	_, err = repo.ChangeMergeability(
+		t.Context(),
+		&PR{Number: 1, GQLID: "prID"},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "query mergeability")
+}
+
+func TestChangeMergeabilityFromGitHub(t *testing.T) {
+	tests := []struct {
+		name           string
+		giveMergeable  githubv4.MergeableState
+		giveMergeState githubv4.MergeStateStatus
+		giveDraft      bool
+		want           forge.ChangeMergeability
+	}{
+		{
+			name:           "Clean",
+			giveMergeable:  githubv4.MergeableStateMergeable,
+			giveMergeState: githubv4.MergeStateStatusClean,
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityReady,
+				Reason: forge.ChangeMergeabilityReasonUnknown,
+			},
+		},
+		{
+			name:           "HasHooks",
+			giveMergeable:  githubv4.MergeableStateMergeable,
+			giveMergeState: githubv4.MergeStateStatusHasHooks,
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityReady,
+				Reason: forge.ChangeMergeabilityReasonUnknown,
+			},
+		},
+		{
+			name:           "Unstable",
+			giveMergeable:  githubv4.MergeableStateMergeable,
+			giveMergeState: githubv4.MergeStateStatusUnstable,
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityReady,
+				Reason: forge.ChangeMergeabilityReasonUnknown,
+			},
+		},
+		{
+			name:           "Dirty",
+			giveMergeable:  githubv4.MergeableStateConflicting,
+			giveMergeState: githubv4.MergeStateStatusDirty,
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityBlocked,
+				Reason: forge.ChangeMergeabilityReasonConflicts,
+			},
+		},
+		{
+			name:           "Behind",
+			giveMergeable:  githubv4.MergeableStateMergeable,
+			giveMergeState: githubv4.MergeStateStatusBehind,
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityBlocked,
+				Reason: forge.ChangeMergeabilityReasonBehind,
+			},
+		},
+		{
+			name:           "DraftStatus",
+			giveMergeable:  githubv4.MergeableStateMergeable,
+			giveMergeState: githubv4.MergeStateStatusDraft,
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityBlocked,
+				Reason: forge.ChangeMergeabilityReasonDraft,
+			},
+		},
+		{
+			name:           "DraftFlag",
+			giveMergeable:  githubv4.MergeableStateMergeable,
+			giveMergeState: githubv4.MergeStateStatusClean,
+			giveDraft:      true,
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityBlocked,
+				Reason: forge.ChangeMergeabilityReasonDraft,
+			},
+		},
+		{
+			name:           "Blocked",
+			giveMergeable:  githubv4.MergeableStateMergeable,
+			giveMergeState: githubv4.MergeStateStatusBlocked,
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityBlocked,
+				Reason: forge.ChangeMergeabilityReasonUnknown,
+			},
+		},
+		{
+			name:           "MergeableWithUnknownStatus",
+			giveMergeable:  githubv4.MergeableStateMergeable,
+			giveMergeState: githubv4.MergeStateStatusUnknown,
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityWaiting,
+				Reason: forge.ChangeMergeabilityReasonUnknown,
+			},
+		},
+		{
+			name:           "ConflictingFallback",
+			giveMergeable:  githubv4.MergeableStateConflicting,
+			giveMergeState: githubv4.MergeStateStatusUnknown,
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityBlocked,
+				Reason: forge.ChangeMergeabilityReasonConflicts,
+			},
+		},
+		{
+			name:           "Waiting",
+			giveMergeable:  githubv4.MergeableStateUnknown,
+			giveMergeState: githubv4.MergeStateStatusUnknown,
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityWaiting,
+				Reason: forge.ChangeMergeabilityReasonUnknown,
+			},
+		},
+		{
+			name:           "Unknown",
+			giveMergeable:  githubv4.MergeableState("RECALIBRATING"),
+			giveMergeState: githubv4.MergeStateStatus("RECALIBRATING"),
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityUnknown,
+				Reason: forge.ChangeMergeabilityReasonUnknown,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, changeMergeabilityFromGitHub(
+				tt.giveMergeable,
+				tt.giveMergeState,
+				tt.giveDraft,
+			))
+		})
+	}
+}

--- a/internal/forge/github/testdata/TestIntegration/ChangeMergeability/Conflicts/base
+++ b/internal/forge/github/testdata/TestIntegration/ChangeMergeability/Conflicts/base
@@ -1,0 +1,1 @@
+"conflict-base-cBqnd2m8"

--- a/internal/forge/github/testdata/TestIntegration/ChangeMergeability/Conflicts/head
+++ b/internal/forge/github/testdata/TestIntegration/ChangeMergeability/Conflicts/head
@@ -1,0 +1,1 @@
+"conflict-head-BUQewFPF"

--- a/internal/forge/github/testdata/TestIntegration/ChangeMergeability/Draft/base
+++ b/internal/forge/github/testdata/TestIntegration/ChangeMergeability/Draft/base
@@ -1,0 +1,1 @@
+"draft-base-7sbpxhAZ"

--- a/internal/forge/github/testdata/TestIntegration/ChangeMergeability/Draft/head
+++ b/internal/forge/github/testdata/TestIntegration/ChangeMergeability/Draft/head
@@ -1,0 +1,1 @@
+"draft-head-AfhiKihF"

--- a/internal/forge/github/testdata/TestIntegration/ChangeMergeability/Ready/base
+++ b/internal/forge/github/testdata/TestIntegration/ChangeMergeability/Ready/base
@@ -1,0 +1,1 @@
+"ready-base-ZX1H7lxh"

--- a/internal/forge/github/testdata/TestIntegration/ChangeMergeability/Ready/head
+++ b/internal/forge/github/testdata/TestIntegration/ChangeMergeability/Ready/head
@@ -1,0 +1,1 @@
+"ready-head-qqHhbcZh"

--- a/internal/forge/github/testdata/fixtures/TestIntegration/ChangeMergeability/Conflicts.yaml
+++ b/internal/forge/github/testdata/fixtures/TestIntegration/ChangeMergeability/Conflicts.yaml
@@ -1,0 +1,134 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 142
+        host: api.github.com
+        body: |
+            {"query":"query($owner:String!$repo:String!){repository(owner: $owner, name: $repo){id}}","variables":{"owner":"test-owner","repo":"test-repo"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"repository":{"id":"R_kgDOMVd0xg"}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 220.632125ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 329
+        host: api.github.com
+        body: |
+            {"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"conflict-base-cBqnd2m8","headRefName":"conflict-head-BUQewFPF","title":"Mergeability conflict-head-BUQewFPF","body":"Mergeability scenario test"}}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs7ott7e","number":100,"url":"https://github.com/test-owner/test-repo/pull/100"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 951.806458ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 139
+        host: api.github.com
+        body: |
+            {"query":"query($id:ID!){node(id: $id){... on PullRequest{mergeable,mergeStateStatus,isDraft}}}","variables":{"id":"PR_kwDOMVd0xs7ott7e"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"node":{"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","isDraft":false}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 569.707459ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 139
+        host: api.github.com
+        body: |
+            {"query":"query($id:ID!){node(id: $id){... on PullRequest{mergeable,mergeStateStatus,isDraft}}}","variables":{"id":"PR_kwDOMVd0xs7ott7e"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"node":{"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","isDraft":false}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 408.535375ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 139
+        host: api.github.com
+        body: |
+            {"query":"query($id:ID!){node(id: $id){... on PullRequest{mergeable,mergeStateStatus,isDraft}}}","variables":{"id":"PR_kwDOMVd0xs7ott7e"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"node":{"mergeable":"CONFLICTING","mergeStateStatus":"DIRTY","isDraft":false}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 292.826208ms

--- a/internal/forge/github/testdata/fixtures/TestIntegration/ChangeMergeability/Draft.yaml
+++ b/internal/forge/github/testdata/fixtures/TestIntegration/ChangeMergeability/Draft.yaml
@@ -1,0 +1,82 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 142
+        host: api.github.com
+        body: |
+            {"query":"query($owner:String!$repo:String!){repository(owner: $owner, name: $repo){id}}","variables":{"owner":"test-owner","repo":"test-repo"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"repository":{"id":"R_kgDOMVd0xg"}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 213.54775ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 333
+        host: api.github.com
+        body: |
+            {"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"draft-base-7sbpxhAZ","headRefName":"draft-head-AfhiKihF","title":"Mergeability draft-head-AfhiKihF","body":"Mergeability scenario test","draft":true}}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs7otuFv","number":101,"url":"https://github.com/test-owner/test-repo/pull/101"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1.024046708s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 139
+        host: api.github.com
+        body: |
+            {"query":"query($id:ID!){node(id: $id){... on PullRequest{mergeable,mergeStateStatus,isDraft}}}","variables":{"id":"PR_kwDOMVd0xs7otuFv"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"node":{"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","isDraft":true}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 409.086292ms

--- a/internal/forge/github/testdata/fixtures/TestIntegration/ChangeMergeability/Ready.yaml
+++ b/internal/forge/github/testdata/fixtures/TestIntegration/ChangeMergeability/Ready.yaml
@@ -1,0 +1,135 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 142
+        host: api.github.com
+        body: |
+            {"query":"query($owner:String!$repo:String!){repository(owner: $owner, name: $repo){id}}","variables":{"owner":"test-owner","repo":"test-repo"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"repository":{"id":"R_kgDOMVd0xg"}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 454.388917ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 320
+        host: api.github.com
+        body: |
+            {"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"ready-base-ZX1H7lxh","headRefName":"ready-head-qqHhbcZh","title":"Mergeability ready-head-qqHhbcZh","body":"Mergeability scenario test"}}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs7ottyc","number":99,"url":"https://github.com/test-owner/test-repo/pull/99"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1.026201417s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 139
+        host: api.github.com
+        body: |
+            {"query":"query($id:ID!){node(id: $id){... on PullRequest{mergeable,mergeStateStatus,isDraft}}}","variables":{"id":"PR_kwDOMVd0xs7ottyc"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"node":{"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","isDraft":false}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 488.611375ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 139
+        host: api.github.com
+        body: |
+            {"query":"query($id:ID!){node(id: $id){... on PullRequest{mergeable,mergeStateStatus,isDraft}}}","variables":{"id":"PR_kwDOMVd0xs7ottyc"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"node":{"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","isDraft":false}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 329.422709ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 139
+        host: api.github.com
+        body: |
+            {"query":"query($id:ID!){node(id: $id){... on PullRequest{mergeable,mergeStateStatus,isDraft}}}","variables":{"id":"PR_kwDOMVd0xs7ottyc"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"node":{"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","isDraft":false}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 540.088709ms


### PR DESCRIPTION
GitHub exposes two relevant merge readiness signals.

Detailed merge state status carries branch protection, draft,
and policy decisions.
The older mergeable field is useful as a fallback for conflict information.
