### PR TITLE
merge: Accept multiple branch flags

### DIFF
--- a/.agents/skills/test-script/SKILL.md
+++ b/.agents/skills/test-script/SKILL.md
@@ -19,7 +19,7 @@ Test scripts verify end-to-end behavior and are stored in `testdata/script/`.
 | Create branch | `gs branch create <name> -m <msg>` |
 | Make commit | `gs commit create -m <msg>` |
 | Compare stdout | `cmp stdout $WORK/golden/file.txt` |
-| Partial match | `stdout 'expected substring'` |
+| Partial match | `stdout 'expected substring'` for non-JSON text only |
 | Check file exists | `exists filename` |
 | Compare with env vars | `cmpenv stdout $WORK/golden/file.txt` |
 | Test interactive | `env ROBOT_INPUT=$WORK/robot.golden ROBOT_OUTPUT=$WORK/robot.actual` |
@@ -39,6 +39,10 @@ Avoid these errors when writing test scripts:
 - ❌ **Using `git checkout -b`**: Use `gs branch create` instead (unless testing non-git-spice scenarios).
 
 - ❌ **Empty golden files with `(empty)`**: Just leave content blank after `-- path --`.
+
+- ❌ **String matching JSON output**: Use `cmpenvJSON`
+  for ShamHub JSON dumps and other JSON outputs.
+  Do not use `stdout` or `stderr` substring assertions on JSON.
 
 ## Writing a test script
 
@@ -423,7 +427,8 @@ Common `shamhub` commands:
   Reject a ShamHub Change Request and close it.
 - `shamhub dump changes/comments`:
   Dump ShamHub state to stdout for verification.
-  (Use `cmp`, `cmpenv`, and `cmpenvJSON` to verify output.)
+  Use `cmpenvJSON` with a golden file.
+  Do not verify JSON with `stdout` substring assertions.
 
 ## Reference
 

