### PR TITLE
gitlab: Translate mergeability state

### DIFF
--- a/internal/forge/gitlab/integration_test.go
+++ b/internal/forge/gitlab/integration_test.go
@@ -115,7 +115,11 @@ func TestIntegration(t *testing.T) {
 			return newRepo
 		},
 		CloseChange: func(t *testing.T, repo forge.Repository, change forge.ChangeID) {
-			require.NoError(t, gitlabforge.CloseChange(t.Context(), repo.(*gitlabforge.Repository), change.(*gitlabforge.MR)))
+			require.NoError(t, gitlabforge.CloseChange(
+				context.WithoutCancel(t.Context()),
+				repo.(*gitlabforge.Repository),
+				change.(*gitlabforge.MR),
+			))
 		},
 		SetChangeCheck: func(
 			t *testing.T,
@@ -158,11 +162,8 @@ func TestIntegration(t *testing.T) {
 				time.Sleep(2 * time.Second)
 			}
 		},
-		// TODO: Remove SkipMergeability after the GitLab provider branch
-		// records scenario fixtures.
 		SetCommentsPageSize:   gitlabforge.SetListChangeCommentsPageSize,
 		BaseBranchMayBeAbsent: true,
-		SkipMergeability:      true,
 		SkipMerge:             true, // Merge requires MR approval settings to be disabled
 		Reviewers:             []string{cfg.Reviewer},
 		Assignees:             []string{cfg.Assignee},

--- a/internal/forge/gitlab/mergeability.go
+++ b/internal/forge/gitlab/mergeability.go
@@ -2,17 +2,135 @@ package gitlab
 
 import (
 	"context"
+	"fmt"
 
 	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/gateway/gitlab"
 )
 
+var _detailedMergeStatusMergeability = map[string]forge.ChangeMergeability{
+	gitlab.DetailedMergeStatusMergeable: {
+		State: forge.ChangeMergeabilityReady,
+	},
+	gitlab.DetailedMergeStatusApprovalsSyncing: {
+		State:  forge.ChangeMergeabilityWaiting,
+		Reason: forge.ChangeMergeabilityReasonReview,
+	},
+	gitlab.DetailedMergeStatusChecking: {
+		State: forge.ChangeMergeabilityWaiting,
+	},
+	gitlab.DetailedMergeStatusPreparing: {
+		State: forge.ChangeMergeabilityWaiting,
+	},
+	gitlab.DetailedMergeStatusUnchecked: {
+		State: forge.ChangeMergeabilityWaiting,
+	},
+	gitlab.DetailedMergeStatusCIStillRunning: {
+		State:  forge.ChangeMergeabilityWaiting,
+		Reason: forge.ChangeMergeabilityReasonChecks,
+	},
+	gitlab.DetailedMergeStatusCIMustPass: {
+		State:  forge.ChangeMergeabilityBlocked,
+		Reason: forge.ChangeMergeabilityReasonChecks,
+	},
+	gitlab.DetailedMergeStatusSecurityPolicyPipelineCheck: {
+		State:  forge.ChangeMergeabilityBlocked,
+		Reason: forge.ChangeMergeabilityReasonChecks,
+	},
+	gitlab.DetailedMergeStatusStatusChecksMustPass: {
+		State:  forge.ChangeMergeabilityBlocked,
+		Reason: forge.ChangeMergeabilityReasonChecks,
+	},
+	gitlab.DetailedMergeStatusConflict: {
+		State:  forge.ChangeMergeabilityBlocked,
+		Reason: forge.ChangeMergeabilityReasonConflicts,
+	},
+	gitlab.DetailedMergeStatusDiscussionsNotResolved: {
+		State:  forge.ChangeMergeabilityBlocked,
+		Reason: forge.ChangeMergeabilityReasonDiscussions,
+	},
+	gitlab.DetailedMergeStatusDraftStatus: {
+		State:  forge.ChangeMergeabilityBlocked,
+		Reason: forge.ChangeMergeabilityReasonDraft,
+	},
+	gitlab.DetailedMergeStatusNeedRebase: {
+		State:  forge.ChangeMergeabilityBlocked,
+		Reason: forge.ChangeMergeabilityReasonBehind,
+	},
+	gitlab.DetailedMergeStatusNotApproved: {
+		State:  forge.ChangeMergeabilityBlocked,
+		Reason: forge.ChangeMergeabilityReasonReview,
+	},
+	gitlab.DetailedMergeStatusRequestedChanges: {
+		State:  forge.ChangeMergeabilityBlocked,
+		Reason: forge.ChangeMergeabilityReasonReview,
+	},
+	gitlab.DetailedMergeStatusCommitsStatus: {
+		State:  forge.ChangeMergeabilityBlocked,
+		Reason: forge.ChangeMergeabilityReasonPolicy,
+	},
+	gitlab.DetailedMergeStatusJiraAssociationMissing: {
+		State:  forge.ChangeMergeabilityBlocked,
+		Reason: forge.ChangeMergeabilityReasonPolicy,
+	},
+	gitlab.DetailedMergeStatusMergeRequestBlocked: {
+		State:  forge.ChangeMergeabilityBlocked,
+		Reason: forge.ChangeMergeabilityReasonPolicy,
+	},
+	gitlab.DetailedMergeStatusMergeTime: {
+		State:  forge.ChangeMergeabilityBlocked,
+		Reason: forge.ChangeMergeabilityReasonPolicy,
+	},
+	gitlab.DetailedMergeStatusNotOpen: {
+		State:  forge.ChangeMergeabilityBlocked,
+		Reason: forge.ChangeMergeabilityReasonPolicy,
+	},
+	gitlab.DetailedMergeStatusSecurityPolicyViolations: {
+		State:  forge.ChangeMergeabilityBlocked,
+		Reason: forge.ChangeMergeabilityReasonPolicy,
+	},
+	gitlab.DetailedMergeStatusLockedPaths: {
+		State:  forge.ChangeMergeabilityBlocked,
+		Reason: forge.ChangeMergeabilityReasonPolicy,
+	},
+	gitlab.DetailedMergeStatusLockedLFSFiles: {
+		State:  forge.ChangeMergeabilityBlocked,
+		Reason: forge.ChangeMergeabilityReasonPolicy,
+	},
+	gitlab.DetailedMergeStatusTitleRegex: {
+		State:  forge.ChangeMergeabilityBlocked,
+		Reason: forge.ChangeMergeabilityReasonPolicy,
+	},
+}
+
 // ChangeMergeability reports whether the merge request can be merged.
-//
-// This compatibility implementation returns unknown until the GitLab-specific
-// mergeability translation is implemented.
 func (r *Repository) ChangeMergeability(
-	context.Context,
-	forge.ChangeID,
+	ctx context.Context,
+	fid forge.ChangeID,
 ) (forge.ChangeMergeability, error) {
-	return forge.ChangeMergeability{}, nil
+	id := mustMR(fid)
+	mr, _, err := r.client.MergeRequestGet(
+		ctx, r.repoID, id.Number, nil,
+	)
+	if err != nil {
+		return forge.ChangeMergeability{}, fmt.Errorf(
+			"get merge request: %w", err,
+		)
+	}
+
+	if mr.DetailedMergeStatus == gitlab.DetailedMergeStatusNeedRebase &&
+		mr.HasConflicts {
+		return forge.ChangeMergeability{
+			State:  forge.ChangeMergeabilityBlocked,
+			Reason: forge.ChangeMergeabilityReasonConflicts,
+		}, nil
+	}
+
+	if mergeability, ok := _detailedMergeStatusMergeability[mr.DetailedMergeStatus]; ok {
+		return mergeability, nil
+	}
+
+	return forge.ChangeMergeability{
+		State: forge.ChangeMergeabilityUnknown,
+	}, nil
 }

