### PR TITLE
merge: Gate commands on merge readiness

### DIFF
--- a/branch_merge.go
+++ b/branch_merge.go
@@ -25,8 +25,10 @@ func (*branchMergeCmd) Help() string {
 		The branch must be based directly on trunk.
 		To merge a stacked branch, use 'gs downstack merge'.
 
-		Before merging, waits for CI checks to pass.
-		Use --build-timeout to configure the maximum wait.
+		Before merging, waits for merge readiness:
+		the forge must observe the pushed head
+		and report that the CR is ready to merge.
+		Use --ready-timeout to configure the maximum wait.
 	`)
 }
 

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -310,9 +310,11 @@ Before merging, the stack is checked for branches
 whose base PR was already merged on the forge.
 Use --no-branch-check to skip this validation.
 
-Before each merge, waits for CI checks to pass.
-Use --build-timeout to configure the maximum wait
-before failing if checks are not ready.
+Before each merge, waits for merge readiness:
+the forge must observe the pushed head
+and report that the CR is ready to merge.
+Use --ready-timeout to configure the maximum wait
+before failing if merge readiness is not reached.
 
 By default, a branch failure skips that branch's upstack descendants,
 but independent sibling branches continue.
@@ -321,12 +323,12 @@ Use --fail-fast to stop the queue after the first branch failure.
 **Flags**
 
 * `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
-* `--build-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.buildTimeout" }](/cli/config.md#spicemergebuildtimeout)): Max time to wait for CI checks before each merge. 0 means check once.
+* `--ready-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.readyTimeout" }](/cli/config.md#spicemergereadytimeout)): Max time to wait for merge readiness before each merge. 0 means check once.
 * `--no-branch-check`: Skip stale base validation before merging.
 * `--fail-fast`: Stop the merge queue after the first branch failure.
 * `--branch=NAME`: Branch whose stack to merge
 
-**Configuration**: [spice.merge.buildTimeout](/cli/config.md#spicemergebuildtimeout), [spice.merge.method](/cli/config.md#spicemergemethod)
+**Configuration**: [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
 
 ### git-spice stack restack {#gs-stack-restack}
 
@@ -624,7 +626,7 @@ This command acts as a local merge queue:
 it merges one Change Request,
 waits for that merge to finish,
 restacks and updates the next Change Request,
-waits for its CI checks to pass,
+waits for merge readiness on the updated Change Request,
 and then repeats the process.
 
 For a stack like this:
@@ -642,13 +644,15 @@ Before merging, the downstack is checked for branches
 whose base PR was already merged on the forge.
 Use --no-branch-check to skip this validation.
 
-Before each merge, waits for CI checks to pass.
-Use --build-timeout to configure the maximum wait
+Before each merge, waits for merge readiness:
+the forge must observe the pushed head
+and report that the CR is ready to merge.
+Use --ready-timeout to configure the maximum wait
 (default: 30m, 0 means fail immediately if not ready).
 
 Between merges, the command waits for each merge
 to complete, restacks and updates the next PR,
-waits for CI checks on the updated PR,
+waits for merge readiness on the updated PR,
 and syncs merged branch cleanup.
 
 Use --no-wait for single branch merging
@@ -658,12 +662,12 @@ when you don't want to wait for the merge to propagate.
 **Flags**
 
 * `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
-* `--build-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.buildTimeout" }](/cli/config.md#spicemergebuildtimeout)): Max time to wait for CI checks before each merge. 0 means check once.
+* `--ready-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.readyTimeout" }](/cli/config.md#spicemergereadytimeout)): Max time to wait for merge readiness before each merge. 0 means check once.
 * `--no-wait`: Skip polling for a single branch merge to propagate.
 * `--no-branch-check`: Skip stale base validation before merging.
 * `--branch=NAME`: Branch to start merging from
 
-**Configuration**: [spice.merge.buildTimeout](/cli/config.md#spicemergebuildtimeout), [spice.merge.method](/cli/config.md#spicemergemethod)
+**Configuration**: [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
 
 ### git-spice downstack edit {#gs-downstack-edit}
 
@@ -1133,16 +1137,18 @@ Use --branch to merge a different branch.
 The branch must be based directly on trunk.
 To merge a stacked branch, use 'gs downstack merge'.
 
-Before merging, waits for CI checks to pass.
-Use --build-timeout to configure the maximum wait.
+Before merging, waits for merge readiness:
+the forge must observe the pushed head
+and report that the CR is ready to merge.
+Use --ready-timeout to configure the maximum wait.
 
 **Flags**
 
 * `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
-* `--build-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.buildTimeout" }](/cli/config.md#spicemergebuildtimeout)): Max time to wait for CI checks before each merge. 0 means check once.
+* `--ready-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.readyTimeout" }](/cli/config.md#spicemergereadytimeout)): Max time to wait for merge readiness before each merge. 0 means check once.
 * `--branch=NAME`: Branch to merge
 
-**Configuration**: [spice.merge.buildTimeout](/cli/config.md#spicemergebuildtimeout), [spice.merge.method](/cli/config.md#spicemergemethod)
+**Configuration**: [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
 
 ### git-spice branch submit {#gs-branch-submit}
 

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -426,16 +426,17 @@ whether the branch is in sync with its pushed counterpart.
   show the number of outgoing and incoming commits in the form `⇡1⇣2`,
   where `⇡` indicates outgoing commits and `⇣` indicates incoming commits
 
-### spice.merge.buildTimeout
+### spice.merge.readyTimeout
 
 <!-- gs:version unreleased -->
 
-Maximum time $$gs downstack merge$$ waits for CI checks to pass
-before merging each branch in the stack.
+Maximum time merge commands wait for merge readiness before each merge.
+Merge readiness requires the forge to report the pushed head
+and report that the CR is ready to merge.
 
 The value must be a duration string such as
 `30m`, `1h`, `90s`, etc.
-Set to `0` to fail immediately if checks aren't already passing.
+Set to `0` to fail immediately if merge readiness is not already reached.
 
 Defaults to `30m`.
 

--- a/downstack_merge.go
+++ b/downstack_merge.go
@@ -27,7 +27,7 @@ func (*downstackMergeCmd) Help() string {
 		it merges one Change Request,
 		waits for that merge to finish,
 		restacks and updates the next Change Request,
-		waits for its CI checks to pass,
+		waits for merge readiness on the updated Change Request,
 		and then repeats the process.
 
 		For a stack like this:
@@ -45,13 +45,15 @@ func (*downstackMergeCmd) Help() string {
 		whose base PR was already merged on the forge.
 		Use --no-branch-check to skip this validation.
 
-		Before each merge, waits for CI checks to pass.
-		Use --build-timeout to configure the maximum wait
+		Before each merge, waits for merge readiness:
+		the forge must observe the pushed head
+		and report that the CR is ready to merge.
+		Use --ready-timeout to configure the maximum wait
 		(default: 30m, 0 means fail immediately if not ready).
 
 		Between merges, the command waits for each merge
 		to complete, restacks and updates the next PR,
-		waits for CI checks on the updated PR,
+		waits for merge readiness on the updated PR,
 		and syncs merged branch cleanup.
 
 		Use --no-wait for single branch merging

--- a/internal/handler/merge/handler.go
+++ b/internal/handler/merge/handler.go
@@ -65,10 +65,10 @@ type Options struct {
 	// Empty means use the configured or forge default.
 	Method forge.MergeMethod `placeholder:"METHOD" config:"merge.method" help:"Preferred merge method. One of 'merge', 'squash', and 'rebase'."`
 
-	// BuildTimeout is the maximum time to wait
-	// for CI checks before each merge attempt.
-	// Zero means check once and fail if CI is not ready.
-	BuildTimeout time.Duration `config:"merge.buildTimeout" default:"30m" help:"Max time to wait for CI checks before each merge. 0 means check once."`
+	// MergeReadinessTimeout is the maximum time for each forge-readiness wait,
+	// including pushed-head visibility and merge readiness.
+	// Zero means check once and fail if merge readiness is not reached.
+	MergeReadinessTimeout time.Duration `name:"ready-timeout" config:"merge.readyTimeout" default:"30m" help:"Max time to wait for merge readiness before each merge. 0 means check once."`
 }
 
 // DownstackMergeOptions controls downstack merge behavior.
@@ -162,9 +162,9 @@ func (h *Handler) MergeDownstack(
 	}
 
 	return h.executePlan(ctx, plan, mergeExecutionOptions{
-		Method:       opts.Method,
-		BuildTimeout: opts.BuildTimeout,
-		NoWait:       opts.NoWait,
+		Method:                opts.Method,
+		MergeReadinessTimeout: opts.MergeReadinessTimeout,
+		NoWait:                opts.NoWait,
 	})
 }
 
@@ -235,9 +235,9 @@ func (h *Handler) MergeStack(
 	}
 
 	return h.executePlan(ctx, plan, mergeExecutionOptions{
-		Method:       opts.Method,
-		BuildTimeout: opts.BuildTimeout,
-		FailFast:     opts.FailFast,
+		Method:                opts.Method,
+		MergeReadinessTimeout: opts.MergeReadinessTimeout,
+		FailFast:              opts.FailFast,
 	})
 }
 
@@ -503,10 +503,10 @@ func (h *Handler) confirm(plan []*mergeItem, title string) error {
 }
 
 type mergeExecutionOptions struct {
-	Method       forge.MergeMethod
-	BuildTimeout time.Duration
-	NoWait       bool
-	FailFast     bool
+	Method                forge.MergeMethod
+	MergeReadinessTimeout time.Duration
+	NoWait                bool
+	FailFast              bool
 }
 
 func (h *Handler) executePlan(
@@ -539,11 +539,11 @@ func (h *Handler) executePlan(
 
 		Progress: progress,
 
-		Trunk:        h.Store.Trunk(),
-		BuildTimeout: opts.BuildTimeout,
-		Method:       opts.Method,
-		NoWait:       opts.NoWait,
-		FailFast:     opts.FailFast,
+		Trunk:                 h.Store.Trunk(),
+		MergeReadinessTimeout: opts.MergeReadinessTimeout,
+		Method:                opts.Method,
+		NoWait:                opts.NoWait,
+		FailFast:              opts.FailFast,
 	}).Execute(ctx, plan)
 	if err != nil {
 		return err
@@ -638,7 +638,7 @@ func (e *mergePlanExecutor) awaitChangeHead(
 	)
 
 	return e.awaitChangeHeadWithDelay(
-		ctx, item, change, e.BuildTimeout, _baseDelay, _maxDelay,
+		ctx, item, change, e.MergeReadinessTimeout, _baseDelay, _maxDelay,
 	)
 }
 
@@ -690,19 +690,20 @@ func (e *mergePlanExecutor) awaitChangeHeadWithDelay(
 		}
 
 		e.Progress.Event(mergeProgressEvent{
-			Kind: mergeProgressWaitingForChecks,
+			Kind: mergeProgressWaitingForForgeHead,
 			Item: item,
 		})
 		if err := sleep(ctx, delay); err != nil {
-			return errors.New("timed out waiting for forge head")
+			return fmt.Errorf("HEAD did not update after %v", timeout)
 		}
 		delay = min(delay*2, maxDelay)
 	}
 }
 
-// awaitChecks polls until CI checks pass for the given change.
+// awaitMergeability polls until the forge reports that the change is
+// ready to merge.
 // Uses truncated exponential backoff.
-func (e *mergePlanExecutor) awaitChecks(
+func (e *mergePlanExecutor) awaitMergeability(
 	ctx context.Context,
 	item *mergeItem,
 ) error {
@@ -711,38 +712,43 @@ func (e *mergePlanExecutor) awaitChecks(
 		_maxDelay  = 30 * time.Second
 	)
 
-	return e.awaitChecksWithDelay(
-		ctx, item, e.BuildTimeout, _baseDelay, _maxDelay,
+	return e.awaitMergeabilityWithDelay(
+		ctx, item, e.MergeReadinessTimeout, _baseDelay, _maxDelay,
 	)
 }
 
-func (e *mergePlanExecutor) awaitChecksWithDelay(
+func (e *mergePlanExecutor) awaitMergeabilityWithDelay(
 	ctx context.Context,
 	item *mergeItem,
 	timeout, baseDelay, maxDelay time.Duration,
 ) error {
 	delay := baseDelay
 	for attempt := 0; ; attempt++ {
-		checks, err := e.RemoteRepository.ChangeChecks(
+		mergeability, err := e.RemoteRepository.ChangeMergeability(
 			ctx, item.changeID,
 		)
 		if err != nil {
-			return fmt.Errorf("query checks: %w", err)
+			return fmt.Errorf("check merge readiness: %w", err)
 		}
-		state := checkState(checks)
-		if state == mergeChecksPassed {
+		switch mergeability.State {
+		case forge.ChangeMergeabilityReady:
 			e.Progress.Event(mergeProgressEvent{
-				Kind: mergeProgressChecksPassed,
+				Kind: mergeProgressMergeabilityReady,
 				Item: item,
 			})
 			return nil
-		}
-		if state == mergeChecksFailed {
-			return errors.New("CI checks failed")
-		}
-
-		if timeout == 0 {
-			return errors.New("CI checks pending (build-timeout=0)")
+		case forge.ChangeMergeabilityWaiting:
+			if timeout == 0 {
+				return fmt.Errorf("not ready after %v", timeout)
+			}
+		case forge.ChangeMergeabilityBlocked:
+			return fmt.Errorf("blocked: %s", mergeability.Reason)
+		case forge.ChangeMergeabilityUnknown:
+			return errors.New("unknown state")
+		case forge.ChangeMergeabilityUnsupported:
+			return errors.New("unknown state")
+		default:
+			return fmt.Errorf("unknown state: %v", mergeability.State)
 		}
 		if attempt == 0 {
 			var cancel context.CancelFunc
@@ -751,35 +757,14 @@ func (e *mergePlanExecutor) awaitChecksWithDelay(
 		}
 
 		e.Progress.Event(mergeProgressEvent{
-			Kind: mergeProgressWaitingForChecks,
+			Kind: mergeProgressWaitingForMergeability,
 			Item: item,
 		})
 		if err := sleep(ctx, delay); err != nil {
-			return errors.New("timed out waiting for CI")
+			return fmt.Errorf("not ready after %v", timeout)
 		}
 		delay = min(delay*2, maxDelay)
 	}
-}
-
-type mergeChecksState int
-
-const (
-	mergeChecksPassed mergeChecksState = iota + 1
-	mergeChecksPending
-	mergeChecksFailed
-)
-
-func checkState(checks []forge.ChangeCheck) mergeChecksState {
-	state := mergeChecksPassed
-	for _, check := range checks {
-		if check.State == forge.ChangeCheckFailed {
-			return mergeChecksFailed
-		}
-		if check.State == forge.ChangeCheckPending {
-			state = mergeChecksPending
-		}
-	}
-	return state
 }
 
 // ensureTargetsTrunk verifies a change targets trunk

--- a/internal/handler/merge/handler_test.go
+++ b/internal/handler/merge/handler_test.go
@@ -96,15 +96,15 @@ func TestAwaitMerged_afterPolling(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestAwaitChecks_passed(t *testing.T) {
+func TestAwaitMergeability_ready(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockRepo := forgetest.NewMockRepository(ctrl)
 	mockRepo.EXPECT().
-		ChangeChecks(
+		ChangeMergeability(
 			gomock.Any(), fakeChangeID("pr-1"),
 		).
-		Return(checks(forge.ChangeCheckPassed), nil)
+		Return(mergeability(forge.ChangeMergeabilityReady), nil)
 
 	h := newTestHandler(t, ctrl, testHandlerOpts{
 		forgeRepo: mockRepo,
@@ -118,19 +118,25 @@ func TestAwaitChecks_passed(t *testing.T) {
 	progress := newLogMergeProgress(silog.Nop())
 	executor := newTestMergePlanExecutor(h, progress)
 
-	err := executor.awaitChecks(t.Context(), item)
+	err := executor.awaitMergeability(t.Context(), item)
 	require.NoError(t, err)
 }
 
-func TestAwaitChecks_failed(t *testing.T) {
+func TestAwaitMergeability_blocked(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockRepo := forgetest.NewMockRepository(ctrl)
 	mockRepo.EXPECT().
-		ChangeChecks(
+		ChangeMergeability(
 			gomock.Any(), fakeChangeID("pr-1"),
 		).
-		Return(checks(forge.ChangeCheckFailed), nil)
+		Return(
+			mergeabilityWithReason(
+				forge.ChangeMergeabilityBlocked,
+				forge.ChangeMergeabilityReasonChecks,
+			),
+			nil,
+		)
 
 	h := newTestHandler(t, ctrl, testHandlerOpts{
 		forgeRepo: mockRepo,
@@ -144,20 +150,20 @@ func TestAwaitChecks_failed(t *testing.T) {
 	progress := newLogMergeProgress(silog.Nop())
 	executor := newTestMergePlanExecutor(h, progress)
 
-	err := executor.awaitChecks(t.Context(), item)
+	err := executor.awaitMergeability(t.Context(), item)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "CI checks failed")
+	assert.Contains(t, err.Error(), "blocked: checks")
 }
 
-func TestAwaitChecks_pendingZeroTimeout(t *testing.T) {
+func TestAwaitMergeability_waitingZeroTimeout(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockRepo := forgetest.NewMockRepository(ctrl)
 	mockRepo.EXPECT().
-		ChangeChecks(
+		ChangeMergeability(
 			gomock.Any(), fakeChangeID("pr-1"),
 		).
-		Return(checks(forge.ChangeCheckPending), nil)
+		Return(mergeability(forge.ChangeMergeabilityWaiting), nil)
 
 	h := newTestHandler(t, ctrl, testHandlerOpts{
 		forgeRepo: mockRepo,
@@ -172,26 +178,26 @@ func TestAwaitChecks_pendingZeroTimeout(t *testing.T) {
 	progress := newLogMergeProgress(silog.Nop())
 	executor := newTestMergePlanExecutor(h, progress)
 
-	executor.BuildTimeout = 0
-	err := executor.awaitChecks(t.Context(), item)
+	executor.MergeReadinessTimeout = 0
+	err := executor.awaitMergeability(t.Context(), item)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "CI checks pending")
+	assert.Contains(t, err.Error(), "not ready after 0s")
 }
 
-func TestAwaitChecks_pendingThenPassed(t *testing.T) {
+func TestAwaitMergeability_waitingThenReady(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockRepo := forgetest.NewMockRepository(ctrl)
 	first := mockRepo.EXPECT().
-		ChangeChecks(
+		ChangeMergeability(
 			gomock.Any(), fakeChangeID("pr-1"),
 		).
-		Return(checks(forge.ChangeCheckPending), nil)
+		Return(mergeability(forge.ChangeMergeabilityWaiting), nil)
 	mockRepo.EXPECT().
-		ChangeChecks(
+		ChangeMergeability(
 			gomock.Any(), fakeChangeID("pr-1"),
 		).
-		Return(checks(forge.ChangeCheckPassed), nil).
+		Return(mergeability(forge.ChangeMergeabilityReady), nil).
 		After(first.Call)
 
 	h := newTestHandler(t, ctrl, testHandlerOpts{
@@ -206,7 +212,7 @@ func TestAwaitChecks_pendingThenPassed(t *testing.T) {
 	progress := newLogMergeProgress(silog.Nop())
 	executor := newTestMergePlanExecutor(h, progress)
 
-	err := executor.awaitChecksWithDelay(
+	err := executor.awaitMergeabilityWithDelay(
 		t.Context(),
 		item,
 		5*time.Second,      // timeout
@@ -216,23 +222,58 @@ func TestAwaitChecks_pendingThenPassed(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestCheckState_allObservedChecksGateReadiness(t *testing.T) {
-	assert.Equal(t, mergeChecksPassed, checkState([]forge.ChangeCheck{
-		{Name: "build", State: forge.ChangeCheckPassed},
-		{Name: "lint", State: forge.ChangeCheckPassed},
-	}))
-	assert.Equal(t, mergeChecksFailed, checkState([]forge.ChangeCheck{
-		{Name: "build", State: forge.ChangeCheckPassed},
-		{Name: "lint", State: forge.ChangeCheckFailed},
-	}))
-	assert.Equal(t, mergeChecksPending, checkState([]forge.ChangeCheck{
-		{Name: "build", State: forge.ChangeCheckPassed},
-		{Name: "lint", State: forge.ChangeCheckPending},
-	}))
-	assert.Equal(t, mergeChecksFailed, checkState([]forge.ChangeCheck{
-		{Name: "build", State: forge.ChangeCheckPending},
-		{Name: "lint", State: forge.ChangeCheckFailed},
-	}))
+func TestAwaitMergeability_unknown(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockRepo := forgetest.NewMockRepository(ctrl)
+	mockRepo.EXPECT().
+		ChangeMergeability(
+			gomock.Any(), fakeChangeID("pr-1"),
+		).
+		Return(mergeability(forge.ChangeMergeabilityUnknown), nil)
+
+	h := newTestHandler(t, ctrl, testHandlerOpts{
+		forgeRepo: mockRepo,
+		logBuffer: nil,
+	})
+
+	item := &mergeItem{
+		branch:   "feat1",
+		changeID: fakeChangeID("pr-1"),
+	}
+	progress := newLogMergeProgress(silog.Nop())
+	executor := newTestMergePlanExecutor(h, progress)
+
+	err := executor.awaitMergeability(t.Context(), item)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown state")
+}
+
+func TestAwaitMergeability_unsupported(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockRepo := forgetest.NewMockRepository(ctrl)
+	mockRepo.EXPECT().
+		ChangeMergeability(
+			gomock.Any(), fakeChangeID("pr-1"),
+		).
+		Return(mergeability(forge.ChangeMergeabilityUnsupported), nil)
+
+	h := newTestHandler(t, ctrl, testHandlerOpts{
+		forgeRepo: mockRepo,
+		logBuffer: nil,
+	})
+
+	item := &mergeItem{
+		branch:   "feat1",
+		changeID: fakeChangeID("pr-1"),
+	}
+	progress := newLogMergeProgress(silog.Nop())
+	executor := newTestMergePlanExecutor(h, progress)
+
+	err := executor.awaitMergeability(t.Context(), item)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown state")
 }
 
 func TestExecutePlan_retargets(t *testing.T) {
@@ -266,7 +307,7 @@ func TestExecutePlan_retargets(t *testing.T) {
 		FindChangeByID(gomock.Any(), pr3).
 		Return(fakeFindResultWithHead("main", "head3"), nil)
 
-	// Each merge: checks -> merge -> awaitMerged -> sync
+	// Each merge: merge readiness -> merge -> awaitMerged -> sync
 	// -> prepare next (except last).
 	expectMergeItem(mockForge, pr1)
 	expectPreparedNext(t, mockForge, pr2)
@@ -370,9 +411,9 @@ func TestExecutePlan_waitsForPreparedChangeHeadBeforeChecks(t *testing.T) {
 
 	// The submit call can return before the forge's change view catches up
 	// to the pushed branch head.
-	// A stale ChecksPassed value at this point belongs to the old head,
+	// A stale merge readiness value at this point belongs to the old head,
 	// so the merge loop must wait until the forge reports new-head2
-	// before asking whether checks passed.
+	// before asking whether the change is ready to merge.
 	mockForge.EXPECT().
 		FindChangeByID(gomock.Any(), pr2).
 		Return(fakeFindResultWithHead("main", "old-head2"), nil)
@@ -383,8 +424,8 @@ func TestExecutePlan_waitsForPreparedChangeHeadBeforeChecks(t *testing.T) {
 			HeadHash: git.Hash("new-head2"),
 		}}, nil)
 	mockForge.EXPECT().
-		ChangeChecks(gomock.Any(), pr2).
-		Return(checks(forge.ChangeCheckPassed), nil).
+		ChangeMergeability(gomock.Any(), pr2).
+		Return(mergeability(forge.ChangeMergeabilityReady), nil).
 		After(status.Call)
 	mockForge.EXPECT().
 		MergeChange(gomock.Any(), pr2, forge.MergeChangeOptions{
@@ -432,7 +473,7 @@ func TestExecutePlan_noWait(t *testing.T) {
 		FindChangeByID(gomock.Any(), pr1).
 		Return(fakeFindResultWithHead("main", "head1"), nil)
 
-	expectChecksAndMerge(mockForge, pr1)
+	expectMergeabilityAndMerge(mockForge, pr1)
 	// No ChangesStates polling (awaitMerged skipped).
 
 	h := newTestHandler(t, ctrl, testHandlerOpts{
@@ -714,8 +755,8 @@ func TestMergeStack_passesFailFastToScheduler(t *testing.T) {
 		FindChangeByID(gomock.Any(), pr2).
 		Return(fakeFindResultWithHead("main", "head2"), nil)
 	mockForge.EXPECT().
-		ChangeChecks(gomock.Any(), pr2).
-		Return(checks(forge.ChangeCheckFailed), nil)
+		ChangeMergeability(gomock.Any(), pr2).
+		Return(mergeability(forge.ChangeMergeabilityBlocked), nil)
 
 	h := newTestHandler(t, ctrl, testHandlerOpts{
 		forgeRepo: mockForge,
@@ -732,7 +773,7 @@ func TestMergeStack_passesFailFastToScheduler(t *testing.T) {
 		},
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "CI checks failed")
+	assert.Contains(t, err.Error(), "blocked")
 }
 
 func TestExecutePlan_syncTrunkFailureStopsLoop(t *testing.T) {
@@ -781,8 +822,8 @@ func TestExecutePlan_mergeMethod(t *testing.T) {
 		FindChangeByID(gomock.Any(), pr1).
 		Return(fakeFindResultWithHead("main", "head1"), nil)
 	mockForge.EXPECT().
-		ChangeChecks(gomock.Any(), pr1).
-		Return(checks(forge.ChangeCheckPassed), nil)
+		ChangeMergeability(gomock.Any(), pr1).
+		Return(mergeability(forge.ChangeMergeabilityReady), nil)
 	mockForge.EXPECT().
 		MergeChange(gomock.Any(), pr1, forge.MergeChangeOptions{
 			Method:   forge.MergeMethodSquash,
@@ -910,11 +951,11 @@ func TestLogMergeProgress_deduplicatesRepeatedState(t *testing.T) {
 		Base: "main",
 	})
 	progress.Event(mergeProgressEvent{
-		Kind: mergeProgressWaitingForChecks,
+		Kind: mergeProgressWaitingForMergeability,
 		Item: item,
 	})
 	progress.Event(mergeProgressEvent{
-		Kind: mergeProgressWaitingForChecks,
+		Kind: mergeProgressWaitingForMergeability,
 		Item: item,
 	})
 	progress.Event(mergeProgressEvent{
@@ -932,7 +973,7 @@ func TestLogMergeProgress_deduplicatesRepeatedState(t *testing.T) {
 	assert.Equal(t, 1, strings.Count(output,
 		"feat1: retargeting pr-1 onto main"))
 	assert.Equal(t, 1, strings.Count(output,
-		"feat1: waiting for CI checks"))
+		"feat1: waiting for merge readiness"))
 	assert.Equal(t, 1, strings.Count(output,
 		"feat1: merging pr-1: http://example.com/1"))
 }
@@ -1187,9 +1228,9 @@ func newTestMergePlanExecutor(
 
 		Progress: progress,
 
-		Trunk:        "main",
-		BuildTimeout: 30 * time.Minute,
-		Method:       forge.MergeMethodDefault,
+		Trunk:                 "main",
+		MergeReadinessTimeout: 30 * time.Minute,
+		Method:                forge.MergeMethodDefault,
 	}
 }
 
@@ -1333,12 +1374,12 @@ func fakeFindResultWithHead(
 }
 
 // expectMergeItem sets up mock expectations for a full
-// merge iteration: checks passed -> merge -> awaitMerged.
+// merge iteration: ready to merge -> merge -> awaitMerged.
 func expectMergeItem(
 	mockForge *forgetest.MockRepository,
 	id fakeChangeID,
 ) {
-	expectChecksAndMerge(mockForge, id)
+	expectMergeabilityAndMerge(mockForge, id)
 	expectMerged(mockForge, id)
 }
 
@@ -1373,8 +1414,8 @@ func expectPreparedNext(
 	t.Helper()
 
 	mockForge.EXPECT().
-		ChangeChecks(gomock.Any(), id).
-		Return(checks(forge.ChangeCheckPassed), nil)
+		ChangeMergeability(gomock.Any(), id).
+		Return(mergeability(forge.ChangeMergeabilityReady), nil)
 }
 
 func assertSubmitUpdate(
@@ -1393,24 +1434,36 @@ func assertSubmitUpdate(
 	}
 }
 
-// expectChecksAndMerge sets up mock expectations for
-// checks passed + merge (without awaitMerged polling).
-func expectChecksAndMerge(
+// expectMergeabilityAndMerge sets up mock expectations for
+// ready to merge + merge (without awaitMerged polling).
+func expectMergeabilityAndMerge(
 	mockForge *forgetest.MockRepository,
 	id fakeChangeID,
 ) {
 	mockForge.EXPECT().
-		ChangeChecks(gomock.Any(), id).
-		Return(checks(forge.ChangeCheckPassed), nil)
+		ChangeMergeability(gomock.Any(), id).
+		Return(mergeability(forge.ChangeMergeabilityReady), nil)
 
 	mockForge.EXPECT().
 		MergeChange(gomock.Any(), id, gomock.Any()).
 		Return(nil)
 }
 
-func checks(state forge.ChangeCheckState) []forge.ChangeCheck {
-	return []forge.ChangeCheck{{
-		Name:  "test",
-		State: state,
-	}}
+func mergeability(
+	state forge.ChangeMergeabilityState,
+) forge.ChangeMergeability {
+	return mergeabilityWithReason(
+		state,
+		forge.ChangeMergeabilityReasonUnknown,
+	)
+}
+
+func mergeabilityWithReason(
+	state forge.ChangeMergeabilityState,
+	reason forge.ChangeMergeabilityReason,
+) forge.ChangeMergeability {
+	return forge.ChangeMergeability{
+		State:  state,
+		Reason: reason,
+	}
 }

--- a/internal/handler/merge/progress.go
+++ b/internal/handler/merge/progress.go
@@ -36,22 +36,24 @@ type mergeProgressEvent struct {
 type mergeProgressEventKind uint8
 
 const (
-	mergeProgressPreparing        mergeProgressEventKind = iota // branch preparation started
-	mergeProgressPrepareFailed                                  // local preparation failed
-	mergeProgressRetargeting                                    // retargeting to trunk started
-	mergeProgressRetargetFailed                                 // retargeting to trunk failed
-	mergeProgressWaitingForChecks                               // CI checks still pending
-	mergeProgressChecksPassed                                   // CI checks passed
-	mergeProgressChecksFailed                                   // CI checks failed or timed out
-	mergeProgressMerging                                        // forge merge request started
-	mergeProgressMergeFailed                                    // forge merge request failed
-	mergeProgressMergeRequested                                 // merge requested without waiting
-	mergeProgressWaitingForMerge                                // waiting for merged state
-	mergeProgressMergeIncomplete                                // merged state did not appear
-	mergeProgressMerged                                         // merged state observed
-	mergeProgressSyncFailed                                     // trunk sync failed
-	mergeProgressFailed                                         // branch failed by scheduler policy
-	mergeProgressSkipped                                        // branch skipped by scheduler policy
+	mergeProgressPreparing              mergeProgressEventKind = iota // branch preparation started
+	mergeProgressPrepareFailed                                        // local preparation failed
+	mergeProgressRetargeting                                          // retargeting to trunk started
+	mergeProgressRetargetFailed                                       // retargeting to trunk failed
+	mergeProgressWaitingForForgeHead                                  // forge HEAD still stale
+	mergeProgressForgeHeadFailed                                      // forge HEAD did not update
+	mergeProgressWaitingForMergeability                               // merge readiness still pending
+	mergeProgressMergeabilityReady                                    // ready to merge
+	mergeProgressMergeabilityFailed                                   // merge readiness blocked or timed out
+	mergeProgressMerging                                              // forge merge request started
+	mergeProgressMergeFailed                                          // forge merge request failed
+	mergeProgressMergeRequested                                       // merge requested without waiting
+	mergeProgressWaitingForMerge                                      // waiting for merged state
+	mergeProgressMergeIncomplete                                      // merged state did not appear
+	mergeProgressMerged                                               // merged state observed
+	mergeProgressSyncFailed                                           // trunk sync failed
+	mergeProgressFailed                                               // branch failed by scheduler policy
+	mergeProgressSkipped                                              // branch skipped by scheduler policy
 )
 
 // logMergeProgress reports merge progress through sparse log messages.
@@ -79,8 +81,10 @@ func (p *logMergeProgress) Event(event mergeProgressEvent) {
 	case mergeProgressRetargeting:
 		p.log.Infof("%s: retargeting %v onto %s",
 			event.Item.branch, event.Item.changeID, event.Base)
-	case mergeProgressWaitingForChecks:
-		p.log.Infof("%s: waiting for CI checks", event.Item.branch)
+	case mergeProgressWaitingForForgeHead:
+		p.log.Infof("%s: waiting for HEAD to update", event.Item.branch)
+	case mergeProgressWaitingForMergeability:
+		p.log.Infof("%s: waiting for merge readiness", event.Item.branch)
 	case mergeProgressMerging:
 		p.log.Infof("%s: merging %v: %s",
 			event.Item.branch, event.Item.changeID, event.URL)
@@ -252,23 +256,35 @@ func widgetProgressEvent(event mergeProgressEvent) mergeprogress.Event {
 			State:   mergeprogress.StateFailed,
 			Message: item.branch + ": retarget failed",
 		}
-	case mergeProgressWaitingForChecks:
+	case mergeProgressWaitingForForgeHead:
 		return mergeprogress.Event{
 			ItemID:  item.branch,
 			State:   mergeprogress.StateActive,
-			Message: item.branch + ": waiting for CI checks",
+			Message: item.branch + ": waiting for HEAD to update",
 		}
-	case mergeProgressChecksPassed:
-		return mergeprogress.Event{
-			ItemID:  item.branch,
-			State:   mergeprogress.StateActive,
-			Message: item.branch + ": CI checks passed",
-		}
-	case mergeProgressChecksFailed:
+	case mergeProgressForgeHeadFailed:
 		return mergeprogress.Event{
 			ItemID:  item.branch,
 			State:   mergeprogress.StateFailed,
-			Message: item.branch + ": CI checks failed",
+			Message: item.branch + ": HEAD did not update",
+		}
+	case mergeProgressWaitingForMergeability:
+		return mergeprogress.Event{
+			ItemID:  item.branch,
+			State:   mergeprogress.StateActive,
+			Message: item.branch + ": waiting for merge readiness",
+		}
+	case mergeProgressMergeabilityReady:
+		return mergeprogress.Event{
+			ItemID:  item.branch,
+			State:   mergeprogress.StateActive,
+			Message: item.branch + ": ready to merge",
+		}
+	case mergeProgressMergeabilityFailed:
+		return mergeprogress.Event{
+			ItemID:  item.branch,
+			State:   mergeprogress.StateFailed,
+			Message: item.branch + ": merge readiness failed",
 		}
 	case mergeProgressMerging:
 		return mergeprogress.Event{

--- a/internal/handler/merge/progress_test.go
+++ b/internal/handler/merge/progress_test.go
@@ -34,7 +34,7 @@ func TestWidgetMergeProgress_FinishAfterRunnerExit(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		progress.Event(mergeProgressEvent{
-			Kind: mergeProgressChecksFailed,
+			Kind: mergeProgressMergeabilityFailed,
 			Item: &mergeItem{
 				branch: "feat1",
 			},

--- a/internal/handler/merge/scheduler.go
+++ b/internal/handler/merge/scheduler.go
@@ -28,11 +28,11 @@ type mergePlanExecutor struct {
 
 	Progress mergeProgress // required
 
-	Trunk        string            // required
-	BuildTimeout time.Duration     // required
-	Method       forge.MergeMethod // required
-	NoWait       bool
-	FailFast     bool
+	Trunk                 string            // required
+	MergeReadinessTimeout time.Duration     // required
+	Method                forge.MergeMethod // required
+	NoWait                bool
+	FailFast              bool
 }
 
 // Execute runs the merge queue over the supplied plan items.
@@ -108,21 +108,21 @@ func (e *mergePlanExecutor) mergeOne(
 		return fmt.Errorf("ensure targets trunk: %w", err)
 	}
 
-	// CI is checked after retargeting and restacking
+	// Merge readiness is checked after retargeting and restacking
 	// so each merge waits on the exact change being merged.
 	if err := e.awaitChangeHead(ctx, item, change); err != nil {
 		e.Progress.Event(mergeProgressEvent{
-			Kind: mergeProgressChecksFailed,
+			Kind: mergeProgressForgeHeadFailed,
 			Item: item,
 		})
 		return fmt.Errorf("wait for pushed head: %w", err)
 	}
-	if err := e.awaitChecks(ctx, item); err != nil {
+	if err := e.awaitMergeability(ctx, item); err != nil {
 		e.Progress.Event(mergeProgressEvent{
-			Kind: mergeProgressChecksFailed,
+			Kind: mergeProgressMergeabilityFailed,
 			Item: item,
 		})
-		return fmt.Errorf("wait for checks: %w", err)
+		return fmt.Errorf("wait for merge readiness: %w", err)
 	}
 
 	e.Progress.Event(mergeProgressEvent{

--- a/internal/handler/merge/scheduler_test.go
+++ b/internal/handler/merge/scheduler_test.go
@@ -119,8 +119,8 @@ func TestMergeScheduler_siblingContinuesAfterSubtreeFails(t *testing.T) {
 		FindChangeByID(gomock.Any(), pr2).
 		Return(fakeFindResultWithHead("main", "head2"), nil)
 	mockForge.EXPECT().
-		ChangeChecks(gomock.Any(), pr2).
-		Return(checks(forge.ChangeCheckFailed), nil)
+		ChangeMergeability(gomock.Any(), pr2).
+		Return(mergeability(forge.ChangeMergeabilityBlocked), nil)
 
 	mockForge.EXPECT().
 		FindChangeByID(gomock.Any(), pr3).
@@ -142,7 +142,7 @@ func TestMergeScheduler_siblingContinuesAfterSubtreeFails(t *testing.T) {
 		testPlanEntry("feat3", "feat1", pr3),
 	))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "CI checks failed")
+	assert.Contains(t, err.Error(), "blocked")
 	assert.True(t, progress.seen(mergeProgressFailed, "feat2"))
 	assert.True(t, progress.seen(mergeProgressSkipped, "feat4"))
 	assert.True(t, progress.seen(mergeProgressMerging, "feat3"))
@@ -231,8 +231,8 @@ func TestMergeScheduler_failFastStopsOnFailure(t *testing.T) {
 		FindChangeByID(gomock.Any(), pr2).
 		Return(fakeFindResultWithHead("main", "head2"), nil)
 	mockForge.EXPECT().
-		ChangeChecks(gomock.Any(), pr2).
-		Return(checks(forge.ChangeCheckFailed), nil)
+		ChangeMergeability(gomock.Any(), pr2).
+		Return(mergeability(forge.ChangeMergeabilityBlocked), nil)
 
 	progress := &recordingMergeProgress{}
 	executor := newTestMergePlanExecutor(
@@ -251,7 +251,7 @@ func TestMergeScheduler_failFastStopsOnFailure(t *testing.T) {
 		testPlanEntry("feat3", "feat1", pr3),
 	))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "CI checks failed")
+	assert.Contains(t, err.Error(), "blocked")
 	assert.False(t, progress.seen(mergeProgressMerging, "feat3"))
 }
 
@@ -313,8 +313,8 @@ func expectMergeWithRecord(
 	operations *[]string,
 ) {
 	mockForge.EXPECT().
-		ChangeChecks(gomock.Any(), id).
-		Return(checks(forge.ChangeCheckPassed), nil)
+		ChangeMergeability(gomock.Any(), id).
+		Return(mergeability(forge.ChangeMergeabilityReady), nil)
 
 	mockForge.EXPECT().
 		MergeChange(gomock.Any(), id, gomock.Any()).

--- a/stack_merge.go
+++ b/stack_merge.go
@@ -33,9 +33,11 @@ func (*stackMergeCmd) Help() string {
 		whose base PR was already merged on the forge.
 		Use --no-branch-check to skip this validation.
 
-		Before each merge, waits for CI checks to pass.
-		Use --build-timeout to configure the maximum wait
-		before failing if checks are not ready.
+		Before each merge, waits for merge readiness:
+		the forge must observe the pushed head
+		and report that the CR is ready to merge.
+		Use --ready-timeout to configure the maximum wait
+		before failing if merge readiness is not reached.
 
 		By default, a branch failure skips that branch's upstack descendants,
 		but independent sibling branches continue.

--- a/testdata/help/branch_merge.txt
+++ b/testdata/help/branch_merge.txt
@@ -8,14 +8,15 @@ different branch.
 The branch must be based directly on trunk. To merge a stacked branch, use 'gs
 downstack merge'.
 
-Before merging, waits for CI checks to pass. Use --build-timeout to configure
+Before merging, waits for merge readiness: the forge must observe the pushed
+head and report that the CR is ready to merge. Use --ready-timeout to configure
 the maximum wait.
 
 Flags:
   --method=METHOD        Preferred merge method. One of 'merge', 'squash',
                          and 'rebase'. (🔧 spice.merge.method)
-  --build-timeout=30m    Max time to wait for CI checks before each merge.
-                         0 means check once. (🔧 spice.merge.buildTimeout)
+  --ready-timeout=30m    Max time to wait for merge readiness before each merge.
+                         0 means check once. (🔧 spice.merge.readyTimeout)
   --branch=NAME          Branch to merge
 
 Global Flags:

--- a/testdata/help/downstack_merge.txt
+++ b/testdata/help/downstack_merge.txt
@@ -5,9 +5,9 @@ Merge a branch and those below it
 Merges the current branch and all branches below it into trunk via the forge
 API, bottom-up. Use --branch to start at a different branch.
 
-This command acts as a local merge queue: it merges one Change Request,
-waits for that merge to finish, restacks and updates the next Change Request,
-waits for its CI checks to pass, and then repeats the process.
+This command acts as a local merge queue: it merges one Change Request, waits
+for that merge to finish, restacks and updates the next Change Request, waits
+for merge readiness on the updated Change Request, and then repeats the process.
 
 For a stack like this:
 
@@ -23,12 +23,13 @@ Change Request to be merged.
 Before merging, the downstack is checked for branches whose base PR was already
 merged on the forge. Use --no-branch-check to skip this validation.
 
-Before each merge, waits for CI checks to pass. Use --build-timeout to configure
+Before each merge, waits for merge readiness: the forge must observe the pushed
+head and report that the CR is ready to merge. Use --ready-timeout to configure
 the maximum wait (default: 30m, 0 means fail immediately if not ready).
 
 Between merges, the command waits for each merge to complete, restacks and
-updates the next PR, waits for CI checks on the updated PR, and syncs merged
-branch cleanup.
+updates the next PR, waits for merge readiness on the updated PR, and syncs
+merged branch cleanup.
 
 Use --no-wait for single branch merging when you don't want to wait for the
 merge to propagate. --no-wait is rejected for multi-branch merges.
@@ -36,8 +37,8 @@ merge to propagate. --no-wait is rejected for multi-branch merges.
 Flags:
   --method=METHOD        Preferred merge method. One of 'merge', 'squash',
                          and 'rebase'. (🔧 spice.merge.method)
-  --build-timeout=30m    Max time to wait for CI checks before each merge.
-                         0 means check once. (🔧 spice.merge.buildTimeout)
+  --ready-timeout=30m    Max time to wait for merge readiness before each merge.
+                         0 means check once. (🔧 spice.merge.readyTimeout)
   --no-wait              Skip polling for a single branch merge to propagate.
   --no-branch-check      Skip stale base validation before merging.
   --branch=NAME          Branch to start merging from

--- a/testdata/help/stack_merge.txt
+++ b/testdata/help/stack_merge.txt
@@ -14,8 +14,9 @@ Change Request to be merged.
 Before merging, the stack is checked for branches whose base PR was already
 merged on the forge. Use --no-branch-check to skip this validation.
 
-Before each merge, waits for CI checks to pass. Use --build-timeout to configure
-the maximum wait before failing if checks are not ready.
+Before each merge, waits for merge readiness: the forge must observe the pushed
+head and report that the CR is ready to merge. Use --ready-timeout to configure
+the maximum wait before failing if merge readiness is not reached.
 
 By default, a branch failure skips that branch's upstack descendants, but
 independent sibling branches continue. Use --fail-fast to stop the queue after
@@ -24,8 +25,8 @@ the first branch failure.
 Flags:
   --method=METHOD        Preferred merge method. One of 'merge', 'squash',
                          and 'rebase'. (🔧 spice.merge.method)
-  --build-timeout=30m    Max time to wait for CI checks before each merge.
-                         0 means check once. (🔧 spice.merge.buildTimeout)
+  --ready-timeout=30m    Max time to wait for merge readiness before each merge.
+                         0 means check once. (🔧 spice.merge.readyTimeout)
   --no-branch-check      Skip stale base validation before merging.
   --fail-fast            Stop the merge queue after the first branch failure.
   --branch=NAME          Branch whose stack to merge

--- a/testdata/script/branch_merge_explicit_branch.txt
+++ b/testdata/script/branch_merge_explicit_branch.txt
@@ -1,4 +1,4 @@
-# 'branch merge --branch' refuses to merge when CI checks failed.
+# 'branch merge --branch' refuses to merge when merge readiness is blocked.
 
 as 'Test <test@example.com>'
 at '2026-06-13T18:29:00Z'
@@ -22,10 +22,10 @@ gs auth login
 git add feature1.txt
 gs bc feature1 -m 'Add feature 1'
 
-# submit the branch and mark its checks failed
+# submit the branch and mark merge readiness blocked
 gs branch submit --fill
 stderr 'Created #1'
-shamhub set-status --name 'unit tests' alice/example 1 failed
+shamhub set-mergeability -reason checks alice/example 1 blocked
 
 # branch merge should stop before sending the merge request.
 gs trunk
@@ -46,7 +46,7 @@ This is feature 1
 >   feature1 (#1)
 true
 -- golden/merge-stderr.txt --
-FTL gs: merge queue item "feature1": wait for checks: CI checks failed
+FTL gs: merge queue item "feature1": wait for merge readiness: blocked: checks
 -- golden/change-1.json --
 {
   "number": 1,

--- a/testdata/script/downstack_merge_mergeability_block_next.txt
+++ b/testdata/script/downstack_merge_mergeability_block_next.txt
@@ -1,4 +1,4 @@
-# 'downstack merge' waits for checks on the next branch after restacking.
+# 'downstack merge' checks merge readiness on the next branch after restacking.
 
 as 'Test <test@example.com>'
 at '2026-05-31T08:07:00Z'
@@ -24,15 +24,15 @@ gs bc feature1 -m 'Add feature 1'
 git add feature2.txt
 gs bc feature2 -m 'Add feature 2'
 
-# submit the stack, pass feature1, and fail feature2.
+# submit the stack, make feature1 ready, and block feature2.
 gs downstack submit --fill
 stderr 'Created #1'
 stderr 'Created #2'
-shamhub set-status --name 'unit tests' alice/example 1 passed
-shamhub set-status --name 'unit tests' alice/example 2 failed
+shamhub set-mergeability alice/example 1 ready
+shamhub set-mergeability -reason checks alice/example 2 blocked
 
 # The queue should merge feature1, update feature2, then stop before
-# merging feature2 because the updated PR's checks are failed.
+# merging feature2 because the updated PR's merge readiness is blocked.
 env ROBOT_INPUT=$WORK/robot-merge.golden ROBOT_OUTPUT=$WORK/robot-merge.actual
 ! gs downstack merge
 cmp $WORK/robot-merge.actual $WORK/robot-merge.golden
@@ -63,7 +63,7 @@ INF feature1: deleted (was dc8aa3d)
 INF feature2: retargeting #2 onto main...
 INF feature2: restacked on main
 INF Updated #2: $SHAMHUB_URL/alice/example/change/2
-FTL gs: merge queue item "feature2": wait for checks: CI checks failed
+FTL gs: merge queue item "feature2": wait for merge readiness: blocked: checks
 -- golden/change-1.json --
 {
   "number": 1,

--- a/testdata/script/downstack_merge_mergeability_blocked.txt
+++ b/testdata/script/downstack_merge_mergeability_blocked.txt
@@ -1,4 +1,4 @@
-# 'downstack merge' refuses to merge when CI checks failed.
+# 'downstack merge' refuses to merge when merge readiness is blocked.
 
 as 'Test <test@example.com>'
 at '2026-05-31T08:05:00Z'
@@ -22,10 +22,10 @@ gs auth login
 git add feature1.txt
 gs bc feature1 -m 'Add feature 1'
 
-# submit the branch and mark its checks failed
+# submit the branch and mark merge readiness blocked
 gs downstack submit --fill
 stderr 'Created #1'
-shamhub set-status --name 'unit tests' alice/example 1 failed
+shamhub set-mergeability -reason checks alice/example 1 blocked
 
 # downstack merge should stop before sending the merge request.
 env ROBOT_INPUT=$WORK/robot-merge.golden ROBOT_OUTPUT=$WORK/robot-merge.actual
@@ -45,7 +45,7 @@ This is feature 1
 >   feature1 (#1)
 true
 -- golden/merge-stderr.txt --
-FTL gs: merge queue item "feature1": wait for checks: CI checks failed
+FTL gs: merge queue item "feature1": wait for merge readiness: blocked: checks
 -- golden/change-1.json --
 {
   "number": 1,

--- a/testdata/script/downstack_merge_mergeability_waiting.txt
+++ b/testdata/script/downstack_merge_mergeability_waiting.txt
@@ -1,4 +1,4 @@
-# 'downstack merge' refuses pending CI checks when build-timeout is zero.
+# 'downstack merge' refuses a not-ready change when ready-timeout is zero.
 
 as 'Test <test@example.com>'
 at '2026-05-31T08:06:00Z'
@@ -22,14 +22,14 @@ gs auth login
 git add feature1.txt
 gs bc feature1 -m 'Add feature 1'
 
-# submit the branch and mark its checks pending
+# submit the branch and mark its merge readiness waiting
 gs downstack submit --fill
 stderr 'Created #1'
-shamhub set-status --name 'unit tests' alice/example 1 pending
+shamhub set-mergeability -reason checks alice/example 1 waiting
 
-# With build-timeout=0, pending checks fail immediately.
+# With ready-timeout=0, waiting merge readiness fails immediately.
 env ROBOT_INPUT=$WORK/robot-merge.golden ROBOT_OUTPUT=$WORK/robot-merge.actual
-! gs downstack merge --build-timeout=0
+! gs downstack merge --ready-timeout=0
 cmp $WORK/robot-merge.actual $WORK/robot-merge.golden
 cmp stderr $WORK/golden/merge-stderr.txt
 
@@ -45,7 +45,7 @@ This is feature 1
 >   feature1 (#1)
 true
 -- golden/merge-stderr.txt --
-FTL gs: merge queue item "feature1": wait for checks: CI checks pending (build-timeout=0)
+FTL gs: merge queue item "feature1": wait for merge readiness: not ready after 0s
 -- golden/change-1.json --
 {
   "number": 1,


### PR DESCRIPTION
Merge commands should wait for the forge to report readiness.
They should not rely only on passed CI checks.
The forge readiness signal includes policy state such as drafts,
conflicts, and pending required checks, so it is the safer gate for the
final merge request.

This updates branch, downstack, and stack merge to poll change merge
readiness before requesting a merge.

The previous build-timeout flag and config key become `--ready-timeout`
and `merge.readyTimeout`.
The wait is no longer limited to build or CI status.
