### PR TITLE
commit: support multiple -m/--message flags

### DIFF
--- a/.changes/unreleased/Added-20260623-050407.yaml
+++ b/.changes/unreleased/Added-20260623-050407.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: >-
+  commit create, commit amend, branch create: The -m/--message flag may now
+  be passed multiple times to add multiple paragraphs to the commit message,
+  matching 'git commit'.
+time: 2026-06-23T05:04:12.000000-07:00

--- a/branch_create.go
+++ b/branch_create.go
@@ -28,9 +28,9 @@ type branchCreateCmd struct {
 	Below  bool   `help:"Place the branch below the target branch and restack its upstack"`
 	Target string `short:"t" placeholder:"BRANCH" help:"Branch to create the new branch above/below"`
 
-	All         bool   `short:"a" help:"Automatically stage modified and deleted files"`
-	Message     string `short:"m" xor:"commit-message-source" placeholder:"MSG" help:"Commit message"`
-	MessageFile string `short:"F" xor:"commit-message-source" placeholder:"FILE" help:"Read the commit message from the given file."`
+	All         bool     `short:"a" help:"Automatically stage modified and deleted files"`
+	Message     []string `short:"m" xor:"commit-message-source" sep:"none" placeholder:"MSG" help:"Use the given message as the commit message. May be repeated to add multiple paragraphs."`
+	MessageFile string   `short:"F" xor:"commit-message-source" placeholder:"FILE" help:"Read the commit message from the given file."`
 
 	NoVerify bool `help:"Bypass pre-commit and commit-msg hooks."`
 	Signoff  bool `config:"commit.signoff" help:"Add Signed-off-by trailer to the commit message"`
@@ -107,7 +107,7 @@ func (cmd *branchCreateCmd) Run(
 	restackHandler RestackHandler,
 ) (err error) {
 	// If a message is specified, automatically enable commits
-	if cmd.Message != "" || cmd.MessageFile != "" {
+	if len(cmd.Message) > 0 || cmd.MessageFile != "" {
 		cmd.Commit = true
 	}
 
@@ -353,7 +353,7 @@ func (cmd *branchCreateCmd) commit(
 
 	if err := wt.Commit(ctx, git.CommitRequest{
 		AllowEmpty:  len(diff) == 0,
-		Message:     cmd.Message,
+		Messages:    cmd.Message,
 		MessageFile: cmd.MessageFile,
 		NoVerify:    cmd.NoVerify,
 		All:         cmd.All,

--- a/commit_amend.go
+++ b/commit_amend.go
@@ -18,10 +18,10 @@ import (
 type commitAmendCmd struct {
 	branchCreateConfig // TODO: find a way to avoid this
 
-	All         bool   `short:"a" help:"Stage all changes before committing."`
-	AllowEmpty  bool   `help:"Create a commit even if it contains no changes."`
-	Message     string `short:"m" xor:"commit-message-source" placeholder:"MSG" help:"Use the given message as the commit message."`
-	MessageFile string `short:"F" xor:"commit-message-source" placeholder:"FILE" help:"Read the commit message from the given file."`
+	All         bool     `short:"a" help:"Stage all changes before committing."`
+	AllowEmpty  bool     `help:"Create a commit even if it contains no changes."`
+	Message     []string `short:"m" xor:"commit-message-source" sep:"none" placeholder:"MSG" help:"Use the given message as the commit message. May be repeated to add multiple paragraphs."`
+	MessageFile string   `short:"F" xor:"commit-message-source" placeholder:"FILE" help:"Read the commit message from the given file."`
 
 	NoEdit   bool `help:"Don't edit the commit message"`
 	NoVerify bool `help:"Bypass pre-commit and commit-msg hooks."`
@@ -219,7 +219,7 @@ func (cmd *commitAmendCmd) Run(
 	}
 
 	if err := wt.Commit(ctx, git.CommitRequest{
-		Message:     cmd.Message,
+		Messages:    cmd.Message,
 		MessageFile: cmd.MessageFile,
 		AllowEmpty:  cmd.AllowEmpty,
 		Amend:       true,

--- a/commit_create.go
+++ b/commit_create.go
@@ -13,13 +13,13 @@ import (
 )
 
 type commitCreateCmd struct {
-	All         bool   `short:"a" help:"Stage all changes before committing."`
-	AllowEmpty  bool   `help:"Create a new commit even if it contains no changes."`
-	Fixup       string `help:"Create a fixup commit. See also 'git-spice commit fixup'." placeholder:"COMMIT"`
-	Message     string `short:"m" xor:"commit-message-source" placeholder:"MSG" help:"Use the given message as the commit message."`
-	MessageFile string `short:"F" xor:"commit-message-source" placeholder:"FILE" help:"Read the commit message from the given file."`
-	NoVerify    bool   `help:"Bypass pre-commit and commit-msg hooks."`
-	Signoff     bool   `config:"commit.signoff" help:"Add Signed-off-by trailer to the commit message"`
+	All         bool     `short:"a" help:"Stage all changes before committing."`
+	AllowEmpty  bool     `help:"Create a new commit even if it contains no changes."`
+	Fixup       string   `help:"Create a fixup commit. See also 'git-spice commit fixup'." placeholder:"COMMIT"`
+	Message     []string `short:"m" xor:"commit-message-source" sep:"none" placeholder:"MSG" help:"Use the given message as the commit message. May be repeated to add multiple paragraphs."`
+	MessageFile string   `short:"F" xor:"commit-message-source" placeholder:"FILE" help:"Read the commit message from the given file."`
+	NoVerify    bool     `help:"Bypass pre-commit and commit-msg hooks."`
+	Signoff     bool     `config:"commit.signoff" help:"Add Signed-off-by trailer to the commit message"`
 }
 
 func (*commitCreateCmd) Help() string {
@@ -51,7 +51,7 @@ func (cmd *commitCreateCmd) Run(
 	restackHandler RestackHandler,
 ) error {
 	if err := wt.Commit(ctx, git.CommitRequest{
-		Message:     cmd.Message,
+		Messages:    cmd.Message,
 		MessageFile: cmd.MessageFile,
 		All:         cmd.All,
 		AllowEmpty:  cmd.AllowEmpty,

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -858,7 +858,7 @@ target (A) to the specified branch:
 * `--below`: Place the branch below the target branch and restack its upstack
 * `-t`, `--target=BRANCH`: Branch to create the new branch above/below
 * `-a`, `--all`: Automatically stage modified and deleted files
-* `-m`, `--message=MSG`: Commit message
+* `-m`, `--message=MSG`: Use the given message as the commit message. May be repeated to add multiple paragraphs.
 * `-F`, `--message-file=FILE`: Read the commit message from the given file.
 * `--no-verify`: Bypass pre-commit and commit-msg hooks.
 * `--signoff` ([:material-wrench:{ .middle title="spice.commit.signoff" }](/cli/config.md#spicecommitsignoff)): Add Signed-off-by trailer to the commit message
@@ -1237,7 +1237,7 @@ when you want to apply changes to an older commit.
 * `-a`, `--all`: Stage all changes before committing.
 * `--allow-empty`: Create a new commit even if it contains no changes.
 * `--fixup=COMMIT`: Create a fixup commit. See also 'git-spice commit fixup'.
-* `-m`, `--message=MSG`: Use the given message as the commit message.
+* `-m`, `--message=MSG`: Use the given message as the commit message. May be repeated to add multiple paragraphs.
 * `-F`, `--message-file=FILE`: Read the commit message from the given file.
 * `--no-verify`: Bypass pre-commit and commit-msg hooks.
 * `--signoff` ([:material-wrench:{ .middle title="spice.commit.signoff" }](/cli/config.md#spicecommitsignoff)): Add Signed-off-by trailer to the commit message
@@ -1276,7 +1276,7 @@ The --no-prompt flag can be used to skip this prompt in scripts.
 
 * `-a`, `--all`: Stage all changes before committing.
 * `--allow-empty`: Create a commit even if it contains no changes.
-* `-m`, `--message=MSG`: Use the given message as the commit message.
+* `-m`, `--message=MSG`: Use the given message as the commit message. May be repeated to add multiple paragraphs.
 * `-F`, `--message-file=FILE`: Read the commit message from the given file.
 * `--no-edit`: Don't edit the commit message
 * `--no-verify`: Bypass pre-commit and commit-msg hooks.

--- a/internal/git/commit_wt.go
+++ b/internal/git/commit_wt.go
@@ -15,6 +15,14 @@ type CommitRequest struct {
 	// $EDITOR is opened to edit the message.
 	Message string
 
+	// Messages are additional commit message paragraphs.
+	//
+	// Each element becomes a separate -m argument,
+	// producing separate paragraphs like git commit's repeated -m behavior.
+	// When both Message and Messages are set,
+	// Messages is appended after Message.
+	Messages []string
+
 	// MessageFile reads the commit message from the given file.
 	MessageFile string
 
@@ -66,6 +74,9 @@ func (w *Worktree) Commit(ctx context.Context, req CommitRequest) error {
 	}
 	if req.Message != "" {
 		args = append(args, "-m", req.Message)
+	}
+	for _, m := range req.Messages {
+		args = append(args, "-m", m)
 	}
 	if req.MessageFile != "" {
 		args = append(args, "-F", req.MessageFile)

--- a/internal/git/commit_wt_test.go
+++ b/internal/git/commit_wt_test.go
@@ -133,3 +133,61 @@ func TestWorktree_Commit_messageFile(t *testing.T) {
 	require.Equal(t, "Add test file", commit.Subject)
 	require.Equal(t, "From file.\n", commit.Body)
 }
+
+func TestWorktree_Commit_multipleMessages(t *testing.T) {
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	t.Setenv("USER", "testuser")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("GIT_COMMITTER_NAME", "Test Committer")
+	t.Setenv("GIT_COMMITTER_EMAIL", "committer@example.com")
+	t.Setenv("GIT_AUTHOR_NAME", "Test Author")
+	t.Setenv("GIT_AUTHOR_EMAIL", "author@example.com")
+
+	fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+		at '2025-08-30T21:28:29Z'
+		as 'Test Owner <test@example.com>'
+
+		git init
+		git commit --allow-empty -m 'Initial commit'
+
+		git add file.txt
+
+		-- file.txt --
+		test content
+	`)))
+	require.NoError(t, err)
+	t.Cleanup(fixture.Cleanup)
+
+	ctx := t.Context()
+	worktree, err := git.OpenWorktree(ctx, fixture.Dir(), git.OpenOptions{
+		Log: silogtest.New(t),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, worktree.Commit(ctx, git.CommitRequest{
+		Messages: []string{
+			"Subject line",
+			"Body paragraph one.",
+			"Body paragraph two.",
+		},
+	}))
+
+	commit, err := worktree.Repository().ReadCommit(ctx, "HEAD")
+	require.NoError(t, err)
+	require.Equal(t, "Subject line", commit.Subject)
+	require.Contains(t, commit.Body,
+		"Body paragraph one.\n\nBody paragraph two.")
+
+	t.Run("SingleMessage", func(t *testing.T) {
+		require.NoError(t, worktree.Commit(ctx, git.CommitRequest{
+			AllowEmpty: true,
+			Messages:   []string{"Only subject"},
+		}))
+
+		commit, err := worktree.Repository().ReadCommit(ctx, "HEAD")
+		require.NoError(t, err)
+		require.Equal(t, "Only subject", commit.Subject)
+		require.Empty(t, commit.Body)
+	})
+}

--- a/testdata/help/branch_create.txt
+++ b/testdata/help/branch_create.txt
@@ -62,7 +62,8 @@ Flags:
                              restack its upstack
   -t, --target=BRANCH        Branch to create the new branch above/below
   -a, --all                  Automatically stage modified and deleted files
-  -m, --message=MSG          Commit message
+  -m, --message=MSG          Use the given message as the commit message.
+                             May be repeated to add multiple paragraphs.
   -F, --message-file=FILE    Read the commit message from the given file.
       --no-verify            Bypass pre-commit and commit-msg hooks.
       --signoff              Add Signed-off-by trailer to the commit message (🔧

--- a/testdata/help/commit_amend.txt
+++ b/testdata/help/commit_amend.txt
@@ -22,6 +22,7 @@ Flags:
   -a, --all                  Stage all changes before committing.
       --allow-empty          Create a commit even if it contains no changes.
   -m, --message=MSG          Use the given message as the commit message.
+                             May be repeated to add multiple paragraphs.
   -F, --message-file=FILE    Read the commit message from the given file.
       --no-edit              Don't edit the commit message
       --no-verify            Bypass pre-commit and commit-msg hooks.

--- a/testdata/help/commit_create.txt
+++ b/testdata/help/commit_create.txt
@@ -22,6 +22,7 @@ Flags:
       --fixup=COMMIT         Create a fixup commit. See also 'git-spice commit
                              fixup'.
   -m, --message=MSG          Use the given message as the commit message.
+                             May be repeated to add multiple paragraphs.
   -F, --message-file=FILE    Read the commit message from the given file.
       --no-verify            Bypass pre-commit and commit-msg hooks.
       --signoff              Add Signed-off-by trailer to the commit message (🔧

--- a/testdata/script/commit_multiple_messages.txt
+++ b/testdata/script/commit_multiple_messages.txt
@@ -1,0 +1,26 @@
+# Commit create accepts repeated message flags.
+
+as 'Test <test@example.com>'
+at '2024-03-30T14:59:32Z'
+
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+git checkout -b feature
+gs branch track --base main
+
+git add foo.txt
+gs commit create -m 'Subject line' -m 'Body paragraph.'
+
+git log -1 --format=%B
+cmp stdout $WORK/golden/message.txt
+
+-- golden/message.txt --
+Subject line
+
+Body paragraph.
+
+-- repo/foo.txt --
+Contents of foo.


### PR DESCRIPTION
`git commit` accepts multiple `-m`/`--message` flags and joins them as
separate paragraphs of the commit message. This teaches git-spice's
commit-creating commands to do the same.

## Why

git-spice positions its commit commands as drop-in shortcuts for
`git commit` (`gs commit create` == `git commit` + restack). But the
`-m` flag was bound to a scalar string, so `gs commit create -m subject
-m body` silently dropped everything but the last message, diverging
from Git and surprising users who rely on the multi-`-m` idiom to write
a subject plus body without opening an editor. Issue #1288 asks that all
commands that create commits mirror Git's repeated-`-m` behavior.

## What changed

- `gs commit create`, `gs commit amend`, and `gs branch create` now bind
  `-m`/`--message` to a repeatable `[]string`. Each occurrence becomes a
  separate paragraph, mirroring `git commit -m ... -m ...`.
- `sep:"none"` is set on the flag so a message containing commas is kept
  verbatim (kong's default comma-splitting would otherwise break messages
  like `-m "Fix bug, take two"`).
- `git.CommitRequest` gains a `Messages []string` field that emits one
  `-m`/value arg pair per element. The existing scalar `Message string`
  field is left untouched, so all other callers keep working. A single
  `-m` produces git arguments identical to before.

## Behavior

```
gs commit create -m "Subject line" -m "Body paragraph."
```

produces a commit whose message has the subject and body as separate
paragraphs, exactly like Git.

## Testing

- New unit test `TestWorktree_Commit_multipleMessages` in
  `internal/git/commit_wt_test.go` covering the multi-paragraph happy path
  and single-message parity.
- New test script `testdata/script/commit_multiple_messages.txt`
  exercising the end-to-end CLI path.
- Regenerated help goldens (`testdata/help/*.txt`) and the CLI reference
  (`doc/includes/cli-reference.md`) for the updated help text.
- Added an `Added` changelog entry.

Fixes #1288
