### PR TITLE
shamhub: Simulate mergeability state

### DIFF
--- a/internal/forge/github/integration_test.go
+++ b/internal/forge/github/integration_test.go
@@ -139,9 +139,6 @@ func TestIntegration(t *testing.T) {
 				check,
 			))
 		},
-		// TODO: Remove SkipMergeability after the GitHub provider branch
-		// records scenario fixtures.
-		SkipMergeability:    true,
 		SetCommentsPageSize: github.SetListChangeCommentsPageSize,
 		Reviewers:           []string{cfg.Reviewer},
 		Assignees:           []string{cfg.Assignee},

--- a/internal/forge/github/mergeability.go
+++ b/internal/forge/github/mergeability.go
@@ -83,7 +83,7 @@ func changeMergeabilityFromGitHub(
 		}
 	case githubv4.MergeStateStatusBlocked:
 		return forge.ChangeMergeability{
-			State:  forge.ChangeMergeabilityBlocked,
+			State:  forge.ChangeMergeabilityWaiting,
 			Reason: forge.ChangeMergeabilityReasonUnknown,
 		}
 	}

--- a/internal/forge/github/mergeability.go
+++ b/internal/forge/github/mergeability.go
@@ -2,17 +2,111 @@ package github
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/shurcooL/githubv4"
 	"go.abhg.dev/gs/internal/forge"
 )
 
 // ChangeMergeability reports whether the pull request can be merged.
-//
-// This compatibility implementation returns unknown until the GitHub-specific
-// mergeability translation is implemented.
 func (r *Repository) ChangeMergeability(
-	context.Context,
-	forge.ChangeID,
+	ctx context.Context,
+	fid forge.ChangeID,
 ) (forge.ChangeMergeability, error) {
-	return forge.ChangeMergeability{}, nil
+	pr := mustPR(fid)
+	gqlID, err := r.graphQLID(ctx, pr)
+	if err != nil {
+		return forge.ChangeMergeability{},
+			fmt.Errorf("resolve PR ID: %w", err)
+	}
+
+	var q struct {
+		Node struct {
+			PullRequest struct {
+				Mergeable        githubv4.MergeableState   `graphql:"mergeable"`
+				MergeStateStatus githubv4.MergeStateStatus `graphql:"mergeStateStatus"`
+				IsDraft          githubv4.Boolean          `graphql:"isDraft"`
+			} `graphql:"... on PullRequest"`
+		} `graphql:"node(id: $id)"`
+	}
+	if err := r.client.Query(ctx, &q, map[string]any{
+		"id": gqlID,
+	}); err != nil {
+		return forge.ChangeMergeability{},
+			fmt.Errorf("query mergeability: %w", err)
+	}
+
+	return changeMergeabilityFromGitHub(
+		q.Node.PullRequest.Mergeable,
+		q.Node.PullRequest.MergeStateStatus,
+		bool(q.Node.PullRequest.IsDraft),
+	), nil
+}
+
+func changeMergeabilityFromGitHub(
+	mergeable githubv4.MergeableState,
+	mergeState githubv4.MergeStateStatus,
+	isDraft bool,
+) forge.ChangeMergeability {
+	if isDraft {
+		// GitHub can report UNKNOWN merge state for drafts while its
+		// mergeability calculation is still settling.
+		// Use isDraft directly so drafts do not look like generic waiting.
+		return forge.ChangeMergeability{
+			State:  forge.ChangeMergeabilityBlocked,
+			Reason: forge.ChangeMergeabilityReasonDraft,
+		}
+	}
+
+	switch mergeState {
+	case githubv4.MergeStateStatusClean,
+		githubv4.MergeStateStatusHasHooks,
+		githubv4.MergeStateStatusUnstable:
+		return forge.ChangeMergeability{
+			State:  forge.ChangeMergeabilityReady,
+			Reason: forge.ChangeMergeabilityReasonUnknown,
+		}
+	case githubv4.MergeStateStatusDirty:
+		return forge.ChangeMergeability{
+			State:  forge.ChangeMergeabilityBlocked,
+			Reason: forge.ChangeMergeabilityReasonConflicts,
+		}
+	case githubv4.MergeStateStatusBehind:
+		return forge.ChangeMergeability{
+			State:  forge.ChangeMergeabilityBlocked,
+			Reason: forge.ChangeMergeabilityReasonBehind,
+		}
+	case githubv4.MergeStateStatusDraft:
+		return forge.ChangeMergeability{
+			State:  forge.ChangeMergeabilityBlocked,
+			Reason: forge.ChangeMergeabilityReasonDraft,
+		}
+	case githubv4.MergeStateStatusBlocked:
+		return forge.ChangeMergeability{
+			State:  forge.ChangeMergeabilityBlocked,
+			Reason: forge.ChangeMergeabilityReasonUnknown,
+		}
+	}
+
+	switch mergeable {
+	case githubv4.MergeableStateConflicting:
+		return forge.ChangeMergeability{
+			State:  forge.ChangeMergeabilityBlocked,
+			Reason: forge.ChangeMergeabilityReasonConflicts,
+		}
+	case githubv4.MergeableStateMergeable,
+		githubv4.MergeableStateUnknown:
+		// PullRequest.mergeable only reports the conflict calculation.
+		// When mergeStateStatus is UNKNOWN or unsupported,
+		// MERGEABLE does not prove that branch protection is satisfied.
+		return forge.ChangeMergeability{
+			State:  forge.ChangeMergeabilityWaiting,
+			Reason: forge.ChangeMergeabilityReasonUnknown,
+		}
+	default:
+		return forge.ChangeMergeability{
+			State:  forge.ChangeMergeabilityUnknown,
+			Reason: forge.ChangeMergeabilityReasonUnknown,
+		}
+	}
 }

--- a/internal/forge/github/mergeability_test.go
+++ b/internal/forge/github/mergeability_test.go
@@ -160,11 +160,11 @@ func TestChangeMergeabilityFromGitHub(t *testing.T) {
 			},
 		},
 		{
-			name:           "Blocked",
+			name:           "BlockedWaits",
 			giveMergeable:  githubv4.MergeableStateMergeable,
 			giveMergeState: githubv4.MergeStateStatusBlocked,
 			want: forge.ChangeMergeability{
-				State:  forge.ChangeMergeabilityBlocked,
+				State:  forge.ChangeMergeabilityWaiting,
 				Reason: forge.ChangeMergeabilityReasonUnknown,
 			},
 		},

