### PR TITLE
refactor(handler/restack): Move options into requests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,3 +20,8 @@ doc/ export-ignore
 # mise files that don't need to be seen in diffs by default.
 mise.lock linguist-generated
 /bin/mise lingust-generated
+
+# Mocks are almost never useful to see in diffs.
+mock_*_test.go -diff linguist-generated=true
+mocks_test.go -diff linguist-generated=true
+mocks.go -diff linguist-generated=true

--- a/branch_create.go
+++ b/branch_create.go
@@ -8,6 +8,7 @@ import (
 
 	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
@@ -324,7 +325,9 @@ func (cmd *branchCreateCmd) Run(
 	}
 
 	if cmd.Below || cmd.Insert {
-		return restackHandler.RestackUpstack(ctx, branchName, nil)
+		return restackHandler.RestackUpstack(ctx, &restack.UpstackRequest{
+			Branch: branchName,
+		})
 	}
 
 	return nil

--- a/branch_edit.go
+++ b/branch_edit.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
@@ -59,5 +60,7 @@ func (*branchEditCmd) Run(
 		})
 	}
 
-	return restackHandler.RestackUpstack(ctx, currentBranch, nil)
+	return restackHandler.RestackUpstack(ctx, &restack.UpstackRequest{
+		Branch: currentBranch,
+	})
 }

--- a/branch_restack.go
+++ b/branch_restack.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/text"
 )
 
@@ -32,5 +33,7 @@ func (cmd *branchRestackCmd) AfterApply(ctx context.Context, wt *git.Worktree) e
 }
 
 func (cmd *branchRestackCmd) Run(ctx context.Context, handler RestackHandler) error {
-	return handler.RestackBranch(ctx, cmd.Branch)
+	return handler.RestackBranch(ctx, &restack.BranchRequest{
+		Branch: cmd.Branch,
+	})
 }

--- a/commit_amend.go
+++ b/commit_amend.go
@@ -241,7 +241,10 @@ func (cmd *commitAmendCmd) Run(
 		return nil
 	}
 