--- a/branch_merge.go
+++ b/branch_merge.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/handler/merge"
@@ -14,16 +15,20 @@ import (
 type branchMergeCmd struct {
 	merge.Options
 
-	Branch string `placeholder:"NAME" help:"Branch to merge" predictor:"trackedBranches"`
+	Branches []string `name:"branch" placeholder:"NAME" help:"Branches to merge. May be repeated." predictor:"trackedBranches"`
 }
 
 func (*branchMergeCmd) Help() string {
 	return text.Dedent(`
 		Merges the CR for the current branch into trunk.
 		Use --branch to merge a different branch.
+		Use --branch multiple times to merge multiple branches.
 
-		The branch must be based directly on trunk.
-		To merge a stacked branch, use 'gs downstack merge'.
+		Only the selected branches are merged.
+		To merge a branch and its downstack,
+		use 'git-spice downstack merge'.
+		To merge a whole stack,
+		use 'git-spice stack merge'.
 
 		Before checking merge readiness,
 		the command waits briefly for the forge to observe the pushed head.
@@ -36,14 +41,14 @@ func (cmd *branchMergeCmd) AfterApply(
 	ctx context.Context,
 	wt *git.Worktree,
 ) error {
-	if cmd.Branch != "" {
+	if len(cmd.Branches) > 0 {
 		return nil
 	}
 	branch, err := wt.CurrentBranch(ctx)
 	if err != nil {
 		return fmt.Errorf("get current branch: %w", err)
 	}
-	cmd.Branch = branch
+	cmd.Branches = []string{branch}
 	return nil
 }
 
@@ -52,12 +57,12 @@ func (cmd *branchMergeCmd) Run(
 	store *state.Store,
 	mergeHandler MergeHandler,
 ) error {
-	if cmd.Branch == store.Trunk() {
+	if slices.Contains(cmd.Branches, store.Trunk()) {
 		return errors.New("cannot merge trunk")
 	}
 
 	return mergeHandler.MergeBranch(ctx, &merge.BranchMergeRequest{
-		Branch:  cmd.Branch,
-		Options: &cmd.Options,
+		Branches: cmd.Branches,
+		Options:  &cmd.Options,
 	})
 }

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -298,10 +298,12 @@ Merge a stack
 
 Merges the CRs for the current branch's stack into trunk.
 Use --branch to merge a different branch's stack.
+Use --branch multiple times to merge multiple stacks.
 
 The stack includes the selected branch,
 its downstack branches down to trunk,
 and every upstack branch.
+Overlapping stacks are merged once.
 
 Already-merged branches are skipped automatically.
 Branches must have an open Change Request to be merged.
@@ -326,7 +328,7 @@ Use --fail-fast to stop the queue after the first branch failure.
 * `--ready-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.readyTimeout" }](/cli/config.md#spicemergereadytimeout)): Max time to wait for merge readiness before each merge. 0 means check once.
 * `--no-branch-check`: Skip stale base validation before merging.
 * `--fail-fast`: Stop the merge queue after the first branch failure.
-* `--branch=NAME`: Branch whose stack to merge
+* `--branch=NAME,...`: Branches whose stacks to merge. May be repeated.
 
 **Configuration**: [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
 
@@ -621,6 +623,11 @@ Merge a branch and those below it
 Merges the current branch and all branches below it
 into trunk via the forge API, bottom-up.
 Use --branch to start at a different branch.
+Use --branch multiple times to merge multiple downstacks.
+
+Each selected branch expands to that branch
+and its downstack branches down to trunk.
+Overlapping downstacks are merged once.
 
 This command acts as a local merge queue:
 it merges one Change Request,
@@ -660,7 +667,7 @@ and syncs merged branch cleanup.
 * `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
 * `--ready-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.readyTimeout" }](/cli/config.md#spicemergereadytimeout)): Max time to wait for merge readiness before each merge. 0 means check once.
 * `--no-branch-check`: Skip stale base validation before merging.
-* `--branch=NAME`: Branch to start merging from
+* `--branch=NAME,...`: Branches to start merging from. May be repeated.
 
 **Configuration**: [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
 
@@ -1128,9 +1135,13 @@ Merge a branch into trunk
 
 Merges the CR for the current branch into trunk.
 Use --branch to merge a different branch.
+Use --branch multiple times to merge multiple branches.
 
-The branch must be based directly on trunk.
-To merge a stacked branch, use 'gs downstack merge'.
+Only the selected branches are merged.
+To merge a branch and its downstack,
+use 'git-spice downstack merge'.
+To merge a whole stack,
+use 'git-spice stack merge'.
 
 Before checking merge readiness,
 the command waits briefly for the forge to observe the pushed head.
@@ -1141,7 +1152,7 @@ Use --ready-timeout to configure the maximum wait.
 
 * `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
 * `--ready-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.readyTimeout" }](/cli/config.md#spicemergereadytimeout)): Max time to wait for merge readiness before each merge. 0 means check once.
-* `--branch=NAME`: Branch to merge
+* `--branch=NAME,...`: Branches to merge. May be repeated.
 
 **Configuration**: [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
 

--- a/downstack_merge.go
+++ b/downstack_merge.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/handler/merge"
@@ -14,7 +15,7 @@ import (
 type downstackMergeCmd struct {
 	merge.DownstackMergeOptions
 
-	Branch string `placeholder:"NAME" help:"Branch to start merging from" predictor:"trackedBranches"`
+	Branches []string `name:"branch" placeholder:"NAME" help:"Branches to start merging from. May be repeated." predictor:"trackedBranches"`
 }
 
 func (*downstackMergeCmd) Help() string {
@@ -22,6 +23,11 @@ func (*downstackMergeCmd) Help() string {
 		Merges the current branch and all branches below it
 		into trunk via the forge API, bottom-up.
 		Use --branch to start at a different branch.
+		Use --branch multiple times to merge multiple downstacks.
+
+		Each selected branch expands to that branch
+		and its downstack branches down to trunk.
+		Overlapping downstacks are merged once.
 
 		This command acts as a local merge queue:
 		it merges one Change Request,
@@ -69,14 +75,14 @@ func (cmd *downstackMergeCmd) AfterApply(
 	ctx context.Context,
 	wt *git.Worktree,
 ) error {
-	if cmd.Branch != "" {
+	if len(cmd.Branches) > 0 {
 		return nil
 	}
 	branch, err := wt.CurrentBranch(ctx)
 	if err != nil {
 		return fmt.Errorf("get current branch: %w", err)
 	}
-	cmd.Branch = branch
+	cmd.Branches = []string{branch}
 	return nil
 }
 
@@ -85,12 +91,12 @@ func (cmd *downstackMergeCmd) Run(
 	store *state.Store,
 	mergeHandler MergeHandler,
 ) error {
-	if cmd.Branch == store.Trunk() {
+	if slices.Contains(cmd.Branches, store.Trunk()) {
 		return errors.New("cannot merge trunk")
 	}
 
 	return mergeHandler.MergeDownstack(ctx, &merge.DownstackMergeRequest{
-		Branch:  cmd.Branch,
-		Options: &cmd.DownstackMergeOptions,
+		Branches: cmd.Branches,
+		Options:  &cmd.DownstackMergeOptions,
 	})
 }

--- a/internal/handler/merge/handler.go
+++ b/internal/handler/merge/handler.go
@@ -164,7 +164,7 @@ func (h *Handler) MergeDownstack(
 	})
 }
 
-// MergeBranch merges one branch that is configured directly on trunk.
+// MergeBranch merges the selected branches without expanding their scopes.
 func (h *Handler) MergeBranch(
 	ctx context.Context, req *BranchMergeRequest,
 ) error {
@@ -174,6 +174,9 @@ func (h *Handler) MergeBranch(
 		return fmt.Errorf("build branch graph: %w", err)
 	}
 
+	// Branch merge treats --branch as an exact branch selection:
+	// unselected bases validate the path to trunk
+	// but do not become merge queue items.
 	for _, name := range req.Branches {
 		seen := map[string]struct{}{name: {}}
 		for current := name; current != graph.Trunk(); {
@@ -365,6 +368,9 @@ func (h *Handler) buildPlan(
 // mergePlanRequest selects the local branches that become merge queue items.
 //
 // Branches provides the prompt order.
+// Scope expansion may append the same branch more than once;
+// buildPlanFromBranches normalizes duplicates before querying
+// forge state or constructing merge queue items.
 // The merge queue still enforces base dependencies before execution.
 type mergePlanRequest struct {
 	Graph *spice.BranchGraph // required

--- a/internal/handler/merge/handler.go
+++ b/internal/handler/merge/handler.go
@@ -183,31 +183,19 @@ func (h *Handler) MergeBranch(
 	// Every selected branch must have its non-trunk bases selected too,
 	// so the selected set itself forms the path to trunk.
 	for _, name := range req.Branches {
-		seen := map[string]struct{}{name: {}}
 		for current := name; current != graph.Trunk(); {
 			branch, ok := graph.Lookup(current)
 			if !ok {
 				return fmt.Errorf("branch %q is not tracked", current)
 			}
 
-			current = branch.Base
-			if _, ok := seen[current]; ok {
-				return fmt.Errorf(
-					"branch %q has a cycle through %q",
-					name, current,
-				)
-			}
-			seen[current] = struct{}{}
-
-			if current == graph.Trunk() {
-				break
-			}
 			if _, ok := selected[current]; !ok {
 				return fmt.Errorf(
 					"branch %q requires selected base %q",
 					name, current,
 				)
 			}
+			current = branch.Base
 		}
 	}
 

--- a/internal/handler/merge/handler.go
+++ b/internal/handler/merge/handler.go
@@ -174,8 +174,41 @@ func (h *Handler) MergeBranch(
 		return fmt.Errorf("build branch graph: %w", err)
 	}
 
-	if err := validateBranchMergeSelection(graph, req.Branches); err != nil {
-		return err
+	selected := make(map[string]struct{}, len(req.Branches))
+	for _, name := range req.Branches {
+		selected[name] = struct{}{}
+	}
+
+	// Branch merge treats --branch as an exact branch selection.
+	// Every selected branch must have its non-trunk bases selected too,
+	// so the selected set itself forms the path to trunk.
+	for _, name := range req.Branches {
+		seen := map[string]struct{}{name: {}}
+		for current := name; current != graph.Trunk(); {
+			branch, ok := graph.Lookup(current)
+			if !ok {
+				return fmt.Errorf("branch %q is not tracked", current)
+			}
+
+			current = branch.Base
+			if _, ok := seen[current]; ok {
+				return fmt.Errorf(
+					"branch %q has a cycle through %q",
+					name, current,
+				)
+			}
+			seen[current] = struct{}{}
+
+			if current == graph.Trunk() {
+				break
+			}
+			if _, ok := selected[current]; !ok {
+				return fmt.Errorf(
+					"branch %q requires selected base %q",
+					name, current,
+				)
+			}
+		}
 	}
 
 	plan, err := h.buildPlanFromBranches(ctx, mergePlanRequest{
@@ -266,49 +299,6 @@ func (h *Handler) MergeStack(
 		FailFast:              opts.FailFast,
 		SyncBeforeStart:       plan.syncBeforeStart,
 	})
-}
-
-func validateBranchMergeSelection(
-	graph *spice.BranchGraph,
-	branches []string,
-) error {
-	selected := make(map[string]struct{}, len(branches))
-	for _, name := range branches {
-		selected[name] = struct{}{}
-	}
-
-	// Branch merge treats --branch as an exact branch selection.
-	// Every selected branch must have its non-trunk bases selected too,
-	// so the selected set itself forms the path to trunk.
-	for _, name := range branches {
-		seen := map[string]struct{}{name: {}}
-		for current := name; current != graph.Trunk(); {
-			branch, ok := graph.Lookup(current)
-			if !ok {
-				return fmt.Errorf("branch %q is not tracked", current)
-			}
-
-			current = branch.Base
-			if _, ok := seen[current]; ok {
-				return fmt.Errorf(
-					"branch %q has a cycle through %q",
-					name, current,
-				)
-			}
-			seen[current] = struct{}{}
-
-			if current == graph.Trunk() {
-				break
-			}
-			if _, ok := selected[current]; !ok {
-				return fmt.Errorf(
-					"branch %q requires selected base %q",
-					name, current,
-				)
-			}
-		}
-	}
-	return nil
 }
 
 // mergeItem is one queue item in a downstack merge plan.

--- a/internal/handler/merge/handler.go
+++ b/internal/handler/merge/handler.go
@@ -174,26 +174,8 @@ func (h *Handler) MergeBranch(
 		return fmt.Errorf("build branch graph: %w", err)
 	}
 
-	// Branch merge treats --branch as an exact branch selection:
-	// unselected bases validate the path to trunk
-	// but do not become merge queue items.
-	for _, name := range req.Branches {
-		seen := map[string]struct{}{name: {}}
-		for current := name; current != graph.Trunk(); {
-			branch, ok := graph.Lookup(current)
-			if !ok {
-				return fmt.Errorf("branch %q is not tracked", current)
-			}
-
-			current = branch.Base
-			if _, ok := seen[current]; ok {
-				return fmt.Errorf(
-					"branch %q has a cycle through %q",
-					name, current,
-				)
-			}
-			seen[current] = struct{}{}
-		}
+	if err := validateBranchMergeSelection(graph, req.Branches); err != nil {
+		return err
 	}
 
 	plan, err := h.buildPlanFromBranches(ctx, mergePlanRequest{
@@ -284,6 +266,49 @@ func (h *Handler) MergeStack(
 		FailFast:              opts.FailFast,
 		SyncBeforeStart:       plan.syncBeforeStart,
 	})
+}
+
+func validateBranchMergeSelection(
+	graph *spice.BranchGraph,
+	branches []string,
+) error {
+	selected := make(map[string]struct{}, len(branches))
+	for _, name := range branches {
+		selected[name] = struct{}{}
+	}
+
+	// Branch merge treats --branch as an exact branch selection.
+	// Every selected branch must have its non-trunk bases selected too,
+	// so the selected set itself forms the path to trunk.
+	for _, name := range branches {
+		seen := map[string]struct{}{name: {}}
+		for current := name; current != graph.Trunk(); {
+			branch, ok := graph.Lookup(current)
+			if !ok {
+				return fmt.Errorf("branch %q is not tracked", current)
+			}
+
+			current = branch.Base
+			if _, ok := seen[current]; ok {
+				return fmt.Errorf(
+					"branch %q has a cycle through %q",
+					name, current,
+				)
+			}
+			seen[current] = struct{}{}
+
+			if current == graph.Trunk() {
+				break
+			}
+			if _, ok := selected[current]; !ok {
+				return fmt.Errorf(
+					"branch %q requires selected base %q",
+					name, current,
+				)
+			}
+		}
+	}
+	return nil
 }
 
 // mergeItem is one queue item in a downstack merge plan.

--- a/internal/handler/merge/handler.go
+++ b/internal/handler/merge/handler.go
@@ -79,10 +79,10 @@ type DownstackMergeOptions struct {
 	NoBranchCheck bool `help:"Skip stale base validation before merging."`
 }
 
-// DownstackMergeRequest asks Handler to merge a branch
+// DownstackMergeRequest asks Handler to merge each requested branch
 // and its downstack ancestors bottom-up.
 type DownstackMergeRequest struct {
-	Branch string // required
+	Branches []string // required
 
 	Options *DownstackMergeOptions // optional
 
@@ -90,10 +90,9 @@ type DownstackMergeRequest struct {
 	BranchGraph *spice.BranchGraph // optional
 }
 
-// BranchMergeRequest asks Handler to merge one branch
-// that is configured directly on trunk.
+// BranchMergeRequest asks Handler to merge the selected branches.
 type BranchMergeRequest struct {
-	Branch string // required
+	Branches []string // required
 
 	Options *Options // optional
 }
@@ -109,11 +108,11 @@ type StackMergeOptions struct {
 	FailFast bool `help:"Stop the merge queue after the first branch failure."`
 }
 
-// StackMergeRequest asks Handler to merge a branch,
+// StackMergeRequest asks Handler to merge each requested branch,
 // its downstack branches down to trunk,
 // and its upstack branches.
 type StackMergeRequest struct {
-	Branch string // required
+	Branches []string // required
 
 	Options *StackMergeOptions // optional
 }
@@ -175,26 +174,49 @@ func (h *Handler) MergeBranch(
 		return fmt.Errorf("build branch graph: %w", err)
 	}
 
-	branch, ok := graph.Lookup(req.Branch)
-	if !ok {
-		return fmt.Errorf("branch %q is not tracked", req.Branch)
-	}
-	trunk := h.Store.Trunk()
-	if branch.Base != trunk {
-		return fmt.Errorf(
-			"branch %q is based on %q, not trunk; "+
-				"use 'gs downstack merge --branch %s' "+
-				"to merge stack branches bottom-up",
-			req.Branch, branch.Base, req.Branch,
-		)
+	for _, name := range req.Branches {
+		seen := map[string]struct{}{name: {}}
+		for current := name; current != graph.Trunk(); {
+			branch, ok := graph.Lookup(current)
+			if !ok {
+				return fmt.Errorf("branch %q is not tracked", current)
+			}
+
+			current = branch.Base
+			if _, ok := seen[current]; ok {
+				return fmt.Errorf(
+					"branch %q has a cycle through %q",
+					name, current,
+				)
+			}
+			seen[current] = struct{}{}
+		}
 	}
 
-	return h.MergeDownstack(ctx, &DownstackMergeRequest{
-		Branch: req.Branch,
-		Options: &DownstackMergeOptions{
-			Options: *opts,
-		},
-		BranchGraph: graph,
+	plan, err := h.buildPlanFromBranches(ctx, mergePlanRequest{
+		Graph:    graph,
+		Branches: req.Branches,
+	})
+	if err != nil {
+		return err
+	}
+
+	if len(plan.items) == 0 {
+		h.Log.Info("No open changes to merge.")
+		return nil
+	}
+
+	if err := h.confirm(
+		plan.items,
+		fmt.Sprintf("Merge %d change(s) bottom-up?", len(plan.items)),
+	); err != nil {
+		return err
+	}
+
+	return h.executePlan(ctx, plan.items, mergeExecutionOptions{
+		Method:                opts.Method,
+		MergeReadinessTimeout: opts.MergeReadinessTimeout,
+		SyncBeforeStart:       plan.syncBeforeStart,
 	})
 }
 
@@ -211,17 +233,25 @@ func (h *Handler) MergeStack(
 	}
 
 	var branches []string
-	for name := range graph.Stack(req.Branch) {
-		branch, ok := graph.Lookup(name)
-		if !ok {
-			branches = append(branches, name)
-			continue
+	for _, name := range req.Branches {
+		if _, ok := graph.Lookup(name); !ok {
+			return fmt.Errorf("branch %q is not tracked", name)
 		}
-		if branch.Change == nil {
-			h.Log.Infof("%s: no published change request, skipping", name)
-			continue
+		for branchName := range graph.Stack(name) {
+			branch, ok := graph.Lookup(branchName)
+			if !ok {
+				branches = append(branches, branchName)
+				continue
+			}
+			if branch.Change == nil {
+				h.Log.Infof(
+					"%s: no published change request, skipping",
+					branchName,
+				)
+				continue
+			}
+			branches = append(branches, branchName)
 		}
-		branches = append(branches, name)
 	}
 
 	plan, err := h.buildPlanFromBranches(ctx, mergePlanRequest{
@@ -312,14 +342,22 @@ func (h *Handler) buildPlan(
 		}
 	}
 
-	// Build the queue bottom-up because each merge changes
-	// the base of the branch above it.
-	downstack := slices.Collect(graph.Downstack(req.Branch))
-	slices.Reverse(downstack)
+	var branches []string
+	for _, name := range req.Branches {
+		if _, ok := graph.Lookup(name); !ok {
+			return mergePlan{}, fmt.Errorf("branch %q is not tracked", name)
+		}
+
+		// Build each downstack bottom-up because each merge changes
+		// the base of the branch above it.
+		downstack := slices.Collect(graph.Downstack(name))
+		slices.Reverse(downstack)
+		branches = append(branches, downstack...)
+	}
 
 	return h.buildPlanFromBranches(ctx, mergePlanRequest{
 		Graph:         graph,
-		Branches:      downstack,
+		Branches:      branches,
 		NoBranchCheck: opts.NoBranchCheck,
 	})
 }
@@ -339,9 +377,10 @@ type mergePlanRequest struct {
 func (h *Handler) buildPlanFromBranches(
 	ctx context.Context, req mergePlanRequest,
 ) (mergePlan, error) {
-	items := make([]*mergeItem, 0, len(req.Branches))
-	ids := make([]forge.ChangeID, 0, len(req.Branches))
-	for _, name := range req.Branches {
+	branches := uniqueBranches(req.Branches)
+	items := make([]*mergeItem, 0, len(branches))
+	ids := make([]forge.ChangeID, 0, len(branches))
+	for _, name := range branches {
 		branch, ok := req.Graph.Lookup(name)
 		if !ok {
 			return mergePlan{}, fmt.Errorf("branch %q is not tracked", name)
@@ -398,7 +437,7 @@ func (h *Handler) buildPlanFromBranches(
 
 	if !req.NoBranchCheck {
 		if err := h.validateFreshBases(
-			ctx, req.Graph, req.Branches,
+			ctx, req.Graph, branches,
 		); err != nil {
 			return mergePlan{}, fmt.Errorf("validate stale bases: %w", err)
 		}
@@ -408,6 +447,23 @@ func (h *Handler) buildPlanFromBranches(
 		items:           plan,
 		syncBeforeStart: sawMerged && len(plan) > 0,
 	}, nil
+}
+
+func uniqueBranches(branches []string) []string {
+	if len(branches) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{}, len(branches))
+	out := make([]string, 0, len(branches))
+	for _, branch := range branches {
+		if _, ok := seen[branch]; ok {
+			continue
+		}
+		seen[branch] = struct{}{}
+		out = append(out, branch)
+	}
+	return out
 }
 
 // validateSynced checks that all branches in the merge plan

--- a/internal/handler/merge/handler_test.go
+++ b/internal/handler/merge/handler_test.go
@@ -912,7 +912,7 @@ func TestMergeStack_ignoresUnsubmittedAboveSubmitted(t *testing.T) {
 	})
 
 	err := h.MergeStack(t.Context(), &StackMergeRequest{
-		Branch: "feat1",
+		Branches: []string{"feat1"},
 		Options: &StackMergeOptions{
 			NoBranchCheck: true,
 		},
@@ -978,7 +978,7 @@ func TestMergeStack_ignoresUnsubmittedBelowSubmitted(t *testing.T) {
 	})
 
 	err := h.MergeStack(t.Context(), &StackMergeRequest{
-		Branch: "feat2",
+		Branches: []string{"feat2"},
 		Options: &StackMergeOptions{
 			NoBranchCheck: true,
 		},
@@ -1016,7 +1016,7 @@ func TestMergeStack_allSelectedBranchesUnsubmitted(t *testing.T) {
 	})
 
 	err := h.MergeStack(t.Context(), &StackMergeRequest{
-		Branch: "feat2",
+		Branches: []string{"feat2"},
 		Options: &StackMergeOptions{
 			NoBranchCheck: true,
 		},

--- a/internal/handler/merge/handler_test.go
+++ b/internal/handler/merge/handler_test.go
@@ -518,34 +518,156 @@ func TestMergeBranch_delegatesToDownstackMerge(t *testing.T) {
 	})
 
 	err := h.MergeBranch(t.Context(), &BranchMergeRequest{
-		Branch: "feat1",
+		Branches: []string{"feat1"},
 	})
 	require.NoError(t, err)
 }
 
-func TestMergeBranch_rejectsBranchNotBasedOnTrunk(t *testing.T) {
+func TestMergeBranch_acceptsMultipleBranches(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockForge := forgetest.NewMockRepository(ctrl)
+	pr1 := fakeChangeID("pr-1")
+	pr2 := fakeChangeID("pr-2")
+	mockForge.EXPECT().
+		ChangeStatuses(gomock.Any(), []forge.ChangeID{pr1, pr2}).
+		Return([]forge.ChangeStatus{
+			{State: forge.ChangeOpen},
+			{State: forge.ChangeOpen},
+		}, nil)
+
+	graph := testBranchGraph(t, []spice.LoadBranchItem{
+		testBranchWithoutUpstream("feat1", "main", pr1),
+		testBranchWithoutUpstream("feat2", "main", pr2),
+	})
+
+	h := newTestHandler(t, ctrl, testHandlerOpts{
+		forgeRepo: mockForge,
+	})
+
+	plan, err := h.buildPlanFromBranches(t.Context(), mergePlanRequest{
+		Graph:    graph,
+		Branches: []string{"feat1", "feat2", "feat1"},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"feat1", "feat2"}, mergePlanBranches(plan))
+}
+
+func TestMergeBranch_acceptsStackedRequestedBranches(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockStore := NewMockStore(ctrl)
-	mockStore.EXPECT().Trunk().Return("main")
+	mockStore.EXPECT().Trunk().Return("main").AnyTimes()
+
+	mockForge := forgetest.NewMockRepository(ctrl)
+	pr1 := fakeChangeID("pr-1")
+	pr2 := fakeChangeID("pr-2")
+	planStatus := mockForge.EXPECT().
+		ChangeStatuses(gomock.Any(), []forge.ChangeID{pr1, pr2}).
+		Return([]forge.ChangeStatus{
+			{State: forge.ChangeOpen},
+			{State: forge.ChangeOpen},
+		}, nil)
+	staleBaseStatus := mockForge.EXPECT().
+		ChangeStatuses(gomock.Any(), []forge.ChangeID{pr1}).
+		Return([]forge.ChangeStatus{{State: forge.ChangeOpen}}, nil).
+		After(planStatus.Call)
+	mockForge.EXPECT().
+		ChangeMergeability(gomock.Any(), pr1).
+		Return(mergeability(forge.ChangeMergeabilityReady), nil).
+		After(staleBaseStatus)
+	mockForge.EXPECT().
+		MergeChange(gomock.Any(), pr1, forge.MergeChangeOptions{}).
+		Return(nil)
+	mockForge.EXPECT().
+		ChangeStatuses(gomock.Any(), []forge.ChangeID{pr1}).
+		Return(
+			[]forge.ChangeStatus{{State: forge.ChangeMerged}}, nil,
+		)
+	expectPushedHead(mockForge, pr2, "head2")
+	expectMergeItem(mockForge, pr2)
+
+	mockService := NewMockService(ctrl)
+	mockService.EXPECT().
+		BranchGraph(gomock.Any(), gomock.Nil()).
+		Return(testBranchGraph(t, []spice.LoadBranchItem{
+			testBranchWithoutUpstream("feat1", "main", pr1),
+			testBranchWithoutUpstream("feat2", "feat1", pr2),
+		}), nil)
+	mockService.EXPECT().
+		VerifyRestacked(gomock.Any(), "feat2").
+		Return(nil)
+
+	mockGit := NewMockGitRepository(ctrl)
+	mockGit.EXPECT().
+		PeelToCommit(gomock.Any(), "feat2").
+		Return(git.Hash("head2"), nil)
 
 	h := newTestHandler(t, ctrl, testHandlerOpts{
-		store: mockStore,
-		service: testBranchGraphService(ctrl,
-			testBranchGraph(t, []spice.LoadBranchItem{
-				testBranch("feat1", "main", fakeChangeID("pr-1")),
-				testBranch("feat2", "feat1", fakeChangeID("pr-2")),
-			}),
-		),
+		forgeRepo: mockForge,
+		store:     mockStore,
+		service:   mockService,
+		gitRepo:   mockGit,
 	})
 
 	err := h.MergeBranch(t.Context(), &BranchMergeRequest{
-		Branch: "feat2",
+		Branches: []string{"feat1", "feat2"},
+	})
+	require.NoError(t, err)
+}
+
+func TestBuildPlan_expandsAndNormalizesDownstackBranches(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockForge := forgetest.NewMockRepository(ctrl)
+	pr1 := fakeChangeID("pr-1")
+	pr2 := fakeChangeID("pr-2")
+	pr3 := fakeChangeID("pr-3")
+	mockForge.EXPECT().
+		ChangeStatuses(gomock.Any(), []forge.ChangeID{pr1, pr2, pr3}).
+		Return([]forge.ChangeStatus{
+			{State: forge.ChangeOpen},
+			{State: forge.ChangeOpen},
+			{State: forge.ChangeOpen},
+		}, nil)
+
+	graph := testBranchGraph(t, []spice.LoadBranchItem{
+		testBranchWithoutUpstream("feat1", "main", pr1),
+		testBranchWithoutUpstream("feat2", "feat1", pr2),
+		testBranchWithoutUpstream("feat3", "feat1", pr3),
+	})
+
+	h := newTestHandler(t, ctrl, testHandlerOpts{
+		forgeRepo: mockForge,
+	})
+	plan, err := h.buildPlan(t.Context(), &DownstackMergeRequest{
+		Branches:    []string{"feat2", "feat3", "feat2"},
+		BranchGraph: graph,
+		Options: &DownstackMergeOptions{
+			NoBranchCheck: true,
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		[]string{"feat1", "feat2", "feat3"},
+		mergePlanBranches(plan),
+	)
+}
+
+func TestBuildPlan_rejectsUnknownDownstackBranch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	h := newTestHandler(t, ctrl, testHandlerOpts{})
+	_, err := h.buildPlan(t.Context(), &DownstackMergeRequest{
+		Branches: []string{"missing"},
+		BranchGraph: testBranchGraph(t, []spice.LoadBranchItem{
+			testBranchWithoutUpstream("feat1", "main", fakeChangeID("pr-1")),
+		}),
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(),
-		"branch \"feat2\" is based on \"feat1\", not trunk")
-	assert.Contains(t, err.Error(), "gs downstack merge --branch feat2")
+	assert.Contains(t, err.Error(), `branch "missing" is not tracked`)
 }
 
 func TestMergeStack_includesUpstackDescendants(t *testing.T) {
@@ -619,7 +741,70 @@ func TestMergeStack_includesUpstackDescendants(t *testing.T) {
 	})
 
 	err := h.MergeStack(t.Context(), &StackMergeRequest{
-		Branch: "feat1",
+		Branches: []string{"feat1"},
+		Options: &StackMergeOptions{
+			NoBranchCheck: true,
+		},
+	})
+	require.NoError(t, err)
+}
+
+func TestMergeStack_normalizesContainedScopes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	pr1 := fakeChangeID("pr-1")
+	pr2 := fakeChangeID("pr-2")
+	pr3 := fakeChangeID("pr-3")
+	graph := testBranchGraph(t, []spice.LoadBranchItem{
+		testBranchWithoutUpstream("feat1", "main", pr1),
+		testBranchWithoutUpstream("feat2", "feat1", pr2),
+		testBranchWithoutUpstream("feat3", "feat1", pr3),
+	})
+
+	mockForge := forgetest.NewMockRepository(ctrl)
+	mockForge.EXPECT().
+		ChangeStatuses(gomock.Any(), []forge.ChangeID{pr1, pr2, pr3}).
+		Return([]forge.ChangeStatus{
+			{State: forge.ChangeOpen},
+			{State: forge.ChangeOpen},
+			{State: forge.ChangeOpen},
+		}, nil)
+
+	mockStore := NewMockStore(ctrl)
+	mockStore.EXPECT().Trunk().Return("main").AnyTimes()
+	mockService := NewMockService(ctrl)
+	mockService.EXPECT().
+		BranchGraph(gomock.Any(), gomock.Nil()).
+		Return(graph, nil)
+	mockService.EXPECT().
+		VerifyRestacked(gomock.Any(), "feat2").
+		Return(nil)
+	mockService.EXPECT().
+		VerifyRestacked(gomock.Any(), "feat3").
+		Return(nil)
+
+	mockGit := NewMockGitRepository(ctrl)
+	mockGit.EXPECT().
+		PeelToCommit(gomock.Any(), "feat2").
+		Return(git.Hash("head2"), nil)
+	mockGit.EXPECT().
+		PeelToCommit(gomock.Any(), "feat3").
+		Return(git.Hash("head3"), nil)
+
+	expectMergeItem(mockForge, pr1)
+	expectPushedHead(mockForge, pr2, "head2")
+	expectMergeItem(mockForge, pr2)
+	expectPushedHead(mockForge, pr3, "head3")
+	expectMergeItem(mockForge, pr3)
+
+	h := newTestHandler(t, ctrl, testHandlerOpts{
+		forgeRepo: mockForge,
+		store:     mockStore,
+		service:   mockService,
+		gitRepo:   mockGit,
+	})
+	err := h.MergeStack(t.Context(), &StackMergeRequest{
+		Branches: []string{"feat1", "feat2"},
 		Options: &StackMergeOptions{
 			NoBranchCheck: true,
 		},
@@ -890,7 +1075,7 @@ func TestMergeStack_passesFailFastToScheduler(t *testing.T) {
 	})
 
 	err := h.MergeStack(t.Context(), &StackMergeRequest{
-		Branch: "feat1",
+		Branches: []string{"feat1"},
 		Options: &StackMergeOptions{
 			NoBranchCheck: true,
 			FailFast:      true,
@@ -1446,15 +1631,24 @@ func testBranch(
 	}
 }
 
-func testBranchGraphService(
-	ctrl *gomock.Controller,
-	graph *spice.BranchGraph,
-) *MockService {
-	mockService := NewMockService(ctrl)
-	mockService.EXPECT().
-		BranchGraph(gomock.Any(), gomock.Nil()).
-		Return(graph, nil)
-	return mockService
+func testBranchWithoutUpstream(
+	name string,
+	base string,
+	changeID fakeChangeID,
+) spice.LoadBranchItem {
+	return spice.LoadBranchItem{
+		Name:   name,
+		Base:   base,
+		Change: testChangeMetadata(changeID),
+	}
+}
+
+func mergePlanBranches(plan mergePlan) []string {
+	branches := make([]string, 0, len(plan.items))
+	for _, item := range plan.items {
+		branches = append(branches, item.branch)
+	}
+	return branches
 }
 
 // expectMergeItem sets up mock expectations for a full

--- a/internal/handler/merge/handler_test.go
+++ b/internal/handler/merge/handler_test.go
@@ -554,7 +554,53 @@ func TestMergeBranch_acceptsMultipleBranches(t *testing.T) {
 	assert.Equal(t, []string{"feat1", "feat2"}, mergePlanBranches(plan))
 }
 
-func TestMergeBranch_acceptsStackedRequestedBranches(t *testing.T) {
+func TestMergeBranch_rejectsSelectedBranchWithoutBase(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockService := NewMockService(ctrl)
+	mockService.EXPECT().
+		BranchGraph(gomock.Any(), gomock.Nil()).
+		Return(testBranchGraph(t, []spice.LoadBranchItem{
+			testBranchWithoutUpstream("feat1", "main", fakeChangeID("pr-1")),
+			testBranchWithoutUpstream("feat2", "feat1", fakeChangeID("pr-2")),
+			testBranchWithoutUpstream("feat3", "feat2", fakeChangeID("pr-3")),
+		}), nil)
+
+	h := newTestHandler(t, ctrl, testHandlerOpts{
+		service: mockService,
+	})
+	err := h.MergeBranch(t.Context(), &BranchMergeRequest{
+		Branches: []string{"feat2"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(),
+		`branch "feat2" requires selected base "feat1"`)
+}
+
+func TestMergeBranch_rejectsSelectedBranchesWithoutPathToTrunk(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockService := NewMockService(ctrl)
+	mockService.EXPECT().
+		BranchGraph(gomock.Any(), gomock.Nil()).
+		Return(testBranchGraph(t, []spice.LoadBranchItem{
+			testBranchWithoutUpstream("feat1", "main", fakeChangeID("pr-1")),
+			testBranchWithoutUpstream("feat2", "feat1", fakeChangeID("pr-2")),
+			testBranchWithoutUpstream("feat3", "feat2", fakeChangeID("pr-3")),
+		}), nil)
+
+	h := newTestHandler(t, ctrl, testHandlerOpts{
+		service: mockService,
+	})
+	err := h.MergeBranch(t.Context(), &BranchMergeRequest{
+		Branches: []string{"feat3", "feat2"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(),
+		`requires selected base "feat1"`)
+}
+
+func TestMergeBranch_acceptsSelectedPathToTrunk(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockStore := NewMockStore(ctrl)

--- a/merge_cmd_test.go
+++ b/merge_cmd_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.abhg.dev/gs/internal/git"
+)
+
+func TestMergeCommandBranchFlag_acceptsRepeatedValues(t *testing.T) {
+	t.Run("BranchMerge", func(t *testing.T) {
+		var cmd branchMergeCmd
+		parser, err := newMergeCommandParser(t, &cmd)
+		require.NoError(t, err)
+
+		_, err = parser.Parse([]string{
+			"--branch", "feat1",
+			"--branch", "feat2",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"feat1", "feat2"}, cmd.Branches)
+	})
+
+	t.Run("DownstackMerge", func(t *testing.T) {
+		var cmd downstackMergeCmd
+		parser, err := newMergeCommandParser(t, &cmd)
+		require.NoError(t, err)
+
+		_, err = parser.Parse([]string{
+			"--branch", "feat1",
+			"--branch", "feat2",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"feat1", "feat2"}, cmd.Branches)
+	})
+
+	t.Run("StackMerge", func(t *testing.T) {
+		var cmd stackMergeCmd
+		parser, err := newMergeCommandParser(t, &cmd)
+		require.NoError(t, err)
+
+		_, err = parser.Parse([]string{
+			"--branch", "feat1",
+			"--branch", "feat2",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"feat1", "feat2"}, cmd.Branches)
+	})
+}
+
+func TestMergeCommandBranchFlag_acceptsCommaSeparatedValues(t *testing.T) {
+	var cmd branchMergeCmd
+	parser, err := newMergeCommandParser(t, &cmd)
+	require.NoError(t, err)
+
+	_, err = parser.Parse([]string{
+		"--branch", "feat1,feat2",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"feat1", "feat2"}, cmd.Branches)
+}
+
+func newMergeCommandParser(t *testing.T, cmd any) (*kong.Kong, error) {
+	t.Helper()
+
+	return kong.New(cmd,
+		kong.BindTo(t.Context(), (*context.Context)(nil)),
+		kong.Bind((*git.Worktree)(nil)),
+	)
+}

--- a/stack_merge.go
+++ b/stack_merge.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/handler/merge"
@@ -14,17 +15,19 @@ import (
 type stackMergeCmd struct {
 	merge.StackMergeOptions
 
-	Branch string `placeholder:"NAME" help:"Branch whose stack to merge" predictor:"trackedBranches"`
+	Branches []string `name:"branch" placeholder:"NAME" help:"Branches whose stacks to merge. May be repeated." predictor:"trackedBranches"`
 }
 
 func (*stackMergeCmd) Help() string {
 	return text.Dedent(`
 		Merges the CRs for the current branch's stack into trunk.
 		Use --branch to merge a different branch's stack.
+		Use --branch multiple times to merge multiple stacks.
 
 		The stack includes the selected branch,
 		its downstack branches down to trunk,
 		and every upstack branch.
+		Overlapping stacks are merged once.
 
 		Already-merged branches are skipped automatically.
 		Branches must have an open Change Request to be merged.
@@ -49,14 +52,14 @@ func (cmd *stackMergeCmd) AfterApply(
 	ctx context.Context,
 	wt *git.Worktree,
 ) error {
-	if cmd.Branch != "" {
+	if len(cmd.Branches) > 0 {
 		return nil
 	}
 	branch, err := wt.CurrentBranch(ctx)
 	if err != nil {
 		return fmt.Errorf("get current branch: %w", err)
 	}
-	cmd.Branch = branch
+	cmd.Branches = []string{branch}
 	return nil
 }
 
@@ -65,12 +68,12 @@ func (cmd *stackMergeCmd) Run(
 	store *state.Store,
 	mergeHandler MergeHandler,
 ) error {
-	if cmd.Branch == store.Trunk() {
+	if slices.Contains(cmd.Branches, store.Trunk()) {
 		return errors.New("cannot merge trunk")
 	}
 
 	return mergeHandler.MergeStack(ctx, &merge.StackMergeRequest{
-		Branch:  cmd.Branch,
-		Options: &cmd.StackMergeOptions,
+		Branches: cmd.Branches,
+		Options:  &cmd.StackMergeOptions,
 	})
 }

--- a/testdata/help/branch_merge.txt
+++ b/testdata/help/branch_merge.txt
@@ -3,10 +3,11 @@ Usage: gs branch (b) merge (m) [flags]
 Merge a branch into trunk
 
 Merges the CR for the current branch into trunk. Use --branch to merge a
-different branch.
+different branch. Use --branch multiple times to merge multiple branches.
 
-The branch must be based directly on trunk. To merge a stacked branch, use 'gs
-downstack merge'.
+Only the selected branches are merged. To merge a branch and its downstack,
+use 'git-spice downstack merge'. To merge a whole stack, use 'git-spice stack
+merge'.
 
 Before checking merge readiness, the command waits briefly for the forge to
 observe the pushed head. Then it waits for the forge to report that the CR is
@@ -17,7 +18,7 @@ Flags:
                          and 'rebase'. (🔧 spice.merge.method)
   --ready-timeout=30m    Max time to wait for merge readiness before each merge.
                          0 means check once. (🔧 spice.merge.readyTimeout)
-  --branch=NAME          Branch to merge
+  --branch=NAME,...      Branches to merge. May be repeated.
 
 Global Flags:
   -h, --help           Show help for the command

--- a/testdata/help/downstack_merge.txt
+++ b/testdata/help/downstack_merge.txt
@@ -3,7 +3,11 @@ Usage: gs downstack (ds) merge (m) [flags]
 Merge a branch and those below it
 
 Merges the current branch and all branches below it into trunk via the forge
-API, bottom-up. Use --branch to start at a different branch.
+API, bottom-up. Use --branch to start at a different branch. Use --branch
+multiple times to merge multiple downstacks.
+
+Each selected branch expands to that branch and its downstack branches down to
+trunk. Overlapping downstacks are merged once.
 
 This command acts as a local merge queue: it merges one Change Request, waits
 for that merge to finish, restacks and updates the next Change Request, waits
@@ -38,7 +42,7 @@ Flags:
   --ready-timeout=30m    Max time to wait for merge readiness before each merge.
                          0 means check once. (🔧 spice.merge.readyTimeout)
   --no-branch-check      Skip stale base validation before merging.
-  --branch=NAME          Branch to start merging from
+  --branch=NAME,...      Branches to start merging from. May be repeated.
 
 Global Flags:
   -h, --help           Show help for the command

--- a/testdata/help/stack_merge.txt
+++ b/testdata/help/stack_merge.txt
@@ -3,10 +3,11 @@ Usage: gs stack (s) merge (m) [flags]
 Merge a stack
 
 Merges the CRs for the current branch's stack into trunk. Use --branch to merge
-a different branch's stack.
+a different branch's stack. Use --branch multiple times to merge multiple
+stacks.
 
 The stack includes the selected branch, its downstack branches down to trunk,
-and every upstack branch.
+and every upstack branch. Overlapping stacks are merged once.
 
 Already-merged branches are skipped automatically. Branches must have an open
 Change Request to be merged.
@@ -30,7 +31,7 @@ Flags:
                          0 means check once. (🔧 spice.merge.readyTimeout)
   --no-branch-check      Skip stale base validation before merging.
   --fail-fast            Stop the merge queue after the first branch failure.
-  --branch=NAME          Branch whose stack to merge
+  --branch=NAME,...      Branches whose stacks to merge. May be repeated.
 
 Global Flags:
   -h, --help           Show help for the command

--- a/testdata/script/README.md
+++ b/testdata/script/README.md
@@ -137,6 +137,8 @@ cmpenvJSON <want> <got>
 Compares the contents of the two files as JSON,
 replacing environment variables in the forms `${VAR}` and `$VAR`
 with their values at the time of the comparison.
+Use this for ShamHub JSON dumps and other JSON outputs.
+Do not verify JSON with `stdout` or `stderr` substring assertions.
 
 ### git
 
@@ -273,6 +275,8 @@ shamhub dump comments [num] ...
 
 Dumps information about all changes, a single change,
 all comments, or comments for specific changes, respectively.
+Verify JSON dumps with `cmpenvJSON` and a golden file,
+not substring matching.
 
 #### shamhub register
 

--- a/testdata/script/branch_merge_stacked_branch.txt
+++ b/testdata/script/branch_merge_stacked_branch.txt
@@ -1,4 +1,4 @@
-# 'branch merge' rejects branches that are configured on another branch.
+# 'branch merge' can merge selected branches from the same stack.
 
 as 'Test <test@example.com>'
 at '2026-06-13T18:29:00Z'
@@ -29,17 +29,36 @@ gs downstack submit --fill
 stderr 'Created #1'
 stderr 'Created #2'
 
-# branch merge is only for branches configured directly on trunk.
-! gs branch merge --branch feature2
-stderr 'branch "feature2" is based on "feature1", not trunk'
-stderr 'gs downstack merge --branch feature2'
+# merge selected branches from the stack
+env ROBOT_INPUT=$WORK/robot-merge.golden ROBOT_OUTPUT=$WORK/robot-merge.actual
+gs branch merge --branch feature1 --branch feature2
+cmp $WORK/robot-merge.actual $WORK/robot-merge.golden
+stderr 'feature1: merging #1:'
+stderr 'feature1: #1 was merged'
+stderr 'feature1: deleted'
+stderr 'feature2: restacked on main'
+stderr 'Updated #2'
+stderr 'feature2: merging #2:'
+stderr 'feature2: #2 was merged'
+stderr 'feature2: deleted'
+stderr 'All 2 change.s. merged.'
 
-# verify both changes are still open
+# verify both changes are merged
 shamhub dump changes
-stdout '"state": "open"'
-! stdout '"merged": true'
+stdout '"merged": true'
+! stdout '"state": "open"'
+
+# verify that the later PR was retargeted to main
+shamhub dump change 2
+stdout '"ref": "main"'
 
 -- repo/feature1.txt --
 This is feature 1
 -- repo/feature2.txt --
 This is feature 2
+-- robot-merge.golden --
+===
+> Merge 2 change(s) bottom-up?: [Y/n]
+>   feature1 (#1)
+>   feature2 (#2)
+true

--- a/testdata/script/branch_merge_stacked_branch.txt
+++ b/testdata/script/branch_merge_stacked_branch.txt
@@ -45,12 +45,11 @@ stderr 'All 2 change.s. merged.'
 
 # verify both changes are merged
 shamhub dump changes
-stdout '"merged": true'
-! stdout '"state": "open"'
+cmpenvJSON stdout $WORK/golden/changes-merged.json
 
 # verify that the later PR was retargeted to main
 shamhub dump change 2
-stdout '"ref": "main"'
+cmpenvJSON stdout $WORK/golden/change-2.json
 
 -- repo/feature1.txt --
 This is feature 1
@@ -62,3 +61,79 @@ This is feature 2
 >   feature1 (#1)
 >   feature2 (#2)
 true
+-- golden/changes-merged.json --
+[
+  {
+    "number": 1,
+    "html_url": "$SHAMHUB_URL/alice/example/change/1",
+    "state": "closed",
+    "merged": true,
+    "title": "Add feature 1",
+    "body": "",
+    "base": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "main",
+      "sha": "d4211170e9e333ce4648017d366472ba07cb63ff"
+    },
+    "head": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "feature1",
+      "sha": "62c3c4e12506afae52cd50383886ea7a815700c3"
+    }
+  },
+  {
+    "number": 2,
+    "html_url": "$SHAMHUB_URL/alice/example/change/2",
+    "state": "closed",
+    "merged": true,
+    "title": "Add feature 2",
+    "body": "",
+    "base": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "main",
+      "sha": "d4211170e9e333ce4648017d366472ba07cb63ff"
+    },
+    "head": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "feature2",
+      "sha": "1d2c26f2593df77c5b00c49eab0e6ae15db266cb"
+    }
+  }
+]
+-- golden/change-2.json --
+{
+  "number": 2,
+  "html_url": "$SHAMHUB_URL/alice/example/change/2",
+  "state": "closed",
+  "merged": true,
+  "title": "Add feature 2",
+  "body": "",
+  "base": {
+    "repository": {
+      "owner": "alice",
+      "name": "example"
+    },
+    "ref": "main",
+    "sha": "d4211170e9e333ce4648017d366472ba07cb63ff"
+  },
+  "head": {
+    "repository": {
+      "owner": "alice",
+      "name": "example"
+    },
+    "ref": "feature2",
+    "sha": "1d2c26f2593df77c5b00c49eab0e6ae15db266cb"
+  }
+}

--- a/testdata/script/downstack_merge_overlapping_branch_scopes.txt
+++ b/testdata/script/downstack_merge_overlapping_branch_scopes.txt
@@ -1,0 +1,74 @@
+# 'downstack merge --branch' normalizes overlapping branch scopes.
+
+as 'Test <test@example.com>'
+at '2026-06-28T10:15:00Z'
+
+# setup
+cd repo
+git init
+git config spice.experiment.merge true
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# create a stack:
+# main -> feature1 -> feature2 -> feature3
+git add feature1.txt
+gs bc feature1 -m 'Add feature 1'
+git add feature2.txt
+gs bc feature2 -m 'Add feature 2'
+git add feature3.txt
+gs bc feature3 -m 'Add feature 3'
+
+# submit the full stack
+gs downstack submit --fill
+stderr 'Created #1'
+stderr 'Created #2'
+stderr 'Created #3'
+
+# Request two overlapping downstack scopes.
+# feature2 selects feature1 and feature2.
+# feature3 selects feature1, feature2, and feature3.
+env ROBOT_INPUT=$WORK/robot-merge.golden ROBOT_OUTPUT=$WORK/robot-merge.actual
+gs downstack merge --branch feature2 --branch feature3
+cmp $WORK/robot-merge.actual $WORK/robot-merge.golden
+stderr 'feature1: merging #1:'
+stderr 'feature1: #1 was merged'
+stderr 'feature1: deleted'
+stderr 'feature2: restacked on main'
+stderr 'Updated #2'
+stderr 'feature2: merging #2:'
+stderr 'feature2: #2 was merged'
+stderr 'feature2: deleted'
+stderr 'feature3: restacked on main'
+stderr 'Updated #3'
+stderr 'feature3: merging #3:'
+stderr 'feature3: #3 was merged'
+stderr 'feature3: deleted'
+stderr 'All 3 change.s. merged.'
+
+# verify all selected changes were merged
+shamhub dump changes
+stdout '"merged": true'
+! stdout '"state": "open"'
+
+-- repo/feature1.txt --
+This is feature 1
+-- repo/feature2.txt --
+This is feature 2
+-- repo/feature3.txt --
+This is feature 3
+-- robot-merge.golden --
+===
+> Merge 3 change(s) bottom-up?: [Y/n]
+>   feature1 (#1)
+>   feature2 (#2)
+>   feature3 (#3)
+true

--- a/testdata/script/downstack_merge_overlapping_branch_scopes.txt
+++ b/testdata/script/downstack_merge_overlapping_branch_scopes.txt
@@ -36,9 +36,7 @@ stderr 'Created #3'
 # Request two overlapping downstack scopes.
 # feature2 selects feature1 and feature2.
 # feature3 selects feature1, feature2, and feature3.
-env ROBOT_INPUT=$WORK/robot-merge.golden ROBOT_OUTPUT=$WORK/robot-merge.actual
-gs downstack merge --branch feature2 --branch feature3
-cmp $WORK/robot-merge.actual $WORK/robot-merge.golden
+gs downstack merge --branch feature2 --branch feature3 --no-prompt
 stderr 'feature1: merging #1:'
 stderr 'feature1: #1 was merged'
 stderr 'feature1: deleted'
@@ -56,8 +54,7 @@ stderr 'All 3 change.s. merged.'
 
 # verify all selected changes were merged
 shamhub dump changes
-stdout '"merged": true'
-! stdout '"state": "open"'
+cmpenvJSON stdout $WORK/golden/changes-merged.json
 
 -- repo/feature1.txt --
 This is feature 1
@@ -65,10 +62,78 @@ This is feature 1
 This is feature 2
 -- repo/feature3.txt --
 This is feature 3
--- robot-merge.golden --
-===
-> Merge 3 change(s) bottom-up?: [Y/n]
->   feature1 (#1)
->   feature2 (#2)
->   feature3 (#3)
-true
+-- golden/changes-merged.json --
+[
+  {
+    "number": 1,
+    "html_url": "$SHAMHUB_URL/alice/example/change/1",
+    "state": "closed",
+    "merged": true,
+    "title": "Add feature 1",
+    "body": "",
+    "base": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "main",
+      "sha": "8c3f7f55475156b47580d1c1e64d37ddb437c312"
+    },
+    "head": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "feature1",
+      "sha": "c4911913f1f3f4ea13768711df593c1b88d8b572"
+    }
+  },
+  {
+    "number": 2,
+    "html_url": "$SHAMHUB_URL/alice/example/change/2",
+    "state": "closed",
+    "merged": true,
+    "title": "Add feature 2",
+    "body": "",
+    "base": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "main",
+      "sha": "8c3f7f55475156b47580d1c1e64d37ddb437c312"
+    },
+    "head": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "feature2",
+      "sha": "54a1cc7d8ed1dac40dab756d73c2691e3b1c1473"
+    }
+  },
+  {
+    "number": 3,
+    "html_url": "$SHAMHUB_URL/alice/example/change/3",
+    "state": "closed",
+    "merged": true,
+    "title": "Add feature 3",
+    "body": "",
+    "base": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "main",
+      "sha": "8c3f7f55475156b47580d1c1e64d37ddb437c312"
+    },
+    "head": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "feature3",
+      "sha": "7011262d613a32ade757acab9cae0a9773782915"
+    }
+  }
+]

--- a/testdata/script/stack_merge_overlapping_branch_scopes.txt
+++ b/testdata/script/stack_merge_overlapping_branch_scopes.txt
@@ -1,0 +1,74 @@
+# 'stack merge --branch' normalizes overlapping branch scopes.
+
+as 'Test <test@example.com>'
+at '2026-06-28T10:16:00Z'
+
+# setup
+cd repo
+git init
+git config spice.experiment.merge true
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# create a stack:
+# main -> feature1 -> feature2 -> feature3
+git add feature1.txt
+gs bc feature1 -m 'Add feature 1'
+git add feature2.txt
+gs bc feature2 -m 'Add feature 2'
+git add feature3.txt
+gs bc feature3 -m 'Add feature 3'
+
+# submit the full stack
+gs stack submit --fill
+stderr 'Created #1'
+stderr 'Created #2'
+stderr 'Created #3'
+
+# Request two overlapping stack scopes.
+# feature1 selects the whole stack.
+# feature2 selects feature1, feature2, and feature3.
+env ROBOT_INPUT=$WORK/robot-merge.golden ROBOT_OUTPUT=$WORK/robot-merge.actual
+gs stack merge --branch feature1 --branch feature2
+cmp $WORK/robot-merge.actual $WORK/robot-merge.golden
+stderr 'feature1: merging #1:'
+stderr 'feature1: #1 was merged'
+stderr 'feature1: deleted'
+stderr 'feature2: restacked on main'
+stderr 'Updated #2'
+stderr 'feature2: merging #2:'
+stderr 'feature2: #2 was merged'
+stderr 'feature2: deleted'
+stderr 'feature3: restacked on main'
+stderr 'Updated #3'
+stderr 'feature3: merging #3:'
+stderr 'feature3: #3 was merged'
+stderr 'feature3: deleted'
+stderr 'All 3 change.s. merged.'
+
+# verify all selected changes were merged
+shamhub dump changes
+stdout '"merged": true'
+! stdout '"state": "open"'
+
+-- repo/feature1.txt --
+This is feature 1
+-- repo/feature2.txt --
+This is feature 2
+-- repo/feature3.txt --
+This is feature 3
+-- robot-merge.golden --
+===
+> Merge 3 change(s)?: [Y/n]
+>   feature1 (#1)
+>   feature2 (#2)
+>   feature3 (#3)
+true

--- a/testdata/script/stack_merge_overlapping_branch_scopes.txt
+++ b/testdata/script/stack_merge_overlapping_branch_scopes.txt
@@ -56,8 +56,7 @@ stderr 'All 3 change.s. merged.'
 
 # verify all selected changes were merged
 shamhub dump changes
-stdout '"merged": true'
-! stdout '"state": "open"'
+cmpenvJSON stdout $WORK/golden/changes-merged.json
 
 -- repo/feature1.txt --
 This is feature 1
@@ -72,3 +71,78 @@ This is feature 3
 >   feature2 (#2)
 >   feature3 (#3)
 true
+-- golden/changes-merged.json --
+[
+  {
+    "number": 1,
+    "html_url": "$SHAMHUB_URL/alice/example/change/1",
+    "state": "closed",
+    "merged": true,
+    "title": "Add feature 1",
+    "body": "",
+    "base": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "main",
+      "sha": "68e655956144a5f78c4dc1bcddcda4abb2992d73"
+    },
+    "head": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "feature1",
+      "sha": "d4721f77eb03f834aafad0df2fcfca7f9d22dc41"
+    }
+  },
+  {
+    "number": 2,
+    "html_url": "$SHAMHUB_URL/alice/example/change/2",
+    "state": "closed",
+    "merged": true,
+    "title": "Add feature 2",
+    "body": "",
+    "base": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "main",
+      "sha": "68e655956144a5f78c4dc1bcddcda4abb2992d73"
+    },
+    "head": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "feature2",
+      "sha": "3d57a0c953e925ab1c80201f366680ea9a2a28b1"
+    }
+  },
+  {
+    "number": 3,
+    "html_url": "$SHAMHUB_URL/alice/example/change/3",
+    "state": "closed",
+    "merged": true,
+    "title": "Add feature 3",
+    "body": "",
+    "base": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "main",
+      "sha": "68e655956144a5f78c4dc1bcddcda4abb2992d73"
+    },
+    "head": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "feature3",
+      "sha": "19c2e2fa285b9c4b88aa34e544bdd8f05ac5af70"
+    }
+  }
+]


### PR DESCRIPTION
Summary

`gs branch merge`, `gs downstack merge`, and `gs stack merge`
now accept repeated `--branch` flags.

This lets one merge command combine multiple requested branch scopes
and normalize overlapping branches before scheduling the merge.

Details

`gs branch merge` treats repeated `--branch` values as an exact
selected set.
The selected set must include every non-trunk branch needed to form
a path to trunk.

`gs downstack merge` and `gs stack merge` expand each requested branch
through their normal scope rules.
The merge handler then deduplicates overlapping scopes before building
the merge queue.

`gs stack merge` preserves the existing local-only branch behavior:
branches without submitted change requests are skipped instead of
blocking submitted changes from merging.

The command help describes repeated `--branch` usage.
Script coverage verifies branch merge, downstack merge, and stack merge
scope normalization with full ShamHub JSON comparisons.

[skip changelog]: unreleased merge feature