--- a/internal/forge/gitlab/mergeability_test.go
+++ b/internal/forge/gitlab/mergeability_test.go
@@ -1,0 +1,96 @@
+package gitlab
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/gateway/gitlab"
+)
+
+func TestRepository_ChangeMergeability(t *testing.T) {
+	tests := []struct {
+		name         string
+		status       string
+		hasConflicts bool
+		want         forge.ChangeMergeability
+	}{
+		{
+			name:   "Ready",
+			status: gitlab.DetailedMergeStatusMergeable,
+			want: forge.ChangeMergeability{
+				State: forge.ChangeMergeabilityReady,
+			},
+		},
+		{
+			name:   "BlockedByDraft",
+			status: gitlab.DetailedMergeStatusDraftStatus,
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityBlocked,
+				Reason: forge.ChangeMergeabilityReasonDraft,
+			},
+		},
+		{
+			name:         "NeedRebaseWithConflicts",
+			status:       gitlab.DetailedMergeStatusNeedRebase,
+			hasConflicts: true,
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityBlocked,
+				Reason: forge.ChangeMergeabilityReasonConflicts,
+			},
+		},
+		{
+			name:   "Unknown",
+			status: "new_gitlab_status",
+			want: forge.ChangeMergeability{
+				State: forge.ChangeMergeabilityUnknown,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, r *http.Request) {
+					assert.Equal(t, http.MethodGet, r.Method)
+					assert.Equal(
+						t,
+						"/api/v4/projects/42/merge_requests/55",
+						r.URL.Path,
+					)
+					assert.Empty(t, r.URL.RawQuery)
+
+					writeJSON(t, w, gitlab.MergeRequest{
+						BasicMergeRequest: gitlab.BasicMergeRequest{
+							DetailedMergeStatus: tt.status,
+							HasConflicts:        tt.hasConflicts,
+						},
+					})
+				},
+			))
+			defer srv.Close()
+
+			client, err := gitlab.NewClient(
+				gitlab.StaticTokenSource(gitlab.Token{
+					Type:  gitlab.TokenTypePrivateToken,
+					Value: "token",
+				}),
+				&gitlab.ClientOptions{
+					BaseURL:    srv.URL,
+					HTTPClient: srv.Client(),
+				},
+			)
+			require.NoError(t, err)
+
+			got, err := (&Repository{
+				client: client,
+				repoID: 42,
+			}).ChangeMergeability(t.Context(), &MR{Number: 55})
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/forge/gitlab/testdata/TestIntegration/ChangeMergeability/Conflicts/base
+++ b/internal/forge/gitlab/testdata/TestIntegration/ChangeMergeability/Conflicts/base
@@ -1,0 +1,1 @@
+"conflict-base-xqf8gR7x"

--- a/internal/forge/gitlab/testdata/TestIntegration/ChangeMergeability/Conflicts/head
+++ b/internal/forge/gitlab/testdata/TestIntegration/ChangeMergeability/Conflicts/head
@@ -1,0 +1,1 @@
+"conflict-head-vq5fX1hH"

--- a/internal/forge/gitlab/testdata/TestIntegration/ChangeMergeability/Draft/base
+++ b/internal/forge/gitlab/testdata/TestIntegration/ChangeMergeability/Draft/base
@@ -1,0 +1,1 @@
+"draft-base-1kuJzvwr"

--- a/internal/forge/gitlab/testdata/TestIntegration/ChangeMergeability/Draft/head
+++ b/internal/forge/gitlab/testdata/TestIntegration/ChangeMergeability/Draft/head
@@ -1,0 +1,1 @@
+"draft-head-dwnjAHAz"

--- a/internal/forge/gitlab/testdata/TestIntegration/ChangeMergeability/Ready/base
+++ b/internal/forge/gitlab/testdata/TestIntegration/ChangeMergeability/Ready/base
@@ -1,0 +1,1 @@
+"ready-base-gLGocWkk"

--- a/internal/forge/gitlab/testdata/TestIntegration/ChangeMergeability/Ready/head
+++ b/internal/forge/gitlab/testdata/TestIntegration/ChangeMergeability/Ready/head
@@ -1,0 +1,1 @@
+"ready-head-HFGvK79v"