-	return restackHandler.RestackUpstack(ctx, currentBranch, &restack.UpstackOptions{
-		SkipStart: true,
+	return restackHandler.RestackUpstack(ctx, &restack.UpstackRequest{
+		Branch: currentBranch,
+		Options: &restack.UpstackOptions{
+			SkipStart: true,
+		},
 	})
 }

--- a/commit_create.go
+++ b/commit_create.go
@@ -79,7 +79,10 @@ func (cmd *commitCreateCmd) Run(
 		return fmt.Errorf("get current branch: %w", err)
 	}
 
-	return restackHandler.RestackUpstack(ctx, currentBranch, &restack.UpstackOptions{
-		SkipStart: true,
+	return restackHandler.RestackUpstack(ctx, &restack.UpstackRequest{
+		Branch: currentBranch,
+		Options: &restack.UpstackOptions{
+			SkipStart: true,
+		},
 	})
 }

--- a/commit_split.go
+++ b/commit_split.go
@@ -110,7 +110,10 @@ func (cmd *commitSplitCmd) Run(
 		return fmt.Errorf("get current branch: %w", err)
 	}
 
-	return restackHandler.RestackUpstack(ctx, currentBranch, &restack.UpstackOptions{
-		SkipStart: true,
+	return restackHandler.RestackUpstack(ctx, &restack.UpstackRequest{
+		Branch: currentBranch,
+		Options: &restack.UpstackOptions{
+			SkipStart: true,
+		},
 	})
 }

--- a/downstack_restack.go
+++ b/downstack_restack.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
 )
@@ -44,5 +45,7 @@ func (cmd *downstackRestackCmd) Run(
 		return errors.New("nothing to restack below trunk")
 	}
 
-	return handler.RestackDownstack(ctx, cmd.Branch)
+	return handler.RestackDownstack(ctx, &restack.DownstackRequest{
+		Branch: cmd.Branch,
+	})
 }

--- a/internal/forge/forgetest/.gitattributes
+++ b/internal/forge/forgetest/.gitattributes
@@ -1,1 +1,0 @@
-mocks.go linguist-generated=true -diff

--- a/internal/git/.gitattributes
+++ b/internal/git/.gitattributes
@@ -1,1 +1,0 @@
-mock_cmd_test.go linguist-generated=true -diff

--- a/internal/handler/cherrypick/handler.go
+++ b/internal/handler/cherrypick/handler.go
@@ -19,7 +19,7 @@ import (
 
 // RestackHandler is a subset of the restack.Handler interface.
 type RestackHandler interface {
-	RestackUpstack(ctx context.Context, branch string, opts *restack.UpstackOptions) error
+	RestackUpstack(ctx context.Context, req *restack.UpstackRequest) error
 }
 
 var _ RestackHandler = (*restack.Handler)(nil)
@@ -225,7 +225,10 @@ func (h *Handler) CherryPickCommit(ctx context.Context, req *Request) (retErr er
 
 	h.Log.Infof("%v: cherry-picked %v: %v", req.Branch, req.Commit.Short(), commit.Subject)
 
-	return h.Restack.RestackUpstack(ctx, req.Branch, &restack.UpstackOptions{
-		SkipStart: true,
+	return h.Restack.RestackUpstack(ctx, &restack.UpstackRequest{
+		Branch: req.Branch,
+		Options: &restack.UpstackOptions{
+			SkipStart: true,
+		},
 	})
 }

--- a/internal/handler/fixup/handler.go
+++ b/internal/handler/fixup/handler.go
@@ -23,7 +23,7 @@ import (
 
 // RestackHandler is a subset of the restack.Handler interface.
 type RestackHandler interface {
-	RestackUpstack(ctx context.Context, branch string, opts *restack.UpstackOptions) error
+	RestackUpstack(ctx context.Context, req *restack.UpstackRequest) error
 }
 
 var _ RestackHandler = (*restack.Handler)(nil)
@@ -266,8 +266,11 @@ func (h *Handler) FixupCommit(ctx context.Context, req *Request) error {
 		return fmt.Errorf("rebase onto new commit: %w", err)
 	}
 
-	return h.Restack.RestackUpstack(ctx, req.TargetBranch, &restack.UpstackOptions{
-		SkipStart: true,
+	return h.Restack.RestackUpstack(ctx, &restack.UpstackRequest{
+		Branch: req.TargetBranch,
+		Options: &restack.UpstackOptions{
+			SkipStart: true,
+		},
 	})
 }
 

--- a/internal/handler/fixup/handler_test.go
+++ b/internal/handler/fixup/handler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/git/gittest"
+	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/sigstack"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/silog/silogtest"
@@ -228,7 +229,12 @@ func TestFixupCommit_success(t *testing.T) {
 	// Will try to restack the upstack of feature1 (target branch)
 	mockRestack := NewMockRestackHandler(mockCtrl)
 	mockRestack.EXPECT().
-		RestackUpstack(gomock.Any(), "feature1", gomock.Any()).
+		RestackUpstack(gomock.Any(), &restack.UpstackRequest{
+			Branch: "feature1",
+			Options: &restack.UpstackOptions{
+				SkipStart: true,
+			},
+		}).
 		Return(nil)
 
 		// Sanity check: feature1:staged.txt does not exist yet.
@@ -333,7 +339,12 @@ func TestFixupCommit_edit(t *testing.T) {
 
 	mockRestack := NewMockRestackHandler(mockCtrl)
 	mockRestack.EXPECT().
-		RestackUpstack(gomock.Any(), "feature1", gomock.Any()).
+		RestackUpstack(gomock.Any(), &restack.UpstackRequest{
+			Branch: "feature1",
+			Options: &restack.UpstackOptions{
+				SkipStart: true,
+			},
+		}).
 		Return(nil)
 
 	var signals sigstack.Stack

--- a/internal/handler/fixup/mocks_test.go
+++ b/internal/handler/fixup/mocks_test.go
@@ -46,17 +46,17 @@ func (m *MockRestackHandler) EXPECT() *MockRestackHandlerMockRecorder {
 }
 
 // RestackUpstack mocks base method.
-func (m *MockRestackHandler) RestackUpstack(ctx context.Context, branch string, opts *restack.UpstackOptions) error {
+func (m *MockRestackHandler) RestackUpstack(ctx context.Context, req *restack.UpstackRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestackUpstack", ctx, branch, opts)
+	ret := m.ctrl.Call(m, "RestackUpstack", ctx, req)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RestackUpstack indicates an expected call of RestackUpstack.
-func (mr *MockRestackHandlerMockRecorder) RestackUpstack(ctx, branch, opts any) *MockRestackHandlerRestackUpstackCall {
+func (mr *MockRestackHandlerMockRecorder) RestackUpstack(ctx, req any) *MockRestackHandlerRestackUpstackCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackUpstack", reflect.TypeOf((*MockRestackHandler)(nil).RestackUpstack), ctx, branch, opts)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackUpstack", reflect.TypeOf((*MockRestackHandler)(nil).RestackUpstack), ctx, req)
 	return &MockRestackHandlerRestackUpstackCall{Call: call}
 }
 
@@ -72,13 +72,13 @@ func (c *MockRestackHandlerRestackUpstackCall) Return(arg0 error) *MockRestackHa
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRestackHandlerRestackUpstackCall) Do(f func(context.Context, string, *restack.UpstackOptions) error) *MockRestackHandlerRestackUpstackCall {
+func (c *MockRestackHandlerRestackUpstackCall) Do(f func(context.Context, *restack.UpstackRequest) error) *MockRestackHandlerRestackUpstackCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRestackHandlerRestackUpstackCall) DoAndReturn(f func(context.Context, string, *restack.UpstackOptions) error) *MockRestackHandlerRestackUpstackCall {
+func (c *MockRestackHandlerRestackUpstackCall) DoAndReturn(f func(context.Context, *restack.UpstackRequest) error) *MockRestackHandlerRestackUpstackCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/handler/merge/handler.go
+++ b/internal/handler/merge/handler.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/handler/submit"
 	"go.abhg.dev/gs/internal/handler/sync"
 
@@ -39,7 +40,7 @@ type Service interface {
 
 // RestackHandler restacks branches after their bases are merged.
 type RestackHandler interface {
-	RestackBranch(context.Context, string) error
+	RestackBranch(ctx context.Context, req *restack.BranchRequest) error
 }
 
 // SubmitHandler updates change requests after branch restacks.
@@ -839,7 +840,9 @@ func (e *mergePlanExecutor) prepareForMerge(
 			return fmt.Errorf("verify restacked: %w", err)
 		}
 
-		if err := e.Restack.RestackBranch(ctx, item.branch); err != nil {
+		if err := e.Restack.RestackBranch(ctx, &restack.BranchRequest{
+			Branch: item.branch,
+		}); err != nil {
 			return fmt.Errorf("restack branch: %w", err)
 		}
 

--- a/internal/handler/merge/handler_test.go
+++ b/internal/handler/merge/handler_test.go
@@ -21,6 +21,7 @@ import (
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/forge/forgetest"
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/mergequeue"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/spice"
@@ -351,10 +352,14 @@ func TestExecutePlan_retargets(t *testing.T) {
 
 	mockRestack := NewMockRestackHandler(ctrl)
 	mockRestack.EXPECT().
-		RestackBranch(gomock.Any(), "feat2").
+		RestackBranch(gomock.Any(), &restack.BranchRequest{
+			Branch: "feat2",
+		}).
 		Return(nil)
 	mockRestack.EXPECT().
-		RestackBranch(gomock.Any(), "feat3").
+		RestackBranch(gomock.Any(), &restack.BranchRequest{
+			Branch: "feat3",
+		}).
 		Return(nil)
 
 	mockSubmit := NewMockSubmitHandler(ctrl)
@@ -427,7 +432,9 @@ func TestExecutePlan_waitsForPreparedChangeHeadBeforeChecks(t *testing.T) {
 
 	mockRestack := NewMockRestackHandler(ctrl)
 	mockRestack.EXPECT().
-		RestackBranch(gomock.Any(), "feat2").
+		RestackBranch(gomock.Any(), &restack.BranchRequest{
+			Branch: "feat2",
+		}).
 		Return(nil)
 
 	mockSubmit := NewMockSubmitHandler(ctrl)

--- a/internal/handler/merge/mocks_test.go
+++ b/internal/handler/merge/mocks_test.go
@@ -13,6 +13,7 @@ import (
 	reflect "reflect"
 
 	git "go.abhg.dev/gs/internal/git"
+	restack "go.abhg.dev/gs/internal/handler/restack"
 	submit "go.abhg.dev/gs/internal/handler/submit"
 	sync "go.abhg.dev/gs/internal/handler/sync"
 	spice "go.abhg.dev/gs/internal/spice"
@@ -207,17 +208,17 @@ func (m *MockRestackHandler) EXPECT() *MockRestackHandlerMockRecorder {
 }
 
 // RestackBranch mocks base method.
-func (m *MockRestackHandler) RestackBranch(arg0 context.Context, arg1 string) error {
+func (m *MockRestackHandler) RestackBranch(ctx context.Context, req *restack.BranchRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestackBranch", arg0, arg1)
+	ret := m.ctrl.Call(m, "RestackBranch", ctx, req)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RestackBranch indicates an expected call of RestackBranch.
-func (mr *MockRestackHandlerMockRecorder) RestackBranch(arg0, arg1 any) *MockRestackHandlerRestackBranchCall {
+func (mr *MockRestackHandlerMockRecorder) RestackBranch(ctx, req any) *MockRestackHandlerRestackBranchCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackBranch", reflect.TypeOf((*MockRestackHandler)(nil).RestackBranch), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackBranch", reflect.TypeOf((*MockRestackHandler)(nil).RestackBranch), ctx, req)
 	return &MockRestackHandlerRestackBranchCall{Call: call}
 }
 
@@ -233,13 +234,13 @@ func (c *MockRestackHandlerRestackBranchCall) Return(arg0 error) *MockRestackHan
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRestackHandlerRestackBranchCall) Do(f func(context.Context, string) error) *MockRestackHandlerRestackBranchCall {
+func (c *MockRestackHandlerRestackBranchCall) Do(f func(context.Context, *restack.BranchRequest) error) *MockRestackHandlerRestackBranchCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRestackHandlerRestackBranchCall) DoAndReturn(f func(context.Context, string) error) *MockRestackHandlerRestackBranchCall {
+func (c *MockRestackHandlerRestackBranchCall) DoAndReturn(f func(context.Context, *restack.BranchRequest) error) *MockRestackHandlerRestackBranchCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/handler/onto/handler.go
+++ b/internal/handler/onto/handler.go
@@ -15,7 +15,7 @@ import (
 
 // RestackHandler restacks branches after their downstack base changes.
 type RestackHandler interface {
-	RestackUpstack(ctx context.Context, branch string, opts *restack.UpstackOptions) error
+	RestackUpstack(ctx context.Context, req *restack.UpstackRequest) error
 }
 
 // Handler coordinates higher-level onto operations.
@@ -95,8 +95,11 @@ func (h *Handler) BranchOnto(ctx context.Context, req *BranchRequest) error {
 			continue
 		}
 
-		if err := h.Restack.RestackUpstack(ctx, above, &restack.UpstackOptions{
-			SkipStart: true,
+		if err := h.Restack.RestackUpstack(ctx, &restack.UpstackRequest{
+			Branch: above,
+			Options: &restack.UpstackOptions{
+				SkipStart: true,
+			},
 		}); err != nil {
 			return h.Service.RebaseRescue(ctx, spice.RebaseRescueRequest{
 				Err:     err,
@@ -151,7 +154,10 @@ func (h *Handler) UpstackOnto(ctx context.Context, req *UpstackRequest) error {
 	}
 	h.Log.Infof("%v: moved upstack onto %v", req.Branch, req.Onto)
 
-	return h.Restack.RestackUpstack(ctx, req.Branch, &restack.UpstackOptions{
-		SkipStart: true,
+	return h.Restack.RestackUpstack(ctx, &restack.UpstackRequest{
+		Branch: req.Branch,
+		Options: &restack.UpstackOptions{
+			SkipStart: true,
+		},
 	})
 }

--- a/internal/handler/restack/branch.go
+++ b/internal/handler/restack/branch.go
@@ -2,10 +2,18 @@ package restack
 
 import "context"
 
+// BranchRequest is a request to restack one branch onto its base.
+type BranchRequest struct {
+	// Branch is the branch to restack.
+	Branch string // required
+
+	Options *Options // optional
+}
+
 // RestackBranch restacks the given branch onto its base.
-func (h *Handler) RestackBranch(ctx context.Context, branch string) error {
+func (h *Handler) RestackBranch(ctx context.Context, req *BranchRequest) error {
 	_, err := h.Restack(ctx, &Request{
-		Branch:          branch,
+		Branch:          req.Branch,
 		ContinueCommand: []string{"branch", "restack"},
 	})
 	return err

--- a/internal/handler/restack/branch_test.go
+++ b/internal/handler/restack/branch_test.go
@@ -47,7 +47,9 @@ func TestHandler_RestackBranch(t *testing.T) {
 			Store:    statetest.NewMemoryStore(t, "main", "", log),
 			Service:  mockService,
 		}
-		require.NoError(t, handler.RestackBranch(t.Context(), "feature"))
+		require.NoError(t, handler.RestackBranch(t.Context(), &BranchRequest{
+			Branch: "feature",
+		}))
 		assert.Contains(t, logBuffer.String(), "feature: restacked on main")
 	})
 
@@ -82,7 +84,9 @@ func TestHandler_RestackBranch(t *testing.T) {
 			Service:  mockService,
 		}
 
-		require.NoError(t, handler.RestackBranch(t.Context(), "feature"))
+		require.NoError(t, handler.RestackBranch(t.Context(), &BranchRequest{
+			Branch: "feature",
+		}))
 	})
 
 	t.Run("UntrackedBranch", func(t *testing.T) {
@@ -113,7 +117,9 @@ func TestHandler_RestackBranch(t *testing.T) {
 			Service:  mockService,
 		}
 
-		err := handler.RestackBranch(t.Context(), "untracked")
+		err := handler.RestackBranch(t.Context(), &BranchRequest{
+			Branch: "untracked",
+		})
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "untracked branch")
 		assert.Contains(t, logBuffer.String(), "untracked: branch not tracked: run '"+cli.Name()+" branch track")
@@ -146,7 +152,9 @@ func TestHandler_RestackBranch(t *testing.T) {
 			Store:    statetest.NewMemoryStore(t, "main", "", log),
 			Service:  mockService,
 		}
-		require.NoError(t, handler.RestackBranch(t.Context(), "already-restacked"))
+		require.NoError(t, handler.RestackBranch(t.Context(), &BranchRequest{
+			Branch: "already-restacked",
+		}))
 		assert.Contains(t, logBuffer.String(), "already-restacked: branch does not need to be restacked.")
 	})
 
@@ -177,7 +185,9 @@ func TestHandler_RestackBranch(t *testing.T) {
 			Store:    statetest.NewMemoryStore(t, "main", "", log),
 			Service:  mockService,
 		}
-		err := handler.RestackBranch(t.Context(), "feature")
+		err := handler.RestackBranch(t.Context(), &BranchRequest{
+			Branch: "feature",
+		})
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "restack branch")
 		assert.ErrorIs(t, err, unexpectedErr)

--- a/internal/handler/restack/downstack.go
+++ b/internal/handler/restack/downstack.go
@@ -2,11 +2,19 @@ package restack
 
 import "context"
 
+// DownstackRequest is a request to restack a branch and its downstack.
+type DownstackRequest struct {
+	// Branch is the top of the downstack to restack.
+	Branch string // required
+
+	Options *Options // optional
+}
+
 // RestackDownstack restacks the downstack of the given branch.
 // This includes the branch itself.
-func (h *Handler) RestackDownstack(ctx context.Context, branch string) error {
+func (h *Handler) RestackDownstack(ctx context.Context, req *DownstackRequest) error {
 	_, err := h.Restack(ctx, &Request{
-		Branch:          branch,
+		Branch:          req.Branch,
 		Scope:           ScopeDownstack,
 		ContinueCommand: []string{"downstack", "restack"},
 	})

--- a/internal/handler/restack/downstack_test.go
+++ b/internal/handler/restack/downstack_test.go
@@ -54,7 +54,9 @@ func TestHandler_RestackDownstack(t *testing.T) {
 			Service:  mockService,
 		}
 
-		require.NoError(t, handler.RestackDownstack(t.Context(), "feature3"))
+		require.NoError(t, handler.RestackDownstack(t.Context(), &DownstackRequest{
+			Branch: "feature3",
+		}))
 		assert.Contains(t, logBuffer.String(), "feature1: restacked on main")
 		assert.Contains(t, logBuffer.String(), "feature2: restacked on feature1")
 		assert.Contains(t, logBuffer.String(), "feature3: restacked on feature2")
@@ -99,6 +101,8 @@ func TestHandler_RestackDownstack(t *testing.T) {
 			Service:  mockService,
 		}
 
-		require.NoError(t, handler.RestackDownstack(t.Context(), "feature2"))
+		require.NoError(t, handler.RestackDownstack(t.Context(), &DownstackRequest{
+			Branch: "feature2",
+		}))
 	})
 }

--- a/internal/handler/restack/handler.go
+++ b/internal/handler/restack/handler.go
@@ -95,6 +95,11 @@ type Request struct {
 	Scope Scope
 }
 
+// Options are optional parameters shared by the high-level restack
+// entry points ([Handler.RestackBranch], [Handler.RestackStack],
+// [Handler.RestackDownstack]).
+type Options struct{}
+
 // Restack restacks one or more branches according to the request.
 func (h *Handler) Restack(ctx context.Context, req *Request) (int, error) {
 	must.NotBeBlankf(req.Branch, "branch must not be blank")

--- a/internal/handler/restack/stack.go
+++ b/internal/handler/restack/stack.go
@@ -2,12 +2,20 @@ package restack
 
 import "context"
 
+// StackRequest is a request to restack all branches in a stack.
+type StackRequest struct {
+	// Branch selects the stack to restack.
+	Branch string // required
+
+	Options *Options // optional
+}
+
 // RestackStack restacks the stack of the given branch.
 // This includes all upstack and downtrack branches,
 // as well as the branch itself.
-func (h *Handler) RestackStack(ctx context.Context, branch string) error {
+func (h *Handler) RestackStack(ctx context.Context, req *StackRequest) error {
 	_, err := h.Restack(ctx, &Request{
-		Branch:          branch,
+		Branch:          req.Branch,
 		Scope:           ScopeStack,
 		ContinueCommand: []string{"stack", "restack"},
 	})

--- a/internal/handler/restack/upstack.go
+++ b/internal/handler/restack/upstack.go
@@ -7,23 +7,33 @@ import (
 
 // UpstackOptions holds options for restacking the upstack of a branch.
 type UpstackOptions struct {
+	Options
+
 	// SkipStart indicates that the starting branch should not be restacked.
 	SkipStart bool `help:"Do not restack the starting branch"`
 }
 
+// UpstackRequest is a request to restack a branch and its upstack.
+type UpstackRequest struct {
+	// Branch is the bottom of the upstack to restack.
+	Branch string // required
+
+	Options *UpstackOptions // optional
+}
+
 // RestackUpstack restacks the upstack of the given branch,
 // including the branch itself, unless SkipStart is set.
-func (h *Handler) RestackUpstack(ctx context.Context, branch string, opts *UpstackOptions) error {
-	opts = cmp.Or(opts, &UpstackOptions{})
-	req := &Request{
-		Branch:          branch,
+func (h *Handler) RestackUpstack(ctx context.Context, req *UpstackRequest) error {
+	opts := cmp.Or(req.Options, &UpstackOptions{})
+	restackReq := &Request{
+		Branch:          req.Branch,
 		Scope:           ScopeUpstack,
 		ContinueCommand: []string{"upstack", "restack"},
 	}
 	if opts.SkipStart {
-		req.Scope = ScopeUpstackExclusive
-		req.ContinueCommand = []string{"upstack", "restack", "--skip-start"}
+		restackReq.Scope = ScopeUpstackExclusive
+		restackReq.ContinueCommand = []string{"upstack", "restack", "--skip-start"}
 	}
-	_, err := h.Restack(ctx, req)
+	_, err := h.Restack(ctx, restackReq)
 	return err
 }

--- a/internal/handler/squash/handler.go
+++ b/internal/handler/squash/handler.go
@@ -54,7 +54,7 @@ var _ Service = (*spice.Service)(nil)
 
 // RestackHandler provides methods to restack branches.
 type RestackHandler interface {
-	RestackUpstack(ctx context.Context, branch string, opts *restack.UpstackOptions) error
+	RestackUpstack(ctx context.Context, req *restack.UpstackRequest) error
 }
 
 // Handler handles git-spice's squash commands.
@@ -186,7 +186,9 @@ func (h *Handler) SquashBranch(ctx context.Context, branchName string, opts *Opt
 	}
 	reattachedHead = true
 
-	return h.Restack.RestackUpstack(ctx, branchName, nil)
+	return h.Restack.RestackUpstack(ctx, &restack.UpstackRequest{
+		Branch: branchName,
+	})
 }
 
 func commitMessageTemplate(

--- a/internal/handler/squash/handler_test.go
+++ b/internal/handler/squash/handler_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/spice"
 	"go.uber.org/mock/gomock"
@@ -165,7 +166,9 @@ func TestHandler_SquashBranch(t *testing.T) {
 
 		mockRestack := NewMockRestackHandler(ctrl)
 		mockRestack.EXPECT().
-			RestackUpstack(t.Context(), branchName, nil).
+			RestackUpstack(t.Context(), &restack.UpstackRequest{
+				Branch: branchName,
+			}).
 			Return(nil)
 
 		handler := &Handler{
@@ -225,7 +228,9 @@ func TestHandler_SquashBranch(t *testing.T) {
 
 		mockRestack := NewMockRestackHandler(ctrl)
 		mockRestack.EXPECT().
-			RestackUpstack(t.Context(), branchName, nil).
+			RestackUpstack(t.Context(), &restack.UpstackRequest{
+				Branch: branchName,
+			}).
 			Return(nil)
 
 		handler := &Handler{
@@ -286,7 +291,9 @@ func TestHandler_SquashBranch(t *testing.T) {
 
 		mockRestack := NewMockRestackHandler(ctrl)
 		mockRestack.EXPECT().
-			RestackUpstack(t.Context(), branchName, nil).
+			RestackUpstack(t.Context(), &restack.UpstackRequest{
+				Branch: branchName,
+			}).
 			Return(nil)
 
 		handler := &Handler{
@@ -357,7 +364,9 @@ func TestHandler_SquashBranch(t *testing.T) {
 
 		mockRestack := NewMockRestackHandler(ctrl)
 		mockRestack.EXPECT().
-			RestackUpstack(t.Context(), branchName, nil).
+			RestackUpstack(t.Context(), &restack.UpstackRequest{
+				Branch: branchName,
+			}).
 			Return(nil)
 
 		handler := &Handler{

--- a/internal/handler/squash/mocks_test.go
+++ b/internal/handler/squash/mocks_test.go
@@ -283,15 +283,15 @@ func (m *MockRestackHandler) EXPECT() *MockRestackHandlerMockRecorder {
 }
 
 // RestackUpstack mocks base method.
-func (m *MockRestackHandler) RestackUpstack(ctx context.Context, branch string, opts *restack.UpstackOptions) error {
+func (m *MockRestackHandler) RestackUpstack(ctx context.Context, req *restack.UpstackRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestackUpstack", ctx, branch, opts)
+	ret := m.ctrl.Call(m, "RestackUpstack", ctx, req)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RestackUpstack indicates an expected call of RestackUpstack.
-func (mr *MockRestackHandlerMockRecorder) RestackUpstack(ctx, branch, opts any) *gomock.Call {
+func (mr *MockRestackHandlerMockRecorder) RestackUpstack(ctx, req any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackUpstack", reflect.TypeOf((*MockRestackHandler)(nil).RestackUpstack), ctx, branch, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackUpstack", reflect.TypeOf((*MockRestackHandler)(nil).RestackUpstack), ctx, req)
 }

--- a/internal/handler/sync/.gitattributes
+++ b/internal/handler/sync/.gitattributes
@@ -1,1 +1,0 @@
-mocks_test.go -diff linguist-generated=true

--- a/internal/handler/sync/handler.go
+++ b/internal/handler/sync/handler.go
@@ -78,8 +78,8 @@ type DeleteHandler interface {
 // RestackHandler allows restacking branches after sync
 // has removed their downstack branches.
 type RestackHandler interface {
-	RestackBranch(ctx context.Context, branch string) error
-	RestackUpstack(ctx context.Context, branch string, opts *restack.UpstackOptions) error
+	RestackBranch(ctx context.Context, req *restack.BranchRequest) error
+	RestackUpstack(ctx context.Context, req *restack.UpstackRequest) error
 }
 
 // AutostashHandler is a subset of the autostash.Handler interface.
@@ -1023,11 +1023,15 @@ func (h *Handler) restackDeletedBranchUpstack(
 ) error {
 	switch {
 	case mode.Includes(spice.RestackUpstack):
-		if err := h.Restack.RestackUpstack(ctx, target, nil); err != nil {
+		if err := h.Restack.RestackUpstack(ctx, &restack.UpstackRequest{
+			Branch: target,
+		}); err != nil {
 			return fmt.Errorf("restack upstack %q: %w", target, err)
 		}
 	case mode.Includes(spice.RestackAboves):
-		if err := h.Restack.RestackBranch(ctx, target); err != nil {
+		if err := h.Restack.RestackBranch(ctx, &restack.BranchRequest{
+			Branch: target,
+		}); err != nil {
 			return fmt.Errorf("restack branch %q: %w", target, err)
 		}
 	case mode.Includes(spice.RestackNone):

--- a/internal/handler/sync/handler_test.go
+++ b/internal/handler/sync/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/handler/autostash"
 	branchdel "go.abhg.dev/gs/internal/handler/delete"
+	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/silog/silogtest"
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/spicetest"
@@ -286,7 +287,9 @@ func TestHandler_SyncTrunk_autostashLazy(t *testing.T) {
 
 		mockRestack := NewMockRestackHandler(ctrl)
 		mockRestack.EXPECT().
-			RestackUpstack(gomock.Any(), "child", nil).
+			RestackUpstack(gomock.Any(), &restack.UpstackRequest{
+				Branch: "child",
+			}).
 			Return(nil)
 
 		handler := &Handler{
@@ -368,7 +371,9 @@ func TestHandler_SyncTrunk_restackDeletedUpstacks(t *testing.T) {
 
 		mockRestack := NewMockRestackHandler(ctrl)
 		mockRestack.EXPECT().
-			RestackBranch(gomock.Any(), "child").
+			RestackBranch(gomock.Any(), &restack.BranchRequest{
+				Branch: "child",
+			}).
 			Return(nil)
 
 		mockAutostash := NewMockAutostashHandler(ctrl)
@@ -457,7 +462,9 @@ func TestHandler_SyncTrunk_restackDeletedUpstacks(t *testing.T) {
 
 		mockRestack := NewMockRestackHandler(ctrl)
 		mockRestack.EXPECT().
-			RestackUpstack(gomock.Any(), "child", nil).
+			RestackUpstack(gomock.Any(), &restack.UpstackRequest{
+				Branch: "child",
+			}).
 			Return(nil)
 
 		mockAutostash := NewMockAutostashHandler(ctrl)
@@ -551,7 +558,9 @@ func TestHandler_SyncTrunk_restackDeletedUpstacks(t *testing.T) {
 
 		mockRestack := NewMockRestackHandler(ctrl)
 		mockRestack.EXPECT().
-			RestackUpstack(gomock.Any(), "c", nil).
+			RestackUpstack(gomock.Any(), &restack.UpstackRequest{
+				Branch: "c",
+			}).
 			Return(nil)
 
 		mockAutostash := NewMockAutostashHandler(ctrl)

--- a/internal/handler/sync/mocks_test.go
+++ b/internal/handler/sync/mocks_test.go
@@ -782,17 +782,17 @@ func (m *MockRestackHandler) EXPECT() *MockRestackHandlerMockRecorder {
 }
 
 // RestackBranch mocks base method.
-func (m *MockRestackHandler) RestackBranch(ctx context.Context, branch string) error {
+func (m *MockRestackHandler) RestackBranch(ctx context.Context, req *restack.BranchRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestackBranch", ctx, branch)
+	ret := m.ctrl.Call(m, "RestackBranch", ctx, req)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RestackBranch indicates an expected call of RestackBranch.
-func (mr *MockRestackHandlerMockRecorder) RestackBranch(ctx, branch any) *MockRestackHandlerRestackBranchCall {
+func (mr *MockRestackHandlerMockRecorder) RestackBranch(ctx, req any) *MockRestackHandlerRestackBranchCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackBranch", reflect.TypeOf((*MockRestackHandler)(nil).RestackBranch), ctx, branch)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackBranch", reflect.TypeOf((*MockRestackHandler)(nil).RestackBranch), ctx, req)
 	return &MockRestackHandlerRestackBranchCall{Call: call}
 }
 
@@ -808,29 +808,29 @@ func (c *MockRestackHandlerRestackBranchCall) Return(arg0 error) *MockRestackHan
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRestackHandlerRestackBranchCall) Do(f func(context.Context, string) error) *MockRestackHandlerRestackBranchCall {
+func (c *MockRestackHandlerRestackBranchCall) Do(f func(context.Context, *restack.BranchRequest) error) *MockRestackHandlerRestackBranchCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRestackHandlerRestackBranchCall) DoAndReturn(f func(context.Context, string) error) *MockRestackHandlerRestackBranchCall {
+func (c *MockRestackHandlerRestackBranchCall) DoAndReturn(f func(context.Context, *restack.BranchRequest) error) *MockRestackHandlerRestackBranchCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // RestackUpstack mocks base method.
-func (m *MockRestackHandler) RestackUpstack(ctx context.Context, branch string, opts *restack.UpstackOptions) error {
+func (m *MockRestackHandler) RestackUpstack(ctx context.Context, req *restack.UpstackRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestackUpstack", ctx, branch, opts)
+	ret := m.ctrl.Call(m, "RestackUpstack", ctx, req)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RestackUpstack indicates an expected call of RestackUpstack.
-func (mr *MockRestackHandlerMockRecorder) RestackUpstack(ctx, branch, opts any) *MockRestackHandlerRestackUpstackCall {
+func (mr *MockRestackHandlerMockRecorder) RestackUpstack(ctx, req any) *MockRestackHandlerRestackUpstackCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackUpstack", reflect.TypeOf((*MockRestackHandler)(nil).RestackUpstack), ctx, branch, opts)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestackUpstack", reflect.TypeOf((*MockRestackHandler)(nil).RestackUpstack), ctx, req)
 	return &MockRestackHandlerRestackUpstackCall{Call: call}
 }
 
@@ -846,13 +846,13 @@ func (c *MockRestackHandlerRestackUpstackCall) Return(arg0 error) *MockRestackHa
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRestackHandlerRestackUpstackCall) Do(f func(context.Context, string, *restack.UpstackOptions) error) *MockRestackHandlerRestackUpstackCall {
+func (c *MockRestackHandlerRestackUpstackCall) Do(f func(context.Context, *restack.UpstackRequest) error) *MockRestackHandlerRestackUpstackCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRestackHandlerRestackUpstackCall) DoAndReturn(f func(context.Context, string, *restack.UpstackOptions) error) *MockRestackHandlerRestackUpstackCall {
+func (c *MockRestackHandlerRestackUpstackCall) DoAndReturn(f func(context.Context, *restack.UpstackRequest) error) *MockRestackHandlerRestackUpstackCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/spice/.gitattributes
+++ b/internal/spice/.gitattributes
@@ -1,1 +1,0 @@
-mock_service_test.go -diff linguist-generated=true

--- a/stack_restack.go
+++ b/stack_restack.go
@@ -7,6 +7,7 @@ import (
 
 	"go.abhg.dev/gs/internal/cli"
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/silog"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/text"
@@ -88,5 +89,7 @@ func (cmd *stackRestackCmd) Run(
 		return err
 	}
 
-	return handler.RestackStack(ctx, cmd.Branch)
+	return handler.RestackStack(ctx, &restack.StackRequest{
+		Branch: cmd.Branch,
+	})
 }

--- a/upstack_restack.go
+++ b/upstack_restack.go
@@ -33,11 +33,11 @@ func (*upstackRestackCmd) Help() string {
 
 // RestackHandler implements high level restack operations.
 type RestackHandler interface {
-	RestackUpstack(ctx context.Context, branch string, opts *restack.UpstackOptions) error
-	RestackDownstack(ctx context.Context, branch string) error
+	RestackUpstack(ctx context.Context, req *restack.UpstackRequest) error
+	RestackDownstack(ctx context.Context, req *restack.DownstackRequest) error
 	Restack(context.Context, *restack.Request) (int, error)
-	RestackStack(ctx context.Context, branch string) error
-	RestackBranch(ctx context.Context, branch string) error
+	RestackStack(ctx context.Context, req *restack.StackRequest) error
+	RestackBranch(ctx context.Context, req *restack.BranchRequest) error
 }
 
 func (cmd *upstackRestackCmd) AfterApply(ctx context.Context, wt *git.Worktree) error {
@@ -62,5 +62,8 @@ func (cmd *upstackRestackCmd) Run(
 		return err
 	}
 
-	return handler.RestackUpstack(ctx, cmd.Branch, &cmd.UpstackOptions)
+	return handler.RestackUpstack(ctx, &restack.UpstackRequest{
+		Branch:  cmd.Branch,
+		Options: &cmd.UpstackOptions,
+	})
 }


### PR DESCRIPTION
Extracted from #1307

Restack handler entry points now receive operation request structs
instead of loose branch and options parameters. The request structs carry
optional Options fields, matching the handler request pattern used by the
surrounding handler packages.

UpstackOptions embeds the shared Options type while keeping SkipStart as
the only active option. AutoResolve is intentionally not part of this
commit.

[skip changelog]: no user facing changes