### PR TITLE
sync: Show commit context in deletion prompts

### DIFF
--- a/.changes/unreleased/Changed-20260703-120323.yaml
+++ b/.changes/unreleased/Changed-20260703-120323.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: >-
+  repo sync: When a merge branch is deleted but the local and remote heads differ,
+  include more information in the deletion prompt to help the user make an informed decision.
+time: 2026-07-03T12:03:23.218908-07:00

--- a/internal/handler/sync/handler.go
+++ b/internal/handler/sync/handler.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"slices"
 	"sort"
+	"strings"
 	"sync"
 
 	"go.abhg.dev/gs/internal/cli"
@@ -24,6 +25,7 @@ import (
 	"go.abhg.dev/gs/internal/handler/restack"
 	"go.abhg.dev/gs/internal/must"
 	"go.abhg.dev/gs/internal/silog"
+	"go.abhg.dev/gs/internal/sliceutil"
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/ui"
@@ -39,6 +41,10 @@ type GitRepository interface {
 	IsAncestor(ctx context.Context, ancestor, descendant git.Hash) bool
 	Fetch(ctx context.Context, opts git.FetchOptions) error
 	CountCommits(ctx context.Context, commitRange git.CommitRange) (int, error)
+	ListCommitsDetails(
+		ctx context.Context,
+		commitRange git.CommitRange,
+	) iter.Seq2[git.CommitDetail, error]
 	DeleteBranch(ctx context.Context, name string, opts git.BranchDeleteOptions) error // TODO:specialize to delete remote branch?
 	RemoteURL(ctx context.Context, remote string) (string, error)
 }
@@ -904,7 +910,8 @@ func (h *Handler) shouldDeleteMergedChange(
 		var shouldDelete bool
 		prompt := ui.NewConfirm().
 			WithTitle(fmt.Sprintf("Delete %v?", branchName)).
-			WithDescription(mismatchMsg).
+			WithDescription(h.mergedChangeHeadMismatchDescription(
+				ctx, branchName, changeID, localHead, remoteHead)).
 			WithValue(&shouldDelete)
 		if err := ui.Run(h.View, prompt); err != nil {
 			h.Log.Warn("Skipping branch", "branch", branchName, "error", err)
@@ -917,6 +924,72 @@ func (h *Handler) shouldDeleteMergedChange(
 		must.Bef(false, "unknown merged change head status")
 		return false
 	}
+}
+
+func (h *Handler) mergedChangeHeadMismatchDescription(
+	ctx context.Context,
+	branchName string,
+	changeID forge.ChangeID,
+	localHead, remoteHead git.Hash,
+) string {
+	const localCommitsLimit = 5
+
+	var desc strings.Builder
+	fmt.Fprintf(&desc,
+		"%v was merged but local SHA (%v) does not match remote SHA (%v)",
+		changeID, localHead.Short(), remoteHead.Short())
+
+	err := func() error {
+		localCommits := git.CommitRangeFrom(localHead).ExcludeFrom(remoteHead)
+
+		count, err := h.Repository.CountCommits(ctx, localCommits)
+		if err != nil {
+			return fmt.Errorf("count unpushed commits: %w", err)
+		}
+
+		if count == 0 {
+			return nil // no unpushed commits
+		}
+
+		localCommitsLimited := localCommits.Limit(localCommitsLimit)
+		commits, err := sliceutil.CollectErr(h.Repository.ListCommitsDetails(ctx, localCommitsLimited))
+		if len(commits) == 0 {
+			// This is not really expected:
+			// if count returned non-zero,
+			// we should be able to list them.
+			// But if it happens, don't fail the whole prompt.
+			fmt.Fprintf(&desc, "\n%v has %d unpushed commit(s).", branchName, count)
+			if err != nil {
+				return fmt.Errorf("list unpushed commits: %w", err)
+			}
+			return nil
+		}
+
+		fmt.Fprintf(&desc, "\n%v has %d unpushed commit(s):", branchName, count)
+		for _, commit := range commits {
+			fmt.Fprintf(&desc, "\n  %v %v", commit.ShortHash, commit.Subject)
+		}
+		if remaining := count - len(commits); remaining > 0 {
+			fmt.Fprintf(&desc, "\n  ... and %d more", remaining)
+		}
+		return nil
+	}()
+	if err != nil {
+		h.Log.Warn("Unable to report unpushed commits", "error", err)
+	}
+
+	for commit, err := range h.Repository.ListCommitsDetails(ctx,
+		git.CommitRangeFrom(remoteHead).Limit(1)) {
+		if err != nil {
+			h.Log.Warn("Unable to list merged head", "error", err)
+			break
+		}
+		fmt.Fprintf(&desc, "\n%v was merged at:", changeID)
+		fmt.Fprintf(&desc, "\n  %v %v", commit.ShortHash, commit.Subject)
+		break
+	}
+
+	return desc.String()
 }
 
 type mergedChangeHeadStatus int

--- a/internal/handler/sync/handler_test.go
+++ b/internal/handler/sync/handler_test.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"iter"
 	"testing"
 
@@ -88,6 +89,168 @@ func TestMergedChangeHeadCheck(t *testing.T) {
 				mergedChangeHeadCheck(t.Context(), mockRepo, tt.local, tt.remote))
 		})
 	}