--- a/internal/forge/github/mergeability_test.go
+++ b/internal/forge/github/mergeability_test.go
@@ -1,0 +1,218 @@
+package github
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/shurcooL/githubv4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/silog/silogtest"
+)
+
+func TestRepository_ChangeMergeability(t *testing.T) {
+	var queried bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+
+		var body struct {
+			Query     string `json:"query"`
+			Variables struct {
+				ID string `json:"id"`
+			} `json:"variables"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "prID", body.Variables.ID)
+		assert.Contains(t, body.Query, "mergeable")
+		assert.Contains(t, body.Query, "mergeStateStatus")
+		assert.Contains(t, body.Query, "isDraft")
+		queried = true
+
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"node": map[string]any{
+					"mergeable":        "MERGEABLE",
+					"mergeStateStatus": "CLEAN",
+					"isDraft":          false,
+				},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	repo, err := newRepository(
+		t.Context(), new(Forge),
+		"owner", "repo",
+		silogtest.New(t),
+		githubv4.NewEnterpriseClient(srv.URL, nil),
+		"repoID",
+	)
+	require.NoError(t, err)
+
+	got, err := repo.ChangeMergeability(
+		t.Context(),
+		&PR{Number: 1, GQLID: "prID"},
+	)
+	require.NoError(t, err)
+	assert.True(t, queried)
+	assert.Equal(t, forge.ChangeMergeability{
+		State:  forge.ChangeMergeabilityReady,
+		Reason: forge.ChangeMergeabilityReasonUnknown,
+	}, got)
+}
+
+func TestRepository_ChangeMergeability_wrapsQueryError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "offline", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	repo, err := newRepository(
+		t.Context(), new(Forge),
+		"owner", "repo",
+		silogtest.New(t),
+		githubv4.NewEnterpriseClient(srv.URL, nil),
+		"repoID",
+	)
+	require.NoError(t, err)
+
+	_, err = repo.ChangeMergeability(
+		t.Context(),
+		&PR{Number: 1, GQLID: "prID"},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "query mergeability")
+}
+
+func TestChangeMergeabilityFromGitHub(t *testing.T) {
+	tests := []struct {
+		name           string
+		giveMergeable  githubv4.MergeableState
+		giveMergeState githubv4.MergeStateStatus
+		giveDraft      bool
+		want           forge.ChangeMergeability
+	}{
+		{
+			name:           "Clean",
+			giveMergeable:  githubv4.MergeableStateMergeable,
+			giveMergeState: githubv4.MergeStateStatusClean,
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityReady,
+				Reason: forge.ChangeMergeabilityReasonUnknown,
+			},
+		},
+		{
+			name:           "HasHooks",
+			giveMergeable:  githubv4.MergeableStateMergeable,
+			giveMergeState: githubv4.MergeStateStatusHasHooks,
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityReady,
+				Reason: forge.ChangeMergeabilityReasonUnknown,
+			},
+		},
+		{
+			name:           "Unstable",
+			giveMergeable:  githubv4.MergeableStateMergeable,
+			giveMergeState: githubv4.MergeStateStatusUnstable,
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityReady,
+				Reason: forge.ChangeMergeabilityReasonUnknown,
+			},
+		},
+		{
+			name:           "Dirty",
+			giveMergeable:  githubv4.MergeableStateConflicting,
+			giveMergeState: githubv4.MergeStateStatusDirty,
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityBlocked,
+				Reason: forge.ChangeMergeabilityReasonConflicts,
+			},
+		},
+		{
+			name:           "Behind",
+			giveMergeable:  githubv4.MergeableStateMergeable,
+			giveMergeState: githubv4.MergeStateStatusBehind,
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityBlocked,
+				Reason: forge.ChangeMergeabilityReasonBehind,
+			},
+		},
+		{
+			name:           "DraftStatus",
+			giveMergeable:  githubv4.MergeableStateMergeable,
+			giveMergeState: githubv4.MergeStateStatusDraft,
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityBlocked,
+				Reason: forge.ChangeMergeabilityReasonDraft,
+			},
+		},
+		{
+			name:           "DraftFlag",
+			giveMergeable:  githubv4.MergeableStateMergeable,
+			giveMergeState: githubv4.MergeStateStatusClean,
+			giveDraft:      true,
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityBlocked,
+				Reason: forge.ChangeMergeabilityReasonDraft,
+			},
+		},
+		{
+			name:           "Blocked",
+			giveMergeable:  githubv4.MergeableStateMergeable,
+			giveMergeState: githubv4.MergeStateStatusBlocked,
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityBlocked,
+				Reason: forge.ChangeMergeabilityReasonUnknown,
+			},
+		},
+		{
+			name:           "MergeableWithUnknownStatus",
+			giveMergeable:  githubv4.MergeableStateMergeable,
+			giveMergeState: githubv4.MergeStateStatusUnknown,
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityWaiting,
+				Reason: forge.ChangeMergeabilityReasonUnknown,
+			},
+		},
+		{
+			name:           "ConflictingFallback",
+			giveMergeable:  githubv4.MergeableStateConflicting,
+			giveMergeState: githubv4.MergeStateStatusUnknown,
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityBlocked,
+				Reason: forge.ChangeMergeabilityReasonConflicts,
+			},
+		},
+		{
+			name:           "Waiting",
+			giveMergeable:  githubv4.MergeableStateUnknown,
+			giveMergeState: githubv4.MergeStateStatusUnknown,
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityWaiting,
+				Reason: forge.ChangeMergeabilityReasonUnknown,
+			},
+		},
+		{
+			name:           "Unknown",
+			giveMergeable:  githubv4.MergeableState("RECALIBRATING"),
+			giveMergeState: githubv4.MergeStateStatus("RECALIBRATING"),
+			want: forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityUnknown,
+				Reason: forge.ChangeMergeabilityReasonUnknown,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, changeMergeabilityFromGitHub(
+				tt.giveMergeable,
+				tt.giveMergeState,
+				tt.giveDraft,
+			))
+		})
+	}
+}

--- a/internal/forge/github/testdata/TestIntegration/ChangeMergeability/Conflicts/base
+++ b/internal/forge/github/testdata/TestIntegration/ChangeMergeability/Conflicts/base
@@ -1,0 +1,1 @@
+"conflict-base-cBqnd2m8"

--- a/internal/forge/github/testdata/TestIntegration/ChangeMergeability/Conflicts/head
+++ b/internal/forge/github/testdata/TestIntegration/ChangeMergeability/Conflicts/head
@@ -1,0 +1,1 @@
+"conflict-head-BUQewFPF"

--- a/internal/forge/github/testdata/TestIntegration/ChangeMergeability/Draft/base
+++ b/internal/forge/github/testdata/TestIntegration/ChangeMergeability/Draft/base
@@ -1,0 +1,1 @@
+"draft-base-7sbpxhAZ"

--- a/internal/forge/github/testdata/TestIntegration/ChangeMergeability/Draft/head
+++ b/internal/forge/github/testdata/TestIntegration/ChangeMergeability/Draft/head
@@ -1,0 +1,1 @@
+"draft-head-AfhiKihF"

--- a/internal/forge/github/testdata/TestIntegration/ChangeMergeability/Ready/base
+++ b/internal/forge/github/testdata/TestIntegration/ChangeMergeability/Ready/base
@@ -1,0 +1,1 @@
+"ready-base-ZX1H7lxh"

--- a/internal/forge/github/testdata/TestIntegration/ChangeMergeability/Ready/head
+++ b/internal/forge/github/testdata/TestIntegration/ChangeMergeability/Ready/head
@@ -1,0 +1,1 @@
+"ready-head-qqHhbcZh"

--- a/internal/forge/github/testdata/fixtures/TestIntegration/ChangeMergeability/Conflicts.yaml
+++ b/internal/forge/github/testdata/fixtures/TestIntegration/ChangeMergeability/Conflicts.yaml
@@ -1,0 +1,134 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 142
+        host: api.github.com
+        body: |
+            {"query":"query($owner:String!$repo:String!){repository(owner: $owner, name: $repo){id}}","variables":{"owner":"test-owner","repo":"test-repo"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"repository":{"id":"R_kgDOMVd0xg"}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 220.632125ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 329
+        host: api.github.com
+        body: |
+            {"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"conflict-base-cBqnd2m8","headRefName":"conflict-head-BUQewFPF","title":"Mergeability conflict-head-BUQewFPF","body":"Mergeability scenario test"}}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs7ott7e","number":100,"url":"https://github.com/test-owner/test-repo/pull/100"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 951.806458ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 139
+        host: api.github.com
+        body: |
+            {"query":"query($id:ID!){node(id: $id){... on PullRequest{mergeable,mergeStateStatus,isDraft}}}","variables":{"id":"PR_kwDOMVd0xs7ott7e"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"node":{"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","isDraft":false}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 569.707459ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 139
+        host: api.github.com
+        body: |
+            {"query":"query($id:ID!){node(id: $id){... on PullRequest{mergeable,mergeStateStatus,isDraft}}}","variables":{"id":"PR_kwDOMVd0xs7ott7e"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"node":{"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","isDraft":false}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 408.535375ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 139
+        host: api.github.com
+        body: |
+            {"query":"query($id:ID!){node(id: $id){... on PullRequest{mergeable,mergeStateStatus,isDraft}}}","variables":{"id":"PR_kwDOMVd0xs7ott7e"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"node":{"mergeable":"CONFLICTING","mergeStateStatus":"DIRTY","isDraft":false}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 292.826208ms

--- a/internal/forge/github/testdata/fixtures/TestIntegration/ChangeMergeability/Draft.yaml
+++ b/internal/forge/github/testdata/fixtures/TestIntegration/ChangeMergeability/Draft.yaml
@@ -1,0 +1,82 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 142
+        host: api.github.com
+        body: |
+            {"query":"query($owner:String!$repo:String!){repository(owner: $owner, name: $repo){id}}","variables":{"owner":"test-owner","repo":"test-repo"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"repository":{"id":"R_kgDOMVd0xg"}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 213.54775ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 333
+        host: api.github.com
+        body: |
+            {"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"draft-base-7sbpxhAZ","headRefName":"draft-head-AfhiKihF","title":"Mergeability draft-head-AfhiKihF","body":"Mergeability scenario test","draft":true}}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs7otuFv","number":101,"url":"https://github.com/test-owner/test-repo/pull/101"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1.024046708s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 139
+        host: api.github.com
+        body: |
+            {"query":"query($id:ID!){node(id: $id){... on PullRequest{mergeable,mergeStateStatus,isDraft}}}","variables":{"id":"PR_kwDOMVd0xs7otuFv"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"node":{"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","isDraft":true}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 409.086292ms

--- a/internal/forge/github/testdata/fixtures/TestIntegration/ChangeMergeability/Ready.yaml
+++ b/internal/forge/github/testdata/fixtures/TestIntegration/ChangeMergeability/Ready.yaml
@@ -1,0 +1,135 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 142
+        host: api.github.com
+        body: |
+            {"query":"query($owner:String!$repo:String!){repository(owner: $owner, name: $repo){id}}","variables":{"owner":"test-owner","repo":"test-repo"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"repository":{"id":"R_kgDOMVd0xg"}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 454.388917ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 320
+        host: api.github.com
+        body: |
+            {"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"ready-base-ZX1H7lxh","headRefName":"ready-head-qqHhbcZh","title":"Mergeability ready-head-qqHhbcZh","body":"Mergeability scenario test"}}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs7ottyc","number":99,"url":"https://github.com/test-owner/test-repo/pull/99"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1.026201417s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 139
+        host: api.github.com
+        body: |
+            {"query":"query($id:ID!){node(id: $id){... on PullRequest{mergeable,mergeStateStatus,isDraft}}}","variables":{"id":"PR_kwDOMVd0xs7ottyc"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"node":{"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","isDraft":false}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 488.611375ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 139
+        host: api.github.com
+        body: |
+            {"query":"query($id:ID!){node(id: $id){... on PullRequest{mergeable,mergeStateStatus,isDraft}}}","variables":{"id":"PR_kwDOMVd0xs7ottyc"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"node":{"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","isDraft":false}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 329.422709ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 139
+        host: api.github.com
+        body: |
+            {"query":"query($id:ID!){node(id: $id){... on PullRequest{mergeable,mergeStateStatus,isDraft}}}","variables":{"id":"PR_kwDOMVd0xs7ottyc"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"node":{"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","isDraft":false}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 540.088709ms

--- a/internal/forge/shamhub/change.go
+++ b/internal/forge/shamhub/change.go
@@ -110,6 +110,9 @@ type shamChange struct {
 
 	// Checks lists the CI/checks reported for the change.
 	Checks []forge.ChangeCheck
+
+	// Mergeability overrides ShamHub's inferred mergeability result.
+	Mergeability *forge.ChangeMergeability
 }
 
 // Change is a change proposal against a repository.

--- a/internal/forge/shamhub/cli.go
+++ b/internal/forge/shamhub/cli.go
@@ -322,6 +322,52 @@ runCommand:
 			State: state,
 		}))
 
+	case "set-mergeability":
+		if sh == nil {
+			ts.Fatalf("ShamHub not initialized")
+		}
+
+		logw, closeLogw := ioutil.PrintfWriter(ts.Logf, "shamhub set-mergeability: ")
+		ts.Defer(closeLogw)
+
+		flag := flag.NewFlagSet("shamhub set-mergeability", flag.ContinueOnError)
+		flag.SetOutput(logw)
+		flag.Usage = func() {
+			fmt.Fprintln(logw,
+				"usage: shamhub set-mergeability "+
+					"[-reason <reason>] <owner/repo> <pr> <state>")
+		}
+
+		reason := flag.String("reason", "", "mergeability reason")
+		ts.Check(flag.Parse(args))
+		args = flag.Args()
+		if len(args) != 3 {
+			flag.Usage()
+			ts.Fatalf("expected 3 arguments, got %d", len(args))
+		}
+
+		ownerRepo, prStr, status := args[0], args[1], args[2]
+		owner, repo, ok := strings.Cut(ownerRepo, "/")
+		if !ok {
+			ts.Fatalf("invalid owner/repo: %s", ownerRepo)
+		}
+		repo = strings.TrimSuffix(repo, ".git")
+		pr, err := strconv.Atoi(prStr)
+		if err != nil {
+			ts.Fatalf("invalid PR number: %s", err)
+		}
+		mergeability, err := parseMergeability(status, *reason)
+		if err != nil {
+			ts.Fatalf("%s", err)
+		}
+
+		ts.Check(sh.SetChangeMergeability(SetChangeMergeabilityRequest{
+			Owner:        owner,
+			Repo:         repo,
+			Number:       pr,
+			Mergeability: mergeability,
+		}))
+
 	case "merge":
 		if sh == nil {
 			ts.Fatalf("ShamHub not initialized")

--- a/internal/forge/shamhub/integration_test.go
+++ b/internal/forge/shamhub/integration_test.go
@@ -193,9 +193,7 @@ func TestIntegration(t *testing.T) {
 				))
 		},
 		SetCommentsPageSize: SetListChangeCommentsPageSize,
-		// TODO: Remove SkipMergeability on the ShamHub provider branch.
-		SkipMergeability: true,
-		Reviewers:        []string{"reviewer1", "reviewer2"},
-		Assignees:        []string{"assignee1", "assignee2"},
+		Reviewers:           []string{"reviewer1", "reviewer2"},
+		Assignees:           []string{"assignee1", "assignee2"},
 	})
 }

--- a/internal/forge/shamhub/mergeability.go
+++ b/internal/forge/shamhub/mergeability.go
@@ -2,17 +2,329 @@ package shamhub
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
 
 	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/xec"
 )
 
-// ChangeMergeability reports whether the change can be merged.
-//
-// This compatibility implementation returns unknown until the ShamHub-specific
-// mergeability simulation is implemented.
-func (r *forgeRepository) ChangeMergeability(
-	context.Context,
-	forge.ChangeID,
+type changeMergeabilityRequest struct {
+	Owner  string `path:"owner" json:"-"`
+	Repo   string `path:"repo" json:"-"`
+	Number int    `path:"number" json:"-"`
+}
+
+type changeMergeabilityResponse struct {
+	State  string `json:"state"`
+	Reason string `json:"reason,omitempty"`
+}
+
+var _ = shamhubRESTHandler(
+	"GET /{owner}/{repo}/change/{number}/mergeability",
+	(*ShamHub).handleChangeMergeability,
+)
+
+func (sh *ShamHub) handleChangeMergeability(
+	_ context.Context,
+	req changeMergeabilityRequest,
+) (*changeMergeabilityResponse, error) {
+	mergeability, err := sh.ChangeMergeability(req.Owner, req.Repo, req.Number)
+	if err != nil {
+		return nil, err
+	}
+	return &changeMergeabilityResponse{
+		State:  mergeability.State.String(),
+		Reason: mergeability.Reason.String(),
+	}, nil
+}
+
+// SetChangeMergeabilityRequest requests a simulated mergeability result
+// for one ShamHub change.
+type SetChangeMergeabilityRequest struct {
+	// Owner is the base repository owner.
+	Owner string
+
+	// Repo is the base repository name.
+	Repo string
+
+	// Number is the change number in the base repository.
+	Number int
+
+	// Mergeability is the result ShamHub should report for the change.
+	Mergeability forge.ChangeMergeability
+}
+
+// SetChangeMergeability sets a simulated mergeability result for a change.
+func (sh *ShamHub) SetChangeMergeability(req SetChangeMergeabilityRequest) error {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+
+	for i, change := range sh.changes {
+		if change.Base.Owner == req.Owner &&
+			change.Base.Repo == req.Repo &&
+			change.Number == req.Number {
+			sh.changes[i].Mergeability = &req.Mergeability
+			return nil
+		}
+	}
+
+	return notFoundErrorf(
+		"change %d (%v/%v) not found",
+		req.Number, req.Owner, req.Repo,
+	)
+}
+
+type setMergeabilityRequest struct {
+	Owner  string `path:"owner" json:"-"`
+	Repo   string `path:"repo" json:"-"`
+	Number int    `path:"number" json:"-"`
+
+	State  string `json:"state"`
+	Reason string `json:"reason,omitempty"`
+}
+
+type setMergeabilityResponse struct{}
+
+var _ = shamhubRESTHandler(
+	"POST /{owner}/{repo}/change/{number}/mergeability",
+	(*ShamHub).handleSetMergeability,
+)
+
+func (sh *ShamHub) handleSetMergeability(
+	_ context.Context,
+	req setMergeabilityRequest,
+) (*setMergeabilityResponse, error) {
+	mergeability, err := parseMergeability(req.State, req.Reason)
+	if err != nil {
+		return nil, badRequestErrorf("%s", err)
+	}
+	if err := sh.SetChangeMergeability(SetChangeMergeabilityRequest{
+		Owner:        req.Owner,
+		Repo:         req.Repo,
+		Number:       req.Number,
+		Mergeability: mergeability,
+	}); err != nil {
+		return nil, err
+	}
+	return &setMergeabilityResponse{}, nil
+}
+
+// ChangeMergeability reports whether ShamHub can merge the change.
+func (sh *ShamHub) ChangeMergeability(
+	owner string,
+	repo string,
+	number int,
 ) (forge.ChangeMergeability, error) {
-	return forge.ChangeMergeability{}, nil
+	change, ok := sh.findChange(owner, repo, number)
+	if !ok {
+		return forge.ChangeMergeability{}, notFoundErrorf(
+			"change %d (%v/%v) not found",
+			number, owner, repo,
+		)
+	}
+	if change.Mergeability != nil {
+		return *change.Mergeability, nil
+	}
+	if change.State != shamChangeOpen {
+		return forge.ChangeMergeability{
+			State: forge.ChangeMergeabilityBlocked,
+		}, nil
+	}
+	if change.Draft {
+		return forge.ChangeMergeability{
+			State:  forge.ChangeMergeabilityBlocked,
+			Reason: forge.ChangeMergeabilityReasonDraft,
+		}, nil
+	}
+
+	if err := sh.canMerge(change); err != nil {
+		var mergeTreeErr mergeTreeError
+		if errors.As(err, &mergeTreeErr) && mergeTreeErr.Conflict() {
+			return forge.ChangeMergeability{
+				State:  forge.ChangeMergeabilityBlocked,
+				Reason: forge.ChangeMergeabilityReasonConflicts,
+			}, nil
+		}
+		return forge.ChangeMergeability{}, fmt.Errorf("check mergeability: %w", err)
+	}
+
+	return forge.ChangeMergeability{
+		State: forge.ChangeMergeabilityReady,
+	}, nil
+}
+
+func (sh *ShamHub) findChange(owner, repo string, number int) (shamChange, bool) {
+	sh.mu.RLock()
+	defer sh.mu.RUnlock()
+
+	for _, change := range sh.changes {
+		if change.Base.Owner == owner &&
+			change.Base.Repo == repo &&
+			change.Number == number {
+			return change, true
+		}
+	}
+	return shamChange{}, false
+}
+
+func (sh *ShamHub) canMerge(change shamChange) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	targetRepoDir := sh.repoDir(change.Base.Owner, change.Base.Repo)
+	if !sh.branchRefExists(
+		ctx, change.Base.Owner, change.Base.Repo, change.Base.Name,
+	) {
+		return fmt.Errorf("base branch %q does not exist", change.Base.Name)
+	}
+
+	headRef := change.Head.Name
+	if change.Head.Owner != change.Base.Owner ||
+		change.Head.Repo != change.Base.Repo {
+		if !sh.branchRefExists(
+			ctx, change.Head.Owner, change.Head.Repo, change.Head.Name,
+		) {
+			return fmt.Errorf("head branch %q does not exist", change.Head.Name)
+		}
+
+		forkRepoDir := sh.repoDir(change.Head.Owner, change.Head.Repo)
+		headRef = "refs/shamhub/mergeability/" +
+			strconv.Itoa(change.Number) + "/head"
+		if err := xec.Command(
+			ctx, sh.log, sh.gitExe, "update-ref", "-d", headRef,
+		).WithDir(targetRepoDir).Run(); err != nil {
+			return fmt.Errorf("delete cached head branch: %w", err)
+		}
+		if err := xec.Command(
+			ctx, sh.log, sh.gitExe,
+			"fetch", forkRepoDir, change.Head.Name+":"+headRef,
+		).WithDir(targetRepoDir).Run(); err != nil {
+			return fmt.Errorf("fetch head branch: %w", err)
+		}
+	} else if !sh.branchRefExists(
+		ctx, change.Head.Owner, change.Head.Repo, change.Head.Name,
+	) {
+		return fmt.Errorf("head branch %q does not exist", change.Head.Name)
+	}
+
+	if err := xec.Command(
+		ctx, sh.log, sh.gitExe,
+		"merge-tree", "--write-tree", change.Base.Name, headRef,
+	).WithDir(targetRepoDir).Run(); err != nil {
+		return mergeTreeError{err: err}
+	}
+	return nil
+}
+
+type mergeTreeError struct {
+	err error
+}
+
+func (e mergeTreeError) Error() string {
+	return "merge-tree: " + e.err.Error()
+}
+
+func (e mergeTreeError) Unwrap() error {
+	return e.err
+}
+
+func (e mergeTreeError) Conflict() bool {
+	var exitErr *xec.ExitError
+	return errors.As(e.err, &exitErr) && exitErr.ExitCode() == 1
+}
+
+// ChangeMergeability reports whether the change can be merged.
+func (r *forgeRepository) ChangeMergeability(
+	ctx context.Context,
+	fid forge.ChangeID,
+) (forge.ChangeMergeability, error) {
+	id := fid.(ChangeID)
+	u := r.apiURL.JoinPath(
+		r.owner, r.repo,
+		"change", strconv.Itoa(int(id)), "mergeability",
+	)
+
+	var res changeMergeabilityResponse
+	if err := r.client.Get(ctx, u.String(), &res); err != nil {
+		return forge.ChangeMergeability{}, fmt.Errorf("get mergeability: %w", err)
+	}
+	return parseMergeability(res.State, res.Reason)
+}
+
+func (r *forgeRepository) setChangeMergeability(
+	ctx context.Context,
+	fid forge.ChangeID,
+	mergeability forge.ChangeMergeability,
+) error {
+	id := fid.(ChangeID)
+	u := r.apiURL.JoinPath(
+		r.owner, r.repo,
+		"change", strconv.Itoa(int(id)), "mergeability",
+	)
+
+	req := setMergeabilityRequest{
+		State:  mergeability.State.String(),
+		Reason: mergeability.Reason.String(),
+	}
+	var res setMergeabilityResponse
+	if err := r.client.Post(ctx, u.String(), req, &res); err != nil {
+		return fmt.Errorf("set mergeability: %w", err)
+	}
+	return nil
+}
+
+func parseMergeability(state, reason string) (forge.ChangeMergeability, error) {
+	mergeabilityState, err := parseMergeabilityState(state)
+	if err != nil {
+		return forge.ChangeMergeability{}, err
+	}
+	mergeabilityReason, err := parseMergeabilityReason(reason)
+	if err != nil {
+		return forge.ChangeMergeability{}, err
+	}
+	return forge.ChangeMergeability{
+		State:  mergeabilityState,
+		Reason: mergeabilityReason,
+	}, nil
+}
+
+func parseMergeabilityState(value string) (forge.ChangeMergeabilityState, error) {
+	switch strings.ToLower(value) {
+	case "", "unknown":
+		return forge.ChangeMergeabilityUnknown, nil
+	case "ready":
+		return forge.ChangeMergeabilityReady, nil
+	case "waiting":
+		return forge.ChangeMergeabilityWaiting, nil
+	case "blocked":
+		return forge.ChangeMergeabilityBlocked, nil
+	default:
+		return 0, fmt.Errorf("unsupported mergeability state %q", value)
+	}
+}
+
+func parseMergeabilityReason(value string) (forge.ChangeMergeabilityReason, error) {
+	switch strings.ToLower(value) {
+	case "", "unknown":
+		return forge.ChangeMergeabilityReasonUnknown, nil
+	case "checks":
+		return forge.ChangeMergeabilityReasonChecks, nil
+	case "review":
+		return forge.ChangeMergeabilityReasonReview, nil
+	case "draft":
+		return forge.ChangeMergeabilityReasonDraft, nil
+	case "conflicts":
+		return forge.ChangeMergeabilityReasonConflicts, nil
+	case "behind":
+		return forge.ChangeMergeabilityReasonBehind, nil
+	case "discussions":
+		return forge.ChangeMergeabilityReasonDiscussions, nil
+	case "policy":
+		return forge.ChangeMergeabilityReasonPolicy, nil
+	default:
+		return 0, fmt.Errorf("unsupported mergeability reason %q", value)
+	}
 }

--- a/internal/forge/shamhub/mergeability_test.go
+++ b/internal/forge/shamhub/mergeability_test.go
@@ -1,0 +1,460 @@
+package shamhub
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rogpeppe/go-internal/testscript"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/silog"
+	"go.abhg.dev/gs/internal/silog/silogtest"
+)
+
+func TestForgeRepository_ChangeMergeability_configured(t *testing.T) {
+	sh, repo := newMergeabilityTestRepository(t)
+	seedMergeabilityChange(sh)
+
+	require.NoError(t, sh.SetChangeMergeability(SetChangeMergeabilityRequest{
+		Owner:  "alice",
+		Repo:   "example",
+		Number: 1,
+		Mergeability: forge.ChangeMergeability{
+			State:  forge.ChangeMergeabilityBlocked,
+			Reason: forge.ChangeMergeabilityReasonPolicy,
+		},
+	}))
+
+	got, err := repo.ChangeMergeability(t.Context(), ChangeID(1))
+	require.NoError(t, err)
+	assert.Equal(t, forge.ChangeMergeability{
+		State:  forge.ChangeMergeabilityBlocked,
+		Reason: forge.ChangeMergeabilityReasonPolicy,
+	}, got)
+}
+
+func TestForgeRepository_setChangeMergeability(t *testing.T) {
+	sh, repo := newMergeabilityTestRepository(t)
+	seedMergeabilityChange(sh)
+
+	require.NoError(t, repo.setChangeMergeability(
+		t.Context(),
+		ChangeID(1),
+		forge.ChangeMergeability{
+			State:  forge.ChangeMergeabilityWaiting,
+			Reason: forge.ChangeMergeabilityReasonChecks,
+		},
+	))
+
+	got, err := repo.ChangeMergeability(t.Context(), ChangeID(1))
+	require.NoError(t, err)
+	assert.Equal(t, forge.ChangeMergeability{
+		State:  forge.ChangeMergeabilityWaiting,
+		Reason: forge.ChangeMergeabilityReasonChecks,
+	}, got)
+}
+
+func TestCmd_setMergeability(t *testing.T) {
+	sh := &ShamHub{}
+	seedMergeabilityChange(sh)
+
+	var cmd Cmd
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "set_mergeability.txt"),
+		[]byte(
+			"shamhub set-mergeability -reason checks alice/example 1 waiting\n"+
+				"assert-mergeability waiting checks\n",
+		),
+		0o644,
+	))
+
+	testscript.Run(t, testscript.Params{
+		Dir: dir,
+		Setup: func(e *testscript.Env) error {
+			cmd.Setup(t, e)
+			e.Values[shamHubKey{}].(*shamHubValue).sh = sh
+			return nil
+		},
+		Cmds: map[string]func(*testscript.TestScript, bool, []string){
+			"shamhub": cmd.Run,
+			"assert-mergeability": func(ts *testscript.TestScript, neg bool, args []string) {
+				if neg || len(args) != 2 {
+					ts.Fatalf("usage: assert-mergeability <state> <reason>")
+				}
+
+				got, err := ts.Value(shamHubKey{}).(*shamHubValue).
+					sh.
+					ChangeMergeability("alice", "example", 1)
+				ts.Check(err)
+				want, err := parseMergeability(args[0], args[1])
+				ts.Check(err)
+				if got != want {
+					ts.Fatalf("mergeability = %#v, want %#v", got, want)
+				}
+			},
+		},
+	})
+}
+
+func TestShamHub_ChangeMergeability_conflicts(t *testing.T) {
+	sh, repo := newMergeabilityTestRepository(t)
+
+	workDir := t.TempDir()
+	worktree, err := git.Clone(t.Context(), sh.RepoURL("alice", "example"), workDir, git.CloneOptions{
+		Log: silogtest.New(t),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(workDir, "README.md"),
+		[]byte("base\n"),
+		0o644,
+	))
+	gitAdd(t, workDir, "README.md")
+	require.NoError(t, worktree.Commit(t.Context(), git.CommitRequest{
+		Message: "Initial commit",
+	}))
+	require.NoError(t, worktree.Push(t.Context(), git.PushOptions{
+		Remote:  "origin",
+		Refspec: "main:main",
+	}))
+
+	require.NoError(t, worktree.Repository().CreateBranch(t.Context(), git.CreateBranchRequest{
+		Name: "feature",
+		Head: "HEAD",
+	}))
+	require.NoError(t, worktree.CheckoutBranch(t.Context(), "feature"))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(workDir, "README.md"),
+		[]byte("feature\n"),
+		0o644,
+	))
+	gitAdd(t, workDir, "README.md")
+	require.NoError(t, worktree.Commit(t.Context(), git.CommitRequest{
+		Message: "Feature change",
+	}))
+	require.NoError(t, worktree.Push(t.Context(), git.PushOptions{
+		Remote:  "origin",
+		Refspec: "feature:feature",
+	}))
+
+	require.NoError(t, worktree.CheckoutBranch(t.Context(), "main"))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(workDir, "README.md"),
+		[]byte("main\n"),
+		0o644,
+	))
+	gitAdd(t, workDir, "README.md")
+	require.NoError(t, worktree.Commit(t.Context(), git.CommitRequest{
+		Message: "Main change",
+	}))
+	require.NoError(t, worktree.Push(t.Context(), git.PushOptions{
+		Remote:  "origin",
+		Refspec: "main:main",
+	}))
+
+	submitMergeabilityChange(t, repo)
+
+	got, err := sh.ChangeMergeability("alice", "example", 1)
+	require.NoError(t, err)
+	assert.Equal(t, forge.ChangeMergeability{
+		State:  forge.ChangeMergeabilityBlocked,
+		Reason: forge.ChangeMergeabilityReasonConflicts,
+	}, got)
+}
+
+func TestShamHub_ChangeMergeability_ready(t *testing.T) {
+	sh, repo := newMergeabilityTestRepository(t)
+
+	workDir := t.TempDir()
+	worktree, err := git.Clone(t.Context(), sh.RepoURL("alice", "example"), workDir, git.CloneOptions{
+		Log: silogtest.New(t),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(workDir, "README.md"),
+		[]byte("base\n"),
+		0o644,
+	))
+	gitAdd(t, workDir, "README.md")
+	require.NoError(t, worktree.Commit(t.Context(), git.CommitRequest{
+		Message: "Initial commit",
+	}))
+	require.NoError(t, worktree.Push(t.Context(), git.PushOptions{
+		Remote:  "origin",
+		Refspec: "main:main",
+	}))
+
+	require.NoError(t, worktree.Repository().CreateBranch(t.Context(), git.CreateBranchRequest{
+		Name: "feature",
+		Head: "HEAD",
+	}))
+	require.NoError(t, worktree.CheckoutBranch(t.Context(), "feature"))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(workDir, "feature.txt"),
+		[]byte("feature\n"),
+		0o644,
+	))
+	gitAdd(t, workDir, "feature.txt")
+	require.NoError(t, worktree.Commit(t.Context(), git.CommitRequest{
+		Message: "Feature change",
+	}))
+	require.NoError(t, worktree.Push(t.Context(), git.PushOptions{
+		Remote:  "origin",
+		Refspec: "feature:feature",
+	}))
+
+	submitMergeabilityChange(t, repo)
+
+	got, err := sh.ChangeMergeability("alice", "example", 1)
+	require.NoError(t, err)
+	assert.Equal(t, forge.ChangeMergeability{
+		State: forge.ChangeMergeabilityReady,
+	}, got)
+}
+
+func TestShamHub_ChangeMergeability_forkedHeadForcePush(t *testing.T) {
+	sh, repo := newMergeabilityTestRepository(t)
+
+	baseDir := t.TempDir()
+	baseWorktree, err := git.Clone(
+		t.Context(),
+		sh.RepoURL("alice", "example"),
+		baseDir,
+		git.CloneOptions{Log: silogtest.New(t)},
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(baseDir, "README.md"),
+		[]byte("base\n"),
+		0o644,
+	))
+	gitAdd(t, baseDir, "README.md")
+	require.NoError(t, baseWorktree.Commit(t.Context(), git.CommitRequest{
+		Message: "Initial commit",
+	}))
+	require.NoError(t, baseWorktree.Push(t.Context(), git.PushOptions{
+		Remote:  "origin",
+		Refspec: "main:main",
+	}))
+
+	forkURL, err := sh.ForkRepository("alice", "example", "bob")
+	require.NoError(t, err)
+
+	forkDir := t.TempDir()
+	forkWorktree, err := git.Clone(
+		t.Context(),
+		forkURL,
+		forkDir,
+		git.CloneOptions{Log: silogtest.New(t)},
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, forkWorktree.Repository().CreateBranch(
+		t.Context(),
+		git.CreateBranchRequest{
+			Name: "feature",
+			Head: "HEAD",
+		},
+	))
+	require.NoError(t, forkWorktree.CheckoutBranch(t.Context(), "feature"))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(forkDir, "feature.txt"),
+		[]byte("feature\n"),
+		0o644,
+	))
+	gitAdd(t, forkDir, "feature.txt")
+	require.NoError(t, forkWorktree.Commit(t.Context(), git.CommitRequest{
+		Message: "Feature change",
+	}))
+	require.NoError(t, forkWorktree.Push(t.Context(), git.PushOptions{
+		Remote:  "origin",
+		Refspec: "feature:feature",
+	}))
+
+	result, err := repo.SubmitChange(t.Context(), forge.SubmitChangeRequest{
+		Subject: "Fork feature",
+		Base:    "main",
+		Head:    "feature",
+		PushRepository: &RepositoryID{
+			url:   forkURL,
+			owner: "bob",
+			repo:  "example",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ChangeID(1), result.ID)
+
+	got, err := sh.ChangeMergeability("alice", "example", 1)
+	require.NoError(t, err)
+	assert.Equal(t, forge.ChangeMergeability{
+		State: forge.ChangeMergeabilityReady,
+	}, got)
+
+	require.NoError(t, forkWorktree.CheckoutBranch(t.Context(), "main"))
+	require.NoError(t, forkWorktree.Repository().CreateBranch(
+		t.Context(),
+		git.CreateBranchRequest{
+			Name:  "feature",
+			Head:  "HEAD",
+			Force: true,
+		},
+	))
+	require.NoError(t, forkWorktree.CheckoutBranch(t.Context(), "feature"))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(forkDir, "other.txt"),
+		[]byte("other\n"),
+		0o644,
+	))
+	gitAdd(t, forkDir, "other.txt")
+	require.NoError(t, forkWorktree.Commit(t.Context(), git.CommitRequest{
+		Message: "Replace feature change",
+	}))
+	require.NoError(t, forkWorktree.Push(t.Context(), git.PushOptions{
+		Remote:  "origin",
+		Refspec: "feature:feature",
+		Force:   true,
+	}))
+
+	got, err = sh.ChangeMergeability("alice", "example", 1)
+	require.NoError(t, err)
+	assert.Equal(t, forge.ChangeMergeability{
+		State: forge.ChangeMergeabilityReady,
+	}, got)
+}
+
+func TestShamHub_ChangeMergeability_deletedHeadErrors(t *testing.T) {
+	sh, repo := newMergeabilityTestRepository(t)
+
+	workDir := t.TempDir()
+	worktree, err := git.Clone(t.Context(), sh.RepoURL("alice", "example"), workDir, git.CloneOptions{
+		Log: silogtest.New(t),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(workDir, "README.md"),
+		[]byte("base\n"),
+		0o644,
+	))
+	gitAdd(t, workDir, "README.md")
+	require.NoError(t, worktree.Commit(t.Context(), git.CommitRequest{
+		Message: "Initial commit",
+	}))
+	require.NoError(t, worktree.Push(t.Context(), git.PushOptions{
+		Remote:  "origin",
+		Refspec: "main:main",
+	}))
+
+	require.NoError(t, worktree.Repository().CreateBranch(t.Context(), git.CreateBranchRequest{
+		Name: "feature",
+		Head: "HEAD",
+	}))
+	require.NoError(t, worktree.CheckoutBranch(t.Context(), "feature"))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(workDir, "feature.txt"),
+		[]byte("feature\n"),
+		0o644,
+	))
+	gitAdd(t, workDir, "feature.txt")
+	require.NoError(t, worktree.Commit(t.Context(), git.CommitRequest{
+		Message: "Feature change",
+	}))
+	require.NoError(t, worktree.Push(t.Context(), git.PushOptions{
+		Remote:  "origin",
+		Refspec: "feature:feature",
+	}))
+
+	submitMergeabilityChange(t, repo)
+
+	require.NoError(t, worktree.Push(t.Context(), git.PushOptions{
+		Remote:  "origin",
+		Refspec: ":feature",
+	}))
+
+	_, err = sh.ChangeMergeability("alice", "example", 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "check mergeability")
+}
+
+func newMergeabilityTestRepository(t *testing.T) (*ShamHub, *forgeRepository) {
+	t.Helper()
+
+	t.Setenv("GIT_CONFIG_COUNT", "1")
+	t.Setenv("GIT_CONFIG_KEY_0", "commit.gpgsign")
+	t.Setenv("GIT_CONFIG_VALUE_0", "false")
+	t.Setenv("GIT_AUTHOR_NAME", "Test")
+	t.Setenv("GIT_AUTHOR_EMAIL", "test@example.com")
+	t.Setenv("GIT_COMMITTER_NAME", "Test")
+	t.Setenv("GIT_COMMITTER_EMAIL", "test@example.com")
+
+	sh, err := New(Config{
+		Log: silogtest.New(t),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, sh.Close())
+	})
+
+	repoURL, err := sh.NewRepository("alice", "example")
+	require.NoError(t, err)
+	require.NoError(t, sh.RegisterUser("test-user"))
+	token, err := sh.IssueToken("test-user")
+	require.NoError(t, err)
+
+	repository, err := newRepository(
+		&Forge{
+			Options: Options{
+				URL:    sh.GitURL(),
+				APIURL: sh.APIURL(),
+			},
+			Log: silog.Nop(),
+		},
+		&AuthenticationToken{tok: token},
+		&RepositoryID{
+			url:   repoURL,
+			owner: "alice",
+			repo:  "example",
+		},
+		http.DefaultClient,
+	)
+	require.NoError(t, err)
+	repo := repository.(*forgeRepository)
+
+	return sh, repo
+}
+
+func seedMergeabilityChange(sh *ShamHub) {
+	sh.changes = append(sh.changes, shamChange{
+		Number: 1,
+		Base: &shamBranch{
+			Owner: "alice",
+			Repo:  "example",
+			Name:  "main",
+		},
+		Head: &shamBranch{
+			Owner: "alice",
+			Repo:  "example",
+			Name:  "feature",
+		},
+	})
+}
+
+func submitMergeabilityChange(t *testing.T, repo *forgeRepository) {
+	t.Helper()
+
+	result, err := repo.SubmitChange(t.Context(), forge.SubmitChangeRequest{
+		Subject: "Feature change",
+		Base:    "main",
+		Head:    "feature",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ChangeID(1), result.ID)
+}

--- a/internal/forge/shamhub/testdata/TestIntegration/ChangeMergeability/Conflicts/base
+++ b/internal/forge/shamhub/testdata/TestIntegration/ChangeMergeability/Conflicts/base
@@ -1,0 +1,1 @@
+"conflict-base-4VU08Pf9"

--- a/internal/forge/shamhub/testdata/TestIntegration/ChangeMergeability/Conflicts/head
+++ b/internal/forge/shamhub/testdata/TestIntegration/ChangeMergeability/Conflicts/head
@@ -1,0 +1,1 @@
+"conflict-head-qsQP5bPg"

--- a/internal/forge/shamhub/testdata/TestIntegration/ChangeMergeability/Draft/base
+++ b/internal/forge/shamhub/testdata/TestIntegration/ChangeMergeability/Draft/base
@@ -1,0 +1,1 @@
+"draft-base-IqJBeOYD"

--- a/internal/forge/shamhub/testdata/TestIntegration/ChangeMergeability/Draft/head
+++ b/internal/forge/shamhub/testdata/TestIntegration/ChangeMergeability/Draft/head
@@ -1,0 +1,1 @@
+"draft-head-gvNhoiez"

--- a/internal/forge/shamhub/testdata/TestIntegration/ChangeMergeability/Ready/base
+++ b/internal/forge/shamhub/testdata/TestIntegration/ChangeMergeability/Ready/base
@@ -1,0 +1,1 @@
+"ready-base-h824mRrI"

--- a/internal/forge/shamhub/testdata/TestIntegration/ChangeMergeability/Ready/head
+++ b/internal/forge/shamhub/testdata/TestIntegration/ChangeMergeability/Ready/head
@@ -1,0 +1,1 @@
+"ready-head-zvtLVlaE"

--- a/internal/forge/shamhub/testdata/fixtures/TestIntegration/ChangeMergeability/Conflicts.yaml
+++ b/internal/forge/shamhub/testdata/fixtures/TestIntegration/ChangeMergeability/Conflicts.yaml
@@ -1,0 +1,58 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 149
+        host: 127.0.0.1:56373
+        body: '{"subject":"Mergeability conflict-head-qsQP5bPg","body":"Mergeability scenario test","base":"conflict-base-4VU08Pf9","head":"conflict-head-qsQP5bPg"}'
+        url: http://127.0.0.1:56373/abhinav/test-repo/changes
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 80
+        body: |
+            {
+              "number": 2,
+              "url": "http://127.0.0.1:56374/abhinav/test-repo/change/2"
+            }
+        headers:
+            Content-Length:
+                - "80"
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 14.67775ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: 127.0.0.1:56373
+        url: http://127.0.0.1:56373/abhinav/test-repo/change/2/mergeability
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 50
+        body: |
+            {
+              "state": "blocked",
+              "reason": "conflicts"
+            }
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 24.304333ms

--- a/internal/forge/shamhub/testdata/fixtures/TestIntegration/ChangeMergeability/Draft.yaml
+++ b/internal/forge/shamhub/testdata/fixtures/TestIntegration/ChangeMergeability/Draft.yaml
@@ -1,0 +1,58 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 153
+        host: 127.0.0.1:56373
+        body: '{"subject":"Mergeability draft-head-gvNhoiez","body":"Mergeability scenario test","base":"draft-base-IqJBeOYD","head":"draft-head-gvNhoiez","draft":true}'
+        url: http://127.0.0.1:56373/abhinav/test-repo/changes
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 80
+        body: |
+            {
+              "number": 3,
+              "url": "http://127.0.0.1:56374/abhinav/test-repo/change/3"
+            }
+        headers:
+            Content-Length:
+                - "80"
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 16.79425ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: 127.0.0.1:56373
+        url: http://127.0.0.1:56373/abhinav/test-repo/change/3/mergeability
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 46
+        body: |
+            {
+              "state": "blocked",
+              "reason": "draft"
+            }
+        headers:
+            Content-Length:
+                - "46"
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 127.25µs

--- a/internal/forge/shamhub/testdata/fixtures/TestIntegration/ChangeMergeability/Ready.yaml
+++ b/internal/forge/shamhub/testdata/fixtures/TestIntegration/ChangeMergeability/Ready.yaml
@@ -1,0 +1,58 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 140
+        host: 127.0.0.1:56373
+        body: '{"subject":"Mergeability ready-head-zvtLVlaE","body":"Mergeability scenario test","base":"ready-base-h824mRrI","head":"ready-head-zvtLVlaE"}'
+        url: http://127.0.0.1:56373/abhinav/test-repo/changes
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 80
+        body: |
+            {
+              "number": 1,
+              "url": "http://127.0.0.1:56374/abhinav/test-repo/change/1"
+            }
+        headers:
+            Content-Length:
+                - "80"
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 12.899ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: 127.0.0.1:56373
+        url: http://127.0.0.1:56373/abhinav/test-repo/change/1/mergeability
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 46
+        body: |
+            {
+              "state": "ready",
+              "reason": "unknown"
+            }
+        headers:
+            Content-Length:
+                - "46"
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 18.580916ms


### PR DESCRIPTION
ShamHub needs to model forge readiness.

Add mergeability storage, API routes, and CLI controls.
Those controls can report ready, waiting, blocked, and unknown states.

The default simulation also checks deleted heads, drafts, conflicts,
and moving fork heads.
