### PR TITLE
mergeprogress: Add glyph set presets

### DIFF
--- a/internal/ui/widget/mergeprogress/animation.go
+++ b/internal/ui/widget/mergeprogress/animation.go
@@ -30,7 +30,10 @@ type animationState struct {
 	tickScheduled bool
 }
 
-func (a animationState) marker(width int) (position int, glyph string, ok bool) {
+func (a animationState) marker(
+	width int,
+	glyphs AnimationGlyphSet,
+) (position int, glyph string, ok bool) {
 	if !a.enabled || width <= 0 {
 		return 0, "", false
 	}
@@ -45,20 +48,20 @@ func (a animationState) marker(width int) (position int, glyph string, ok bool) 
 	position = int(math.Round(eased * float64(width-1)))
 
 	if phase < 0.05 || phase >= 0.95 {
-		return position, "╺", true
+		return position, glyphs.LeftEdge, true
 	}
 	if phase > 0.45 && phase < 0.55 {
-		return position, "╸", true
+		return position, glyphs.RightEdge, true
 	}
 
 	speed := math.Abs(math.Sin(2 * math.Pi * phase))
 	switch {
 	case speed > 0.85:
-		return position, "—", true
+		return position, glyphs.Fast, true
 	case speed > 0.45:
-		return position, "–", true
+		return position, glyphs.Medium, true
 	default:
-		return position, "-", true
+		return position, glyphs.Slow, true
 	}
 }
 

--- a/internal/ui/widget/mergeprogress/progress.go
+++ b/internal/ui/widget/mergeprogress/progress.go
@@ -82,6 +82,62 @@ var DefaultKeyMap = KeyMap{
 	),
 }
 
