### PR TITLE
merge: Order progress slots by dependency layer

### DIFF
--- a/internal/graph/bfs.go
+++ b/internal/graph/bfs.go
@@ -1,0 +1,63 @@
+package graph
+
+import "go.abhg.dev/gs/internal/must"
+
+// BreadthFirstSort orders nodes by breadth-first dependency layers.
+//
+// parent returns the index of a node's parent in nodes,
+// or -1 if the node doesn't have one.
+// Callers own node identity,
+// so nodes may contain values that are not comparable.
+//
+// BreadthFirstSort returns roots first,
+// then direct children,
+// then deeper descendants.
+// Input order is the stable tie-breaker for roots and siblings.
+func BreadthFirstSort[N any](
+	nodes []N,
+	parent func(idx int, node N) int,
+) []N {
+	children := make([][]int, len(nodes))
+	roots := make([]int, 0, len(nodes))
+	for idx, node := range nodes {
+		parentIdx := parent(idx, node)
+		if parentIdx == -1 {
+			roots = append(roots, idx)
+			continue
+		}
+		must.Bef(parentIdx >= 0 && parentIdx < len(nodes),
+			"parent index %d for node index %d out of range", parentIdx, idx)
+		children[parentIdx] = append(children[parentIdx], idx)
+	}
+
+	visited := make([]bool, len(nodes))
+	queue := make([]int, 0, len(nodes))
+	sorted := make([]N, 0, len(nodes))
+
+	enqueue := func(idx int) {
+		if visited[idx] {
+			return
+		}
+		visited[idx] = true
+		queue = append(queue, idx)
+	}
+
+	drain := func() {
+		for len(queue) > 0 {
+			idx := queue[0]
+			queue = queue[1:]
+
+			sorted = append(sorted, nodes[idx])
+			for _, child := range children[idx] {
+				enqueue(child)
+			}
+		}
+	}
+
+	for _, root := range roots {
+		enqueue(root)
+	}
+	drain()
+
+	return sorted
+}