--- a/internal/forge/gitlab/testdata/fixtures/TestIntegration/ChangeMergeability/Conflicts.yaml
+++ b/internal/forge/gitlab/testdata/fixtures/TestIntegration/ChangeMergeability/Conflicts.yaml
@@ -1,0 +1,185 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            User-Agent:
+                - git-spice
+        url: https://gitlab.com/api/v4/projects/test-owner%2Ftest-repo
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":64779801,"description":null,"name":"test-repo","name_with_namespace":"Abhinav Gupta / test-repo","path":"test-repo","path_with_namespace":"test-owner/test-repo","created_at":"2024-11-23T16:35:46.252Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:test-owner/test-repo.git","http_url_to_repo":"https://gitlab.com/test-owner/test-repo.git","web_url":"https://gitlab.com/test-owner/test-repo","readme_url":null,"forks_count":1,"avatar_url":null,"star_count":0,"last_activity_at":"2026-06-20T21:11:40.971Z","visibility":"public","namespace":{"id":1117393,"name":"Abhinav Gupta","path":"test-owner","kind":"user","full_path":"test-owner","parent_id":null,"avatar_url":"https://secure.gravatar.com/avatar/e9a34bfd0e7f9ab63137b7653f656daaddbb65e84d3ef0852febd4c3e889a835?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner"},"container_registry_image_prefix":"registry.gitlab.com/test-owner/test-repo","_links":{"self":"https://gitlab.com/api/v4/projects/64779801","merge_requests":"https://gitlab.com/api/v4/projects/64779801/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/64779801/repository/branches","labels":"https://gitlab.com/api/v4/projects/64779801/labels","events":"https://gitlab.com/api/v4/projects/64779801/events","members":"https://gitlab.com/api/v4/projects/64779801/members","cluster_agents":"https://gitlab.com/api/v4/projects/64779801/cluster_agents"},"marked_for_deletion_at":null,"marked_for_deletion_on":null,"packages_enabled":false,"empty_repo":false,"archived":false,"owner":{"id":930270,"username":"test-owner","public_email":"","name":"Abhinav Gupta","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/e9a34bfd0e7f9ab63137b7653f656daaddbb65e84d3ef0852febd4c3e889a835?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner"},"resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2024-11-24T16:35:46.274Z"},"repository_object_format":"sha1","issues_enabled":false,"merge_requests_enabled":true,"wiki_enabled":false,"jobs_enabled":false,"snippets_enabled":false,"container_registry_enabled":false,"service_desk_enabled":true,"can_create_merge_request_in":true,"issues_access_level":"disabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"disabled","builds_access_level":"disabled","snippets_access_level":"disabled","pages_access_level":"disabled","analytics_access_level":"disabled","container_registry_access_level":"disabled","security_and_compliance_access_level":"disabled","releases_access_level":"disabled","environments_access_level":"disabled","feature_flags_access_level":"disabled","infrastructure_access_level":"disabled","monitor_access_level":"disabled","model_experiments_access_level":"disabled","model_registry_access_level":"disabled","package_registry_access_level":"disabled","emails_disabled":true,"emails_enabled":false,"show_diff_preview_in_email":false,"shared_runners_enabled":true,"lfs_enabled":false,"creator_id":930270,"import_url":null,"import_type":null,"import_status":"none","import_error":null,"description_html":"","updated_at":"2026-06-20T21:16:53.512Z","ci_default_git_depth":20,"ci_delete_pipelines_in_seconds":null,"ci_forward_deployment_enabled":true,"ci_forward_deployment_rollback_allowed":true,"ci_job_token_scope_enabled":false,"ci_separated_caches":true,"ci_allow_fork_pipelines_to_run_in_parent_project":true,"ci_id_token_sub_claim_components":["project_path","ref_type","ref"],"build_git_strategy":"fetch","keep_latest_artifact":true,"restrict_user_defined_variables":false,"ci_pipeline_variables_minimum_override_role":"developer","runner_token_expiration_interval":null,"group_runners_enabled":true,"resource_group_default_process_mode":"unordered","auto_cancel_pending_pipelines":"enabled","build_timeout":3600,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","ci_push_repository_for_job_token_allowed":false,"protect_merge_request_pipelines":false,"ci_display_pipeline_variables":false,"runners_token":"GR1348941cpXSMHzfUhGHayaS5Bxv","ci_config_path":"","public_jobs":true,"shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"ff","squash_option":"default_on","enforce_auth_checks_on_uploads":true,"suggestion_commit_message":"","merge_commit_template":null,"squash_commit_template":null,"mr_default_title_template":null,"issue_branch_template":null,"warn_about_potentially_unwanted_characters":true,"autoclose_referenced_issues":true,"max_artifacts_size":null,"external_authorization_classification_label":"","requirements_enabled":false,"requirements_access_level":"enabled","security_and_compliance_enabled":false,"compliance_frameworks":[],"web_based_commit_signing_enabled":false,"permissions":{"project_access":{"access_level":50,"notification_level":3},"group_access":null}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 209.606291ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            User-Agent:
+                - git-spice
+        url: https://gitlab.com/api/v4/user
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":930270,"username":"test-owner","public_email":"","name":"Abhinav Gupta","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/e9a34bfd0e7f9ab63137b7653f656daaddbb65e84d3ef0852febd4c3e889a835?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner","created_at":"2017-01-07T03:40:46.795Z","bio":"","location":"","linkedin":"","twitter":"","discord":"","website_url":"https://abhinavg.net","github":"","job_title":"","pronouns":"","organization":"","bot":false,"work_information":null,"local_time":null,"last_sign_in_at":"2026-03-12T18:51:34.248Z","confirmed_at":"2021-10-19T01:30:11.688Z","last_activity_on":"2026-06-20","email":"mail@abhinavg.net","theme_id":3,"color_scheme_id":2,"projects_limit":100000,"current_sign_in_at":"2026-05-02T20:37:39.186Z","identities":[{"provider":"github","extern_uid":"41730","saml_provider_id":null}],"can_create_group":true,"can_create_project":true,"two_factor_enabled":true,"external":false,"private_profile":false,"commit_email":"mail@abhinavg.net","preferred_language":"en","shared_runners_minutes_limit":null,"extra_shared_runners_minutes_limit":null,"scim_identities":[]}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 172.007584ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 172
+        host: gitlab.com
+        body: '{"title":"Mergeability conflict-head-vq5fX1hH","description":"Mergeability scenario test","source_branch":"conflict-head-vq5fX1hH","target_branch":"conflict-base-xqf8gR7x"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - git-spice
+        url: https://gitlab.com/api/v4/projects/64779801/merge_requests
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1845
+        body: '{"id":498077611,"iid":79,"project_id":64779801,"title":"Mergeability conflict-head-vq5fX1hH","description":"Mergeability scenario test","state":"opened","created_at":"2026-06-20T21:17:14.546Z","updated_at":"2026-06-20T21:17:14.546Z","merged_by":null,"merge_user":null,"merged_at":null,"closed_by":null,"closed_at":null,"target_branch":"conflict-base-xqf8gR7x","source_branch":"conflict-head-vq5fX1hH","user_notes_count":0,"upvotes":0,"downvotes":0,"author":{"id":930270,"username":"test-owner","public_email":"","name":"Abhinav Gupta","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/e9a34bfd0e7f9ab63137b7653f656daaddbb65e84d3ef0852febd4c3e889a835?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner"},"assignees":[],"assignee":null,"reviewers":[],"source_project_id":64779801,"target_project_id":64779801,"labels":[],"draft":false,"imported":false,"imported_from":"none","work_in_progress":false,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"checking","detailed_merge_status":"preparing","merge_after":null,"sha":"40477c3a060378e29f947cdd41643eee72b06b04","merge_commit_sha":null,"squash_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":true,"prepared_at":null,"reference":"!79","references":{"short":"!79","relative":"!79","full":"test-owner/test-repo!79"},"web_url":"https://gitlab.com/test-owner/test-repo/-/merge_requests/79","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":true,"squash_on_merge":true,"task_completion_status":{"count":0,"completed_count":0},"has_conflicts":false,"blocking_discussions_resolved":true,"approvals_before_merge":null,"subscribed":true,"changes_count":null,"head_pipeline":null,"diff_refs":null,"merge_error":null,"user":{"can_merge":true}}'
+        headers:
+            Content-Length:
+                - "1845"
+            Content-Type:
+                - application/json
+        status: 201 Created
+        code: 201
+        duration: 465.742291ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            User-Agent:
+                - git-spice
+        url: https://gitlab.com/api/v4/projects/64779801/merge_requests/79
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":498077611,"iid":79,"project_id":64779801,"title":"Mergeability conflict-head-vq5fX1hH","description":"Mergeability scenario test","state":"opened","created_at":"2026-06-20T21:17:14.546Z","updated_at":"2026-06-20T21:17:14.546Z","merged_by":null,"merge_user":null,"merged_at":null,"closed_by":null,"closed_at":null,"target_branch":"conflict-base-xqf8gR7x","source_branch":"conflict-head-vq5fX1hH","user_notes_count":0,"upvotes":0,"downvotes":0,"author":{"id":930270,"username":"test-owner","public_email":"","name":"Abhinav Gupta","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/e9a34bfd0e7f9ab63137b7653f656daaddbb65e84d3ef0852febd4c3e889a835?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner"},"assignees":[],"assignee":null,"reviewers":[],"source_project_id":64779801,"target_project_id":64779801,"labels":[],"draft":false,"imported":false,"imported_from":"none","work_in_progress":false,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"checking","detailed_merge_status":"preparing","merge_after":null,"sha":"40477c3a060378e29f947cdd41643eee72b06b04","merge_commit_sha":null,"squash_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":true,"prepared_at":null,"reference":"!79","references":{"short":"!79","relative":"!79","full":"test-owner/test-repo!79"},"web_url":"https://gitlab.com/test-owner/test-repo/-/merge_requests/79","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":true,"squash_on_merge":true,"task_completion_status":{"count":0,"completed_count":0},"has_conflicts":false,"blocking_discussions_resolved":true,"approvals_before_merge":null,"subscribed":true,"changes_count":null,"head_pipeline":null,"diff_refs":null,"merge_error":null,"first_contribution":false,"user":{"can_merge":true}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 248.923167ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            User-Agent:
+                - git-spice
+        url: https://gitlab.com/api/v4/projects/64779801/merge_requests/79
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":498077611,"iid":79,"project_id":64779801,"title":"Mergeability conflict-head-vq5fX1hH","description":"Mergeability scenario test","state":"opened","created_at":"2026-06-20T21:17:14.546Z","updated_at":"2026-06-20T21:17:14.546Z","merged_by":null,"merge_user":null,"merged_at":null,"closed_by":null,"closed_at":null,"target_branch":"conflict-base-xqf8gR7x","source_branch":"conflict-head-vq5fX1hH","user_notes_count":0,"upvotes":0,"downvotes":0,"author":{"id":930270,"username":"test-owner","public_email":"","name":"Abhinav Gupta","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/e9a34bfd0e7f9ab63137b7653f656daaddbb65e84d3ef0852febd4c3e889a835?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner"},"assignees":[],"assignee":null,"reviewers":[],"source_project_id":64779801,"target_project_id":64779801,"labels":[],"draft":false,"imported":false,"imported_from":"none","work_in_progress":false,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"checking","detailed_merge_status":"checking","merge_after":null,"sha":"40477c3a060378e29f947cdd41643eee72b06b04","merge_commit_sha":null,"squash_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":true,"prepared_at":null,"reference":"!79","references":{"short":"!79","relative":"!79","full":"test-owner/test-repo!79"},"web_url":"https://gitlab.com/test-owner/test-repo/-/merge_requests/79","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":true,"squash_on_merge":true,"task_completion_status":{"count":0,"completed_count":0},"has_conflicts":false,"blocking_discussions_resolved":true,"approvals_before_merge":null,"subscribed":true,"changes_count":"1","head_pipeline":null,"diff_refs":{"base_sha":"027a92ee885af88f36b90ec20ea933dcd3f444c6","head_sha":"40477c3a060378e29f947cdd41643eee72b06b04","start_sha":"382a9436e8dae177c55183dd57871e99fd5b8506"},"merge_error":null,"first_contribution":false,"user":{"can_merge":true}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 266.211709ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            User-Agent:
+                - git-spice
+        url: https://gitlab.com/api/v4/projects/64779801/merge_requests/79
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":498077611,"iid":79,"project_id":64779801,"title":"Mergeability conflict-head-vq5fX1hH","description":"Mergeability scenario test","state":"opened","created_at":"2026-06-20T21:17:14.546Z","updated_at":"2026-06-20T21:17:15.537Z","merged_by":null,"merge_user":null,"merged_at":null,"closed_by":null,"closed_at":null,"target_branch":"conflict-base-xqf8gR7x","source_branch":"conflict-head-vq5fX1hH","user_notes_count":0,"upvotes":0,"downvotes":0,"author":{"id":930270,"username":"test-owner","public_email":"","name":"Abhinav Gupta","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/e9a34bfd0e7f9ab63137b7653f656daaddbb65e84d3ef0852febd4c3e889a835?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner"},"assignees":[],"assignee":null,"reviewers":[],"source_project_id":64779801,"target_project_id":64779801,"labels":[],"draft":false,"imported":false,"imported_from":"none","work_in_progress":false,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"cannot_be_merged","detailed_merge_status":"need_rebase","merge_after":null,"sha":"40477c3a060378e29f947cdd41643eee72b06b04","merge_commit_sha":null,"squash_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":true,"prepared_at":"2026-06-20T21:17:15.532Z","reference":"!79","references":{"short":"!79","relative":"!79","full":"test-owner/test-repo!79"},"web_url":"https://gitlab.com/test-owner/test-repo/-/merge_requests/79","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":true,"squash_on_merge":true,"task_completion_status":{"count":0,"completed_count":0},"has_conflicts":true,"blocking_discussions_resolved":true,"approvals_before_merge":null,"subscribed":true,"changes_count":"1","head_pipeline":null,"diff_refs":{"base_sha":"027a92ee885af88f36b90ec20ea933dcd3f444c6","head_sha":"40477c3a060378e29f947cdd41643eee72b06b04","start_sha":"382a9436e8dae177c55183dd57871e99fd5b8506"},"merge_error":null,"first_contribution":false,"user":{"can_merge":true}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 285.10325ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 23
+        host: gitlab.com
+        body: '{"state_event":"close"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - git-spice
+        url: https://gitlab.com/api/v4/projects/64779801/merge_requests/79
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":498077611,"iid":79,"project_id":64779801,"title":"Mergeability conflict-head-vq5fX1hH","description":"Mergeability scenario test","state":"closed","created_at":"2026-06-20T21:17:14.546Z","updated_at":"2026-06-20T21:17:16.322Z","merged_by":null,"merge_user":null,"merged_at":null,"closed_by":{"id":930270,"username":"test-owner","public_email":"","name":"Abhinav Gupta","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/e9a34bfd0e7f9ab63137b7653f656daaddbb65e84d3ef0852febd4c3e889a835?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner"},"closed_at":"2026-06-20T21:17:16.207Z","target_branch":"conflict-base-xqf8gR7x","source_branch":"conflict-head-vq5fX1hH","user_notes_count":0,"upvotes":0,"downvotes":0,"author":{"id":930270,"username":"test-owner","public_email":"","name":"Abhinav Gupta","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/e9a34bfd0e7f9ab63137b7653f656daaddbb65e84d3ef0852febd4c3e889a835?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner"},"assignees":[],"assignee":null,"reviewers":[],"source_project_id":64779801,"target_project_id":64779801,"labels":[],"draft":false,"imported":false,"imported_from":"none","work_in_progress":false,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"cannot_be_merged","detailed_merge_status":"not_open","merge_after":null,"sha":"40477c3a060378e29f947cdd41643eee72b06b04","merge_commit_sha":null,"squash_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":true,"prepared_at":"2026-06-20T21:17:15.532Z","reference":"!79","references":{"short":"!79","relative":"!79","full":"test-owner/test-repo!79"},"web_url":"https://gitlab.com/test-owner/test-repo/-/merge_requests/79","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":true,"squash_on_merge":true,"task_completion_status":{"count":0,"completed_count":0},"has_conflicts":true,"blocking_discussions_resolved":true,"approvals_before_merge":null,"subscribed":true,"changes_count":"1","head_pipeline":null,"diff_refs":{"base_sha":"027a92ee885af88f36b90ec20ea933dcd3f444c6","head_sha":"40477c3a060378e29f947cdd41643eee72b06b04","start_sha":"382a9436e8dae177c55183dd57871e99fd5b8506"},"merge_error":null,"user":{"can_merge":true}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 435.224334ms

