### PR TITLE
fix(submit): Avoid terminal hang after template warning

### DIFF
--- a/.changes/unreleased/Fixed-20260702-053109.yaml
+++ b/.changes/unreleased/Fixed-20260702-053109.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: >-
+  branch submit: Fix deadlock and terminal display corruption
+  if CR template lookup failed during interactive prompt.
+time: 2026-07-02T05:31:09.777099-07:00

--- a/internal/forge/shamhub/cli.go
+++ b/internal/forge/shamhub/cli.go
@@ -260,6 +260,16 @@ runCommand:
 
 		key, value := args[0], args[1]
 		switch key {
+		case "changeTemplateErrorDelay":
+			delay, err := time.ParseDuration(value)
+			if err != nil {
+				ts.Fatalf("parse duration: %s", err)
+			}
+
+			sh.mu.Lock()
+			sh.changeTemplateErrorDelay = delay
+			sh.mu.Unlock()
+
 		case "mergeMethod":
 			mergeMethod, err := parseMergeMethod(value)
 			if err != nil {

--- a/internal/forge/shamhub/shamhub.go
+++ b/internal/forge/shamhub/shamhub.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/xec"
@@ -43,6 +44,9 @@ type ShamHub struct {
 
 	tokens             map[string]string // token -> username
 	defaultMergeMethod MergeMethod       // used when API merge requests omit a method
+	// changeTemplateErrorDelay makes the change-template endpoint return a
+	// delayed error, allowing terminal tests to exercise background failures.
+	changeTemplateErrorDelay time.Duration
 }
 
 // Config configures a ShamHub server.

--- a/internal/forge/shamhub/template.go
+++ b/internal/forge/shamhub/template.go
@@ -3,9 +3,11 @@ package shamhub
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"path"
 	"slices"
 	"strings"
+	"time"
 
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/scanutil"
@@ -40,6 +42,21 @@ type changeTemplate struct {
 
 func (sh *ShamHub) handleChangeTemplate(ctx context.Context, req *changeTemplateRequest) (changeTemplateResponse, error) {
 	owner, repo := req.Owner, req.Repo
+
+	sh.mu.RLock()
+	changeTemplateErrorDelay := sh.changeTemplateErrorDelay
+	sh.mu.RUnlock()
+	if changeTemplateErrorDelay > 0 {
+		select {
+		case <-time.After(changeTemplateErrorDelay):
+			return nil, &httpError{
+				code:    http.StatusInternalServerError,
+				message: "change template lookup failed",
+			}
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
 
 	templatePathSet := make(map[string]struct{}, len(_changeTemplatePaths)*3)
 	for _, p := range _changeTemplatePaths {

--- a/internal/ui/outputwriter.go
+++ b/internal/ui/outputwriter.go
@@ -17,9 +17,13 @@ import (
 // so the renderer can place them without corrupting the rendered frame.
 type OutputWriter struct {
 	mu sync.Mutex
+	// cond wakes sendLoop when an active program has complete lines to print.
+	cond *sync.Cond
+	wg   sync.WaitGroup
 
 	out     io.Writer    // underlying writer
 	program printProgram // bubble tea program
+	closing bool         // sendLoop should exit instead of waiting for output
 
 	// tea.Println needs complete lines
 	// so we'll buffer them in memory and flush
@@ -27,11 +31,17 @@ type OutputWriter struct {
 	lines lineBuffer
 }
 
-var _ io.Writer = (*OutputWriter)(nil)
+var (
+	_ io.Writer = (*OutputWriter)(nil)
+	_ io.Closer = (*OutputWriter)(nil)
+)
 
 // NewOutputWriter builds an OutputWriter over the given writer.
 func NewOutputWriter(out io.Writer) *OutputWriter {
-	return &OutputWriter{out: out}
+	w := &OutputWriter{out: out}
+	w.cond = sync.NewCond(&w.mu)
+	w.wg.Go(w.sendLoop)
+	return w
 }
 
 type printProgram interface{ Send(tea.Msg) }
@@ -48,6 +58,7 @@ func (w *OutputWriter) printTo(program printProgram) (cleanup func()) {
 
 	w.program = program
 	w.lines = lineBuffer{}
+	w.cond.Signal()
 
 	return func() {
 		w.mu.Lock()
@@ -69,22 +80,62 @@ func (w *OutputWriter) Write(p []byte) (int, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	if w.program == nil {
+	if w.closing || w.program == nil {
 		return w.out.Write(p)
 	}
 
 	w.lines.Write(p)
-	for line := range w.lines.TakeLines() {
-		// Bubble Tea print messages add their own newline.
-		// Trim the CR from CRLF output before routing the line.
-		line = bytes.TrimSuffix(line, []byte("\r"))
-
-		// Use Send instead of Print or Printf
-		// so late writes after shutdown are ignored
-		// instead of blocking on a stopped program.
-		w.program.Send(tea.Println(string(line))())
-	}
+	w.cond.Signal()
 	return len(p), nil
+}
+
+// Close stops the background print dispatcher.
+//
+// Callers should stop the active program and run the printTo cleanup before
+// Close.
+// Close does not flush buffered active-program output.
+func (w *OutputWriter) Close() error {
+	w.mu.Lock()
+	w.closing = true
+	w.cond.Signal()
+	w.mu.Unlock()
+
+	w.wg.Wait()
+	return nil
+}
+
+// sendLoop owns delivery of completed print lines to the active program.
+// Write only appends to the buffer and signals this loop,
+// so ordinary log output never waits on Bubble Tea's update loop.
+func (w *OutputWriter) sendLoop() {
+	for {
+		w.mu.Lock()
+		for !w.closing && (w.program == nil || !w.lines.HasLine()) {
+			w.cond.Wait()
+		}
+		if w.closing {
+			w.mu.Unlock()
+			return
+		}
+
+		program := w.program
+		var msgs []tea.Msg
+		for line := range w.lines.TakeLines() {
+			// Bubble Tea print messages add their own newline.
+			// Trim the CR from CRLF output before routing the line.
+			line = bytes.TrimSuffix(line, []byte("\r"))
+
+			msgs = append(msgs, tea.Println(string(line))())
+		}
+		w.mu.Unlock()
+
+		for _, msg := range msgs {
+			// Use Send instead of Print or Printf
+			// so late writes after shutdown are ignored
+			// instead of blocking on a stopped program.
+			program.Send(msg)
+		}
+	}
 }
 
 // Unwrap reports the underlying writer.
@@ -108,6 +159,11 @@ type lineBuffer struct {
 // Write appends raw output bytes without interpreting partial lines.
 func (b *lineBuffer) Write(p []byte) {
 	b.pending = append(b.pending, p...)
+}
+
+// HasLine reports whether the buffer has at least one complete line.
+func (b *lineBuffer) HasLine() bool {
+	return bytes.Contains(b.pending, []byte{'\n'})
 }
 
 // TakeLines yields complete lines and consumes them from the buffer.

--- a/internal/ui/outputwriter_program_test.go
+++ b/internal/ui/outputwriter_program_test.go
@@ -18,6 +18,9 @@ import (
 func TestOutputWriter_TeaProgram_printsLines(t *testing.T) {
 	var raw lockedBuffer
 	output := ui.NewOutputWriter(&raw)
+	defer func() {
+		require.NoError(t, output.Close())
+	}()
 	model := new(outputWriterProgramModel)
 
 	errc := make(chan error, 1)
@@ -62,6 +65,72 @@ func TestOutputWriter_TeaProgram_printsLines(t *testing.T) {
 	}
 }
 
+func TestOutputWriter_TeaProgram_writeReturnsWhileModelBlocked(t *testing.T) {
+	var raw lockedBuffer
+	output := ui.NewOutputWriter(&raw)
+	defer func() {
+		require.NoError(t, output.Close())
+	}()
+	release := make(chan struct{})
+	model := &outputWriterBlockedModel{
+		blocked: make(chan struct{}),
+		release: release,
+	}
+
+	errc := make(chan error, 1)
+	go func() {
+		errc <- ui.RunModel(model, &ui.RunOptions{
+			Input:          bytes.NewReader(nil),
+			Output:         output,
+			Width:          40,
+			Height:         8,
+			TERM:           "xterm-256color",
+			WithoutSignals: true,
+		})
+	}()
+
+	// The model must enter its blocking Update before the write.
+	// Otherwise, the test only proves that output can be delivered to an idle
+	// Bubble Tea program.
+	require.Eventually(t, func() bool {
+		return slices.Contains(
+			renderedRowsFrom(t, raw.Bytes()),
+			"blocked model",
+		)
+	}, time.Second, 10*time.Millisecond)
+
+	select {
+	case <-model.blocked:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for model to block")
+	}
+
+	// This write is the deadlock boundary.
+	// A synchronous Program.Send needs the Bubble Tea update loop to receive
+	// the print message, but the update loop is intentionally blocked above.
+	writec := make(chan error, 1)
+	go func() {
+		_, err := output.Write([]byte("log line\n"))
+		writec <- err
+	}()
+
+	select {
+	case err := <-writec:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for output write")
+	}
+
+	close(release)
+
+	select {
+	case err := <-errc:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for program to stop")
+	}
+}
+
 type outputWriterProgramModel struct {
 	done atomic.Bool
 }
@@ -96,6 +165,43 @@ func (m *outputWriterProgramModel) View() tea.View {
 // Stop asks the next tick message to stop the Bubble Tea program.
 func (m *outputWriterProgramModel) Stop() {
 	m.done.Store(true)
+}
+
+// outputWriterBlockedModel simulates a Bubble Tea program that is alive but
+// unable to receive print messages through its update loop.
+//
+// This matches the branch-submit failure shape: the form waits for a background
+// result while that background path tries to log through the active program.
+type outputWriterBlockedModel struct {
+	blocked chan struct{}   // closed after Update enters the blocked section
+	release <-chan struct{} // unblocks Update so the test can shut down
+
+	once sync.Once
+}
+
+type outputWriterBlockedMsg struct{}
+
+func (m *outputWriterBlockedModel) Init() tea.Cmd {
+	return tea.Tick(10*time.Millisecond, func(time.Time) tea.Msg {
+		return outputWriterBlockedMsg{}
+	})
+}
+
+func (m *outputWriterBlockedModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if _, ok := msg.(outputWriterBlockedMsg); !ok {
+		return m, nil
+	}
+
+	// Keep Update blocked until the test proves OutputWriter.Write returned.
+	m.once.Do(func() {
+		close(m.blocked)
+	})
+	<-m.release
+	return m, tea.Quit
+}
+
+func (m *outputWriterBlockedModel) View() tea.View {
+	return tea.NewView("blocked model")
 }
 
 // lockedBuffer protects terminal output while the program is still rendering.

--- a/internal/ui/outputwriter_test.go
+++ b/internal/ui/outputwriter_test.go
@@ -3,7 +3,9 @@ package ui
 import (
 	"bytes"
 	"reflect"
+	"sync"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
@@ -13,6 +15,9 @@ import (
 func TestOutputWriter_Write_inactiveWritesDirect(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewOutputWriter(&buf)
+	defer func() {
+		require.NoError(t, w.Close())
+	}()
 
 	_, err := w.Write([]byte("direct output\n"))
 
@@ -24,19 +29,25 @@ func TestOutputWriter_Write_activeSendsCompletedLines(t *testing.T) {
 	var buf bytes.Buffer
 	var program captureProgram
 	w := NewOutputWriter(&buf)
+	defer func() {
+		require.NoError(t, w.Close())
+	}()
 	stopPrinting := w.printTo(&program)
 
 	_, err := w.Write([]byte("one"))
 	require.NoError(t, err)
-	assert.Empty(t, program.msgs)
+	assert.Empty(t, program.Messages())
 	assert.Empty(t, buf.String())
 
 	_, err = w.Write([]byte("\r\ntwo\npartial"))
 	require.NoError(t, err)
 
-	require.Len(t, program.msgs, 2)
-	assertPrintLineMessage(t, program.msgs[0], "one")
-	assertPrintLineMessage(t, program.msgs[1], "two")
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Len(c, program.Messages(), 2)
+	}, time.Second, 10*time.Millisecond)
+	msgs := program.Messages()
+	assertPrintLineMessage(t, msgs[0], "one")
+	assertPrintLineMessage(t, msgs[1], "two")
 	assert.Empty(t, buf.String())
 
 	stopPrinting()
@@ -46,11 +57,22 @@ func TestOutputWriter_Write_activeSendsCompletedLines(t *testing.T) {
 }
 
 type captureProgram struct {
+	mu   sync.Mutex
 	msgs []tea.Msg
 }
 
 func (p *captureProgram) Send(msg tea.Msg) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	p.msgs = append(p.msgs, msg)
+}
+
+func (p *captureProgram) Messages() []tea.Msg {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return append([]tea.Msg(nil), p.msgs...)
 }
 
 func assertPrintLineMessage(t *testing.T, msg tea.Msg, want string) {

--- a/testdata/script/issue1329_branch_submit_template_warning_terminal.txt
+++ b/testdata/script/issue1329_branch_submit_template_warning_terminal.txt
@@ -1,0 +1,70 @@
+# branch submit continues after delayed template lookup warnings.
+# https://github.com/abhinav/git-spice/issues/1329
+
+[!unix] skip # pending github.com/creack/pty/pull/155
+
+as 'Test <test@example.com>'
+at '2026-07-02T12:40:00Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+
+# set up a fake remote
+shamhub init
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+git add feature.txt
+gs bc feature -m 'Add feature'
+
+shamhub config changeTemplateErrorDelay 200ms
+env GIT_EDITOR=true EDITOR=true
+with-term $WORK/input/prompt.txt -- gs branch submit
+
+shamhub dump changes
+cmpenvJSON stdout $WORK/golden/changes.json
+
+-- repo/feature.txt --
+Contents of feature
+
+-- input/prompt.txt --
+await Title:
+feed \r
+await Body:
+feed \r
+await Draft:
+feed \r
+await Created
+
+-- golden/changes.json --
+[
+  {
+    "number": 1,
+    "html_url": "$SHAMHUB_URL/alice/example/change/1",
+    "state": "open",
+    "title": "Add feature",
+    "body": "",
+    "base": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "main",
+      "sha": "2ac8d4fa35f97afa1b2adc32ad4cf8c567af9ce3"
+    },
+    "head": {
+      "repository": {
+        "owner": "alice",
+        "name": "example"
+      },
+      "ref": "feature",
+      "sha": "4d3f7f8fce4adeb5a8291933606828ad3131c59a"
+    }
+  }
+]

--- a/tools/ci/install-git/main.go
+++ b/tools/ci/install-git/main.go
@@ -90,6 +90,10 @@ func run(log *silog.Logger, req installRequest) error {
 		// If we're on a Debian-based system, we need to install
 		// build dependencies with apt-get.
 		if req.Debian {
+			if err := xec.Command(ctx, log, "sudo", "apt-get", "update").Run(); err != nil {
+				return fmt.Errorf("apt-get update: %w", wrapExecError(err))
+			}
+
 			installArgs := append([]string{"apt-get", "install"}, _gitBuildDependencies...)
 			if err := xec.Command(ctx, log, "sudo", installArgs...).Run(); err != nil {
 				return fmt.Errorf("apt-get: %w", wrapExecError(err))


### PR DESCRIPTION
## Problem

branch submit could hang after the title prompt
if CR template lookup returned a warning
while the interactive form was waiting for the template result.

```
script error: await: "Body:" not found
signal: killed
```

The warning path wrote through OutputWriter
while Bubble Tea owned the terminal.
OutputWriter routed that write through Program.Send,
but the Bubble Tea update loop was waiting
for the same background result that produced the warning.

## Solution

Route completed output lines through a background goroutine.

Write now only buffers completed-line input and wakes the goroutine,
so warning output cannot block the caller waiting for the form.

OutputWriter.Close stops the goroutine to avoid leakage.
This was not incorporated into main()
as that would require a more invasive refactor in exchange for no value
(as the program is exiting anyway).

## Testing

The test script delays ShamHub template lookup and causes the warning.
A similar failure was reproduced in the test script without the fix.

The output writer unit test also verifies this issue
by blocking the Bubble Tea update loop and verifying that Write returns.

---

Resolves #1329
