### PR TITLE
fix(repo sync): Handle reused manual branch names

### DIFF
--- a/.changes/unreleased/Fixed-20260622-182305.yaml
+++ b/.changes/unreleased/Fixed-20260622-182305.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'repo sync: Detect manually submitted merged changes when a source branch name is reused by a newer open change.'
+time: 2026-06-22T18:23:05.333324-07:00

--- a/internal/forge/shamhub/find.go
+++ b/internal/forge/shamhub/find.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -95,10 +96,6 @@ func (sh *ShamHub) handleFindChangesByBranch(_ context.Context, req *findChanges
 	sh.mu.RLock()
 nextChange:
 	for _, c := range sh.changes {
-		if len(got) >= limit {
-			break
-		}
-
 		for _, f := range filters {
 			if !f(c) {
 				continue nextChange
@@ -109,11 +106,21 @@ nextChange:
 	}
 	sh.mu.RUnlock()
 
+	// Return newest changes first,
+	// matching the order of hosted forges that prioritize recent activity.
+	slices.Reverse(got)
+	if len(got) > limit {
+		got = got[:limit]
+	}
+
 	changes := make([]*Change, len(got))
 	for i, c := range got {
 		change, err := sh.toChange(c)
 		if err != nil {
 			return nil, fmt.Errorf("convert shamChange to Change: %w", err)
+		}
+		if c.HeadHash != "" {
+			change.Head.Hash = c.HeadHash
 		}
 
 		changes[i] = change

--- a/internal/handler/sync/handler.go
+++ b/internal/handler/sync/handler.go
@@ -545,8 +545,12 @@ func (h *Handler) findForgeFinishedBranches(
 	//    with 'gh pr create' or similar.
 	//
 	// For the first, we can perform a cheap API call to check the CR status.
-	// For the second, we need to find recently merged PRs with that branch
-	// name, and match the remote head SHA to the branch head SHA.
+	// For the second, we need to find open and merged PRs with that branch
+	// name. An open PR normally means the branch is still live,
+	// but a source branch name may be reused after an older PR was merged.
+	// A merged PR whose remote head contains the local head proves that the
+	// local branch is safe to delete,
+	// so it wins over an open PR for the same branch name.
 	//
 	// We'll try to do these checks concurrently.
 
@@ -620,24 +624,64 @@ func (h *Handler) findForgeFinishedBranches(
 						continue
 					}
 
-					var change *forge.FindChangeItem
+					// Closed-unmerged changes cannot prove that this branch is
+					// safe to delete,
+					// so avoid resolving local head state unless a live or
+					// merged change could affect the sync decision.
+					var hasOpenOrMergedChange bool
 					for _, c := range changes {
-						if c.State == forge.ChangeOpen {
-							change = c
+						if c.State == forge.ChangeOpen || c.State == forge.ChangeMerged {
+							hasOpenOrMergedChange = true
 							break
 						}
-						if c.State == forge.ChangeMerged && change == nil {
-							change = c
+					}
+					if !hasOpenOrMergedChange {
+						continue
+					}
+
+					// A reused source branch name is ambiguous until we compare
+					// the forge's head hashes with the local branch head.
+					localSHA, err := h.Repository.PeelToCommit(ctx, b.Name)
+					if err != nil {
+						h.Log.Error("Failed to resolve local head SHA", "branch", b.Name, "error", err)
+						continue
+					}
+
+					// Track the best candidates in forge order,
+					// but let a proven-safe merged change outrank an open
+					// change for the same reused source branch name.
+					var (
+						openChange       *forge.FindChangeItem
+						mergedChange     *forge.FindChangeItem
+						safeMergedChange *forge.FindChangeItem
+					)
+				findSafeMergedChange:
+					for _, c := range changes {
+						switch c.State {
+						case forge.ChangeOpen:
+							openChange = cmp.Or(openChange, c)
+						case forge.ChangeMerged:
+							mergedChange = cmp.Or(mergedChange, c)
+							if mergedChangeHeadCheck(ctx, h.Repository,
+								localSHA, c.HeadHash) != mergedChangeHeadMismatch {
+								safeMergedChange = c
+								break findSafeMergedChange
+							}
 						}
 					}
 
-					if change != nil {
-						localSHA, err := h.Repository.PeelToCommit(ctx, b.Name)
-						if err != nil {
-							h.Log.Error("Failed to resolve local head SHA", "branch", b.Name, "error", err)
-							continue
-						}
+					// Prefer an open change unless a merged change proves
+					// the local head was included,
+					// preserving the conservative behavior for ambiguous
+					// branch-name matches.
+					change := openChange
+					if safeMergedChange != nil {
+						change = safeMergedChange
+					} else if openChange == nil {
+						change = mergedChange
+					}
 
+					if change != nil {
 						b.Merged = change.State == forge.ChangeMerged
 						b.Change = change.ID
 						b.RemoteHeadSHA = change.HeadHash

--- a/testdata/script/repo_sync_reused_branch_open_before_merged.txt
+++ b/testdata/script/repo_sync_reused_branch_open_before_merged.txt
@@ -1,0 +1,112 @@
+# 'repo sync' deletes a manually tracked branch
+# when a newer open CR reuses the same source branch name.
+
+as 'Test <test@example.com>'
+at '2026-06-23T12:00:00Z'
+
+# Setup.
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# Set up a fake GitHub remote.
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# Create and merge the older CR for feature.
+# The original repo keeps its local feature branch at this merged head.
+git add feature-v1.txt
+gs bc -m 'Add feature v1' feature
+gs branch submit --fill
+stderr 'Created #1'
+shamhub merge alice/example 1
+git push origin --delete feature
+
+# A second checkout creates a newer open CR with the same source branch name.
+cd ..
+shamhub clone alice/example.git other
+cd other
+gs repo init --trunk=main --remote=origin
+cp $WORK/extra/feature-v2.txt feature-v2.txt
+git add feature-v2.txt
+gs bc -m 'Add feature v2' feature
+gs branch submit --fill
+stderr 'Created #2'
+
+# Forget the original repo's CR metadata so repo sync must inspect CRs
+# by source branch name. The forge returns #2 before #1.
+cd ../repo
+gs repo init --reset --trunk=main --remote=origin
+gs branch track --base=main feature
+gs repo sync
+stderr 'feature: #1 was merged'
+stderr 'feature: deleted \(was 8c7a786\)'
+
+git branch --list feature
+cmp stdout $WORK/golden/no-branches.txt
+
+shamhub dump changes
+cmpenvJSON stdout $WORK/golden/changes.json
+
+-- repo/feature-v1.txt --
+Contents of feature v1
+
+-- extra/feature-v2.txt --
+Contents of feature v2
+
+-- golden/no-branches.txt --
+-- golden/changes.json --
+[
+  {
+    "base": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "main",
+      "sha": "b0393bc4dcfcec7ef4218974b998afe35eebcfeb"
+    },
+    "body": "",
+    "head": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "feature",
+      "sha": "02c39434c145c87fd068369784677e58e827c75b"
+    },
+    "html_url": "$SHAMHUB_URL/alice/example/change/1",
+    "merged": true,
+    "number": 1,
+    "state": "closed",
+    "title": "Add feature v1"
+  },
+  {
+    "base": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "main",
+      "sha": "b0393bc4dcfcec7ef4218974b998afe35eebcfeb"
+    },
+    "body": "",
+    "head": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "feature",
+      "sha": "02c39434c145c87fd068369784677e58e827c75b"
+    },
+    "html_url": "$SHAMHUB_URL/alice/example/change/2",
+    "number": 2,
+    "state": "open",
+    "title": "Add feature v2"
+  }
+]


### PR DESCRIPTION
`repo sync` looks up manually submitted changes by source branch name
before deciding whether a local branch is safe to delete.
That source branch name can be reused after an earlier manual change
has merged.

Before this patch,
the failure sequence was:

1. `repo sync` asked the forge for recent changes with the branch name.
2. A newer open change appeared before an older merged change.
3. `repo sync` selected the open change.
4. The older merged change was never checked against the local branch head.
5. The local branch stayed behind even though its commits were merged.

The regression script builds that boundary with two CRs that both use
`feature` as the source branch.
With the production selection logic reverted,
the script fails because `repo sync` never reports the older merged CR:

    no match for `feature: #1 was merged` found in stderr

`repo sync` now resolves the local branch head before choosing among
manual change results.
A merged change whose forge head contains the local head proves that
the local branch is safe to delete,
so that merged change outranks an open change returned for the same
reused source branch name.

The same script now verifies that `repo sync` reports the merged CR,
deletes the local `feature` branch,
and leaves the newer open CR intact.