--- a/internal/forge/gitlab/testdata/fixtures/TestIntegration/ChangeMergeability/Draft.yaml
+++ b/internal/forge/gitlab/testdata/fixtures/TestIntegration/ChangeMergeability/Draft.yaml
@@ -1,0 +1,185 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            User-Agent:
+                - git-spice
+        url: https://gitlab.com/api/v4/projects/test-owner%2Ftest-repo
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":64779801,"description":null,"name":"test-repo","name_with_namespace":"Abhinav Gupta / test-repo","path":"test-repo","path_with_namespace":"test-owner/test-repo","created_at":"2024-11-23T16:35:46.252Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:test-owner/test-repo.git","http_url_to_repo":"https://gitlab.com/test-owner/test-repo.git","web_url":"https://gitlab.com/test-owner/test-repo","readme_url":null,"forks_count":1,"avatar_url":null,"star_count":0,"last_activity_at":"2026-06-20T21:11:40.971Z","visibility":"public","namespace":{"id":1117393,"name":"Abhinav Gupta","path":"test-owner","kind":"user","full_path":"test-owner","parent_id":null,"avatar_url":"https://secure.gravatar.com/avatar/e9a34bfd0e7f9ab63137b7653f656daaddbb65e84d3ef0852febd4c3e889a835?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner"},"container_registry_image_prefix":"registry.gitlab.com/test-owner/test-repo","_links":{"self":"https://gitlab.com/api/v4/projects/64779801","merge_requests":"https://gitlab.com/api/v4/projects/64779801/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/64779801/repository/branches","labels":"https://gitlab.com/api/v4/projects/64779801/labels","events":"https://gitlab.com/api/v4/projects/64779801/events","members":"https://gitlab.com/api/v4/projects/64779801/members","cluster_agents":"https://gitlab.com/api/v4/projects/64779801/cluster_agents"},"marked_for_deletion_at":null,"marked_for_deletion_on":null,"packages_enabled":false,"empty_repo":false,"archived":false,"owner":{"id":930270,"username":"test-owner","public_email":"","name":"Abhinav Gupta","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/e9a34bfd0e7f9ab63137b7653f656daaddbb65e84d3ef0852febd4c3e889a835?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner"},"resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2024-11-24T16:35:46.274Z"},"repository_object_format":"sha1","issues_enabled":false,"merge_requests_enabled":true,"wiki_enabled":false,"jobs_enabled":false,"snippets_enabled":false,"container_registry_enabled":false,"service_desk_enabled":true,"can_create_merge_request_in":true,"issues_access_level":"disabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"disabled","builds_access_level":"disabled","snippets_access_level":"disabled","pages_access_level":"disabled","analytics_access_level":"disabled","container_registry_access_level":"disabled","security_and_compliance_access_level":"disabled","releases_access_level":"disabled","environments_access_level":"disabled","feature_flags_access_level":"disabled","infrastructure_access_level":"disabled","monitor_access_level":"disabled","model_experiments_access_level":"disabled","model_registry_access_level":"disabled","package_registry_access_level":"disabled","emails_disabled":true,"emails_enabled":false,"show_diff_preview_in_email":false,"shared_runners_enabled":true,"lfs_enabled":false,"creator_id":930270,"import_url":null,"import_type":null,"import_status":"none","import_error":null,"description_html":"","updated_at":"2026-06-20T21:16:53.512Z","ci_default_git_depth":20,"ci_delete_pipelines_in_seconds":null,"ci_forward_deployment_enabled":true,"ci_forward_deployment_rollback_allowed":true,"ci_job_token_scope_enabled":false,"ci_separated_caches":true,"ci_allow_fork_pipelines_to_run_in_parent_project":true,"ci_id_token_sub_claim_components":["project_path","ref_type","ref"],"build_git_strategy":"fetch","keep_latest_artifact":true,"restrict_user_defined_variables":false,"ci_pipeline_variables_minimum_override_role":"developer","runner_token_expiration_interval":null,"group_runners_enabled":true,"resource_group_default_process_mode":"unordered","auto_cancel_pending_pipelines":"enabled","build_timeout":3600,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","ci_push_repository_for_job_token_allowed":false,"protect_merge_request_pipelines":false,"ci_display_pipeline_variables":false,"runners_token":"GR1348941cpXSMHzfUhGHayaS5Bxv","ci_config_path":"","public_jobs":true,"shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"ff","squash_option":"default_on","enforce_auth_checks_on_uploads":true,"suggestion_commit_message":"","merge_commit_template":null,"squash_commit_template":null,"mr_default_title_template":null,"issue_branch_template":null,"warn_about_potentially_unwanted_characters":true,"autoclose_referenced_issues":true,"max_artifacts_size":null,"external_authorization_classification_label":"","requirements_enabled":false,"requirements_access_level":"enabled","security_and_compliance_enabled":false,"compliance_frameworks":[],"web_based_commit_signing_enabled":false,"permissions":{"project_access":{"access_level":50,"notification_level":3},"group_access":null}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 247.883208ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            User-Agent:
+                - git-spice
+        url: https://gitlab.com/api/v4/user
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":930270,"username":"test-owner","public_email":"","name":"Abhinav Gupta","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/e9a34bfd0e7f9ab63137b7653f656daaddbb65e84d3ef0852febd4c3e889a835?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner","created_at":"2017-01-07T03:40:46.795Z","bio":"","location":"","linkedin":"","twitter":"","discord":"","website_url":"https://abhinavg.net","github":"","job_title":"","pronouns":"","organization":"","bot":false,"work_information":null,"local_time":null,"last_sign_in_at":"2026-03-12T18:51:34.248Z","confirmed_at":"2021-10-19T01:30:11.688Z","last_activity_on":"2026-06-20","email":"mail@abhinavg.net","theme_id":3,"color_scheme_id":2,"projects_limit":100000,"current_sign_in_at":"2026-05-02T20:37:39.186Z","identities":[{"provider":"github","extern_uid":"41730","saml_provider_id":null}],"can_create_group":true,"can_create_project":true,"two_factor_enabled":true,"external":false,"private_profile":false,"commit_email":"mail@abhinavg.net","preferred_language":"en","shared_runners_minutes_limit":null,"extra_shared_runners_minutes_limit":null,"scim_identities":[]}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 157.480292ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 170
+        host: gitlab.com
+        body: '{"title":"Draft: Mergeability draft-head-dwnjAHAz","description":"Mergeability scenario test","source_branch":"draft-head-dwnjAHAz","target_branch":"draft-base-1kuJzvwr"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - git-spice
+        url: https://gitlab.com/api/v4/projects/64779801/merge_requests
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1841
+        body: '{"id":498077605,"iid":78,"project_id":64779801,"title":"Draft: Mergeability draft-head-dwnjAHAz","description":"Mergeability scenario test","state":"opened","created_at":"2026-06-20T21:17:09.272Z","updated_at":"2026-06-20T21:17:09.272Z","merged_by":null,"merge_user":null,"merged_at":null,"closed_by":null,"closed_at":null,"target_branch":"draft-base-1kuJzvwr","source_branch":"draft-head-dwnjAHAz","user_notes_count":0,"upvotes":0,"downvotes":0,"author":{"id":930270,"username":"test-owner","public_email":"","name":"Abhinav Gupta","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/e9a34bfd0e7f9ab63137b7653f656daaddbb65e84d3ef0852febd4c3e889a835?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner"},"assignees":[],"assignee":null,"reviewers":[],"source_project_id":64779801,"target_project_id":64779801,"labels":[],"draft":true,"imported":false,"imported_from":"none","work_in_progress":true,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"checking","detailed_merge_status":"preparing","merge_after":null,"sha":"1368ac5049bee3a9bae247a69beb5fcb26465cfb","merge_commit_sha":null,"squash_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":true,"prepared_at":null,"reference":"!78","references":{"short":"!78","relative":"!78","full":"test-owner/test-repo!78"},"web_url":"https://gitlab.com/test-owner/test-repo/-/merge_requests/78","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":true,"squash_on_merge":true,"task_completion_status":{"count":0,"completed_count":0},"has_conflicts":false,"blocking_discussions_resolved":true,"approvals_before_merge":null,"subscribed":true,"changes_count":null,"head_pipeline":null,"diff_refs":null,"merge_error":null,"user":{"can_merge":true}}'
+        headers:
+            Content-Length:
+                - "1841"
+            Content-Type:
+                - application/json
+        status: 201 Created
+        code: 201
+        duration: 574.846625ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            User-Agent:
+                - git-spice
+        url: https://gitlab.com/api/v4/projects/64779801/merge_requests/78
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":498077605,"iid":78,"project_id":64779801,"title":"Draft: Mergeability draft-head-dwnjAHAz","description":"Mergeability scenario test","state":"opened","created_at":"2026-06-20T21:17:09.272Z","updated_at":"2026-06-20T21:17:09.272Z","merged_by":null,"merge_user":null,"merged_at":null,"closed_by":null,"closed_at":null,"target_branch":"draft-base-1kuJzvwr","source_branch":"draft-head-dwnjAHAz","user_notes_count":0,"upvotes":0,"downvotes":0,"author":{"id":930270,"username":"test-owner","public_email":"","name":"Abhinav Gupta","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/e9a34bfd0e7f9ab63137b7653f656daaddbb65e84d3ef0852febd4c3e889a835?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner"},"assignees":[],"assignee":null,"reviewers":[],"source_project_id":64779801,"target_project_id":64779801,"labels":[],"draft":true,"imported":false,"imported_from":"none","work_in_progress":true,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"checking","detailed_merge_status":"preparing","merge_after":null,"sha":"1368ac5049bee3a9bae247a69beb5fcb26465cfb","merge_commit_sha":null,"squash_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":true,"prepared_at":null,"reference":"!78","references":{"short":"!78","relative":"!78","full":"test-owner/test-repo!78"},"web_url":"https://gitlab.com/test-owner/test-repo/-/merge_requests/78","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":true,"squash_on_merge":true,"task_completion_status":{"count":0,"completed_count":0},"has_conflicts":false,"blocking_discussions_resolved":true,"approvals_before_merge":null,"subscribed":true,"changes_count":null,"head_pipeline":null,"diff_refs":null,"merge_error":null,"first_contribution":false,"user":{"can_merge":true}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 324.515667ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            User-Agent:
+                - git-spice
+        url: https://gitlab.com/api/v4/projects/64779801/merge_requests/78
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":498077605,"iid":78,"project_id":64779801,"title":"Draft: Mergeability draft-head-dwnjAHAz","description":"Mergeability scenario test","state":"opened","created_at":"2026-06-20T21:17:09.272Z","updated_at":"2026-06-20T21:17:09.272Z","merged_by":null,"merge_user":null,"merged_at":null,"closed_by":null,"closed_at":null,"target_branch":"draft-base-1kuJzvwr","source_branch":"draft-head-dwnjAHAz","user_notes_count":0,"upvotes":0,"downvotes":0,"author":{"id":930270,"username":"test-owner","public_email":"","name":"Abhinav Gupta","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/e9a34bfd0e7f9ab63137b7653f656daaddbb65e84d3ef0852febd4c3e889a835?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner"},"assignees":[],"assignee":null,"reviewers":[],"source_project_id":64779801,"target_project_id":64779801,"labels":[],"draft":true,"imported":false,"imported_from":"none","work_in_progress":true,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"checking","detailed_merge_status":"checking","merge_after":null,"sha":"1368ac5049bee3a9bae247a69beb5fcb26465cfb","merge_commit_sha":null,"squash_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":true,"prepared_at":null,"reference":"!78","references":{"short":"!78","relative":"!78","full":"test-owner/test-repo!78"},"web_url":"https://gitlab.com/test-owner/test-repo/-/merge_requests/78","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":true,"squash_on_merge":true,"task_completion_status":{"count":0,"completed_count":0},"has_conflicts":false,"blocking_discussions_resolved":true,"approvals_before_merge":null,"subscribed":true,"changes_count":"1","head_pipeline":null,"diff_refs":{"base_sha":"027a92ee885af88f36b90ec20ea933dcd3f444c6","head_sha":"1368ac5049bee3a9bae247a69beb5fcb26465cfb","start_sha":"027a92ee885af88f36b90ec20ea933dcd3f444c6"},"merge_error":null,"first_contribution":false,"user":{"can_merge":true}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 241.062166ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            User-Agent:
+                - git-spice
+        url: https://gitlab.com/api/v4/projects/64779801/merge_requests/78
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":498077605,"iid":78,"project_id":64779801,"title":"Draft: Mergeability draft-head-dwnjAHAz","description":"Mergeability scenario test","state":"opened","created_at":"2026-06-20T21:17:09.272Z","updated_at":"2026-06-20T21:17:10.167Z","merged_by":null,"merge_user":null,"merged_at":null,"closed_by":null,"closed_at":null,"target_branch":"draft-base-1kuJzvwr","source_branch":"draft-head-dwnjAHAz","user_notes_count":0,"upvotes":0,"downvotes":0,"author":{"id":930270,"username":"test-owner","public_email":"","name":"Abhinav Gupta","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/e9a34bfd0e7f9ab63137b7653f656daaddbb65e84d3ef0852febd4c3e889a835?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner"},"assignees":[],"assignee":null,"reviewers":[],"source_project_id":64779801,"target_project_id":64779801,"labels":[],"draft":true,"imported":false,"imported_from":"none","work_in_progress":true,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"can_be_merged","detailed_merge_status":"draft_status","merge_after":null,"sha":"1368ac5049bee3a9bae247a69beb5fcb26465cfb","merge_commit_sha":null,"squash_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":true,"prepared_at":"2026-06-20T21:17:10.162Z","reference":"!78","references":{"short":"!78","relative":"!78","full":"test-owner/test-repo!78"},"web_url":"https://gitlab.com/test-owner/test-repo/-/merge_requests/78","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":true,"squash_on_merge":true,"task_completion_status":{"count":0,"completed_count":0},"has_conflicts":false,"blocking_discussions_resolved":true,"approvals_before_merge":null,"subscribed":true,"changes_count":"1","head_pipeline":null,"diff_refs":{"base_sha":"027a92ee885af88f36b90ec20ea933dcd3f444c6","head_sha":"1368ac5049bee3a9bae247a69beb5fcb26465cfb","start_sha":"027a92ee885af88f36b90ec20ea933dcd3f444c6"},"merge_error":null,"first_contribution":false,"user":{"can_merge":true}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 223.374666ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 23
+        host: gitlab.com
+        body: '{"state_event":"close"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - git-spice
+        url: https://gitlab.com/api/v4/projects/64779801/merge_requests/78
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":498077605,"iid":78,"project_id":64779801,"title":"Draft: Mergeability draft-head-dwnjAHAz","description":"Mergeability scenario test","state":"closed","created_at":"2026-06-20T21:17:09.272Z","updated_at":"2026-06-20T21:17:11.005Z","merged_by":null,"merge_user":null,"merged_at":null,"closed_by":{"id":930270,"username":"test-owner","public_email":"","name":"Abhinav Gupta","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/e9a34bfd0e7f9ab63137b7653f656daaddbb65e84d3ef0852febd4c3e889a835?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner"},"closed_at":"2026-06-20T21:17:10.849Z","target_branch":"draft-base-1kuJzvwr","source_branch":"draft-head-dwnjAHAz","user_notes_count":0,"upvotes":0,"downvotes":0,"author":{"id":930270,"username":"test-owner","public_email":"","name":"Abhinav Gupta","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/e9a34bfd0e7f9ab63137b7653f656daaddbb65e84d3ef0852febd4c3e889a835?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner"},"assignees":[],"assignee":null,"reviewers":[],"source_project_id":64779801,"target_project_id":64779801,"labels":[],"draft":true,"imported":false,"imported_from":"none","work_in_progress":true,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"can_be_merged","detailed_merge_status":"not_open","merge_after":null,"sha":"1368ac5049bee3a9bae247a69beb5fcb26465cfb","merge_commit_sha":null,"squash_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":true,"prepared_at":"2026-06-20T21:17:10.162Z","reference":"!78","references":{"short":"!78","relative":"!78","full":"test-owner/test-repo!78"},"web_url":"https://gitlab.com/test-owner/test-repo/-/merge_requests/78","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":true,"squash_on_merge":true,"task_completion_status":{"count":0,"completed_count":0},"has_conflicts":false,"blocking_discussions_resolved":true,"approvals_before_merge":null,"subscribed":true,"changes_count":"1","head_pipeline":null,"diff_refs":{"base_sha":"027a92ee885af88f36b90ec20ea933dcd3f444c6","head_sha":"1368ac5049bee3a9bae247a69beb5fcb26465cfb","start_sha":"027a92ee885af88f36b90ec20ea933dcd3f444c6"},"merge_error":null,"user":{"can_merge":true}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 427.253875ms

