### PR TITLE
mergeprogress: Hide event messages from widget

### DIFF
--- a/internal/handler/merge/progress.go
+++ b/internal/handler/merge/progress.go
@@ -239,89 +239,73 @@ func widgetProgressEvent(event mergeProgressEvent) mergeprogress.Event {
 	switch event.Kind {
 	case mergeProgressPreparing:
 		return mergeprogress.Event{
-			ItemID:  item.branch,
-			State:   mergeprogress.StateActive,
-			Message: fmt.Sprintf("%s: preparing %v", item.branch, item.changeID),
+			ItemID: item.branch,
+			State:  mergeprogress.StateActive,
 		}
 	case mergeProgressPrepareFailed:
 		return mergeprogress.Event{
-			ItemID:  item.branch,
-			State:   mergeprogress.StateFailed,
-			Message: item.branch + ": prepare failed",
+			ItemID: item.branch,
+			State:  mergeprogress.StateFailed,
 		}
 	case mergeProgressRetargeting:
 		return mergeprogress.Event{
 			ItemID: item.branch,
 			State:  mergeprogress.StateActive,
-			Message: fmt.Sprintf("%s: retargeting %v onto %s",
-				item.branch, item.changeID, event.Base),
 		}
 	case mergeProgressRetargetFailed:
 		return mergeprogress.Event{
-			ItemID:  item.branch,
-			State:   mergeprogress.StateFailed,
-			Message: item.branch + ": retarget failed",
+			ItemID: item.branch,
+			State:  mergeprogress.StateFailed,
 		}
 	case mergeProgressWaitingForForgeHead:
 		return mergeprogress.Event{
-			ItemID:  item.branch,
-			State:   mergeprogress.StateActive,
-			Message: item.branch + ": waiting for HEAD to update",
+			ItemID: item.branch,
+			State:  mergeprogress.StateActive,
 		}
 	case mergeProgressForgeHeadFailed:
 		return mergeprogress.Event{
-			ItemID:  item.branch,
-			State:   mergeprogress.StateFailed,
-			Message: item.branch + ": HEAD did not update",
+			ItemID: item.branch,
+			State:  mergeprogress.StateFailed,
 		}
 	case mergeProgressWaitingForMergeability:
 		return mergeprogress.Event{
-			ItemID:  item.branch,
-			State:   mergeprogress.StateActive,
-			Message: item.branch + ": waiting for merge readiness",
+			ItemID: item.branch,
+			State:  mergeprogress.StateActive,
 		}
 	case mergeProgressMergeabilityReady:
 		return mergeprogress.Event{
-			ItemID:  item.branch,
-			State:   mergeprogress.StateActive,
-			Message: item.branch + ": ready to merge",
+			ItemID: item.branch,
+			State:  mergeprogress.StateActive,
 		}
 	case mergeProgressMergeabilityFailed:
 		return mergeprogress.Event{
-			ItemID:  item.branch,
-			State:   mergeprogress.StateFailed,
-			Message: item.branch + ": merge readiness failed",
+			ItemID: item.branch,
+			State:  mergeprogress.StateFailed,
 		}
 	case mergeProgressMerging:
 		return mergeprogress.Event{
 			ItemID: item.branch,
 			State:  mergeprogress.StateActive,
-			Message: fmt.Sprintf("%s: merging %v: %s",
-				item.branch, item.changeID, event.URL),
 		}
 	case mergeProgressMergeFailed:
 		return mergeprogress.Event{
-			ItemID:  item.branch,
-			State:   mergeprogress.StateFailed,
-			Message: item.branch + ": merge failed",
+			ItemID: item.branch,
+			State:  mergeprogress.StateFailed,
 		}
 	case mergeProgressWaitingForMerge:
 		return mergeprogress.Event{
-			ItemID:  item.branch,
-			State:   mergeprogress.StateActive,
-			Message: item.branch + ": waiting for merge",
+			ItemID: item.branch,
+			State:  mergeprogress.StateActive,
 		}
 	case mergeProgressMergeIncomplete:
 		return mergeprogress.Event{
-			ItemID:  item.branch,
-			State:   mergeprogress.StateFailed,
-			Message: item.branch + ": merge did not complete",
+			ItemID: item.branch,
+			State:  mergeprogress.StateFailed,
 		}
 	case mergeProgressMerged:
 		return mergeprogress.Event{
-			ItemID:  item.branch,
-			State:   mergeprogress.StateMerged,
-			Message: item.branch + ": merged",
+			ItemID: item.branch,
+			State:  mergeprogress.StateMerged,
 		}
 	case mergeProgressFailed:
 		return mergeprogress.Event{
@@ -330,9 +314,8 @@ func widgetProgressEvent(event mergeProgressEvent) mergeprogress.Event {
 		}
 	case mergeProgressSkipped:
 		return mergeprogress.Event{
-			ItemID:  item.branch,
-			State:   mergeprogress.StateSkipped,
-			Message: item.branch + ": skipped",
+			ItemID: item.branch,
+			State:  mergeprogress.StateSkipped,
 		}
 	default:
 		panic(fmt.Sprintf("unknown merge progress event kind: %d",

--- a/internal/ui/widget/mergeprogress/cmd/demo/main.go
+++ b/internal/ui/widget/mergeprogress/cmd/demo/main.go
@@ -99,6 +99,9 @@ func (r *request) run(output *ui.OutputWriter) error {
 	}); err != nil {
 		return fmt.Errorf("run program: %w", err)
 	}
+	if model.err != nil {
+		log.Errorf("merge demo failed: %v", model.err)
+	}
 	return nil
 }
 
@@ -223,6 +226,7 @@ type demoModel struct {
 	items  []mergequeue.Item
 	events chan tea.Msg
 	log    *silog.Logger
+	err    error
 }
 
 func newDemoModel(
@@ -262,14 +266,8 @@ func (m *demoModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case schedulerDoneMsg:
 		m.cancel()
-		if msg.err != nil {
-			model, cmd := m.Widget.Update(mergeprogress.Event{
-				Message: "merge demo failed: " + msg.err.Error(),
-			})
-			if widget, ok := model.(*mergeprogress.Widget); ok {
-				m.Widget = widget
-			}
-			return m, tea.Batch(cmd, tea.Quit)
+		if msg.err != nil && !errors.Is(msg.err, context.Canceled) {
+			m.err = msg.err
 		}
 		return m, tea.Quit
 	case mergeprogress.Event:
@@ -334,18 +332,16 @@ func (o demoObserver) Done(mergequeue.Item) {}
 func (o demoObserver) Failed(item mergequeue.Item, _ error) {
 	o.log.Errorf("%s: failed", item.ID())
 	o.send(mergeprogress.Event{
-		ItemID:  item.ID(),
-		State:   mergeprogress.StateFailed,
-		Message: item.ID() + ": failed",
+		ItemID: item.ID(),
+		State:  mergeprogress.StateFailed,
 	})
 }
 
 func (o demoObserver) Skipped(item mergequeue.Item, _ mergequeue.SkipReason) {
 	o.log.Warnf("%s: skipped", item.ID())
 	o.send(mergeprogress.Event{
-		ItemID:  item.ID(),
-		State:   mergeprogress.StateSkipped,
-		Message: item.ID() + ": skipped",
+		ItemID: item.ID(),
+		State:  mergeprogress.StateSkipped,
 	})
 }
 
@@ -389,9 +385,8 @@ func (i *syntheticItem) Parent() string {
 
 func (i *syntheticItem) Prepare(ctx context.Context) error {
 	i.emit(ctx, mergeprogress.Event{
-		ItemID:  i.id,
-		State:   mergeprogress.StateActive,
-		Message: i.id + ": preparing",
+		ItemID: i.id,
+		State:  mergeprogress.StateActive,
 	})
 	if err := sleep(ctx, i.prepareDelay); err != nil {
 		return err
@@ -404,9 +399,8 @@ func (i *syntheticItem) Prepare(ctx context.Context) error {
 	}
 	if i.failStage == failStagePrepare {
 		i.emit(ctx, mergeprogress.Event{
-			ItemID:  i.id,
-			State:   mergeprogress.StateFailed,
-			Message: i.id + ": prepare failed",
+			ItemID: i.id,
+			State:  mergeprogress.StateFailed,
 		})
 		return errors.New("prepare failed")
 	}
@@ -415,18 +409,16 @@ func (i *syntheticItem) Prepare(ctx context.Context) error {
 
 func (i *syntheticItem) Run(ctx context.Context) error {
 	i.emit(ctx, mergeprogress.Event{
-		ItemID:  i.id,
-		State:   mergeprogress.StateActive,
-		Message: i.id + ": waiting for merge readiness",
+		ItemID: i.id,
+		State:  mergeprogress.StateActive,
 	})
 	if err := sleep(ctx, i.runDelay); err != nil {
 		return err
 	}
 	if i.failStage == failStageRun {
 		i.emit(ctx, mergeprogress.Event{
-			ItemID:  i.id,
-			State:   mergeprogress.StateFailed,
-			Message: i.id + ": merge readiness failed",
+			ItemID: i.id,
+			State:  mergeprogress.StateFailed,
 		})
 		return errors.New("merge readiness failed")
 	}
@@ -434,9 +426,8 @@ func (i *syntheticItem) Run(ctx context.Context) error {
 	i.log.Infof("%s: pulled 1 new commit(s)", i.id)
 	i.log.Infof("%s: deleted (was %s)", i.id, fakeHash(i.changeNumber))
 	i.emit(ctx, mergeprogress.Event{
-		ItemID:  i.id,
-		State:   mergeprogress.StateMerged,
-		Message: i.id + ": merged",
+		ItemID: i.id,
+		State:  mergeprogress.StateMerged,
 	})
 	return nil
 }

--- a/internal/ui/widget/mergeprogress/progress.go
+++ b/internal/ui/widget/mergeprogress/progress.go
@@ -59,14 +59,11 @@ type Item struct {
 type Event struct {
 	// ItemID identifies the item to update.
 	//
-	// Empty means the event updates only the operation message.
+	// Empty means the event does not update item state.
 	ItemID string
 
 	// State is the new state for the item.
 	State State
-
-	// Message is the current operation detail shown below the bar.
-	Message string
 }
 
 // KeyMap defines key bindings for [Widget].
@@ -148,7 +145,6 @@ type Style struct {
 
 	Title   ui.Style
 	Summary ui.Style
-	Detail  ui.Style
 	Hint    ui.Style
 }
 
@@ -165,8 +161,7 @@ var DefaultStyle = styleForGlyphSet(SymbolsGlyphSet())
 // The widget renders every item into one continuous horizontal bar.
 // Terminal width changes each item's segment width,
 // but not which fields are rendered:
-// branch names stay out of the bar,
-// and the current operation detail is shown below it.
+// branch names and operation details stay out of the widget.
 //
 // The widget does not import or depend on forge APIs.
 // Translate forge-specific states into [State] values at the command boundary.
@@ -176,7 +171,6 @@ type Widget struct {
 
 	items     []Item
 	index     map[string]int // item ID => items index
-	message   string
 	err       error
 	width     int
 	theme     ui.Theme
@@ -213,9 +207,6 @@ func (w *Widget) apply(event Event) {
 		if idx, ok := w.index[event.ItemID]; ok {
 			w.items[idx].State = event.State
 		}
-	}
-	if event.Message != "" {
-		w.message = event.Message
 	}
 }
 
@@ -319,10 +310,6 @@ func (w *Widget) render(out ui.Writer, theme ui.Theme) {
 	}
 	out.WriteString("\n\n")
 
-	if w.message != "" {
-		out.WriteString(w.Style.Detail.Render(theme, w.message))
-		out.WriteString("\n")
-	}
 	out.WriteString(w.Style.Hint.Render(theme,
 		"Press Ctrl-C to cancel merge operation."))
 }
@@ -438,7 +425,6 @@ func styleForGlyphSet(glyphs GlyphSet) Style {
 
 		Title:   ui.NewStyle().Bold(true),
 		Summary: ui.NewStyle().Foreground(ui.Plain),
-		Detail:  ui.NewStyle().Foreground(ui.Plain),
 		Hint:    ui.NewStyle().Foreground(ui.Gray),
 	}
 }

--- a/internal/ui/widget/mergeprogress/progress_test.go
+++ b/internal/ui/widget/mergeprogress/progress_test.go
@@ -28,65 +28,55 @@ merged: 0   waiting: 0   pending: 10
 Press Ctrl-C to cancel merge operation.`).Equal(t, renderPlain(widget))
 
 	mustUpdate(t, widget, Event{
-		ItemID:  "1",
-		State:   StateActive,
-		Message: "Waiting for CI checks on feature-01 (#101).",
+		ItemID: "1",
+		State:  StateActive,
 	})
 	autogold.Expect(`Merging: 0 of 10 changes
 
 ◆◆◆◆□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□
 merged: 0   waiting: 1   pending: 9
 
-Waiting for CI checks on feature-01 (#101).
 Press Ctrl-C to cancel merge operation.`).Equal(t, renderPlain(widget))
 
 	mustUpdate(t, widget, Event{
-		ItemID:  "1",
-		State:   StateMerged,
-		Message: "Merged feature-01 (#101).",
+		ItemID: "1",
+		State:  StateMerged,
 	})
 	mustUpdate(t, widget, Event{
-		ItemID:  "2",
-		State:   StateActive,
-		Message: "Waiting for CI checks on feature-02 (#102).",
+		ItemID: "2",
+		State:  StateActive,
 	})
 	mustUpdate(t, widget, Event{
-		ItemID:  "3",
-		State:   StateActive,
-		Message: "Waiting for CI checks on feature-02 (#102) and feature-03 (#103).",
+		ItemID: "3",
+		State:  StateActive,
 	})
 	autogold.Expect(`Merging: 1 of 10 changes
 
 ■■■■◆◆◆◆◆◆◆◆□□□□□□□□□□□□□□□□□□□□□□□□□□□□
 merged: 1   waiting: 2   pending: 7
 
-Waiting for CI checks on feature-02 (#102) and feature-03 (#103).
 Press Ctrl-C to cancel merge operation.`).Equal(t, renderPlain(widget))
 
 	mustUpdate(t, widget, Event{
-		ItemID:  "2",
-		State:   StateMerged,
-		Message: "Merged feature-02 (#102); still waiting for feature-03 (#103).",
+		ItemID: "2",
+		State:  StateMerged,
 	})
 	autogold.Expect(`Merging: 2 of 10 changes
 
 ■■■■■■■■◆◆◆◆□□□□□□□□□□□□□□□□□□□□□□□□□□□□
 merged: 2   waiting: 1   pending: 7
 
-Merged feature-02 (#102); still waiting for feature-03 (#103).
 Press Ctrl-C to cancel merge operation.`).Equal(t, renderPlain(widget))
 
 	mustUpdate(t, widget, Event{
-		ItemID:  "3",
-		State:   StateFailed,
-		Message: "CI checks failed for feature-03 (#103).",
+		ItemID: "3",
+		State:  StateFailed,
 	})
 	autogold.Expect(`Merging: 2 of 10 changes
 
 ■■■■■■■■××××□□□□□□□□□□□□□□□□□□□□□□□□□□□□
 merged: 2   waiting: 0   pending: 7   failed: 1
 
-CI checks failed for feature-03 (#103).
 Press Ctrl-C to cancel merge operation.`).Equal(t, renderPlain(widget))
 }
 
@@ -101,24 +91,16 @@ func TestWidget_Render_scalingKeepsShape(t *testing.T) {
 		WithTheme(ui.DefaultThemeDark()).
 		WithAnimation(false)
 	mustUpdate(t, wideWidget, tea.WindowSizeMsg{Width: 72})
-	mustUpdate(t, wideWidget, Event{
-		Message: "Waiting for CI checks on feature-08 (#108).",
-	})
 	wide := renderPlain(wideWidget)
 
 	narrowWidget := New(items...).
 		WithTheme(ui.DefaultThemeDark()).
 		WithAnimation(false)
 	mustUpdate(t, narrowWidget, tea.WindowSizeMsg{Width: 24})
-	mustUpdate(t, narrowWidget, Event{
-		Message: "Waiting for CI checks on feature-08 (#108).",
-	})
 	narrow := renderPlain(narrowWidget)
 
 	assert.Contains(t, wide, "Merging: 7 of 18 changes")
 	assert.Contains(t, wide, "merged: 7   waiting: 1   pending: 10")
-	assert.Contains(t, wide,
-		"Waiting for CI checks on feature-08 (#108).")
 	assert.NotContains(t, barLine(wide), "feature")
 	assert.NotContains(t, barLine(narrow), "feature")
 	assert.Equal(t, 72, lipgloss.Width(barLine(wide)))
@@ -139,9 +121,6 @@ func TestWidget_Render_failedAndSkipped(t *testing.T) {
 		WithTheme(ui.DefaultThemeDark()).
 		WithAnimation(false)
 	mustUpdate(t, widget, tea.WindowSizeMsg{Width: 20})
-	mustUpdate(t, widget, Event{
-		Message: "CI checks failed for feature-04 (#104).",
-	})
 	got := renderPlain(widget)
 
 	assert.Contains(t, got, "merged: 1   waiting: 1   pending: 1")


### PR DESCRIPTION
The merge progress widget now shows only aggregate queue state:
the title, progress bar, summary counts, and cancellation hint.
Event.Message remains accepted for source compatibility.
The widget no longer renders branch-specific operation details.

[skip changelog]: no user facing changes
