### PR TITLE
test(merge): Stabilize stack fail-fast test

### DIFF
--- a/internal/handler/merge/handler_test.go
+++ b/internal/handler/merge/handler_test.go
@@ -2082,9 +2082,14 @@ func TestMergeStack_passesFailFastToScheduler(t *testing.T) {
 	mockService.EXPECT().
 		VerifyRestacked(gomock.Any(), "feat2").
 		Return(nil)
+	// feat3 is an already-ready sibling when feat2 fails.
+	// Fail-fast may stop scheduling before feat3 enters preparation,
+	// or feat3 may already be in preparation by the time feat2 reports
+	// blocked.
 	mockService.EXPECT().
 		VerifyRestacked(gomock.Any(), "feat3").
-		Return(nil)
+		Return(nil).
+		AnyTimes()
 
 	mockGit := NewMockGitRepository(ctrl)
 	mockGit.EXPECT().

--- a/internal/handler/merge/progress_test.go
+++ b/internal/handler/merge/progress_test.go
@@ -3,7 +3,7 @@ package merge
 import (
 	"io"
 	"testing"
-	"time"
+	"testing/synctest"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
@@ -14,35 +14,39 @@ import (
 )
 
 func TestWidgetMergeProgress_FinishAfterRunnerExit(t *testing.T) {
-	view := new(earlyExitModelView)
-	progress := newWidgetMergeProgress(view, ui.DefaultThemeLight())
-	progress.Start(t.Context(), []*mergeItem{{
-		branch: "feat1",
-	}})
+	synctest.Test(t, func(t *testing.T) {
+		view := new(earlyExitModelView)
+		progress := newWidgetMergeProgress(view, ui.DefaultThemeLight())
+		progress.Start(t.Context(), []*mergeItem{{
+			branch: "feat1",
+		}})
 
-	select {
-	case <-progress.stopped:
-	case <-time.After(time.Second):
-		t.Fatal("progress model did not exit")
-	}
+		synctest.Wait()
+		select {
+		case <-progress.stopped:
+		default:
+			t.Fatal("progress model did not exit")
+		}
 
-	done := make(chan error, 1)
-	go func() {
-		progress.Event(mergeProgressEvent{
-			Kind: mergeProgressMergeabilityFailed,
-			Item: &mergeItem{
-				branch: "feat1",
-			},
-		})
-		done <- progress.Finish()
-	}()
+		done := make(chan error, 1)
+		go func() {
+			progress.Event(mergeProgressEvent{
+				Kind: mergeProgressMergeabilityFailed,
+				Item: &mergeItem{
+					branch: "feat1",
+				},
+			})
+			done <- progress.Finish()
+		}()
 
-	select {
-	case err := <-done:
-		require.NoError(t, err)
-	case <-time.After(time.Second):
-		t.Fatal("Finish blocked after progress model exited")
-	}
+		synctest.Wait()
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		default:
+			t.Fatal("Finish blocked after progress model exited")
+		}
+	})
 }
 
 func TestMergeProgressItems_ordersByDependencyLayer(t *testing.T) {

--- a/internal/handler/merge/scheduler_test.go
+++ b/internal/handler/merge/scheduler_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	stdsync "sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -83,79 +84,132 @@ func TestMergeScheduler_parentMergeUnlocksIndependentChildren(t *testing.T) {
 }
 
 func TestMergeScheduler_siblingMergeRequestsRunWhileSyncBlocked(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	synctest.Test(t, func(t *testing.T) {
+		ctrl := gomock.NewController(t)
 
-	mockForge := forgetest.NewMockRepository(ctrl)
-	mockStore := NewMockStore(ctrl)
-	mockStore.EXPECT().Trunk().Return("main")
+		mockForge := forgetest.NewMockRepository(ctrl)
+		mockStore := NewMockStore(ctrl)
+		mockStore.EXPECT().Trunk().Return("main")
 
-	pr1 := fakeChangeID("pr-1")
-	pr2 := fakeChangeID("pr-2")
-	pr3 := fakeChangeID("pr-3")
-	mockForge.EXPECT().
-		ChangeMergeability(gomock.Any(), pr1).
-		Return(forge.ChangeMergeability{State: forge.ChangeMergeabilityReady, Reason: forge.ChangeMergeabilityReasonUnknown}, nil)
-	mockForge.EXPECT().
-		MergeChange(gomock.Any(), pr1, gomock.Any()).
-		Return(nil)
-	mockForge.EXPECT().
-		ChangeStatuses(gomock.Any(), []forge.ChangeID{pr1}).
-		Return([]forge.ChangeStatus{{State: forge.ChangeMerged}}, nil)
+		pr1 := fakeChangeID("pr-1")
+		pr2 := fakeChangeID("pr-2")
+		pr3 := fakeChangeID("pr-3")
+		mockForge.EXPECT().
+			ChangeMergeability(gomock.Any(), pr1).
+			Return(forge.ChangeMergeability{State: forge.ChangeMergeabilityReady, Reason: forge.ChangeMergeabilityReasonUnknown}, nil)
+		mockForge.EXPECT().
+			MergeChange(gomock.Any(), pr1, gomock.Any()).
+			Return(nil)
+		mockForge.EXPECT().
+			ChangeStatuses(gomock.Any(), []forge.ChangeID{pr1}).
+			Return([]forge.ChangeStatus{{State: forge.ChangeMerged}}, nil)
 
-	mockService := NewMockService(ctrl)
-	mockService.EXPECT().
-		VerifyRestacked(gomock.Any(), "feat2").
-		Return(nil)
-	mockService.EXPECT().
-		VerifyRestacked(gomock.Any(), "feat3").
-		Return(nil)
+		mockService := NewMockService(ctrl)
+		mockService.EXPECT().
+			VerifyRestacked(gomock.Any(), "feat2").
+			Return(nil)
+		mockService.EXPECT().
+			VerifyRestacked(gomock.Any(), "feat3").
+			Return(nil)
 
-	mockGit := NewMockGitRepository(ctrl)
-	mockGit.EXPECT().
-		PeelToCommit(gomock.Any(), "feat2").
-		Return(git.Hash("head2"), nil)
-	mockGit.EXPECT().
-		PeelToCommit(gomock.Any(), "feat3").
-		Return(git.Hash("head3"), nil)
-	mockForge.EXPECT().
-		ChangeStatuses(gomock.Any(), []forge.ChangeID{pr2}).
-		Return([]forge.ChangeStatus{{State: forge.ChangeOpen, HeadHash: git.Hash("head2")}}, nil)
-	mockForge.EXPECT().
-		ChangeStatuses(gomock.Any(), []forge.ChangeID{pr3}).
-		Return([]forge.ChangeStatus{{State: forge.ChangeOpen, HeadHash: git.Hash("head3")}}, nil)
+		mockGit := NewMockGitRepository(ctrl)
+		mockGit.EXPECT().
+			PeelToCommit(gomock.Any(), "feat2").
+			Return(git.Hash("head2"), nil)
+		mockGit.EXPECT().
+			PeelToCommit(gomock.Any(), "feat3").
+			Return(git.Hash("head3"), nil)
+		mockForge.EXPECT().
+			ChangeStatuses(gomock.Any(), []forge.ChangeID{pr2}).
+			Return([]forge.ChangeStatus{{State: forge.ChangeOpen, HeadHash: git.Hash("head2")}}, nil)
+		mockForge.EXPECT().
+			ChangeStatuses(gomock.Any(), []forge.ChangeID{pr3}).
+			Return([]forge.ChangeStatus{{State: forge.ChangeOpen, HeadHash: git.Hash("head3")}}, nil)
 
-	siblingMerge := make(chan struct{}, 2)
-	expectMergeWithSignal(mockForge, pr2, siblingMerge)
-	expectMergeWithSignal(mockForge, pr3, siblingMerge)
+		feat3WaitingForReadiness := make(chan struct{})
+		syncBlocked := make(chan struct{})
+		feat3MergeRequested := make(chan struct{})
 
-	// The second SyncTrunk call belongs to one of the sibling branches.
-	// Blocking that call proves the other sibling can still request its merge
-	// without waiting for local trunk synchronization to finish.
-	syncHandler := &blockingSecondSyncHandler{
-		siblingMerge:    siblingMerge,
-		siblingBranches: 2,
-	}
-	h := newTestHandler(t, ctrl, testHandlerOpts{
-		forgeRepo: mockForge,
-		store:     mockStore,
-		service:   mockService,
-		gitRepo:   mockGit,
-		sync:      syncHandler,
+		mockForge.EXPECT().
+			ChangeMergeability(gomock.Any(), pr2).
+			Return(forge.ChangeMergeability{State: forge.ChangeMergeabilityReady, Reason: forge.ChangeMergeabilityReasonUnknown}, nil)
+		mockForge.EXPECT().
+			MergeChange(gomock.Any(), pr2, gomock.Any()).
+			Return(nil)
+		mockForge.EXPECT().
+			ChangeStatuses(gomock.Any(), []forge.ChangeID{pr2}).
+			DoAndReturn(func(
+				ctx context.Context,
+				_ []forge.ChangeID,
+			) ([]forge.ChangeStatus, error) {
+				// Keep pr2 from completing until pr3 has entered Run.
+				// Otherwise the sync barrier may correctly block pr3 preparation,
+				// and this test would depend on scheduler timing.
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-feat3WaitingForReadiness:
+					return []forge.ChangeStatus{{State: forge.ChangeMerged}}, nil
+				}
+			})
+
+		mockForge.EXPECT().
+			ChangeMergeability(gomock.Any(), pr3).
+			DoAndReturn(func(
+				ctx context.Context,
+				_ forge.ChangeID,
+			) (forge.ChangeMergeability, error) {
+				close(feat3WaitingForReadiness)
+				select {
+				case <-ctx.Done():
+					return forge.ChangeMergeability{}, ctx.Err()
+				case <-syncBlocked:
+					return forge.ChangeMergeability{State: forge.ChangeMergeabilityReady, Reason: forge.ChangeMergeabilityReasonUnknown}, nil
+				}
+			})
+		mockForge.EXPECT().
+			MergeChange(gomock.Any(), pr3, gomock.Any()).
+			DoAndReturn(func(
+				context.Context,
+				forge.ChangeID,
+				forge.MergeChangeOptions,
+			) error {
+				close(feat3MergeRequested)
+				return nil
+			})
+		mockForge.EXPECT().
+			ChangeStatuses(gomock.Any(), []forge.ChangeID{pr3}).
+			Return([]forge.ChangeStatus{{State: forge.ChangeMerged}}, nil)
+
+		// The second SyncTrunk call belongs to one of the sibling branches.
+		// Blocking that call proves the other sibling can still request its merge
+		// without waiting for local trunk synchronization to finish.
+		syncHandler := &blockingSecondSyncHandler{
+			syncBlocked:           syncBlocked,
+			waitForSiblingRequest: feat3MergeRequested,
+		}
+		h := newTestHandler(t, ctrl, testHandlerOpts{
+			forgeRepo: mockForge,
+			store:     mockStore,
+			service:   mockService,
+			gitRepo:   mockGit,
+			sync:      syncHandler,
+		})
+
+		// The timeout is a regression guard for the old gate placement:
+		// if SyncTrunk still guards the merge request path,
+		// the second sibling merge cannot happen while the first sibling sync
+		// is blocked.
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		defer cancel()
+		err := h.executePlan(ctx, testMergePlanWithBases(
+			testPlanEntry("feat1", "main", pr1),
+			testPlanEntry("feat2", "feat1", pr2),
+			testPlanEntry("feat3", "feat1", pr3),
+		), mergeExecutionOptions{})
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, syncHandler.calls, 2)
 	})
-
-	// The timeout is a regression guard for the old gate placement:
-	// if SyncTrunk still guards the merge request path,
-	// the second sibling merge cannot happen while the first sibling sync
-	// is blocked.
-	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
-	defer cancel()
-	err := h.executePlan(ctx, testMergePlanWithBases(
-		testPlanEntry("feat1", "main", pr1),
-		testPlanEntry("feat2", "feat1", pr2),
-		testPlanEntry("feat3", "feat1", pr3),
-	), mergeExecutionOptions{})
-	require.NoError(t, err)
-	assert.GreaterOrEqual(t, syncHandler.calls, 2)
 }
 
 func TestMergeScheduler_syncBarrierRunsBeforePreparingAboves(t *testing.T) {
@@ -613,11 +667,12 @@ type blockingSecondSyncHandler struct {
 	// after the parent branch has already synced.
 	calls int
 
-	// siblingMerge receives one signal per sibling merge request.
-	siblingMerge <-chan struct{}
+	// syncBlocked is closed when the sibling sync barrier starts blocking.
+	syncBlocked chan<- struct{}
 
-	// siblingBranches is the number of sibling merge requests to wait for.
-	siblingBranches int
+	// waitForSiblingRequest lets the blocked sync wait until another
+	// already-running sibling requests its merge.
+	waitForSiblingRequest <-chan struct{}
 }
 
 func (h *blockingSecondSyncHandler) SyncTrunk(
@@ -629,14 +684,13 @@ func (h *blockingSecondSyncHandler) SyncTrunk(
 		return nil
 	}
 
-	for range h.siblingBranches {
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("waiting for sibling merge requests: %w", ctx.Err())
-		case <-h.siblingMerge:
-		}
+	close(h.syncBlocked)
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("waiting for sibling merge request: %w", ctx.Err())
+	case <-h.waitForSiblingRequest:
+		return nil
 	}
-	return nil
 }
 
 type operationRecorder struct {
@@ -731,31 +785,6 @@ func expectMergeWithRecord(
 			forge.MergeChangeOptions,
 		) error {
 			operations.append("merge " + id.String())
-			return nil
-		})
-
-	mockForge.EXPECT().
-		ChangeStatuses(gomock.Any(), []forge.ChangeID{id}).
-		Return([]forge.ChangeStatus{{State: forge.ChangeMerged}}, nil)
-}
-
-func expectMergeWithSignal(
-	mockForge *forgetest.MockRepository,
-	id fakeChangeID,
-	merged chan<- struct{},
-) {
-	mockForge.EXPECT().
-		ChangeMergeability(gomock.Any(), id).
-		Return(forge.ChangeMergeability{State: forge.ChangeMergeabilityReady, Reason: forge.ChangeMergeabilityReasonUnknown}, nil)
-
-	mockForge.EXPECT().
-		MergeChange(gomock.Any(), id, gomock.Any()).
-		DoAndReturn(func(
-			context.Context,
-			forge.ChangeID,
-			forge.MergeChangeOptions,
-		) error {
-			merged <- struct{}{}
 			return nil
 		})
 


### PR DESCRIPTION
The stack merge fail-fast test was asserting that every ready sibling enters preparation after the first sibling reports a blocked merge.

The scheduler is allowed to stop scheduling as soon as fail-fast observes that blocked result.
It may also have already handed another sibling to preparation by then.
Treat the sibling preparation call as optional so the test covers the fail-fast contract instead of one scheduler interleaving.

[skip changelog]: Test-only change.