--- a/internal/graph/bfs_test.go
+++ b/internal/graph/bfs_test.go
@@ -1,0 +1,84 @@
+package graph_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.abhg.dev/gs/internal/graph"
+)
+
+func TestBreadthFirstSort(t *testing.T) {
+	tests := []struct {
+		name string
+
+		nodes   []string
+		parents map[string]string
+		want    []string
+	}{
+		{
+			name:  "Linear",
+			nodes: []string{"child", "grandchild", "root"},
+			parents: map[string]string{
+				"child":      "root",
+				"grandchild": "child",
+			},
+			want: []string{"root", "child", "grandchild"},
+		},
+		{
+			name:  "MultipleRoots",
+			nodes: []string{"root-b", "child-a", "root-a", "child-b"},
+			parents: map[string]string{
+				"child-a": "root-a",
+				"child-b": "root-b",
+			},
+			want: []string{"root-b", "root-a", "child-b", "child-a"},
+		},
+		{
+			name:  "DivergentChildren",
+			nodes: []string{"third", "root", "first", "second"},
+			parents: map[string]string{
+				"first":  "root",
+				"second": "root",
+				"third":  "root",
+			},
+			want: []string{"root", "third", "first", "second"},
+		},
+		{
+			name:  "DeeperDescendant",
+			nodes: []string{"great-grandchild", "child", "root", "grandchild"},
+			parents: map[string]string{
+				"child":            "root",
+				"grandchild":       "child",
+				"great-grandchild": "grandchild",
+			},
+			want: []string{"root", "child", "grandchild", "great-grandchild"},
+		},
+		{
+			name:  "BreadthFirstLayerOrder",
+			nodes: []string{"D", "Y", "B", "A", "C", "X"},
+			parents: map[string]string{
+				"B": "A",
+				"C": "A",
+				"D": "B",
+				"Y": "X",
+			},
+			want: []string{"A", "X", "B", "C", "Y", "D"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := graph.BreadthFirstSort(tt.nodes,
+				func(_ int, n string) int {
+					parent, ok := tt.parents[n]
+					if !ok {
+						return -1
+					}
+					return slices.Index(tt.nodes, parent)
+				})
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/handler/merge/progress.go
+++ b/internal/handler/merge/progress.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	tea "charm.land/bubbletea/v2"
+	"go.abhg.dev/gs/internal/graph"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/ui"
 	"go.abhg.dev/gs/internal/ui/widget/mergeprogress"
@@ -150,16 +151,8 @@ func (p *widgetMergeProgress) Start(
 	p.events = make(chan tea.Msg, 1)
 	p.stopped = make(chan struct{})
 
-	progressItems := make([]mergeprogress.Item, len(items))
-	for idx, item := range items {
-		progressItems[idx] = mergeprogress.Item{
-			ID:    item.branch,
-			State: mergeprogress.StatePending,
-		}
-	}
-
 	model := &mergeProgressModel{
-		Widget: mergeprogress.New(progressItems...).
+		Widget: mergeprogress.New(mergeProgressItems(items)...).
 			WithTheme(p.theme),
 		events: p.events,
 	}
@@ -171,6 +164,33 @@ func (p *widgetMergeProgress) Start(
 		close(p.stopped)
 	}()
 	return ctx
+}
+
+func mergeProgressItems(items []*mergeItem) []mergeprogress.Item {
+	indexByBranch := make(map[string]int, len(items))
+	branches := make([]string, len(items))
+	for idx, item := range items {
+		branches[idx] = item.branch
+		indexByBranch[item.branch] = idx
+	}
+
+	branches = graph.BreadthFirstSort(branches,
+		func(idx int, _ string) int {
+			parentIdx, ok := indexByBranch[items[idx].base]
+			if !ok {
+				return -1
+			}
+			return parentIdx
+		})
+
+	progressItems := make([]mergeprogress.Item, len(branches))
+	for idx, branch := range branches {
+		progressItems[idx] = mergeprogress.Item{
+			ID:    branch,
+			State: mergeprogress.StatePending,
+		}
+	}
+	return progressItems
 }
 
 func (p *widgetMergeProgress) Event(event mergeProgressEvent) {

--- a/internal/handler/merge/progress_test.go
+++ b/internal/handler/merge/progress_test.go
@@ -6,9 +6,11 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.abhg.dev/gs/internal/ui"
+	"go.abhg.dev/gs/internal/ui/widget/mergeprogress"
 )
 
 func TestWidgetMergeProgress_FinishAfterRunnerExit(t *testing.T) {
@@ -43,6 +45,26 @@ func TestWidgetMergeProgress_FinishAfterRunnerExit(t *testing.T) {
 	}
 }
 
+func TestMergeProgressItems_ordersByDependencyLayer(t *testing.T) {
+	got := mergeProgressItems([]*mergeItem{
+		{branch: "D", base: "B"},
+		{branch: "Y", base: "X"},
+		{branch: "B", base: "A"},
+		{branch: "A", base: "main"},
+		{branch: "C", base: "A"},
+		{branch: "X", base: "main"},
+	})
+
+	assert.Equal(t, []string{
+		"A",
+		"X",
+		"B",
+		"C",
+		"Y",
+		"D",
+	}, progressItemIDs(got))
+}
+
 func (*earlyExitModelView) Write(p []byte) (int, error) {
 	return io.Discard.Write(p)
 }
@@ -58,4 +80,12 @@ func (v *earlyExitModelView) RunModel(_ tea.Model, opts *ui.RunOptions) error {
 
 type earlyExitModelView struct {
 	opts *ui.RunOptions
+}
+
+func progressItemIDs(items []mergeprogress.Item) []string {
+	ids := make([]string, len(items))
+	for idx, item := range items {
+		ids[idx] = item.ID
+	}
+	return ids
 }

--- a/internal/ui/widget/mergeprogress/cmd/demo/main.go
+++ b/internal/ui/widget/mergeprogress/cmd/demo/main.go
@@ -12,6 +12,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/colorprofile"
+	"go.abhg.dev/gs/internal/graph"
 	"go.abhg.dev/gs/internal/mergequeue"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/ui"
@@ -178,10 +179,25 @@ type scenario struct {
 }
 
 func (s *scenario) progressItems() []mergeprogress.Item {
-	items := make([]mergeprogress.Item, len(s.items))
+	indexByID := make(map[string]int, len(s.items))
+	ids := make([]string, len(s.items))
 	for idx, item := range s.items {
+		ids[idx] = item.id
+		indexByID[item.id] = idx
+	}
+
+	ids = graph.BreadthFirstSort(ids, func(idx int, _ string) int {
+		parentIdx, ok := indexByID[s.items[idx].parent]
+		if !ok {
+			return -1
+		}
+		return parentIdx
+	})
+
+	items := make([]mergeprogress.Item, len(ids))
+	for idx, id := range ids {
 		items[idx] = mergeprogress.Item{
-			ID:    item.id,
+			ID:    id,
 			State: mergeprogress.StatePending,
 		}
 	}

--- a/internal/ui/widget/mergeprogress/progress_test.go
+++ b/internal/ui/widget/mergeprogress/progress_test.go
@@ -145,6 +145,23 @@ func TestWidget_Render_ASCIIGlyphSet(t *testing.T) {
 	assert.Equal(t, "####oooo====xxxx----", barLine(renderPlain(widget)))
 }
 
+func TestWidget_UpdatePreservesItemOrder(t *testing.T) {
+	widget := New(
+		Item{ID: "root"},
+		Item{ID: "sibling"},
+		Item{ID: "child"},
+	).WithTheme(ui.DefaultThemeDark()).
+		WithAnimation(false)
+	mustUpdate(t, widget, tea.WindowSizeMsg{Width: 12})
+
+	mustUpdate(t, widget, Event{ItemID: "child", State: StateFailed})
+	mustUpdate(t, widget, Event{ItemID: "root", State: StateMerged})
+	mustUpdate(t, widget, Event{ItemID: "sibling", State: StateActive})
+	mustUpdate(t, widget, Event{ItemID: "child", State: StateSkipped})
+
+	assert.Equal(t, "■■■■◆◆◆◆○○○○", barLine(renderPlain(widget)))
+}
+
 func renderPlain(widget *Widget) string {
 	return ansi.Strip(widget.View().Content)
 }


### PR DESCRIPTION
The merge progress bar is a flat horizontal display,
and branch names are intentionally kept out of the bar.
Previously, order of items in the bar was unspecified.

This changes it to use a BFS ordering.
For example, given these merge dependencies:

```text
trunk
├─ feat1
│  ├─ feat3
│  │  └─ feat6
│  └─ feat4
├─ feat2
│  └─ feat5
└─ feat7
```

The progress bar now receives this order:

```text
feat1 feat2 feat7 feat3 feat4 feat5 feat6
```

The effect is that roots are displayed first,
then their immediate children (in the same order as the roots),
then deeper descendants.
While progress won't move left-to-right all the time,
this is closer to that expectation.

<img width="787" height="470" alt="demo" src="https://github.com/user-attachments/assets/0b2ae7fc-f8ae-4d0d-a933-d4bb40e729cc" />


[skip changelog]: unreleased feature
