### PR TITLE
merge: Add configurable completion timeout

### DIFF
--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -326,11 +326,12 @@ Use --fail-fast to stop the queue after the first branch failure.
 
 * `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
 * `--ready-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.readyTimeout" }](/cli/config.md#spicemergereadytimeout)): Max time to wait for merge readiness before each merge. 0 means check once.
+* `--merge-timeout=2m` ([:material-wrench:{ .middle title="spice.merge.mergeTimeout" }](/cli/config.md#spicemergemergetimeout)): Max time to wait for merge completion after requesting merge.
 * `--no-branch-check`: Skip stale base validation before merging.
 * `--fail-fast`: Stop the merge queue after the first branch failure.
 * `--branch=NAME,...`: Branches whose stacks to merge. May be repeated.
 
-**Configuration**: [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
+**Configuration**: [spice.merge.mergeTimeout](/cli/config.md#spicemergemergetimeout), [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
 
 ### git-spice stack restack {#gs-stack-restack}
 
@@ -666,10 +667,11 @@ and syncs merged branch cleanup.
 
 * `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
 * `--ready-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.readyTimeout" }](/cli/config.md#spicemergereadytimeout)): Max time to wait for merge readiness before each merge. 0 means check once.
+* `--merge-timeout=2m` ([:material-wrench:{ .middle title="spice.merge.mergeTimeout" }](/cli/config.md#spicemergemergetimeout)): Max time to wait for merge completion after requesting merge.
 * `--no-branch-check`: Skip stale base validation before merging.
 * `--branch=NAME,...`: Branches to start merging from. May be repeated.
 
-**Configuration**: [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
+**Configuration**: [spice.merge.mergeTimeout](/cli/config.md#spicemergemergetimeout), [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
 
 ### git-spice downstack edit {#gs-downstack-edit}
 
@@ -1152,9 +1154,10 @@ Use --ready-timeout to configure the maximum wait.
 
 * `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
 * `--ready-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.readyTimeout" }](/cli/config.md#spicemergereadytimeout)): Max time to wait for merge readiness before each merge. 0 means check once.
+* `--merge-timeout=2m` ([:material-wrench:{ .middle title="spice.merge.mergeTimeout" }](/cli/config.md#spicemergemergetimeout)): Max time to wait for merge completion after requesting merge.
 * `--branch=NAME,...`: Branches to merge. May be repeated.
 
-**Configuration**: [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
+**Configuration**: [spice.merge.mergeTimeout](/cli/config.md#spicemergemergetimeout), [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
 
 ### git-spice branch submit {#gs-branch-submit}
 

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -486,6 +486,18 @@ Set to `0` to fail immediately if merge readiness is not already reached.
 
 Defaults to `30m`.
 
+### spice.merge.mergeTimeout
+
+<!-- gs:version unreleased -->
+
+Maximum time merge commands wait for the forge to report
+that the CR is merged after requesting merge.
+
+The value must be a duration string such as
+`2m`, `30s`, `5m`, etc.
+
+Defaults to `2m`.
+
 ### spice.merge.method
 
 <!-- gs:version unreleased -->

--- a/internal/handler/merge/handler.go
+++ b/internal/handler/merge/handler.go
@@ -20,6 +20,8 @@ import (
 	"go.abhg.dev/gs/internal/ui"
 )
 
+const defaultMergeTimeout = 2 * time.Minute
+
 // Store provides read access to the state store.
 type Store interface {
 	Trunk() string
@@ -69,6 +71,10 @@ type Options struct {
 	// to report that a change is ready to merge.
 	// Zero means check once and fail if merge readiness is not reached.
 	MergeReadinessTimeout time.Duration `name:"ready-timeout" config:"merge.readyTimeout" default:"30m" help:"Max time to wait for merge readiness before each merge. 0 means check once."`
+
+	// MergeTimeout is the maximum time to wait for the forge
+	// to report that a change is merged after requesting merge.
+	MergeTimeout time.Duration `name:"merge-timeout" config:"merge.mergeTimeout" default:"2m" help:"Max time to wait for merge completion after requesting merge."`
 }
 
 // DownstackMergeOptions controls downstack merge behavior.
@@ -160,6 +166,7 @@ func (h *Handler) MergeDownstack(
 	return h.executePlan(ctx, plan.items, mergeExecutionOptions{
 		Method:                opts.Method,
 		MergeReadinessTimeout: opts.MergeReadinessTimeout,
+		MergeTimeout:          opts.MergeTimeout,
 		SyncBeforeStart:       plan.syncBeforeStart,
 	})
 }
@@ -222,6 +229,7 @@ func (h *Handler) MergeBranch(
 	return h.executePlan(ctx, plan.items, mergeExecutionOptions{
 		Method:                opts.Method,
 		MergeReadinessTimeout: opts.MergeReadinessTimeout,
+		MergeTimeout:          opts.MergeTimeout,
 		SyncBeforeStart:       plan.syncBeforeStart,
 	})
 }
@@ -284,6 +292,7 @@ func (h *Handler) MergeStack(
 	return h.executePlan(ctx, plan.items, mergeExecutionOptions{
 		Method:                opts.Method,
 		MergeReadinessTimeout: opts.MergeReadinessTimeout,
+		MergeTimeout:          opts.MergeTimeout,
 		FailFast:              opts.FailFast,
 		SyncBeforeStart:       plan.syncBeforeStart,
 	})
@@ -594,8 +603,16 @@ func (h *Handler) confirm(plan []*mergeItem, title string) error {
 type mergeExecutionOptions struct {
 	Method                forge.MergeMethod
 	MergeReadinessTimeout time.Duration
+	MergeTimeout          time.Duration
 	FailFast              bool
 	SyncBeforeStart       bool
+}
+
+func (opts mergeExecutionOptions) mergeTimeout() time.Duration {
+	if opts.MergeTimeout == 0 {
+		return defaultMergeTimeout
+	}
+	return opts.MergeTimeout
 }
 
 func (h *Handler) executePlan(
@@ -641,6 +658,7 @@ func (h *Handler) executePlan(
 
 		Trunk:                 h.Store.Trunk(),
 		MergeReadinessTimeout: opts.MergeReadinessTimeout,
+		MergeTimeout:          opts.mergeTimeout(),
 		Method:                opts.Method,
 		FailFast:              opts.FailFast,
 	}).Execute(ctx, plan)
@@ -874,10 +892,9 @@ func (e *mergePlanExecutor) awaitMerged(
 	const (
 		_initialDelay = 500 * time.Millisecond
 		_maxDelay     = 8 * time.Second
-		_timeout      = 2 * time.Minute
 	)
 
-	ctx, cancel := context.WithTimeout(ctx, _timeout)
+	ctx, cancel := context.WithTimeout(ctx, e.MergeTimeout)
 	defer cancel()
 
 	// TODO: This only waits for the immediate change to reach

--- a/internal/handler/merge/handler_test.go
+++ b/internal/handler/merge/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"testing/synctest"
 	"time"
 
+	"github.com/alecthomas/kong"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -33,6 +34,17 @@ import (
 type fakeChangeID string
 
 func (f fakeChangeID) String() string { return string(f) }
+
+func TestOptions_mergeTimeoutDefault(t *testing.T) {
+	var got Options
+	parser, err := kong.New(&got)
+	require.NoError(t, err)
+
+	_, err = parser.Parse(nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2*time.Minute, got.MergeTimeout)
+}
 
 func TestAwaitMerged_immediate(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -97,6 +109,38 @@ func TestAwaitMerged_afterPolling(t *testing.T) {
 
 		err := executor.awaitMerged(t.Context(), item)
 		require.NoError(t, err)
+	})
+}
+
+func TestAwaitMerged_respectsMergeTimeout(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		ids := []forge.ChangeID{fakeChangeID("pr-1")}
+		mockRepo := forgetest.NewMockRepository(ctrl)
+		mockRepo.EXPECT().
+			ChangeStatuses(gomock.Any(), ids).
+			Return(
+				[]forge.ChangeStatus{{State: forge.ChangeOpen}}, nil,
+			).
+			AnyTimes()
+
+		h := newTestHandler(t, ctrl, testHandlerOpts{
+			forgeRepo: mockRepo,
+			logBuffer: nil,
+		})
+
+		item := &mergeItem{
+			branch:   "feat1",
+			changeID: fakeChangeID("pr-1"),
+		}
+		progress := newLogMergeProgress(silog.Nop())
+		executor := newTestMergePlanExecutor(h, progress)
+		executor.MergeTimeout = time.Nanosecond
+
+		err := executor.awaitMerged(t.Context(), item)
+		require.Error(t, err)
+		assert.EqualError(t, err, "timed out waiting for merge")
 	})
 }
 
@@ -1565,6 +1609,7 @@ func newTestMergePlanExecutor(
 
 		Trunk:                 "main",
 		MergeReadinessTimeout: 30 * time.Minute,
+		MergeTimeout:          2 * time.Minute,
 		Method:                forge.MergeMethodDefault,
 	}
 }

--- a/internal/handler/merge/scheduler.go
+++ b/internal/handler/merge/scheduler.go
@@ -28,6 +28,7 @@ type mergePlanExecutor struct {
 
 	Trunk                 string            // required
 	MergeReadinessTimeout time.Duration     // required
+	MergeTimeout          time.Duration     // required
 	Method                forge.MergeMethod // required
 	FailFast              bool
 }

--- a/testdata/help/branch_merge.txt
+++ b/testdata/help/branch_merge.txt
@@ -18,6 +18,8 @@ Flags:
                          and 'rebase'. (🔧 spice.merge.method)
   --ready-timeout=30m    Max time to wait for merge readiness before each merge.
                          0 means check once. (🔧 spice.merge.readyTimeout)
+  --merge-timeout=2m     Max time to wait for merge completion after requesting
+                         merge. (🔧 spice.merge.mergeTimeout)
   --branch=NAME,...      Branches to merge. May be repeated.
 
 Global Flags:

--- a/testdata/help/downstack_merge.txt
+++ b/testdata/help/downstack_merge.txt
@@ -41,6 +41,8 @@ Flags:
                          and 'rebase'. (🔧 spice.merge.method)
   --ready-timeout=30m    Max time to wait for merge readiness before each merge.
                          0 means check once. (🔧 spice.merge.readyTimeout)
+  --merge-timeout=2m     Max time to wait for merge completion after requesting
+                         merge. (🔧 spice.merge.mergeTimeout)
   --no-branch-check      Skip stale base validation before merging.
   --branch=NAME,...      Branches to start merging from. May be repeated.
 

--- a/testdata/help/stack_merge.txt
+++ b/testdata/help/stack_merge.txt
@@ -29,6 +29,8 @@ Flags:
                          and 'rebase'. (🔧 spice.merge.method)
   --ready-timeout=30m    Max time to wait for merge readiness before each merge.
                          0 means check once. (🔧 spice.merge.readyTimeout)
+  --merge-timeout=2m     Max time to wait for merge completion after requesting
+                         merge. (🔧 spice.merge.mergeTimeout)
   --no-branch-check      Skip stale base validation before merging.
   --fail-fast            Stop the merge queue after the first branch failure.
   --branch=NAME,...      Branches whose stacks to merge. May be repeated.


### PR DESCRIPTION
Merge commands now accept `spice.merge.mergeTimeout` and the matching `--merge-timeout` flag to control how long git-spice waits after requesting a forge merge for the change to report merged. The default stays at two minutes to preserve the previous await-merge behavior.

The setting is separate from `spice.merge.readyTimeout`, which still only controls the pre-request readiness wait.

Validation:

- `internal/handler/merge` unit tests cover the default option value and the `awaitMerged` timeout path.
- Generated CLI help and config references include `spice.merge.mergeTimeout` for the public merge commands.

[skip changelog]: This feature is unreleased and has not shipped.