--- a/internal/forge/gitlab/testdata/fixtures/TestIntegration/ChangeMergeability/Ready.yaml
+++ b/internal/forge/gitlab/testdata/fixtures/TestIntegration/ChangeMergeability/Ready.yaml
@@ -1,0 +1,160 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            User-Agent:
+                - git-spice
+        url: https://gitlab.com/api/v4/projects/test-owner%2Ftest-repo
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":64779801,"description":null,"name":"test-repo","name_with_namespace":"Abhinav Gupta / test-repo","path":"test-repo","path_with_namespace":"test-owner/test-repo","created_at":"2024-11-23T16:35:46.252Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:test-owner/test-repo.git","http_url_to_repo":"https://gitlab.com/test-owner/test-repo.git","web_url":"https://gitlab.com/test-owner/test-repo","readme_url":null,"forks_count":1,"avatar_url":null,"star_count":0,"last_activity_at":"2026-06-20T21:11:40.971Z","visibility":"public","namespace":{"id":1117393,"name":"Abhinav Gupta","path":"test-owner","kind":"user","full_path":"test-owner","parent_id":null,"avatar_url":"https://secure.gravatar.com/avatar/e9a34bfd0e7f9ab63137b7653f656daaddbb65e84d3ef0852febd4c3e889a835?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner"},"container_registry_image_prefix":"registry.gitlab.com/test-owner/test-repo","_links":{"self":"https://gitlab.com/api/v4/projects/64779801","merge_requests":"https://gitlab.com/api/v4/projects/64779801/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/64779801/repository/branches","labels":"https://gitlab.com/api/v4/projects/64779801/labels","events":"https://gitlab.com/api/v4/projects/64779801/events","members":"https://gitlab.com/api/v4/projects/64779801/members","cluster_agents":"https://gitlab.com/api/v4/projects/64779801/cluster_agents"},"marked_for_deletion_at":null,"marked_for_deletion_on":null,"packages_enabled":false,"empty_repo":false,"archived":false,"owner":{"id":930270,"username":"test-owner","public_email":"","name":"Abhinav Gupta","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/e9a34bfd0e7f9ab63137b7653f656daaddbb65e84d3ef0852febd4c3e889a835?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner"},"resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2024-11-24T16:35:46.274Z"},"repository_object_format":"sha1","issues_enabled":false,"merge_requests_enabled":true,"wiki_enabled":false,"jobs_enabled":false,"snippets_enabled":false,"container_registry_enabled":false,"service_desk_enabled":true,"can_create_merge_request_in":true,"issues_access_level":"disabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"disabled","builds_access_level":"disabled","snippets_access_level":"disabled","pages_access_level":"disabled","analytics_access_level":"disabled","container_registry_access_level":"disabled","security_and_compliance_access_level":"disabled","releases_access_level":"disabled","environments_access_level":"disabled","feature_flags_access_level":"disabled","infrastructure_access_level":"disabled","monitor_access_level":"disabled","model_experiments_access_level":"disabled","model_registry_access_level":"disabled","package_registry_access_level":"disabled","emails_disabled":true,"emails_enabled":false,"show_diff_preview_in_email":false,"shared_runners_enabled":true,"lfs_enabled":false,"creator_id":930270,"import_url":null,"import_type":null,"import_status":"none","import_error":null,"description_html":"","updated_at":"2026-06-20T21:16:53.512Z","ci_default_git_depth":20,"ci_delete_pipelines_in_seconds":null,"ci_forward_deployment_enabled":true,"ci_forward_deployment_rollback_allowed":true,"ci_job_token_scope_enabled":false,"ci_separated_caches":true,"ci_allow_fork_pipelines_to_run_in_parent_project":true,"ci_id_token_sub_claim_components":["project_path","ref_type","ref"],"build_git_strategy":"fetch","keep_latest_artifact":true,"restrict_user_defined_variables":false,"ci_pipeline_variables_minimum_override_role":"developer","runner_token_expiration_interval":null,"group_runners_enabled":true,"resource_group_default_process_mode":"unordered","auto_cancel_pending_pipelines":"enabled","build_timeout":3600,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","ci_push_repository_for_job_token_allowed":false,"protect_merge_request_pipelines":false,"ci_display_pipeline_variables":false,"runners_token":"GR1348941cpXSMHzfUhGHayaS5Bxv","ci_config_path":"","public_jobs":true,"shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"ff","squash_option":"default_on","enforce_auth_checks_on_uploads":true,"suggestion_commit_message":"","merge_commit_template":null,"squash_commit_template":null,"mr_default_title_template":null,"issue_branch_template":null,"warn_about_potentially_unwanted_characters":true,"autoclose_referenced_issues":true,"max_artifacts_size":null,"external_authorization_classification_label":"","requirements_enabled":false,"requirements_access_level":"enabled","security_and_compliance_enabled":false,"compliance_frameworks":[],"web_based_commit_signing_enabled":false,"permissions":{"project_access":{"access_level":50,"notification_level":3},"group_access":null}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 361.672292ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            User-Agent:
+                - git-spice
+        url: https://gitlab.com/api/v4/user
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":930270,"username":"test-owner","public_email":"","name":"Abhinav Gupta","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/e9a34bfd0e7f9ab63137b7653f656daaddbb65e84d3ef0852febd4c3e889a835?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner","created_at":"2017-01-07T03:40:46.795Z","bio":"","location":"","linkedin":"","twitter":"","discord":"","website_url":"https://abhinavg.net","github":"","job_title":"","pronouns":"","organization":"","bot":false,"work_information":null,"local_time":null,"last_sign_in_at":"2026-03-12T18:51:34.248Z","confirmed_at":"2021-10-19T01:30:11.688Z","last_activity_on":"2026-06-20","email":"mail@abhinavg.net","theme_id":3,"color_scheme_id":2,"projects_limit":100000,"current_sign_in_at":"2026-05-02T20:37:39.186Z","identities":[{"provider":"github","extern_uid":"41730","saml_provider_id":null}],"can_create_group":true,"can_create_project":true,"two_factor_enabled":true,"external":false,"private_profile":false,"commit_email":"mail@abhinavg.net","preferred_language":"en","shared_runners_minutes_limit":null,"extra_shared_runners_minutes_limit":null,"scim_identities":[]}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 184.111083ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 163
+        host: gitlab.com
+        body: '{"title":"Mergeability ready-head-HFGvK79v","description":"Mergeability scenario test","source_branch":"ready-head-HFGvK79v","target_branch":"ready-base-gLGocWkk"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - git-spice
+        url: https://gitlab.com/api/v4/projects/64779801/merge_requests
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1836
+        body: '{"id":498077593,"iid":77,"project_id":64779801,"title":"Mergeability ready-head-HFGvK79v","description":"Mergeability scenario test","state":"opened","created_at":"2026-06-20T21:16:55.876Z","updated_at":"2026-06-20T21:16:55.876Z","merged_by":null,"merge_user":null,"merged_at":null,"closed_by":null,"closed_at":null,"target_branch":"ready-base-gLGocWkk","source_branch":"ready-head-HFGvK79v","user_notes_count":0,"upvotes":0,"downvotes":0,"author":{"id":930270,"username":"test-owner","public_email":"","name":"Abhinav Gupta","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/e9a34bfd0e7f9ab63137b7653f656daaddbb65e84d3ef0852febd4c3e889a835?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner"},"assignees":[],"assignee":null,"reviewers":[],"source_project_id":64779801,"target_project_id":64779801,"labels":[],"draft":false,"imported":false,"imported_from":"none","work_in_progress":false,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"checking","detailed_merge_status":"preparing","merge_after":null,"sha":"be82eb68de2de87fa0fc9366e9222f9dd3ec2e85","merge_commit_sha":null,"squash_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":true,"prepared_at":null,"reference":"!77","references":{"short":"!77","relative":"!77","full":"test-owner/test-repo!77"},"web_url":"https://gitlab.com/test-owner/test-repo/-/merge_requests/77","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":true,"squash_on_merge":true,"task_completion_status":{"count":0,"completed_count":0},"has_conflicts":false,"blocking_discussions_resolved":true,"approvals_before_merge":null,"subscribed":true,"changes_count":null,"head_pipeline":null,"diff_refs":null,"merge_error":null,"user":{"can_merge":true}}'
+        headers:
+            Content-Length:
+                - "1836"
+            Content-Type:
+                - application/json
+        status: 201 Created
+        code: 201
+        duration: 822.538542ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            User-Agent:
+                - git-spice
+        url: https://gitlab.com/api/v4/projects/64779801/merge_requests/77
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":498077593,"iid":77,"project_id":64779801,"title":"Mergeability ready-head-HFGvK79v","description":"Mergeability scenario test","state":"opened","created_at":"2026-06-20T21:16:55.876Z","updated_at":"2026-06-20T21:16:55.876Z","merged_by":null,"merge_user":null,"merged_at":null,"closed_by":null,"closed_at":null,"target_branch":"ready-base-gLGocWkk","source_branch":"ready-head-HFGvK79v","user_notes_count":0,"upvotes":0,"downvotes":0,"author":{"id":930270,"username":"test-owner","public_email":"","name":"Abhinav Gupta","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/e9a34bfd0e7f9ab63137b7653f656daaddbb65e84d3ef0852febd4c3e889a835?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner"},"assignees":[],"assignee":null,"reviewers":[],"source_project_id":64779801,"target_project_id":64779801,"labels":[],"draft":false,"imported":false,"imported_from":"none","work_in_progress":false,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"checking","detailed_merge_status":"preparing","merge_after":null,"sha":"be82eb68de2de87fa0fc9366e9222f9dd3ec2e85","merge_commit_sha":null,"squash_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":true,"prepared_at":null,"reference":"!77","references":{"short":"!77","relative":"!77","full":"test-owner/test-repo!77"},"web_url":"https://gitlab.com/test-owner/test-repo/-/merge_requests/77","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":true,"squash_on_merge":true,"task_completion_status":{"count":0,"completed_count":0},"has_conflicts":false,"blocking_discussions_resolved":true,"approvals_before_merge":null,"subscribed":true,"changes_count":"1","head_pipeline":null,"diff_refs":{"base_sha":"027a92ee885af88f36b90ec20ea933dcd3f444c6","head_sha":"be82eb68de2de87fa0fc9366e9222f9dd3ec2e85","start_sha":"027a92ee885af88f36b90ec20ea933dcd3f444c6"},"merge_error":null,"first_contribution":false,"user":{"can_merge":true}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 337.088333ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            User-Agent:
+                - git-spice
+        url: https://gitlab.com/api/v4/projects/64779801/merge_requests/77
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":498077593,"iid":77,"project_id":64779801,"title":"Mergeability ready-head-HFGvK79v","description":"Mergeability scenario test","state":"opened","created_at":"2026-06-20T21:16:55.876Z","updated_at":"2026-06-20T21:16:57.007Z","merged_by":null,"merge_user":null,"merged_at":null,"closed_by":null,"closed_at":null,"target_branch":"ready-base-gLGocWkk","source_branch":"ready-head-HFGvK79v","user_notes_count":0,"upvotes":0,"downvotes":0,"author":{"id":930270,"username":"test-owner","public_email":"","name":"Abhinav Gupta","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/e9a34bfd0e7f9ab63137b7653f656daaddbb65e84d3ef0852febd4c3e889a835?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner"},"assignees":[],"assignee":null,"reviewers":[],"source_project_id":64779801,"target_project_id":64779801,"labels":[],"draft":false,"imported":false,"imported_from":"none","work_in_progress":false,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"can_be_merged","detailed_merge_status":"mergeable","merge_after":null,"sha":"be82eb68de2de87fa0fc9366e9222f9dd3ec2e85","merge_commit_sha":null,"squash_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":true,"prepared_at":"2026-06-20T21:16:57.002Z","reference":"!77","references":{"short":"!77","relative":"!77","full":"test-owner/test-repo!77"},"web_url":"https://gitlab.com/test-owner/test-repo/-/merge_requests/77","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":true,"squash_on_merge":true,"task_completion_status":{"count":0,"completed_count":0},"has_conflicts":false,"blocking_discussions_resolved":true,"approvals_before_merge":null,"subscribed":true,"changes_count":"1","head_pipeline":null,"diff_refs":{"base_sha":"027a92ee885af88f36b90ec20ea933dcd3f444c6","head_sha":"be82eb68de2de87fa0fc9366e9222f9dd3ec2e85","start_sha":"027a92ee885af88f36b90ec20ea933dcd3f444c6"},"merge_error":null,"first_contribution":false,"user":{"can_merge":true}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 286.391958ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 23
+        host: gitlab.com
+        body: '{"state_event":"close"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - git-spice
+        url: https://gitlab.com/api/v4/projects/64779801/merge_requests/77
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":498077593,"iid":77,"project_id":64779801,"title":"Mergeability ready-head-HFGvK79v","description":"Mergeability scenario test","state":"closed","created_at":"2026-06-20T21:16:55.876Z","updated_at":"2026-06-20T21:16:57.475Z","merged_by":null,"merge_user":null,"merged_at":null,"closed_by":{"id":930270,"username":"test-owner","public_email":"","name":"Abhinav Gupta","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/e9a34bfd0e7f9ab63137b7653f656daaddbb65e84d3ef0852febd4c3e889a835?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner"},"closed_at":"2026-06-20T21:16:57.378Z","target_branch":"ready-base-gLGocWkk","source_branch":"ready-head-HFGvK79v","user_notes_count":0,"upvotes":0,"downvotes":0,"author":{"id":930270,"username":"test-owner","public_email":"","name":"Abhinav Gupta","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/e9a34bfd0e7f9ab63137b7653f656daaddbb65e84d3ef0852febd4c3e889a835?s=80\u0026d=identicon","web_url":"https://gitlab.com/test-owner"},"assignees":[],"assignee":null,"reviewers":[],"source_project_id":64779801,"target_project_id":64779801,"labels":[],"draft":false,"imported":false,"imported_from":"none","work_in_progress":false,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"can_be_merged","detailed_merge_status":"not_open","merge_after":null,"sha":"be82eb68de2de87fa0fc9366e9222f9dd3ec2e85","merge_commit_sha":null,"squash_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":true,"prepared_at":"2026-06-20T21:16:57.002Z","reference":"!77","references":{"short":"!77","relative":"!77","full":"test-owner/test-repo!77"},"web_url":"https://gitlab.com/test-owner/test-repo/-/merge_requests/77","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":true,"squash_on_merge":true,"task_completion_status":{"count":0,"completed_count":0},"has_conflicts":false,"blocking_discussions_resolved":true,"approvals_before_merge":null,"subscribed":true,"changes_count":"1","head_pipeline":null,"diff_refs":{"base_sha":"027a92ee885af88f36b90ec20ea933dcd3f444c6","head_sha":"be82eb68de2de87fa0fc9366e9222f9dd3ec2e85","start_sha":"027a92ee885af88f36b90ec20ea933dcd3f444c6"},"merge_error":null,"user":{"can_merge":true}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 374.644041ms

