### PR TITLE
fix(shamhub): Use singular change URLs

### DIFF
--- a/internal/forge/shamhub/forge.go
+++ b/internal/forge/shamhub/forge.go
@@ -124,7 +124,7 @@ func (rid *RepositoryID) String() string {
 func (rid *RepositoryID) ChangeURL(id forge.ChangeID) string {
 	cr := id.(ChangeID)
 
-	return fmt.Sprintf("%s/%s/%s/changes/%v", rid.url, rid.owner, rid.repo, int(cr))
+	return fmt.Sprintf("%s/%s/%s/change/%v", rid.url, rid.owner, rid.repo, int(cr))
 }
 
 func extractRepoInfo(path string) (owner, repo string, err error) {

--- a/internal/forge/shamhub/forge_test.go
+++ b/internal/forge/shamhub/forge_test.go
@@ -18,6 +18,6 @@ func TestForge_ParseRepositoryPath_knownForge(t *testing.T) {
 
 	assert.Equal(t, "example/repo", rid.String())
 	assert.Equal(t,
-		"https://shamhub.example/example/repo/changes/123",
+		"https://shamhub.example/example/repo/change/123",
 		rid.ChangeURL(ChangeID(123)))
 }

--- a/mise.toml
+++ b/mise.toml
@@ -66,7 +66,7 @@ complete "script" run="ls testdata/script/*.txt | cut -d/ -f3 | sed 's/.txt$//'"
 run = """
 gotestsum --format={{usage.format}} -- {# -#}
   -tags=script {# enable script tests -#}
-  -run TestScript/{{usage.run}} {# run only script tests -#}
+  -run TestScript/{{usage.run|quote}} {# run only script tests -#}
   -count {{usage.count}} {# number of times to run tests -#}
   -race={{usage.race}} {# race detection -#}
   -shard-index={{usage.shard_index}} {# shard index -#}

--- a/testdata/script/branch_submit_create_update.txt
+++ b/testdata/script/branch_submit_create_update.txt
@@ -107,5 +107,5 @@ New contents of feature1
 ┏━■ feature1 (#1) ◀
 main
 -- golden/ls.json --
-{"name":"feature1","current":true,"down":{"name":"main"},"change":{"id":"#1","url":"$SHAMHUB_URL/alice/example/changes/1","status":"open"},"push":{"ahead":0,"behind":0}}
+{"name":"feature1","current":true,"down":{"name":"main"},"change":{"id":"#1","url":"$SHAMHUB_URL/alice/example/change/1","status":"open"},"push":{"ahead":0,"behind":0}}
 {"name":"main","ups":[{"name":"feature1"}]}

--- a/testdata/script/config_log_change_format.txt
+++ b/testdata/script/config_log_change_format.txt
@@ -45,13 +45,13 @@ cmpenv stderr $WORK/golden/ll-after-crformat-url.txt
 -- golden/ls-after-crformat-url.txt --
     ┏━■ feat3 ◀
   ┏━┻□ feat2
-┏━┻□ feat1 ($SHAMHUB_URL/alice/example/changes/1)
+┏━┻□ feat1 ($SHAMHUB_URL/alice/example/change/1)
 main
 -- golden/ll-after-crformat-url.txt --
     ┏━■ feat3 ◀
     ┃   7b5eba4 feat3 (now)
   ┏━┻□ feat2
   ┃    562c8c6 feat2 (now)
-┏━┻□ feat1 ($SHAMHUB_URL/alice/example/changes/1)
+┏━┻□ feat1 ($SHAMHUB_URL/alice/example/change/1)
 ┃    ecc906e feat1 (now)
 main

--- a/testdata/script/config_log_combined_change_format.txt
+++ b/testdata/script/config_log_combined_change_format.txt
@@ -62,12 +62,12 @@ cmpenv stderr $WORK/golden/ll-fallback-id.txt
 
 -- golden/ls-general-url.txt --
   ┏━■ feat2 ◀
-┏━┻□ feat1 ($SHAMHUB_URL/alice/example/changes/1)
+┏━┻□ feat1 ($SHAMHUB_URL/alice/example/change/1)
 main
 -- golden/ll-general-url.txt --
   ┏━■ feat2 ◀
   ┃   562c8c6 feat2 (now)
-┏━┻□ feat1 ($SHAMHUB_URL/alice/example/changes/1)
+┏━┻□ feat1 ($SHAMHUB_URL/alice/example/change/1)
 ┃    ecc906e feat1 (now)
 main
 -- golden/ls-specific-id.txt --
@@ -77,7 +77,7 @@ main
 -- golden/ll-specific-url.txt --
   ┏━■ feat2 ◀
   ┃   562c8c6 feat2 (now)
-┏━┻□ feat1 ($SHAMHUB_URL/alice/example/changes/1)
+┏━┻□ feat1 ($SHAMHUB_URL/alice/example/change/1)
 ┃    ecc906e feat1 (now)
 main
 -- golden/ls-fallback-id.txt --

--- a/testdata/script/config_log_long_change_format.txt
+++ b/testdata/script/config_log_long_change_format.txt
@@ -67,7 +67,7 @@ main
 -- golden/ll-loglong-url.txt --
   ┏━■ feat2 ◀
   ┃   562c8c6 feat2 (now)
-┏━┻□ feat1 ($SHAMHUB_URL/alice/example/changes/1)
+┏━┻□ feat1 ($SHAMHUB_URL/alice/example/change/1)
 ┃    ecc906e feat1 (now)
 main
 -- golden/ll-loglong-id.txt --
@@ -79,7 +79,7 @@ main
 -- golden/ll-fallback-url.txt --
   ┏━■ feat2 ◀
   ┃   562c8c6 feat2 (now)
-┏━┻□ feat1 ($SHAMHUB_URL/alice/example/changes/1)
+┏━┻□ feat1 ($SHAMHUB_URL/alice/example/change/1)
 ┃    ecc906e feat1 (now)
 main
 -- golden/ll-override-id.txt --

--- a/testdata/script/config_log_short_change_format.txt
+++ b/testdata/script/config_log_short_change_format.txt
@@ -64,7 +64,7 @@ cmpenv stderr $WORK/golden/ls-override-id.txt
 main
 -- golden/ls-logshort-url.txt --
   ┏━■ feat2 ◀
-┏━┻□ feat1 ($SHAMHUB_URL/alice/example/changes/1)
+┏━┻□ feat1 ($SHAMHUB_URL/alice/example/change/1)
 main
 -- golden/ls-logshort-id.txt --
   ┏━■ feat2 ◀
@@ -72,7 +72,7 @@ main
 main
 -- golden/ls-fallback-url.txt --
   ┏━■ feat2 ◀
-┏━┻□ feat1 ($SHAMHUB_URL/alice/example/changes/1)
+┏━┻□ feat1 ($SHAMHUB_URL/alice/example/change/1)
 main
 -- golden/ls-override-id.txt --
   ┏━■ feat2 ◀

--- a/testdata/script/downstack_merge_mergeability_block_next.txt
+++ b/testdata/script/downstack_merge_mergeability_block_next.txt
@@ -55,7 +55,7 @@ This is feature 2
 >   feature2 (#2)
 true
 -- golden/merge-stderr.txt --
-INF feature1: merging #1: $SHAMHUB_URL/alice/example/changes/1
+INF feature1: merging #1: $SHAMHUB_URL/alice/example/change/1
 INF main: pulled 2 new commit(s)
 INF feature1: #1 was merged
 INF feature2: retargeted upstack onto main

--- a/testdata/script/log_comments.txt
+++ b/testdata/script/log_comments.txt
@@ -94,22 +94,22 @@ main
 ┃    92fc5a4 feat1 (now)
 main
 -- golden/ls-without-comments.json --
-{"name":"feat1","down":{"name":"main"},"ups":[{"name":"feat2"}],"change":{"id":"#1","url":"$SHAMHUB_URL/alice/example/changes/1"},"push":{"ahead":0,"behind":0}}
-{"name":"feat2","down":{"name":"feat1"},"ups":[{"name":"feat3"}],"change":{"id":"#2","url":"$SHAMHUB_URL/alice/example/changes/2"},"push":{"ahead":0,"behind":0}}
-{"name":"feat3","current":true,"down":{"name":"feat2"},"change":{"id":"#3","url":"$SHAMHUB_URL/alice/example/changes/3"},"push":{"ahead":0,"behind":0}}
+{"name":"feat1","down":{"name":"main"},"ups":[{"name":"feat2"}],"change":{"id":"#1","url":"$SHAMHUB_URL/alice/example/change/1"},"push":{"ahead":0,"behind":0}}
+{"name":"feat2","down":{"name":"feat1"},"ups":[{"name":"feat3"}],"change":{"id":"#2","url":"$SHAMHUB_URL/alice/example/change/2"},"push":{"ahead":0,"behind":0}}
+{"name":"feat3","current":true,"down":{"name":"feat2"},"change":{"id":"#3","url":"$SHAMHUB_URL/alice/example/change/3"},"push":{"ahead":0,"behind":0}}
 {"name":"main","ups":[{"name":"feat1"}]}
 -- golden/ll-without-comments.json --
-{"name":"feat1","down":{"name":"main"},"ups":[{"name":"feat2"}],"commits":[{"sha":"92fc5a4cc99e01014388a99f08e6e93dd5ce9e64","subject":"feat1"}],"change":{"id":"#1","url":"$SHAMHUB_URL/alice/example/changes/1"},"push":{"ahead":0,"behind":0}}
-{"name":"feat2","down":{"name":"feat1"},"ups":[{"name":"feat3"}],"commits":[{"sha":"87abb98561265516e610dc3cc2d4765114bb0c14","subject":"feat2"}],"change":{"id":"#2","url":"$SHAMHUB_URL/alice/example/changes/2"},"push":{"ahead":0,"behind":0}}
-{"name":"feat3","current":true,"down":{"name":"feat2"},"commits":[{"sha":"7112afba5ab632bb4ebd8215b716c36c6c3dd824","subject":"feat3"}],"change":{"id":"#3","url":"$SHAMHUB_URL/alice/example/changes/3"},"push":{"ahead":0,"behind":0}}
+{"name":"feat1","down":{"name":"main"},"ups":[{"name":"feat2"}],"commits":[{"sha":"92fc5a4cc99e01014388a99f08e6e93dd5ce9e64","subject":"feat1"}],"change":{"id":"#1","url":"$SHAMHUB_URL/alice/example/change/1"},"push":{"ahead":0,"behind":0}}
+{"name":"feat2","down":{"name":"feat1"},"ups":[{"name":"feat3"}],"commits":[{"sha":"87abb98561265516e610dc3cc2d4765114bb0c14","subject":"feat2"}],"change":{"id":"#2","url":"$SHAMHUB_URL/alice/example/change/2"},"push":{"ahead":0,"behind":0}}
+{"name":"feat3","current":true,"down":{"name":"feat2"},"commits":[{"sha":"7112afba5ab632bb4ebd8215b716c36c6c3dd824","subject":"feat3"}],"change":{"id":"#3","url":"$SHAMHUB_URL/alice/example/change/3"},"push":{"ahead":0,"behind":0}}
 {"name":"main","ups":[{"name":"feat1"}]}
 -- golden/ls-with-comments.json --
-{"name":"feat1","down":{"name":"main"},"ups":[{"name":"feat2"}],"change":{"id":"#1","url":"$SHAMHUB_URL/alice/example/changes/1","comments":{"total":2,"resolved":1,"unresolved":1}},"push":{"ahead":0,"behind":0}}
-{"name":"feat2","down":{"name":"feat1"},"ups":[{"name":"feat3"}],"change":{"id":"#2","url":"$SHAMHUB_URL/alice/example/changes/2","comments":{"total":1,"resolved":1,"unresolved":0}},"push":{"ahead":0,"behind":0}}
-{"name":"feat3","current":true,"down":{"name":"feat2"},"change":{"id":"#3","url":"$SHAMHUB_URL/alice/example/changes/3","comments":{"total":0,"resolved":0,"unresolved":0}},"push":{"ahead":0,"behind":0}}
+{"name":"feat1","down":{"name":"main"},"ups":[{"name":"feat2"}],"change":{"id":"#1","url":"$SHAMHUB_URL/alice/example/change/1","comments":{"total":2,"resolved":1,"unresolved":1}},"push":{"ahead":0,"behind":0}}
+{"name":"feat2","down":{"name":"feat1"},"ups":[{"name":"feat3"}],"change":{"id":"#2","url":"$SHAMHUB_URL/alice/example/change/2","comments":{"total":1,"resolved":1,"unresolved":0}},"push":{"ahead":0,"behind":0}}
+{"name":"feat3","current":true,"down":{"name":"feat2"},"change":{"id":"#3","url":"$SHAMHUB_URL/alice/example/change/3","comments":{"total":0,"resolved":0,"unresolved":0}},"push":{"ahead":0,"behind":0}}
 {"name":"main","ups":[{"name":"feat1"}]}
 -- golden/ll-with-comments.json --
-{"name":"feat1","down":{"name":"main"},"ups":[{"name":"feat2"}],"commits":[{"sha":"92fc5a4cc99e01014388a99f08e6e93dd5ce9e64","subject":"feat1"}],"change":{"id":"#1","url":"$SHAMHUB_URL/alice/example/changes/1","comments":{"total":2,"resolved":1,"unresolved":1}},"push":{"ahead":0,"behind":0}}
-{"name":"feat2","down":{"name":"feat1"},"ups":[{"name":"feat3"}],"commits":[{"sha":"87abb98561265516e610dc3cc2d4765114bb0c14","subject":"feat2"}],"change":{"id":"#2","url":"$SHAMHUB_URL/alice/example/changes/2","comments":{"total":1,"resolved":1,"unresolved":0}},"push":{"ahead":0,"behind":0}}
-{"name":"feat3","current":true,"down":{"name":"feat2"},"commits":[{"sha":"7112afba5ab632bb4ebd8215b716c36c6c3dd824","subject":"feat3"}],"change":{"id":"#3","url":"$SHAMHUB_URL/alice/example/changes/3","comments":{"total":0,"resolved":0,"unresolved":0}},"push":{"ahead":0,"behind":0}}
+{"name":"feat1","down":{"name":"main"},"ups":[{"name":"feat2"}],"commits":[{"sha":"92fc5a4cc99e01014388a99f08e6e93dd5ce9e64","subject":"feat1"}],"change":{"id":"#1","url":"$SHAMHUB_URL/alice/example/change/1","comments":{"total":2,"resolved":1,"unresolved":1}},"push":{"ahead":0,"behind":0}}
+{"name":"feat2","down":{"name":"feat1"},"ups":[{"name":"feat3"}],"commits":[{"sha":"87abb98561265516e610dc3cc2d4765114bb0c14","subject":"feat2"}],"change":{"id":"#2","url":"$SHAMHUB_URL/alice/example/change/2","comments":{"total":1,"resolved":1,"unresolved":0}},"push":{"ahead":0,"behind":0}}
+{"name":"feat3","current":true,"down":{"name":"feat2"},"commits":[{"sha":"7112afba5ab632bb4ebd8215b716c36c6c3dd824","subject":"feat3"}],"change":{"id":"#3","url":"$SHAMHUB_URL/alice/example/change/3","comments":{"total":0,"resolved":0,"unresolved":0}},"push":{"ahead":0,"behind":0}}
 {"name":"main","ups":[{"name":"feat1"}]}

--- a/testdata/script/log_cr_status.txt
+++ b/testdata/script/log_cr_status.txt
@@ -98,22 +98,22 @@ main
 ┃    ed5e364 feat1 (now)
 main
 -- golden/ls-without-status.json --
-{"name":"feat1","down":{"name":"main"},"ups":[{"name":"feat2"}],"change":{"id":"#1","url":"$SHAMHUB_URL/alice/example/changes/1"},"push":{"ahead":0,"behind":0}}
-{"name":"feat2","down":{"name":"feat1"},"ups":[{"name":"feat3"}],"change":{"id":"#2","url":"$SHAMHUB_URL/alice/example/changes/2"},"push":{"ahead":0,"behind":0}}
-{"name":"feat3","current":true,"down":{"name":"feat2"},"change":{"id":"#3","url":"$SHAMHUB_URL/alice/example/changes/3"},"push":{"ahead":0,"behind":0}}
+{"name":"feat1","down":{"name":"main"},"ups":[{"name":"feat2"}],"change":{"id":"#1","url":"$SHAMHUB_URL/alice/example/change/1"},"push":{"ahead":0,"behind":0}}
+{"name":"feat2","down":{"name":"feat1"},"ups":[{"name":"feat3"}],"change":{"id":"#2","url":"$SHAMHUB_URL/alice/example/change/2"},"push":{"ahead":0,"behind":0}}
+{"name":"feat3","current":true,"down":{"name":"feat2"},"change":{"id":"#3","url":"$SHAMHUB_URL/alice/example/change/3"},"push":{"ahead":0,"behind":0}}
 {"name":"main","ups":[{"name":"feat1"}]}
 -- golden/ll-without-status.json --
-{"name":"feat1","down":{"name":"main"},"ups":[{"name":"feat2"}],"commits":[{"sha":"ed5e364e35378f4b742951de90ec15d10fd6aae2","subject":"feat1"}],"change":{"id":"#1","url":"$SHAMHUB_URL/alice/example/changes/1"},"push":{"ahead":0,"behind":0}}
-{"name":"feat2","down":{"name":"feat1"},"ups":[{"name":"feat3"}],"commits":[{"sha":"769cbf5b61f500126a5580d6fd8e89ac78c468da","subject":"feat2"}],"change":{"id":"#2","url":"$SHAMHUB_URL/alice/example/changes/2"},"push":{"ahead":0,"behind":0}}
-{"name":"feat3","current":true,"down":{"name":"feat2"},"commits":[{"sha":"67480b64efd70742a4cf6da3cf01c56bddc14fe8","subject":"feat3"}],"change":{"id":"#3","url":"$SHAMHUB_URL/alice/example/changes/3"},"push":{"ahead":0,"behind":0}}
+{"name":"feat1","down":{"name":"main"},"ups":[{"name":"feat2"}],"commits":[{"sha":"ed5e364e35378f4b742951de90ec15d10fd6aae2","subject":"feat1"}],"change":{"id":"#1","url":"$SHAMHUB_URL/alice/example/change/1"},"push":{"ahead":0,"behind":0}}
+{"name":"feat2","down":{"name":"feat1"},"ups":[{"name":"feat3"}],"commits":[{"sha":"769cbf5b61f500126a5580d6fd8e89ac78c468da","subject":"feat2"}],"change":{"id":"#2","url":"$SHAMHUB_URL/alice/example/change/2"},"push":{"ahead":0,"behind":0}}
+{"name":"feat3","current":true,"down":{"name":"feat2"},"commits":[{"sha":"67480b64efd70742a4cf6da3cf01c56bddc14fe8","subject":"feat3"}],"change":{"id":"#3","url":"$SHAMHUB_URL/alice/example/change/3"},"push":{"ahead":0,"behind":0}}
 {"name":"main","ups":[{"name":"feat1"}]}
 -- golden/ls-with-status.json --
-{"name":"feat1","down":{"name":"main"},"ups":[{"name":"feat2"}],"change":{"id":"#1","url":"$SHAMHUB_URL/alice/example/changes/1","status":"merged"},"push":{"ahead":0,"behind":0}}
-{"name":"feat2","down":{"name":"feat1"},"ups":[{"name":"feat3"}],"change":{"id":"#2","url":"$SHAMHUB_URL/alice/example/changes/2","status":"open"},"push":{"ahead":0,"behind":0}}
-{"name":"feat3","current":true,"down":{"name":"feat2"},"change":{"id":"#3","url":"$SHAMHUB_URL/alice/example/changes/3","status":"closed"},"push":{"ahead":0,"behind":0}}
+{"name":"feat1","down":{"name":"main"},"ups":[{"name":"feat2"}],"change":{"id":"#1","url":"$SHAMHUB_URL/alice/example/change/1","status":"merged"},"push":{"ahead":0,"behind":0}}
+{"name":"feat2","down":{"name":"feat1"},"ups":[{"name":"feat3"}],"change":{"id":"#2","url":"$SHAMHUB_URL/alice/example/change/2","status":"open"},"push":{"ahead":0,"behind":0}}
+{"name":"feat3","current":true,"down":{"name":"feat2"},"change":{"id":"#3","url":"$SHAMHUB_URL/alice/example/change/3","status":"closed"},"push":{"ahead":0,"behind":0}}
 {"name":"main","ups":[{"name":"feat1"}]}
 -- golden/ll-with-status.json --
-{"name":"feat1","down":{"name":"main"},"ups":[{"name":"feat2"}],"commits":[{"sha":"ed5e364e35378f4b742951de90ec15d10fd6aae2","subject":"feat1"}],"change":{"id":"#1","url":"$SHAMHUB_URL/alice/example/changes/1","status":"merged"},"push":{"ahead":0,"behind":0}}
-{"name":"feat2","down":{"name":"feat1"},"ups":[{"name":"feat3"}],"commits":[{"sha":"769cbf5b61f500126a5580d6fd8e89ac78c468da","subject":"feat2"}],"change":{"id":"#2","url":"$SHAMHUB_URL/alice/example/changes/2","status":"open"},"push":{"ahead":0,"behind":0}}
-{"name":"feat3","current":true,"down":{"name":"feat2"},"commits":[{"sha":"67480b64efd70742a4cf6da3cf01c56bddc14fe8","subject":"feat3"}],"change":{"id":"#3","url":"$SHAMHUB_URL/alice/example/changes/3","status":"closed"},"push":{"ahead":0,"behind":0}}
+{"name":"feat1","down":{"name":"main"},"ups":[{"name":"feat2"}],"commits":[{"sha":"ed5e364e35378f4b742951de90ec15d10fd6aae2","subject":"feat1"}],"change":{"id":"#1","url":"$SHAMHUB_URL/alice/example/change/1","status":"merged"},"push":{"ahead":0,"behind":0}}
+{"name":"feat2","down":{"name":"feat1"},"ups":[{"name":"feat3"}],"commits":[{"sha":"769cbf5b61f500126a5580d6fd8e89ac78c468da","subject":"feat2"}],"change":{"id":"#2","url":"$SHAMHUB_URL/alice/example/change/2","status":"open"},"push":{"ahead":0,"behind":0}}
+{"name":"feat3","current":true,"down":{"name":"feat2"},"commits":[{"sha":"67480b64efd70742a4cf6da3cf01c56bddc14fe8","subject":"feat3"}],"change":{"id":"#3","url":"$SHAMHUB_URL/alice/example/change/3","status":"closed"},"push":{"ahead":0,"behind":0}}
 {"name":"main","ups":[{"name":"feat1"}]}


### PR DESCRIPTION
ShamHub REST use the singular `/change/<num>` path
but `RepositoryID.ChangeURL` was using `/changes/<num>`.

Make them use the same path and update fixtures.
