### PR TITLE
fix(git): Preserve merge-tree wait errors

### DIFF
--- a/internal/git/merge_tree.go
+++ b/internal/git/merge_tree.go
@@ -139,7 +139,7 @@ func (r *Repository) MergeTree(ctx context.Context, req MergeTreeRequest) (_ Has
 
 	waitErr := cmd.Wait() // will use below
 	if waitErr != nil {
-		waitErr = fmt.Errorf("git merge-tree: %w", err)
+		waitErr = fmt.Errorf("git merge-tree: %w", waitErr)
 	}
 
 	o := outputs[0]

--- a/internal/git/merge_tree_int_test.go
+++ b/internal/git/merge_tree_int_test.go
@@ -1,10 +1,15 @@
 package git
 
 import (
+	"errors"
+	"io"
+	"os/exec"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 // SetConflictStyle exports test-only functionality
@@ -12,6 +17,47 @@ import (
 // for a merge-tree operation.
 func SetConflictStyle(req *MergeTreeRequest, style string) {
 	req.conflictStyle = style
+}
+
+func TestRepository_MergeTree_waitError(t *testing.T) {
+	ctx := t.Context()
+	mockExecer := NewMockExecer(gomock.NewController(t))
+	repo, _ := NewFakeRepository(t, "", mockExecer)
+	waitErr := errors.New("wait failed")
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	mockExecer.EXPECT().
+		Start(gomock.Any()).
+		Do(func(cmd *exec.Cmd) error {
+			assert.Equal(t, []string{
+				"merge-tree",
+				"--write-tree",
+				"--stdin",
+				"-z",
+			}, cmd.Args[1:])
+
+			wg.Go(func() {
+				_, err := io.WriteString(cmd.Stdout,
+					"1\x001234567890abcdef1234567890abcdef12345678\x00\x00")
+				assert.NoError(t, err)
+				assert.NoError(t, cmd.Stdout.(io.Closer).Close())
+			})
+			return nil
+		})
+	mockExecer.EXPECT().
+		Wait(gomock.Any()).
+		Return(waitErr)
+
+	got, err := repo.MergeTree(ctx, MergeTreeRequest{
+		Branch1: "branch1",
+		Branch2: "branch2",
+	})
+	require.Error(t, err)
+	assert.Equal(t, Hash("1234567890abcdef1234567890abcdef12345678"), got)
+	assert.ErrorContains(t, err, "git merge-tree: wait failed")
+	assert.ErrorIs(t, err, waitErr)
 }
 
 func TestParseConflictStage(t *testing.T) {


### PR DESCRIPTION
Repository.MergeTree parses git merge-tree stdout before it waits for the process to finish.
If parsing succeeded but cmd.Wait failed,
the old error path wrapped the stale parse error variable instead of the wait error.
That produced git merge-tree: %!w(<nil>) and hid the real process failure.

Wrap waitErr so callers receive the command-completion failure and can still unwrap it with errors.Is.
The regression test fails against the old implementation with the malformed nil wrap,
and passes after the wait error is preserved.

[skip changelog]: internal diagnostic correctness fix