--- a/internal/gateway/gitlab/api.go
+++ b/internal/gateway/gitlab/api.go
@@ -524,6 +524,8 @@ type BasicMergeRequest struct {
 	SHA                     string       `json:"sha"`
 	WebURL                  string       `json:"web_url"`
 	ForceRemoveSourceBranch bool         `json:"force_remove_source_branch"`
+	DetailedMergeStatus     string       `json:"detailed_merge_status"`
+	HasConflicts            bool         `json:"has_conflicts"`
 }
 
 // MergeRequest matches the merge request response shape
@@ -574,6 +576,36 @@ const (
 	PipelineStatusSkipped            = "skipped"
 	PipelineStatusManual             = "manual"
 	PipelineStatusScheduled          = "scheduled"
+)
+
+// GitLab detailed merge status values.
+//
+// https://docs.gitlab.com/api/merge_requests/#merge-status
+const (
+	DetailedMergeStatusApprovalsSyncing            = "approvals_syncing"
+	DetailedMergeStatusChecking                    = "checking"
+	DetailedMergeStatusCIMustPass                  = "ci_must_pass"
+	DetailedMergeStatusCIStillRunning              = "ci_still_running"
+	DetailedMergeStatusCommitsStatus               = "commits_status"
+	DetailedMergeStatusConflict                    = "conflict"
+	DetailedMergeStatusDiscussionsNotResolved      = "discussions_not_resolved"
+	DetailedMergeStatusDraftStatus                 = "draft_status"
+	DetailedMergeStatusJiraAssociationMissing      = "jira_association_missing"
+	DetailedMergeStatusMergeable                   = "mergeable"
+	DetailedMergeStatusMergeRequestBlocked         = "merge_request_blocked"
+	DetailedMergeStatusMergeTime                   = "merge_time"
+	DetailedMergeStatusNeedRebase                  = "need_rebase"
+	DetailedMergeStatusNotApproved                 = "not_approved"
+	DetailedMergeStatusNotOpen                     = "not_open"
+	DetailedMergeStatusPreparing                   = "preparing"
+	DetailedMergeStatusRequestedChanges            = "requested_changes"
+	DetailedMergeStatusSecurityPolicyPipelineCheck = "security_policy_pipeline_check"
+	DetailedMergeStatusSecurityPolicyViolations    = "security_policy_violations"
+	DetailedMergeStatusStatusChecksMustPass        = "status_checks_must_pass"
+	DetailedMergeStatusUnchecked                   = "unchecked"
+	DetailedMergeStatusLockedPaths                 = "locked_paths"
+	DetailedMergeStatusLockedLFSFiles              = "locked_lfs_files"
+	DetailedMergeStatusTitleRegex                  = "title_regex"
 )
 
 // NoteAuthor matches the nested author object in note responses.

