### PR TITLE
fix(release): Avoid repeated PPA orig uploads

### DIFF
--- a/.changes/unreleased/Fixed-20260630-101752.yaml
+++ b/.changes/unreleased/Fixed-20260630-101752.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'release: Fix Ubuntu PPA publishing to avoid re-uploading the upstream orig tarball for later Ubuntu series.'
+time: 2026-06-30T10:17:52.504171-07:00

--- a/tools/ci/launchpad-ppa/main.go
+++ b/tools/ci/launchpad-ppa/main.go
@@ -190,9 +190,16 @@ func run(log *silog.Logger, req publishRequest) error {
 	}
 
 	var dputCommands []string
-	for _, series := range plan.Series {
+	for i, series := range plan.Series {
+		uploadMode := sourceUploadWithOrig
+		if i > 0 {
+			uploadMode = sourceUploadWithoutOrig
+		}
+
 		changes, err := buildSeries(
-			ctx, log, root, sourceDir, workDir, origTar, plan, series, mtime)
+			ctx, log,
+			root, sourceDir, workDir, origTar,
+			plan, series, uploadMode, mtime)
 		if err != nil {
 			return fmt.Errorf("build %s: %w", series, err)
 		}
@@ -313,6 +320,42 @@ type packagePlan struct {
 
 	// DputTarget is the destination passed to dput.
 	DputTarget string
+}
+
+// sourceUploadMode controls whether the generated .changes upload manifest
+// includes the upstream orig tarball.
+type sourceUploadMode int
+
+const (
+	sourceUploadWithOrig sourceUploadMode = iota
+	sourceUploadWithoutOrig
+)
+
+func (m sourceUploadMode) String() string {
+	switch m {
+	case sourceUploadWithOrig:
+		return "with-orig"
+	case sourceUploadWithoutOrig:
+		return "without-orig"
+	default:
+		return fmt.Sprintf("sourceUploadMode(%d)", m)
+	}
+}
+
+func (m sourceUploadMode) dpkgBuildpackageArgs() []string {
+	args := []string{
+		"-S", // build source package only
+	}
+	if m == sourceUploadWithoutOrig {
+		args = append(args,
+			"-sd", // omit the upstream orig tarball from .changes
+		)
+	}
+	return append(args,
+		"-us", // leave the .dsc unsigned
+		"-uc", // leave .buildinfo and .changes unsigned
+		"-d",  // skip build dependency checks on CI runners
+	)
 }
 
 func newPackagePlan(req publishRequest) (packagePlan, error) {
@@ -567,9 +610,10 @@ func buildSeries(
 	origTar string,
 	plan packagePlan,
 	series string,
+	uploadMode sourceUploadMode,
 	mtime time.Time,
 ) (string, error) {
-	log.Info("Building source package", "series", series)
+	log.Info("Building source package", "series", series, "uploadMode", uploadMode)
 
 	ubuntuVersion, err := ubuntuVersionForSeries(ctx, log, series)
 	if err != nil {
@@ -586,7 +630,7 @@ func buildSeries(
 		return "", fmt.Errorf("clean previous build products: %w", err)
 	}
 
-	if err := xec.Command(ctx, log, "dpkg-buildpackage", "-S", "-us", "-uc", "-d").
+	if err := xec.Command(ctx, log, "dpkg-buildpackage", uploadMode.dpkgBuildpackageArgs()...).
 		WithDir(sourceDir).
 		AppendEnv("SOURCE_DATE_EPOCH=" + strconv.FormatInt(mtime.Unix(), 10)).
 		Run(); err != nil {
@@ -600,8 +644,19 @@ func buildSeries(
 	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		return "", fmt.Errorf("create output directory: %w", err)
 	}
-	if err := copyFile(origTar, filepath.Join(outDir, filepath.Base(origTar))); err != nil {
-		return "", fmt.Errorf("copy orig tarball: %w", err)
+	if uploadMode == sourceUploadWithOrig {
+		// The first series upload must carry the upstream orig tarball.
+		// Later source uploads can refer to the tarball Launchpad already has.
+		if err := copyFile(origTar, filepath.Join(outDir, filepath.Base(origTar))); err != nil {
+			return "", fmt.Errorf("copy orig tarball: %w", err)
+		}
+	} else {
+		// With -sd, dpkg-buildpackage omits the orig tarball from .changes.
+		// Do not copy it next to the upload manifest,
+		// so the dry-run output matches what dput will upload.
+		log.Info("Omitting orig tarball from source upload",
+			"series", series,
+			"origTar", filepath.Base(origTar))
 	}
 
 	pattern := filepath.Join(workDir, _packageName+"_"+debianVersion+"*")

--- a/tools/ci/launchpad-ppa/main_test.go
+++ b/tools/ci/launchpad-ppa/main_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package main
 
 import (

--- a/tools/ci/launchpad-ppa/main_test.go
+++ b/tools/ci/launchpad-ppa/main_test.go
@@ -136,6 +136,98 @@ func TestRenderDputCommand(t *testing.T) {
 		))
 }
 
+func TestBuildSeries_omitsOrigTarAfterFirstSeries(t *testing.T) {
+	root := t.TempDir()
+	workDir := t.TempDir()
+	sourceDir := filepath.Join(workDir, "git-spice-0.30.0")
+	require.NoError(t, os.MkdirAll(filepath.Join(sourceDir, "debian"), 0o755))
+
+	origTar := filepath.Join(workDir, "git-spice_0.30.0.orig.tar.gz")
+	require.NoError(t, os.WriteFile(origTar, []byte("orig tarball"), 0o644))
+
+	binDir := t.TempDir()
+	writeExecutable(t,
+		filepath.Join(binDir, "ubuntu-distro-info"),
+		`#!/bin/sh
+set -eu
+case "$1" in
+  --series=noble) echo "24.04 LTS" ;;
+  --series=questing) echo "25.10" ;;
+  *) echo "unexpected series $1" >&2; exit 1 ;;
+esac
+`)
+	writeExecutable(t,
+		filepath.Join(binDir, "dpkg-buildpackage"),
+		`#!/bin/sh
+set -eu
+include_orig=1
+for arg do
+  if [ "$arg" = "-sd" ]; then
+    include_orig=0
+  fi
+done
+version=$(sed -n '1s/.*(\([^)]*\)).*/\1/p' debian/changelog)
+series=$(sed -n '1s/.*) \([^;]*\);.*/\1/p' debian/changelog)
+base="../git-spice_${version}"
+printf 'Source: git-spice\nVersion: %s\nFiles:\n abc 1 git-spice_0.30.0.orig.tar.gz\n def 1 git-spice_%s.debian.tar.xz\n' "$version" "$version" > "$base.dsc"
+printf 'debian tarball' > "$base.debian.tar.xz"
+printf 'build info' > "${base}_source.buildinfo"
+{
+  printf 'Source: git-spice\n'
+  printf 'Version: %s\n' "$version"
+  printf 'Distribution: %s\n' "$series"
+  printf 'Files:\n'
+  printf ' abc 1 vcs optional git-spice_%s.dsc\n' "$version"
+  if [ "$include_orig" = 1 ]; then
+    printf ' def 1 vcs optional git-spice_0.30.0.orig.tar.gz\n'
+  fi
+  printf ' ghi 1 vcs optional git-spice_%s.debian.tar.xz\n' "$version"
+  printf ' jkl 1 vcs optional git-spice_%s_source.buildinfo\n' "$version"
+} > "${base}_source.changes"
+`)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	plan := packagePlan{
+		Version:           "v0.30.0",
+		UpstreamVersion:   "0.30.0",
+		BaseDebianVersion: "0.30.0-1~ppa1",
+	}
+
+	nobleChanges, err := buildSeries(
+		t.Context(),
+		silog.Nop(),
+		root,
+		sourceDir,
+		workDir,
+		origTar,
+		plan,
+		"noble",
+		sourceUploadWithOrig,
+		time.Unix(1_700_000_000, 0).UTC(),
+	)
+	require.NoError(t, err)
+	assertFileContains(t, nobleChanges, "git-spice_0.30.0.orig.tar.gz")
+	assert.FileExists(t,
+		filepath.Join(root, "dist", "debian", "noble", "git-spice_0.30.0.orig.tar.gz"))
+
+	questingChanges, err := buildSeries(
+		t.Context(),
+		silog.Nop(),
+		root,
+		sourceDir,
+		workDir,
+		origTar,
+		plan,
+		"questing",
+		sourceUploadWithoutOrig,
+		time.Unix(1_700_000_000, 0).UTC(),
+	)
+	require.NoError(t, err)
+	assertFileNotContains(t, questingChanges, "git-spice_0.30.0.orig.tar.gz")
+	assert.NoFileExists(t,
+		filepath.Join(root, "dist", "debian", "questing", "git-spice_0.30.0.orig.tar.gz"))
+}
+
 func TestWriteOrigTar_usesSourceModificationTime(t *testing.T) {
 	sourceDir := t.TempDir()
 	require.NoError(t,
@@ -176,4 +268,26 @@ func TestWriteOrigTar_usesSourceModificationTime(t *testing.T) {
 		assert.Equal(t, wantTime.Unix(), header.ChangeTime.Unix())
 		return
 	}
+}
+
+func writeExecutable(t *testing.T, path string, body string) {
+	t.Helper()
+
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o755))
+}
+
+func assertFileContains(t *testing.T, path string, want string) {
+	t.Helper()
+
+	bs, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(bs), want)
+}
+
+func assertFileNotContains(t *testing.T, path string, want string) {
+	t.Helper()
+
+	bs, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.NotContains(t, string(bs), want)
 }


### PR DESCRIPTION
Failure Mode

The PPA publisher previously built every Ubuntu series as a full
source upload.
Historical 0.29.2 artifacts showed that noble, questing, and
resolute all carried the same upstream tarball.
Each output directory had `git-spice_0.29.2.orig.tar.gz` with
SHA-256:

    30eaf9e3fb1ff69e8cde8a80a780d2a248f11dd3834cf9d05dd659e4ab31d8b5

The per-series Debian diff tarballs were different,
with SHA-256 prefixes `852dbfff`, `63093741`, and `605d8d66`.
Despite that split, each series `.changes` file still listed the
same upstream orig tarball for upload.

That made the 0.30.0 pipeline repeatedly push the same upstream
archive while publishing different per-series Debian revisions.
The second `dput` returned a non-zero status even though Launchpad
accepted the upload,
and later per-series reruns with bumped PPA revisions succeeded.

Changed Behavior

Build the first requested series as the full source upload.
Build later series with:

    dpkg-buildpackage -S -sd

That makes `dpkg-genchanges` write a `.changes` file containing only
the `.dsc`, Debian diff tarball, and buildinfo for that series.
The `dpkg-buildpackage(1)` and `dpkg-genchanges(1)` manpages document
`-sd` as the mode where the source is the diff and `.dsc` only.
The Ubuntu Launchpad PPA package-upload guide describes PPA publishing
as source uploads that Launchpad processes into archive publications.
Ask Ubuntu question 544978 recommends `-sd` for later uploads when the
upstream orig tarball is already present:

    https://askubuntu.com/q/544978

Validation

An Ubuntu dry run executed the release tool without `-dput` for
noble, questing, and resolute.
The real `dpkg-buildpackage` log showed that `dpkg-genchanges` used
`-sd` for questing and resolute.
The generated noble `.changes` listed `git-spice_0.30.0.orig.tar.gz`;
the generated questing and resolute `.changes` files did not.