### PR TITLE
fix(submit): Refuse trunk submit upstreams

### DIFF
--- a/.changes/unreleased/Fixed-20260625-225551.yaml
+++ b/.changes/unreleased/Fixed-20260625-225551.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: "branch submit: Accidental pushes to trunk are now prevented when a branch's upstream is trunk."
+time: 2026-06-25T22:55:51.101877222Z

--- a/internal/handler/submit/handler.go
+++ b/internal/handler/submit/handler.go
@@ -1226,6 +1226,13 @@ func (h *Handler) resolveUpstreamBranch(
 	// Stored upstream branch state wins because it reflects the branch name
 	// previously used for submission, even if the local branch was renamed.
 	if storedUpstream != "" {
+		if storedUpstream == h.Store.Trunk() {
+			return "", fmt.Errorf(
+				"refusing to push branch %q to trunk %q; "+
+					"run '%s branch untrack %s' and track the branch again",
+				branch, storedUpstream, cli.Name(), branch)
+		}
+
 		return storedUpstream, nil
 	}
 
@@ -1241,6 +1248,13 @@ func (h *Handler) resolveUpstreamBranch(
 	}
 
 	if b, ok := strings.CutPrefix(upstream, remote+"/"); ok {
+		if b == h.Store.Trunk() {
+			return "", fmt.Errorf(
+				"refusing to push branch %q to trunk %q; "+
+					"run 'git branch --unset-upstream %s'",
+				branch, b, branch)
+		}
+
 		h.Log.Infof("%v: Using upstream name '%v'", branch, b)
 		h.Log.Infof("%v: If this is incorrect, cancel this operation and run 'git branch --unset-upstream %v'.", branch, branch)
 		return b, nil

--- a/internal/handler/submit/handler_test.go
+++ b/internal/handler/submit/handler_test.go
@@ -185,6 +185,52 @@ func TestHandler_SubmitBatch_rejectsStaleBaseBeforeSubmitting(t *testing.T) {
 	assert.Contains(t, logBuffer.String(), "base=feat1")
 }
 
+func TestHandler_resolveUpstreamBranch_refusesStoredTrunk(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+
+	mockStore := NewMockStore(mockCtrl)
+	mockStore.EXPECT().
+		Trunk().
+		Return("main")
+
+	handler := &Handler{
+		Log:        silog.Nop(),
+		View:       ui.NewFileView(&bytes.Buffer{}),
+		Repository: nil,
+		Worktree:   nil,
+		Store:      mockStore,
+		Service:    nil,
+		Browser:    &browser.Noop{},
+		FindRemote: func(context.Context) (state.Remote, error) {
+			return state.Remote{}, nil
+		},
+		OpenRepository: func(
+			context.Context,
+			forge.Forge,
+			forge.RepositoryID,
+		) (forge.Repository, error) {
+			return nil, nil
+		},
+		ResolveRepository: func(
+			context.Context,
+			string,
+		) (forge.Forge, forge.RepositoryID, error) {
+			return nil, nil, nil
+		},
+	}
+
+	_, err := handler.resolveUpstreamBranch(
+		t.Context(),
+		"origin",
+		"feature",
+		"main",
+	)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, `refusing to push branch "feature" to trunk "main"`)
+	assert.ErrorContains(t, err, "branch untrack feature")
+}
+
 func TestHandler_checkStaleSubmissionBases_forceSkipsValidation(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 

--- a/testdata/script/issue1311_branch_submit_refuses_trunk_upstream.txt
+++ b/testdata/script/issue1311_branch_submit_refuses_trunk_upstream.txt
@@ -1,0 +1,45 @@
+# Regression test for https://github.com/abhinav/git-spice/issues/1311.
+# branch submit must not push a feature branch to the trunk ref when the
+# branch's Git upstream is configured directly to origin/main.
+
+as 'Test <test@example.com>'
+at '2026-06-25T00:00:00Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# Set up a fake GitHub remote.
+shamhub init
+shamhub register alice
+shamhub new origin alice/example.git
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# Create a git-spice-tracked feature branch, then configure its Git upstream
+# directly to the trunk remote ref using the same style as the reported issue.
+git add feature.txt
+gs branch create feature -m 'Add feature'
+git branch --set-upstream-to=origin/main feature
+
+! gs branch submit --draft --fill
+stderr 'refusing to push branch "feature" to trunk "main"'
+
+# The failed submit must not advance origin/main or create a CR.
+git rev-parse main
+cmp stdout $WORK/golden/main.txt
+git rev-parse origin/main
+cmp stdout $WORK/golden/main.txt
+
+shamhub dump changes
+cmpenvJSON stdout $WORK/golden/changes.json
+
+-- repo/feature.txt --
+feature
+-- golden/main.txt --
+aff9520a4bb3d33784bd9c359489d7fce9f0f698
+-- golden/changes.json --
+[]


### PR DESCRIPTION
branch submit uses an upstream branch name from git-spice state or from
the branch's Git upstream to choose the remote head it pushes.

If that upstream resolves to trunk, a non-trunk branch can push its commits
onto the trunk ref before change request creation fails. Refuse both stored
and Git-derived trunk upstreams before building the push refspec, with
recovery guidance for the state that supplied the unsafe upstream.

The script regression proves the fresh Git upstream case by showing
origin/main remains unchanged and no change request is created. The unit
test covers cached git-spice upstream state equal to trunk.

Resolves #1311