--- a/internal/gateway/gitlab/api_test.go
+++ b/internal/gateway/gitlab/api_test.go
@@ -126,10 +126,11 @@ func TestClient_MergeRequestGet(t *testing.T) {
 		assert.Equal(t, "/api/v4/projects/42/merge_requests/55", r.URL.Path)
 		writeJSON(t, w, http.StatusOK, MergeRequest{
 			BasicMergeRequest: BasicMergeRequest{
-				IID:          55,
-				Title:        "Stabilize nacelles",
-				TargetBranch: "main",
-				Labels:       []string{"engineering"},
+				IID:                 55,
+				Title:               "Stabilize nacelles",
+				TargetBranch:        "main",
+				Labels:              []string{"engineering"},
+				DetailedMergeStatus: DetailedMergeStatusMergeable,
 				Reviewers: []*BasicUser{
 					{ID: 12, Username: "spock"},
 				},
@@ -142,6 +143,7 @@ func TestClient_MergeRequestGet(t *testing.T) {
 	mr, _, err := client.MergeRequestGet(t.Context(), int64(42), 55, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "Stabilize nacelles", mr.Title)
+	assert.Equal(t, DetailedMergeStatusMergeable, mr.DetailedMergeStatus)
 	require.Len(t, mr.Reviewers, 1)
 	assert.Equal(t, "spock", mr.Reviewers[0].Username)
 }


### PR DESCRIPTION
GitLab exposes merge readiness through detailed merge status on merge requests.
Map that provider-specific status into the shared forge result.
Merge commands can then wait on that same contract across forges.

GitLab reports some conflicting fast-forward-only merge requests as
`need_rebase` with `has_conflicts` set.
Decode that extra field so those merge requests report conflicts.
They should not report a plain behind state.
