### PR TITLE
merge: Add merge command hook

### DIFF
--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -331,7 +331,7 @@ Use --fail-fast to stop the queue after the first branch failure.
 * `--fail-fast`: Stop the merge queue after the first branch failure.
 * `--branch=NAME,...`: Branches whose stacks to merge. May be repeated.
 
-**Configuration**: [spice.merge.mergeTimeout](/cli/config.md#spicemergemergetimeout), [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
+**Configuration**: [spice.merge.command](/cli/config.md#spicemergecommand), [spice.merge.mergeTimeout](/cli/config.md#spicemergemergetimeout), [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
 
 ### git-spice stack restack {#gs-stack-restack}
 
@@ -671,7 +671,7 @@ and syncs merged branch cleanup.
 * `--no-branch-check`: Skip stale base validation before merging.
 * `--branch=NAME,...`: Branches to start merging from. May be repeated.
 
-**Configuration**: [spice.merge.mergeTimeout](/cli/config.md#spicemergemergetimeout), [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
+**Configuration**: [spice.merge.command](/cli/config.md#spicemergecommand), [spice.merge.mergeTimeout](/cli/config.md#spicemergemergetimeout), [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
 
 ### git-spice downstack edit {#gs-downstack-edit}
 
@@ -1157,7 +1157,7 @@ Use --ready-timeout to configure the maximum wait.
 * `--merge-timeout=2m` ([:material-wrench:{ .middle title="spice.merge.mergeTimeout" }](/cli/config.md#spicemergemergetimeout)): Max time to wait for merge completion after requesting merge.
 * `--branch=NAME,...`: Branches to merge. May be repeated.
 
-**Configuration**: [spice.merge.mergeTimeout](/cli/config.md#spicemergemergetimeout), [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
+**Configuration**: [spice.merge.command](/cli/config.md#spicemergecommand), [spice.merge.mergeTimeout](/cli/config.md#spicemergemergetimeout), [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
 
 ### git-spice branch submit {#gs-branch-submit}
 

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -216,7 +216,6 @@ the repository path.
 
 Accepted values are registered forge IDs,
 including `github`, `gitlab`, `bitbucket`, `gitea`, and `forgejo`.
-Test repositories may also use `shamhub`.
 
 Alternatively, set this option with the `GIT_SPICE_FORGE_KIND`
 environment variable.
@@ -505,6 +504,8 @@ Defaults to `2m`.
 Preferred merge method for $$gs downstack merge$$.
 If unset, git-spice lets the forge use its default merge method.
 
+This setting is ignored if `spice.merge.command` is set.
+
 Merge methods are forge-specific.
 If the selected forge does not recognize the configured method,
 git-spice warns and lets the forge use its default merge method.
@@ -514,6 +515,42 @@ git-spice warns and lets the forge use its default merge method.
 - `merge`: create a merge commit
 - `squash`: squash commits before merging
 - `rebase`: rebase commits before merging
+
+### spice.merge.command
+
+<!-- gs:version unreleased -->
+
+Command to run to request a forge merge
+when a CR is deemed mergeable by a merge command.
+If unset, git-spice requests the merge through the forge API.
+
+git-spice still waits for the forge to report merge readiness before running
+the command,
+and still waits for the forge to report that the CR merged after the command
+exits successfully.
+git-spice may run the command concurrently for different CRs.
+
+Exit status `0` means the command requested the merge.
+Any non-zero exit status means the merge request failed for that CR.
+
+The command receives these common environment variables:
+
+- `GIT_SPICE_FORGE_ID`
+- `GIT_SPICE_BRANCH`
+- `GIT_SPICE_BASE_BRANCH`
+- `GIT_SPICE_TRUNK_BRANCH`
+- `GIT_SPICE_CHANGE_URL`
+- `GIT_SPICE_HEAD_SHA`
+
+Forges may also provide provider-specific variables.
+
+**Provider-specific variables:**
+
+- `GIT_SPICE_GITHUB_PR_NUMBER`
+- `GIT_SPICE_GITLAB_MR_IID`
+- `GIT_SPICE_BITBUCKET_PR_ID`
+- `GIT_SPICE_FORGEJO_PR_NUMBER`
+- `GIT_SPICE_GITEA_PR_NUMBER`
 
 ### spice.rebaseContinue.edit
 

--- a/internal/forge/bitbucket/merge_command.go
+++ b/internal/forge/bitbucket/merge_command.go
@@ -1,0 +1,18 @@
+package bitbucket
+
+import (
+	"context"
+	"strconv"
+
+	"go.abhg.dev/gs/internal/forge"
+)
+
+// MergeCommandEnvironment returns Bitbucket-specific variables for merge hooks.
+func (r *Repository) MergeCommandEnvironment(
+	_ context.Context,
+	id forge.ChangeID,
+) (map[string]string, error) {
+	return map[string]string{
+		"GIT_SPICE_BITBUCKET_PR_ID": strconv.FormatInt(mustPR(id).Number, 10),
+	}, nil
+}

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -290,6 +290,14 @@ type Repository interface {
 	// MergeChange merges an open change into its base branch.
 	MergeChange(ctx context.Context, id ChangeID, opts MergeChangeOptions) error
 
+	// MergeCommandEnvironment returns forge-specific environment variables
+	// for a command that requests merge of the given change.
+	//
+	// Keys must use the GIT_SPICE_ prefix.
+	// Callers own common git-spice variables
+	// and may ignore forge values that collide with those keys.
+	MergeCommandEnvironment(ctx context.Context, id ChangeID) (map[string]string, error)
+
 	// ChangeMergeability reports whether the forge currently considers
 	// the change mergeable.
 	//

--- a/internal/forge/forgejo/merge_command.go
+++ b/internal/forge/forgejo/merge_command.go
@@ -1,0 +1,18 @@
+package forgejo
+
+import (
+	"context"
+	"strconv"
+
+	"go.abhg.dev/gs/internal/forge"
+)
+
+// MergeCommandEnvironment returns Forgejo-specific variables for merge hooks.
+func (r *Repository) MergeCommandEnvironment(
+	_ context.Context,
+	id forge.ChangeID,
+) (map[string]string, error) {
+	return map[string]string{
+		"GIT_SPICE_FORGEJO_PR_NUMBER": strconv.FormatInt(mustPR(id).Number, 10),
+	}, nil
+}

--- a/internal/forge/forgetest/mocks.go
+++ b/internal/forge/forgetest/mocks.go
@@ -1172,6 +1172,45 @@ func (c *MockRepositoryMergeChangeCall) DoAndReturn(f func(context.Context, forg
 	return c
 }
 
+// MergeCommandEnvironment mocks base method.
+func (m *MockRepository) MergeCommandEnvironment(ctx context.Context, id forge.ChangeID) (map[string]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MergeCommandEnvironment", ctx, id)
+	ret0, _ := ret[0].(map[string]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MergeCommandEnvironment indicates an expected call of MergeCommandEnvironment.
+func (mr *MockRepositoryMockRecorder) MergeCommandEnvironment(ctx, id any) *MockRepositoryMergeCommandEnvironmentCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MergeCommandEnvironment", reflect.TypeOf((*MockRepository)(nil).MergeCommandEnvironment), ctx, id)
+	return &MockRepositoryMergeCommandEnvironmentCall{Call: call}
+}
+
+// MockRepositoryMergeCommandEnvironmentCall wrap *gomock.Call
+type MockRepositoryMergeCommandEnvironmentCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockRepositoryMergeCommandEnvironmentCall) Return(arg0 map[string]string, arg1 error) *MockRepositoryMergeCommandEnvironmentCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockRepositoryMergeCommandEnvironmentCall) Do(f func(context.Context, forge.ChangeID) (map[string]string, error)) *MockRepositoryMergeCommandEnvironmentCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockRepositoryMergeCommandEnvironmentCall) DoAndReturn(f func(context.Context, forge.ChangeID) (map[string]string, error)) *MockRepositoryMergeCommandEnvironmentCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // NewChangeMetadata mocks base method.
 func (m *MockRepository) NewChangeMetadata(ctx context.Context, id forge.ChangeID) (forge.ChangeMetadata, error) {
 	m.ctrl.T.Helper()

--- a/internal/forge/gitea/merge_command.go
+++ b/internal/forge/gitea/merge_command.go
@@ -1,0 +1,18 @@
+package gitea
+
+import (
+	"context"
+	"strconv"
+
+	"go.abhg.dev/gs/internal/forge"
+)
+
+// MergeCommandEnvironment returns Gitea-specific variables for merge hooks.
+func (r *Repository) MergeCommandEnvironment(
+	_ context.Context,
+	id forge.ChangeID,
+) (map[string]string, error) {
+	return map[string]string{
+		"GIT_SPICE_GITEA_PR_NUMBER": strconv.FormatInt(mustPR(id).Number, 10),
+	}, nil
+}

--- a/internal/forge/github/merge_command.go
+++ b/internal/forge/github/merge_command.go
@@ -1,0 +1,18 @@
+package github
+
+import (
+	"context"
+	"strconv"
+
+	"go.abhg.dev/gs/internal/forge"
+)
+
+// MergeCommandEnvironment returns GitHub-specific variables for merge hooks.
+func (r *Repository) MergeCommandEnvironment(
+	_ context.Context,
+	id forge.ChangeID,
+) (map[string]string, error) {
+	return map[string]string{
+		"GIT_SPICE_GITHUB_PR_NUMBER": strconv.Itoa(mustPR(id).Number),
+	}, nil
+}

--- a/internal/forge/gitlab/merge_command.go
+++ b/internal/forge/gitlab/merge_command.go
@@ -1,0 +1,18 @@
+package gitlab
+
+import (
+	"context"
+	"strconv"
+
+	"go.abhg.dev/gs/internal/forge"
+)
+
+// MergeCommandEnvironment returns GitLab-specific variables for merge hooks.
+func (r *Repository) MergeCommandEnvironment(
+	_ context.Context,
+	id forge.ChangeID,
+) (map[string]string, error) {
+	return map[string]string{
+		"GIT_SPICE_GITLAB_MR_IID": strconv.FormatInt(mustMR(id).Number, 10),
+	}, nil
+}

--- a/internal/forge/shamhub/merge_command.go
+++ b/internal/forge/shamhub/merge_command.go
@@ -1,0 +1,20 @@
+package shamhub
+
+import (
+	"context"
+	"strconv"
+
+	"go.abhg.dev/gs/internal/forge"
+)
+
+// MergeCommandEnvironment returns ShamHub-specific variables for merge hooks.
+func (r *forgeRepository) MergeCommandEnvironment(
+	_ context.Context,
+	id forge.ChangeID,
+) (map[string]string, error) {
+	return map[string]string{
+		"GIT_SPICE_SHAMHUB_CHANGE_NUMBER": strconv.Itoa(int(id.(ChangeID))),
+		"GIT_SPICE_SHAMHUB_API_URL":       r.apiURL.String(),
+		"GIT_SPICE_SHAMHUB_TOKEN":         r.client.headers["Authentication-Token"],
+	}, nil
+}

--- a/internal/handler/merge/handler.go
+++ b/internal/handler/merge/handler.go
@@ -15,6 +15,7 @@ import (
 
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/scriptrun"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/ui"
@@ -66,6 +67,10 @@ type Options struct {
 	// Method selects the forge merge strategy.
 	// Empty means use the configured or forge default.
 	Method forge.MergeMethod `placeholder:"METHOD" config:"merge.method" help:"Preferred merge method. One of 'merge', 'squash', and 'rebase'."`
+
+	// Command requests merges through a user-defined command.
+	// Empty means use the forge merge API.
+	Command string `hidden:"" config:"merge.command" help:"Command to request merge instead of using the forge merge API."`
 
 	// MergeReadinessTimeout is the maximum time to wait for the forge
 	// to report that a change is ready to merge.
@@ -165,6 +170,7 @@ func (h *Handler) MergeDownstack(
 
 	return h.executePlan(ctx, plan.items, mergeExecutionOptions{
 		Method:                opts.Method,
+		Command:               opts.Command,
 		MergeReadinessTimeout: opts.MergeReadinessTimeout,
 		MergeTimeout:          opts.MergeTimeout,
 		SyncBeforeStart:       plan.syncBeforeStart,
@@ -228,6 +234,7 @@ func (h *Handler) MergeBranch(
 
 	return h.executePlan(ctx, plan.items, mergeExecutionOptions{
 		Method:                opts.Method,
+		Command:               opts.Command,
 		MergeReadinessTimeout: opts.MergeReadinessTimeout,
 		MergeTimeout:          opts.MergeTimeout,
 		SyncBeforeStart:       plan.syncBeforeStart,
@@ -291,6 +298,7 @@ func (h *Handler) MergeStack(
 
 	return h.executePlan(ctx, plan.items, mergeExecutionOptions{
 		Method:                opts.Method,
+		Command:               opts.Command,
 		MergeReadinessTimeout: opts.MergeReadinessTimeout,
 		MergeTimeout:          opts.MergeTimeout,
 		FailFast:              opts.FailFast,
@@ -602,6 +610,7 @@ func (h *Handler) confirm(plan []*mergeItem, title string) error {
 
 type mergeExecutionOptions struct {
 	Method                forge.MergeMethod
+	Command               string
 	MergeReadinessTimeout time.Duration
 	MergeTimeout          time.Duration
 	FailFast              bool
@@ -645,6 +654,20 @@ func (h *Handler) executePlan(
 		progress = newLogMergeProgress(h.Log)
 	}
 
+	requester := mergeRequester(&directMergeRequester{
+		repo:   h.RemoteRepository,
+		method: opts.Method,
+	})
+	if opts.Command != "" {
+		requester = &commandMergeRequester{
+			log:     h.Log,
+			repo:    h.RemoteRepository,
+			forgeID: h.RemoteRepository.Forge().ID(),
+			trunk:   h.Store.Trunk(),
+			command: opts.Command,
+		}
+	}
+
 	err = (&mergePlanExecutor{
 		RemoteRepository: h.RemoteRepository,
 		Repository:       h.Repository,
@@ -654,7 +677,8 @@ func (h *Handler) executePlan(
 		Submit:  h.Submit,
 		Sync:    h.Sync,
 
-		Progress: progress,
+		Progress:  progress,
+		Requester: requester,
 
 		Trunk:                 h.Store.Trunk(),
 		MergeReadinessTimeout: opts.MergeReadinessTimeout,
@@ -668,6 +692,105 @@ func (h *Handler) executePlan(
 
 	h.Log.Infof("All %d change(s) merged.", len(plan))
 	return nil
+}
+
+// mergeRequester requests the forge-side merge after readiness checks pass.
+//
+// A successful request does not mean the change has merged.
+// The merge executor must still wait for the forge to report the merged state.
+type mergeRequester interface {
+	RequestMerge(context.Context, *mergeItem) error
+}
+
+// directMergeRequester requests merges through the forge API.
+type directMergeRequester struct {
+	repo   forge.Repository // required
+	method forge.MergeMethod
+}
+
+func (r *directMergeRequester) RequestMerge(
+	ctx context.Context,
+	item *mergeItem,
+) error {
+	return r.repo.MergeChange(ctx, item.changeID, forge.MergeChangeOptions{
+		Method:   r.method,
+		HeadHash: item.headHash,
+	})
+}
+
+// commandMergeRequester requests merges through a user-configured command.
+//
+// The command is only the merge request step.
+// The caller remains responsible for waiting until the forge reports the
+// change as merged.
+type commandMergeRequester struct {
+	log     *silog.Logger    // required
+	repo    forge.Repository // required
+	forgeID string           // required
+	trunk   string           // required
+	command string           // required
+}
+
+func (r *commandMergeRequester) RequestMerge(
+	ctx context.Context,
+	item *mergeItem,
+) error {
+	env, err := r.mergeCommandEnvironment(ctx, item)
+	if err != nil {
+		return fmt.Errorf("build environment: %w", err)
+	}
+
+	output, flushOutput := silog.Writer(
+		r.log.WithPrefix("merge"),
+		silog.LevelInfo,
+	)
+	defer flushOutput()
+
+	result, err := new(scriptrun.Runner).Run(ctx, &scriptrun.RunRequest{
+		Script: r.command,
+		Env:    env,
+		Stdout: output,
+		Stderr: output,
+	})
+	if err != nil {
+		return err
+	}
+	if result.ExitCode != 0 {
+		return fmt.Errorf("command exited with status %d", result.ExitCode)
+	}
+	return nil
+}
+
+func (r *commandMergeRequester) mergeCommandEnvironment(
+	ctx context.Context,
+	item *mergeItem,
+) ([]string, error) {
+	common := map[string]string{
+		"GIT_SPICE_FORGE_ID":     r.forgeID,
+		"GIT_SPICE_BRANCH":       item.branch,
+		"GIT_SPICE_BASE_BRANCH":  item.base,
+		"GIT_SPICE_TRUNK_BRANCH": r.trunk,
+		"GIT_SPICE_CHANGE_URL":   item.mergeURL,
+		"GIT_SPICE_HEAD_SHA":     item.headHash.String(),
+	}
+
+	forgeEnv, err := r.repo.MergeCommandEnvironment(ctx, item.changeID)
+	if err != nil {
+		return nil, fmt.Errorf("forge environment: %w", err)
+	}
+	for key, value := range forgeEnv {
+		if _, blocked := common[key]; blocked {
+			continue
+		}
+		common[key] = value
+	}
+
+	env := make([]string, 0, len(common))
+	for key, value := range common {
+		env = append(env, key+"="+value)
+	}
+	slices.Sort(env)
+	return env, nil
 }
 
 func (h *Handler) validateFreshBases(

--- a/internal/handler/merge/handler_test.go
+++ b/internal/handler/merge/handler_test.go
@@ -1252,6 +1252,121 @@ func TestExecutePlan_mergeMethod(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestExecutePlan_mergeCommandRequestsThenAwaitsMerge(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	var logBuffer bytes.Buffer
+
+	mockForge := forgetest.NewMockRepository(ctrl)
+	mockForgeForge := forgetest.NewMockForge(ctrl)
+	mockForgeForge.EXPECT().
+		ID().
+		Return("shamhub").
+		AnyTimes()
+	mockForge.EXPECT().
+		Forge().
+		Return(mockForgeForge).
+		AnyTimes()
+	mockStore := NewMockStore(ctrl)
+	mockStore.EXPECT().
+		Trunk().
+		Return("main").
+		AnyTimes()
+
+	pr1 := fakeChangeID("pr-1")
+	expectPushedHead(mockForge, pr1, "head1")
+	mockForge.EXPECT().
+		ChangeMergeability(gomock.Any(), pr1).
+		Return(mergeability(forge.ChangeMergeabilityReady), nil)
+	mockForge.EXPECT().
+		MergeCommandEnvironment(gomock.Any(), pr1).
+		Return(map[string]string{
+			"GIT_SPICE_SHAMHUB_CHANGE_NUMBER": "1",
+			"GIT_SPICE_BRANCH":                "wrong",
+		}, nil)
+	expectMerged(mockForge, pr1)
+
+	mockSync := NewMockSyncHandler(ctrl)
+	mockSync.EXPECT().
+		SyncTrunk(gomock.Any(), syncTrunkOptions()).
+		Return(nil)
+
+	h := newTestHandler(t, ctrl, testHandlerOpts{
+		forgeRepo: mockForge,
+		store:     mockStore,
+		sync:      mockSync,
+		logBuffer: &logBuffer,
+	})
+
+	err := h.executePlan(t.Context(), testMergePlan([]*mergeItem{
+		{
+			branch:   "feat1",
+			changeID: pr1,
+			headHash: git.Hash("head1"),
+		},
+	}), mergeExecutionOptions{
+		Command: strings.Join([]string{
+			"test \"$GIT_SPICE_FORGE_ID\" = shamhub",
+			"test \"$GIT_SPICE_BRANCH\" = feat1",
+			"test \"$GIT_SPICE_BASE_BRANCH\" = main",
+			"test \"$GIT_SPICE_TRUNK_BRANCH\" = main",
+			"test \"$GIT_SPICE_CHANGE_URL\" = http://example.com/1",
+			"test \"$GIT_SPICE_HEAD_SHA\" = head1",
+			"test \"$GIT_SPICE_SHAMHUB_CHANGE_NUMBER\" = 1",
+			"test -z \"$GIT_SPICE_CHANGE_ID\"",
+			"echo command stdout",
+			"echo command stderr >&2",
+		}, "\n"),
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, logBuffer.String(), "INF merge: command stdout")
+	assert.Contains(t, logBuffer.String(), "INF merge: command stderr")
+}
+
+func TestExecutePlan_mergeCommandFailureFailsItem(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockForge := forgetest.NewMockRepository(ctrl)
+	mockForgeForge := forgetest.NewMockForge(ctrl)
+	mockForgeForge.EXPECT().
+		ID().
+		Return("shamhub").
+		AnyTimes()
+	mockForge.EXPECT().
+		Forge().
+		Return(mockForgeForge).
+		AnyTimes()
+	mockStore := NewMockStore(ctrl)
+	mockStore.EXPECT().
+		Trunk().
+		Return("main").
+		AnyTimes()
+
+	pr1 := fakeChangeID("pr-1")
+	mockForge.EXPECT().
+		ChangeMergeability(gomock.Any(), pr1).
+		Return(mergeability(forge.ChangeMergeabilityReady), nil)
+	mockForge.EXPECT().
+		MergeCommandEnvironment(gomock.Any(), pr1).
+		Return(nil, nil)
+
+	h := newTestHandler(t, ctrl, testHandlerOpts{
+		forgeRepo: mockForge,
+		store:     mockStore,
+	})
+
+	err := h.executePlan(t.Context(), testMergePlan([]*mergeItem{
+		{
+			branch:   "feat1",
+			changeID: pr1,
+		},
+	}), mergeExecutionOptions{
+		Command: "exit 42",
+	})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "command exited with status 42")
+}
+
 func TestExecutePlan_firstItemAlreadyOnTrunk(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	var logBuffer bytes.Buffer
@@ -1606,6 +1721,10 @@ func newTestMergePlanExecutor(
 		Sync:    h.Sync,
 
 		Progress: progress,
+		Requester: &directMergeRequester{
+			repo:   h.RemoteRepository,
+			method: forge.MergeMethodDefault,
+		},
 
 		Trunk:                 "main",
 		MergeReadinessTimeout: 30 * time.Minute,

--- a/internal/handler/merge/scheduler.go
+++ b/internal/handler/merge/scheduler.go
@@ -24,7 +24,8 @@ type mergePlanExecutor struct {
 	Submit  SubmitHandler  // required
 	Sync    SyncHandler    // required
 
-	Progress mergeProgress // required
+	Progress  mergeProgress  // required
+	Requester mergeRequester // required
 
 	Trunk                 string            // required
 	MergeReadinessTimeout time.Duration     // required
@@ -169,13 +170,7 @@ func (e *mergePlanExecutor) mergeItem(
 		Item: item,
 		URL:  item.mergeURL,
 	})
-	if err := e.RemoteRepository.MergeChange(
-		ctx, item.changeID,
-		forge.MergeChangeOptions{
-			Method:   e.Method,
-			HeadHash: item.headHash,
-		},
-	); err != nil {
+	if err := e.Requester.RequestMerge(ctx, item); err != nil {
 		e.Progress.Event(mergeProgressEvent{
 			Kind: mergeProgressMergeFailed,
 			Item: item,

--- a/internal/scriptrun/scriptrun.go
+++ b/internal/scriptrun/scriptrun.go
@@ -20,8 +20,12 @@
 //
 // # Output handling
 //
-// stdout and stderr are captured independently. Neither is parsed by
-// scriptrun itself — the caller decides what to do with them.
+// stdout and stderr are captured independently
+// unless callers provide explicit output writers.
+// Explicit writers receive output during execution
+// and opt that stream out of result capture.
+// Neither stream is parsed by scriptrun itself:
+// the caller decides what to do with the output.
 //
 // A non-zero exit code is not an error from Run's perspective: it is
 // reported in the returned RunResult. Errors are reserved for cases
@@ -77,6 +81,14 @@ type RunRequest struct {
 
 	// Stdin, if non-nil, is supplied to the script as its stdin.
 	Stdin io.Reader
+
+	// Stdout, if non-nil, receives stdout while the script is running.
+	// RunResult.Stdout is not populated in that case.
+	Stdout io.Writer
+
+	// Stderr, if non-nil, receives stderr while the script is running.
+	// RunResult.Stderr is not populated in that case.
+	Stderr io.Writer
 }
 
 // RunResult is the outcome of a single script invocation.
@@ -85,9 +97,11 @@ type RunResult struct {
 	ExitCode int
 
 	// Stdout is the captured standard output of the script.
+	// If RunRequest.Stdout was set, Stdout is not populated.
 	Stdout []byte
 
 	// Stderr is the captured standard error of the script.
+	// If RunRequest.Stderr was set, Stderr is not populated.
 	Stderr []byte
 }
 
@@ -125,7 +139,15 @@ func (r *Runner) Run(ctx context.Context, req *RunRequest) (*RunResult, error) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	cmd.WithStdout(&stdout).WithStderr(&stderr)
+	stdoutWriter := io.Writer(&stdout)
+	if req.Stdout != nil {
+		stdoutWriter = req.Stdout
+	}
+	stderrWriter := io.Writer(&stderr)
+	if req.Stderr != nil {
+		stderrWriter = req.Stderr
+	}
+	cmd.WithStdout(stdoutWriter).WithStderr(stderrWriter)
 
 	runErr := cmd.Run()
 	exitErr := new(xec.ExitError)

--- a/internal/scriptrun/scriptrun_test.go
+++ b/internal/scriptrun/scriptrun_test.go
@@ -1,13 +1,17 @@
 package scriptrun
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -86,6 +90,52 @@ func TestRunner_Run_nonZeroExit(t *testing.T) {
 	assert.Equal(t, 7, res.ExitCode)
 	assert.Equal(t, "out\n", string(res.Stdout))
 	assert.Equal(t, "err\n", string(res.Stderr))
+}
+
+func TestRunner_Run_streamsOutputBeforeExit(t *testing.T) {
+	r := &Runner{Log: silog.Nop()}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	stdout := newSignalWriter()
+	stderr := newSignalWriter()
+	done := make(chan error, 1)
+	go func() {
+		_, err := r.Run(ctx, &RunRequest{
+			Script: `echo stdout; echo stderr >&2; sleep 2`,
+			Stdout: stdout,
+			Stderr: stderr,
+		})
+		done <- err
+	}()
+
+	requireWrittenBeforeExit(t, stdout.Written(), done)
+	requireWrittenBeforeExit(t, stderr.Written(), done)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("script did not exit after context cancellation")
+	}
+}
+
+func TestRunner_Run_streamsOutputWithoutCapture(t *testing.T) {
+	r := &Runner{Log: silog.Nop()}
+
+	var stdout, stderr bytes.Buffer
+	res, err := r.Run(t.Context(), &RunRequest{
+		Script: `echo stdout; echo stderr >&2`,
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, res.ExitCode)
+	assert.Equal(t, "stdout\n", stdout.String())
+	assert.Equal(t, "stderr\n", stderr.String())
+	assert.Empty(t, res.Stdout)
+	assert.Empty(t, res.Stderr)
 }
 
 func TestRunner_Run_shebangScript(t *testing.T) {
@@ -185,3 +235,42 @@ func TestRunner_Run_nilLogger(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "ok\n", string(res.Stdout))
 }
+
+type signalWriter struct {
+	once    sync.Once
+	written chan struct{}
+}
+
+func newSignalWriter() *signalWriter {
+	return &signalWriter{written: make(chan struct{})}
+}
+
+func (w *signalWriter) Write(p []byte) (int, error) {
+	w.once.Do(func() {
+		close(w.written)
+	})
+	return len(p), nil
+}
+
+func (w *signalWriter) Written() <-chan struct{} {
+	return w.written
+}
+
+func requireWrittenBeforeExit(
+	t *testing.T,
+	written <-chan struct{},
+	done <-chan error,
+) {
+	t.Helper()
+
+	select {
+	case <-written:
+	case err := <-done:
+		require.NoError(t, err)
+		t.Fatal("script exited before output was streamed")
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("output was not streamed before script exit")
+	}
+}
+
+var _ io.Writer = (*signalWriter)(nil)

--- a/testdata/help/branch_merge.txt
+++ b/testdata/help/branch_merge.txt
@@ -28,3 +28,7 @@ Global Flags:
   -v, --verbose        Enable verbose output ($GIT_SPICE_VERBOSE)
   -C, --dir=DIR        Change to DIR before doing anything
       --[no-]prompt    Whether to prompt for missing information
+
+Configuration (🔧):
+  spice.merge.command    Command to request merge instead of using the forge
+                         merge API.

--- a/testdata/help/downstack_merge.txt
+++ b/testdata/help/downstack_merge.txt
@@ -52,3 +52,7 @@ Global Flags:
   -v, --verbose        Enable verbose output ($GIT_SPICE_VERBOSE)
   -C, --dir=DIR        Change to DIR before doing anything
       --[no-]prompt    Whether to prompt for missing information
+
+Configuration (🔧):
+  spice.merge.command    Command to request merge instead of using the forge
+                         merge API.

--- a/testdata/help/stack_merge.txt
+++ b/testdata/help/stack_merge.txt
@@ -41,3 +41,7 @@ Global Flags:
   -v, --verbose        Enable verbose output ($GIT_SPICE_VERBOSE)
   -C, --dir=DIR        Change to DIR before doing anything
       --[no-]prompt    Whether to prompt for missing information
+
+Configuration (🔧):
+  spice.merge.command    Command to request merge instead of using the forge
+                         merge API.

--- a/testdata/script/branch_merge_command.txt
+++ b/testdata/script/branch_merge_command.txt
@@ -1,0 +1,97 @@
+# 'branch merge' can request merge through spice.merge.command.
+
+as 'Test <test@example.com>'
+at '2026-06-28T12:00:00Z'
+
+# setup
+cd repo
+git init
+git config spice.experiment.merge true
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# create a branch directly on trunk
+git add feature1.txt
+gs bc feature1 -m 'Add feature 1'
+
+# submit the branch
+gs branch submit --fill
+stderr 'Created #1'
+
+# configure a merge hook that verifies the public environment
+chmod 755 $WORK/merge-command.sh
+git config spice.merge.command $WORK/merge-command.sh
+
+# merge the current branch through the configured command
+env ROBOT_INPUT=$WORK/robot-merge.golden ROBOT_OUTPUT=$WORK/robot-merge.actual
+gs branch merge
+cmp $WORK/robot-merge.actual $WORK/robot-merge.golden
+stderr 'feature1: merging #1:'
+stderr 'feature1: #1 was merged'
+stderr 'All 1 change.s. merged.'
+
+# verify the command requested the merge and git-spice waited for it
+shamhub dump changes
+cmpenvJSON stdout $WORK/golden/changes.json
+
+-- repo/feature1.txt --
+This is feature 1
+-- merge-command.sh --
+#!/bin/sh
+
+test "$GIT_SPICE_FORGE_ID" = shamhub
+test "$GIT_SPICE_BRANCH" = feature1
+test "$GIT_SPICE_BASE_BRANCH" = main
+test "$GIT_SPICE_TRUNK_BRANCH" = main
+test -n "$GIT_SPICE_CHANGE_URL"
+test -n "$GIT_SPICE_HEAD_SHA"
+test "$GIT_SPICE_SHAMHUB_CHANGE_NUMBER" = 1
+test -n "$GIT_SPICE_SHAMHUB_API_URL"
+test -n "$GIT_SPICE_SHAMHUB_TOKEN"
+test -z "$GIT_SPICE_CHANGE_ID"
+
+curl -fsS -X POST \
+  -H 'Content-Type: application/json' \
+  -H "Authentication-Token: $GIT_SPICE_SHAMHUB_TOKEN" \
+  -d '{}' \
+  "$GIT_SPICE_SHAMHUB_API_URL/alice/example/change/$GIT_SPICE_SHAMHUB_CHANGE_NUMBER/merge"
+-- robot-merge.golden --
+===
+> Merge 1 change(s) bottom-up?: [Y/n]
+>   feature1 (#1)
+true
+-- golden/changes.json --
+[
+  {
+    "number": 1,
+    "html_url": "$SHAMHUB_URL/alice/example/change/1",
+    "state": "closed",
+    "merged": true,
+    "title": "Add feature 1",
+    "body": "",
+    "base": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "main",
+      "sha": "552ba3fd1fe9eadbaae36004b4ed9af6648d4dbe"
+    },
+    "head": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "feature1",
+      "sha": "df84c0162baca54872ec984e03f90871232594cf"
+    }
+  }
+]

--- a/testdata/script/branch_merge_command_failure.txt
+++ b/testdata/script/branch_merge_command_failure.txt
@@ -1,0 +1,76 @@
+# 'branch merge' fails an item when spice.merge.command exits non-zero.
+
+as 'Test <test@example.com>'
+at '2026-06-29T12:00:00Z'
+
+# setup
+cd repo
+git init
+git config spice.experiment.merge true
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake GitHub remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# create a branch directly on trunk
+git add feature1.txt
+gs bc feature1 -m 'Add feature 1'
+
+# submit the branch
+gs branch submit --fill
+stderr 'Created #1'
+
+# configure a merge hook that refuses to request the forge merge
+git config spice.merge.command 'echo merge rejected >&2; exit 17'
+
+# merge reports the hook failure instead of waiting for the CR to merge
+env ROBOT_INPUT=$WORK/robot-merge.golden ROBOT_OUTPUT=$WORK/robot-merge.actual
+! gs branch merge
+cmp $WORK/robot-merge.actual $WORK/robot-merge.golden
+stderr 'feature1: merging #1:'
+stderr 'command exited with status 17'
+! stderr 'feature1: #1 was merged'
+
+# verify the command did not request a forge merge
+shamhub dump changes
+cmpenvJSON stdout $WORK/golden/changes.json
+
+-- repo/feature1.txt --
+This is feature 1
+-- robot-merge.golden --
+===
+> Merge 1 change(s) bottom-up?: [Y/n]
+>   feature1 (#1)
+true
+-- golden/changes.json --
+[
+  {
+    "number": 1,
+    "html_url": "$SHAMHUB_URL/alice/example/change/1",
+    "state": "open",
+    "title": "Add feature 1",
+    "body": "",
+    "base": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "main",
+      "sha": "4534ecd83e64a03eb6ab28c54c179f31255d98c5"
+    },
+    "head": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "feature1",
+      "sha": "0a81a9aa40eeebda39d579657c084e3ab99c632e"
+    }
+  }
+]


### PR DESCRIPTION
Repositories can configure `spice.merge.command` to request a merge through a user-defined command instead of the forge merge API. The command runs after git-spice observes the pushed head and after the forge reports that the change is ready to merge.

The hook environment includes common `GIT_SPICE_*` branch, forge, URL, trunk, base, and head-SHA variables. Forge-specific identifiers use provider-specific names, and forge-provided values cannot overwrite common variables.

The command is only the merge request step. A successful command still flows into the existing await-merged path, and a non-zero command exit fails that merge queue item. Command output streams through the merge logger as it is produced instead of being buffered into the script result.

Validation covers the handler path, the script runner streaming contract, successful merge command execution through ShamHub, and merge command failure without a forge merge request.

[skip changelog]: merge command support is unreleased.