+}
+
+func TestHandler_mergedChangeHeadMismatchDescription(t *testing.T) {
+	t.Run("LimitsUnpushedCommits", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		mockRepo := NewMockGitRepository(ctrl)
+		localOnly := git.CommitRangeFrom("local").ExcludeFrom("remote")
+		mockRepo.EXPECT().
+			CountCommits(gomock.Any(), localOnly).
+			Return(7, nil)
+		mockRepo.EXPECT().
+			ListCommitsDetails(gomock.Any(), gomock.Any()).
+			Return(commitDetailsIter(
+				git.CommitDetail{
+					ShortHash: "aaaaaaa",
+					Subject:   "Update field one",
+				},
+				git.CommitDetail{
+					ShortHash: "bbbbbbb",
+					Subject:   "Update field two",
+				},
+				git.CommitDetail{
+					ShortHash: "ccccccc",
+					Subject:   "Update field three",
+				},
+				git.CommitDetail{
+					ShortHash: "ddddddd",
+					Subject:   "Update field four",
+				},
+				git.CommitDetail{
+					ShortHash: "eeeeeee",
+					Subject:   "Update field five",
+				},
+			))
+		mockRepo.EXPECT().
+			ListCommitsDetails(gomock.Any(),
+				git.CommitRangeFrom(git.Hash("remote")).Limit(1)).
+			Return(commitDetailsIter(git.CommitDetail{
+				ShortHash: "fffffff",
+				Subject:   "Add feature",
+			}))
+
+		handler := &Handler{
+			Log:        silogtest.New(t),
+			View:       ui.NewFileView(t.Output()),
+			Repository: mockRepo,
+			Worktree:   NewMockGitWorktree(ctrl),
+			Store:      NewMockStore(ctrl),
+			Service:    NewMockService(ctrl),
+			Delete:     NewMockDeleteHandler(ctrl),
+			Restack:    NewMockRestackHandler(ctrl),
+			Autostash:  NewMockAutostashHandler(ctrl),
+			Remote:     "",
+		}
+
+		assert.Equal(t, ""+
+			"#1 was merged but local SHA (local) does not match remote SHA (remote)\n"+
+			"feature has 7 unpushed commit(s):\n"+
+			"  aaaaaaa Update field one\n"+
+			"  bbbbbbb Update field two\n"+
+			"  ccccccc Update field three\n"+
+			"  ddddddd Update field four\n"+
+			"  eeeeeee Update field five\n"+
+			"  ... and 2 more\n"+
+			"#1 was merged at:\n"+
+			"  fffffff Add feature",
+			handler.mergedChangeHeadMismatchDescription(
+				t.Context(),
+				"feature",
+				fakeChangeID("#1"),
+				"local",
+				"remote"))
+	})
+
+	t.Run("SkipsEmptyUnpushedCommits", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		mockRepo := NewMockGitRepository(ctrl)
+		mockRepo.EXPECT().
+			CountCommits(gomock.Any(),
+				git.CommitRangeFrom(git.Hash("local")).ExcludeFrom("remote")).
+			Return(0, nil)
+		mockRepo.EXPECT().
+			ListCommitsDetails(gomock.Any(),
+				git.CommitRangeFrom(git.Hash("remote")).Limit(1)).
+			Return(commitDetailsIter(git.CommitDetail{
+				ShortHash: "fffffff",
+				Subject:   "Add feature",
+			}))
+
+		handler := &Handler{
+			Log:        silogtest.New(t),
+			View:       ui.NewFileView(t.Output()),
+			Repository: mockRepo,
+			Worktree:   NewMockGitWorktree(ctrl),
+			Store:      NewMockStore(ctrl),
+			Service:    NewMockService(ctrl),
+			Delete:     NewMockDeleteHandler(ctrl),
+			Restack:    NewMockRestackHandler(ctrl),
+			Autostash:  NewMockAutostashHandler(ctrl),
+			Remote:     "",
+		}
+
+		assert.Equal(t, ""+
+			"#1 was merged but local SHA (local) does not match remote SHA (remote)\n"+
+			"#1 was merged at:\n"+
+			"  fffffff Add feature",
+			handler.mergedChangeHeadMismatchDescription(
+				t.Context(),
+				"feature",
+				fakeChangeID("#1"),
+				"local",
+				"remote"))
+	})
+
+	t.Run("FallsBackWhenUnpushedDetailsUnavailable", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		mockRepo := NewMockGitRepository(ctrl)
+		localOnly := git.CommitRangeFrom("local").ExcludeFrom("remote")
+		mockRepo.EXPECT().
+			CountCommits(gomock.Any(), localOnly).
+			Return(7, nil)
+		mockRepo.EXPECT().
+			ListCommitsDetails(gomock.Any(), gomock.Any()).
+			Return(func(yield func(git.CommitDetail, error) bool) {
+				yield(git.CommitDetail{}, errors.New("rev-list"))
+			})
+		mockRepo.EXPECT().
+			ListCommitsDetails(gomock.Any(),
+				git.CommitRangeFrom(git.Hash("remote")).Limit(1)).
+			Return(commitDetailsIter(git.CommitDetail{
+				ShortHash: "fffffff",
+				Subject:   "Add feature",
+			}))
+
+		handler := &Handler{
+			Log:        silogtest.New(t),
+			View:       ui.NewFileView(t.Output()),
+			Repository: mockRepo,
+			Worktree:   NewMockGitWorktree(ctrl),
+			Store:      NewMockStore(ctrl),
+			Service:    NewMockService(ctrl),
+			Delete:     NewMockDeleteHandler(ctrl),
+			Restack:    NewMockRestackHandler(ctrl),
+			Autostash:  NewMockAutostashHandler(ctrl),
+			Remote:     "",
+		}
+
+		assert.Equal(t, ""+
+			"#1 was merged but local SHA (local) does not match remote SHA (remote)\n"+
+			"feature has 7 unpushed commit(s).\n"+
+			"#1 was merged at:\n"+
+			"  fffffff Add feature",
+			handler.mergedChangeHeadMismatchDescription(
+				t.Context(),
+				"feature",
+				fakeChangeID("#1"),
+				"local",
+				"remote"))
+	})
 }
 
 func TestHandler_SyncTrunk_autostashLazy(t *testing.T) {
@@ -717,6 +880,16 @@ func branchIter(branches ...git.LocalBranch) iter.Seq2[git.LocalBranch, error] {
 	return func(yield func(git.LocalBranch, error) bool) {
 		for _, branch := range branches {
 			if !yield(branch, nil) {
+				return
+			}
+		}
+	}
+}
+
+func commitDetailsIter(commits ...git.CommitDetail) iter.Seq2[git.CommitDetail, error] {
+	return func(yield func(git.CommitDetail, error) bool) {
+		for _, commit := range commits {
+			if !yield(commit, nil) {
 				return
 			}
 		}

--- a/internal/handler/sync/mocks_test.go
+++ b/internal/handler/sync/mocks_test.go
@@ -200,6 +200,44 @@ func (c *MockGitRepositoryIsAncestorCall) DoAndReturn(f func(context.Context, gi
 	return c
 }
 
+// ListCommitsDetails mocks base method.
+func (m *MockGitRepository) ListCommitsDetails(ctx context.Context, commitRange git.CommitRange) iter.Seq2[git.CommitDetail, error] {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListCommitsDetails", ctx, commitRange)
+	ret0, _ := ret[0].(iter.Seq2[git.CommitDetail, error])
+	return ret0
+}
+
+// ListCommitsDetails indicates an expected call of ListCommitsDetails.
+func (mr *MockGitRepositoryMockRecorder) ListCommitsDetails(ctx, commitRange any) *MockGitRepositoryListCommitsDetailsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCommitsDetails", reflect.TypeOf((*MockGitRepository)(nil).ListCommitsDetails), ctx, commitRange)
+	return &MockGitRepositoryListCommitsDetailsCall{Call: call}
+}
+
+// MockGitRepositoryListCommitsDetailsCall wrap *gomock.Call
+type MockGitRepositoryListCommitsDetailsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockGitRepositoryListCommitsDetailsCall) Return(arg0 iter.Seq2[git.CommitDetail, error]) *MockGitRepositoryListCommitsDetailsCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockGitRepositoryListCommitsDetailsCall) Do(f func(context.Context, git.CommitRange) iter.Seq2[git.CommitDetail, error]) *MockGitRepositoryListCommitsDetailsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockGitRepositoryListCommitsDetailsCall) DoAndReturn(f func(context.Context, git.CommitRange) iter.Seq2[git.CommitDetail, error]) *MockGitRepositoryListCommitsDetailsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // LocalBranches mocks base method.
 func (m *MockGitRepository) LocalBranches(ctx context.Context, opts *git.LocalBranchesOptions) iter.Seq2[git.LocalBranch, error] {
 	m.ctrl.T.Helper()

--- a/testdata/script/repo_sync_external_pr_head_mismatch.txt
+++ b/testdata/script/repo_sync_external_pr_head_mismatch.txt
@@ -53,6 +53,10 @@ New contents of feature
 ===
 > Delete feature?: [y/N]
 > #1 was merged but local SHA (4513f9f) does not match remote SHA (a1b54a6)
+> feature has 1 unpushed commit(s):
+>   4513f9f Modify feature
+> #1 was merged at:
+>   a1b54a6 Add feature
 true
 -- golden/merged-log.txt --
 *   f512e87 (HEAD -> main, origin/main) Merge change #1


### PR DESCRIPTION
repo sync asks before deleting a merged branch
when the local and forge-reported heads differ.
Just reporting the commit hashes wasn't very helpful.

Include the local unpushed commit count, up to five local commits,
and the merged head, so users can decide without copying hashes.

Refs #1186

<img width="900" height="500" alt="git-spice-repo-sync-merged-head-prompt" src="https://github.com/user-attachments/assets/6aef652d-8e7b-4f75-bc23-b52578d7f136" />