+// GlyphSet defines the characters used for queue states.
+type GlyphSet struct {
+	Merged  string // merged item
+	Active  string // active item base fill
+	Pending string // item not yet started
+	Failed  string // item that failed
+	Skipped string // item skipped by scheduler policy
+
+	Animation AnimationGlyphSet // active item marker glyphs
+}
+
+// AnimationGlyphSet defines active-segment animation characters.
+type AnimationGlyphSet struct {
+	LeftEdge  string // marker at the left edge
+	RightEdge string // marker at the right edge
+	Slow      string // marker while moving slowly
+	Medium    string // marker while moving at medium speed
+	Fast      string // marker while moving fastest
+}
+
+// SymbolsGlyphSet returns the default symbol glyph set.
+func SymbolsGlyphSet() GlyphSet {
+	return GlyphSet{
+		Merged:  "■",
+		Active:  "◆",
+		Pending: "□",
+		Failed:  "×",
+		Skipped: "○",
+		Animation: AnimationGlyphSet{
+			LeftEdge:  "◆",
+			RightEdge: "◆",
+			Slow:      "◆",
+			Medium:    "◇",
+			Fast:      "◇",
+		},
+	}
+}
+
+// ASCIIGlyphSet returns the glyph set for basic terminal compatibility.
+func ASCIIGlyphSet() GlyphSet {
+	return GlyphSet{
+		Merged:  "#",
+		Active:  "=",
+		Pending: "-",
+		Failed:  "x",
+		Skipped: "o",
+		Animation: AnimationGlyphSet{
+			LeftEdge:  "-",
+			RightEdge: "-",
+			Slow:      "-",
+			Medium:    "-",
+			Fast:      "-",
+		},
+	}
+}
+
 // Style defines the visual style of [Widget].
 type Style struct {
 	Merged  ui.Style // requires value
@@ -97,28 +153,10 @@ type Style struct {
 }
 
 // DefaultStyle is the default visual style of [Widget].
-var DefaultStyle = Style{
-	Merged: ui.NewStyle().
-		Foreground(ui.Green).
-		SetString("■"),
-	Active: ui.NewStyle().
-		Foreground(ui.Yellow).
-		SetString("="),
-	Pending: ui.NewStyle().
-		Foreground(ui.Gray).
-		SetString("-"),
-	Failed: ui.NewStyle().
-		Foreground(ui.Red).
-		SetString("!"),
-	Skipped: ui.NewStyle().
-		Foreground(ui.Plain).
-		SetString("·"),
-
-	Title:   ui.NewStyle().Bold(true),
-	Summary: ui.NewStyle().Foreground(ui.Plain),
-	Detail:  ui.NewStyle().Foreground(ui.Plain),
-	Hint:    ui.NewStyle().Foreground(ui.Gray),
-}
+//
+// TODO: Add merge configuration plumbing to select [ASCIIGlyphSet]
+// for terminals where the symbol glyphs do not render well.
+var DefaultStyle = styleForGlyphSet(SymbolsGlyphSet())
 
 // Widget is a Bubble Tea model for stack merge progress.
 //
@@ -143,6 +181,7 @@ type Widget struct {
 	width     int
 	theme     ui.Theme
 	animation animationState
+	glyphs    GlyphSet
 }
 
 var _ tea.Model = (*Widget)(nil)
@@ -152,6 +191,7 @@ func New(items ...Item) *Widget {
 	w := &Widget{
 		KeyMap: DefaultKeyMap,
 		Style:  DefaultStyle,
+		glyphs: SymbolsGlyphSet(),
 		animation: animationState{
 			enabled: true,
 		},
@@ -182,6 +222,13 @@ func (w *Widget) apply(event Event) {
 // WithTheme sets the theme used by Bubble Tea rendering.
 func (w *Widget) WithTheme(theme ui.Theme) *Widget {
 	w.theme = theme
+	return w
+}
+
+// WithGlyphSet changes the queue state characters used by the widget.
+func (w *Widget) WithGlyphSet(glyphs GlyphSet) *Widget {
+	w.glyphs = glyphs
+	w.Style = styleForGlyphSet(glyphs)
 	return w
 }
 
@@ -305,7 +352,7 @@ func (w *Widget) renderSegment(
 	width int,
 ) {
 	if state == StateActive {
-		position, glyph, ok := w.animation.marker(width)
+		position, glyph, ok := w.animation.marker(width, w.glyphs.Animation)
 		if ok {
 			active := w.Style.Active.String(theme)
 			out.WriteString(strings.Repeat(active, position))
@@ -369,4 +416,29 @@ func distribute(width, segments int) []int {
 		}
 	}
 	return widths
+}
+
+func styleForGlyphSet(glyphs GlyphSet) Style {
+	return Style{
+		Merged: ui.NewStyle().
+			Foreground(ui.Green).
+			SetString(glyphs.Merged),
+		Active: ui.NewStyle().
+			Foreground(ui.Yellow).
+			SetString(glyphs.Active),
+		Pending: ui.NewStyle().
+			Foreground(ui.Gray).
+			SetString(glyphs.Pending),
+		Failed: ui.NewStyle().
+			Foreground(ui.Red).
+			SetString(glyphs.Failed),
+		Skipped: ui.NewStyle().
+			Foreground(ui.Plain).
+			SetString(glyphs.Skipped),
+
+		Title:   ui.NewStyle().Bold(true),
+		Summary: ui.NewStyle().Foreground(ui.Plain),
+		Detail:  ui.NewStyle().Foreground(ui.Plain),
+		Hint:    ui.NewStyle().Foreground(ui.Gray),
+	}
 }

--- a/internal/ui/widget/mergeprogress/progress_test.go
+++ b/internal/ui/widget/mergeprogress/progress_test.go
@@ -22,7 +22,7 @@ func TestWidget_RenderProgression(t *testing.T) {
 
 	autogold.Expect(`Merging: 0 of 10 changes
 
-----------------------------------------
+□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□
 merged: 0   waiting: 0   pending: 10
 
 Press Ctrl-C to cancel merge operation.`).Equal(t, renderPlain(widget))
@@ -34,7 +34,7 @@ Press Ctrl-C to cancel merge operation.`).Equal(t, renderPlain(widget))
 	})
 	autogold.Expect(`Merging: 0 of 10 changes
 
-====------------------------------------
+◆◆◆◆□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□
 merged: 0   waiting: 1   pending: 9
 
 Waiting for CI checks on feature-01 (#101).
@@ -57,7 +57,7 @@ Press Ctrl-C to cancel merge operation.`).Equal(t, renderPlain(widget))
 	})
 	autogold.Expect(`Merging: 1 of 10 changes
 
-■■■■========----------------------------
+■■■■◆◆◆◆◆◆◆◆□□□□□□□□□□□□□□□□□□□□□□□□□□□□
 merged: 1   waiting: 2   pending: 7
 
 Waiting for CI checks on feature-02 (#102) and feature-03 (#103).
@@ -70,7 +70,7 @@ Press Ctrl-C to cancel merge operation.`).Equal(t, renderPlain(widget))
 	})
 	autogold.Expect(`Merging: 2 of 10 changes
 
-■■■■■■■■====----------------------------
+■■■■■■■■◆◆◆◆□□□□□□□□□□□□□□□□□□□□□□□□□□□□
 merged: 2   waiting: 1   pending: 7
 
 Merged feature-02 (#102); still waiting for feature-03 (#103).
@@ -83,7 +83,7 @@ Press Ctrl-C to cancel merge operation.`).Equal(t, renderPlain(widget))
 	})
 	autogold.Expect(`Merging: 2 of 10 changes
 
-■■■■■■■■!!!!----------------------------
+■■■■■■■■××××□□□□□□□□□□□□□□□□□□□□□□□□□□□□
 merged: 2   waiting: 0   pending: 7   failed: 1
 
 CI checks failed for feature-03 (#103).
@@ -124,8 +124,8 @@ func TestWidget_Render_scalingKeepsShape(t *testing.T) {
 	assert.Equal(t, 72, lipgloss.Width(barLine(wide)))
 	assert.Equal(t, 24, lipgloss.Width(barLine(narrow)))
 	assert.Contains(t, barLine(wide), "■")
-	assert.Contains(t, barLine(wide), "=")
-	assert.Contains(t, barLine(wide), "-")
+	assert.Contains(t, barLine(wide), "◆")
+	assert.Contains(t, barLine(wide), "□")
 }
 
 func TestWidget_Render_failedAndSkipped(t *testing.T) {
@@ -147,7 +147,23 @@ func TestWidget_Render_failedAndSkipped(t *testing.T) {
 	assert.Contains(t, got, "merged: 1   waiting: 1   pending: 1")
 	assert.Contains(t, got, "failed: 1")
 	assert.Contains(t, got, "skipped: 1")
-	assert.Equal(t, "■■■■····====!!!!----", barLine(got))
+	assert.Equal(t, "■■■■○○○○◆◆◆◆××××□□□□", barLine(got))
+}
+
+func TestWidget_Render_ASCIIGlyphSet(t *testing.T) {
+	items := makeItems(5)
+	items[0].State = StateMerged
+	items[1].State = StateSkipped
+	items[2].State = StateActive
+	items[3].State = StateFailed
+
+	widget := New(items...).
+		WithTheme(ui.DefaultThemeDark()).
+		WithGlyphSet(ASCIIGlyphSet()).
+		WithAnimation(false)
+	mustUpdate(t, widget, tea.WindowSizeMsg{Width: 20})
+
+	assert.Equal(t, "####oooo====xxxx----", barLine(renderPlain(widget)))
 }
 
 func renderPlain(widget *Widget) string {


### PR DESCRIPTION
Replace merge progress bar glyphs with a better set.
Glyphs all have the same height now for a more balanced bar shape.

<img width="787" height="470" alt="demo" src="https://github.com/user-attachments/assets/f1246e15-ade7-47a0-804e-ab24a8ec7123" />

ASCII glyph set is available for a future configuration option.

[skip changelog]: unreleased feature