### PR TITLE
merge: Rename merge config keys

### DIFF
--- a/.changes/unreleased/Added-20260630-163640.yaml
+++ b/.changes/unreleased/Added-20260630-163640.yaml
@@ -1,5 +1,5 @@
 kind: Added
 body: >-
-  merge: Add 'spice.merge.readyCommand' configuration option
+  merge: Add 'spice.merge.ready.command' configuration option
   to customize what is considered ready-to-merge for a CR.
 time: 2026-06-30T16:36:40.452559-07:00

--- a/.changes/unreleased/Changed-20260704-111037.yaml
+++ b/.changes/unreleased/Changed-20260704-111037.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'merge: Rename ''spice.merge.readyTimeout'' to ''spice.merge.ready.timeout''.'
+time: 2026-07-04T11:10:37.463618-07:00

--- a/.changes/unreleased/Changed-20260704-111041.yaml
+++ b/.changes/unreleased/Changed-20260704-111041.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'merge: Rename ''spice.merge.mergeTimeout'' to ''spice.merge.timeout''.'
+time: 2026-07-04T11:10:41.621809-07:00

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -324,7 +324,7 @@ When those are ready to merge, they are merged in turn, and the process repeats.
 
 A branch is considered ready to merge when the forge reports it as mergeable,
 based on the forge and the repository configuration.
-Override this with the 'spice.merge.readyCommand' configuration option.
+Override this with the 'spice.merge.ready.command' configuration option.
 
 Branches are merged using the forge's merge API.
 Override this with the 'spice.merge.command' configuration option.
@@ -339,12 +339,12 @@ after the first branch failure.
 **Flags**
 
 * `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
-* `--ready-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.readyTimeout" }](/cli/config.md#spicemergereadytimeout)): Max time to wait for merge readiness before each merge. 0 means check once.
-* `--merge-timeout=2m` ([:material-wrench:{ .middle title="spice.merge.mergeTimeout" }](/cli/config.md#spicemergemergetimeout)): Max time to wait for merge completion after requesting merge.
+* `--ready-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.ready.timeout" }](/cli/config.md#spicemergereadytimeout)): Max time to wait for merge readiness before each merge. 0 means check once.
+* `--merge-timeout=2m` ([:material-wrench:{ .middle title="spice.merge.timeout" }](/cli/config.md#spicemergetimeout)): Max time to wait for merge completion after requesting merge.
 * `--fail-fast`: Stop scheduling remaining merge queue work after the first branch failure.
 * `--branch=NAME,...`: Branches whose stacks to merge. May be repeated.
 
-**Configuration**: [spice.merge.command](/cli/config.md#spicemergecommand), [spice.merge.mergeTimeout](/cli/config.md#spicemergemergetimeout), [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyCommand](/cli/config.md#spicemergereadycommand), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
+**Configuration**: [spice.merge.command](/cli/config.md#spicemergecommand), [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.ready.command](/cli/config.md#spicemergereadycommand), [spice.merge.ready.timeout](/cli/config.md#spicemergereadytimeout), [spice.merge.timeout](/cli/config.md#spicemergetimeout)
 
 ### git-spice stack restack {#gs-stack-restack}
 
@@ -664,7 +664,7 @@ When those are ready to merge, they are merged in turn, and the process repeats.
 
 A branch is considered ready to merge when the forge reports it as mergeable,
 based on the forge and the repository configuration.
-Override this with the 'spice.merge.readyCommand' configuration option.
+Override this with the 'spice.merge.ready.command' configuration option.
 
 Branches are merged using the forge's merge API.
 Override this with the 'spice.merge.command' configuration option.
@@ -679,12 +679,12 @@ after the first branch failure.
 **Flags**
 
 * `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
-* `--ready-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.readyTimeout" }](/cli/config.md#spicemergereadytimeout)): Max time to wait for merge readiness before each merge. 0 means check once.
-* `--merge-timeout=2m` ([:material-wrench:{ .middle title="spice.merge.mergeTimeout" }](/cli/config.md#spicemergemergetimeout)): Max time to wait for merge completion after requesting merge.
+* `--ready-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.ready.timeout" }](/cli/config.md#spicemergereadytimeout)): Max time to wait for merge readiness before each merge. 0 means check once.
+* `--merge-timeout=2m` ([:material-wrench:{ .middle title="spice.merge.timeout" }](/cli/config.md#spicemergetimeout)): Max time to wait for merge completion after requesting merge.
 * `--fail-fast`: Stop scheduling remaining merge queue work after the first branch failure.
 * `--branch=NAME,...`: Branches to start merging from. May be repeated.
 
-**Configuration**: [spice.merge.command](/cli/config.md#spicemergecommand), [spice.merge.mergeTimeout](/cli/config.md#spicemergemergetimeout), [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyCommand](/cli/config.md#spicemergereadycommand), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
+**Configuration**: [spice.merge.command](/cli/config.md#spicemergecommand), [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.ready.command](/cli/config.md#spicemergereadycommand), [spice.merge.ready.timeout](/cli/config.md#spicemergereadytimeout), [spice.merge.timeout](/cli/config.md#spicemergetimeout)
 
 ### git-spice downstack edit {#gs-downstack-edit}
 
@@ -1180,7 +1180,7 @@ When those are ready to merge, they are merged in turn, and the process repeats.
 
 A branch is considered ready to merge when the forge reports it as mergeable,
 based on the forge and the repository configuration.
-Override this with the 'spice.merge.readyCommand' configuration option.
+Override this with the 'spice.merge.ready.command' configuration option.
 
 Branches are merged using the forge's merge API.
 Override this with the 'spice.merge.command' configuration option.
@@ -1195,12 +1195,12 @@ after the first branch failure.
 **Flags**
 
 * `--method=METHOD` ([:material-wrench:{ .middle title="spice.merge.method" }](/cli/config.md#spicemergemethod)): Preferred merge method. One of 'merge', 'squash', and 'rebase'.
-* `--ready-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.readyTimeout" }](/cli/config.md#spicemergereadytimeout)): Max time to wait for merge readiness before each merge. 0 means check once.
-* `--merge-timeout=2m` ([:material-wrench:{ .middle title="spice.merge.mergeTimeout" }](/cli/config.md#spicemergemergetimeout)): Max time to wait for merge completion after requesting merge.
+* `--ready-timeout=30m` ([:material-wrench:{ .middle title="spice.merge.ready.timeout" }](/cli/config.md#spicemergereadytimeout)): Max time to wait for merge readiness before each merge. 0 means check once.
+* `--merge-timeout=2m` ([:material-wrench:{ .middle title="spice.merge.timeout" }](/cli/config.md#spicemergetimeout)): Max time to wait for merge completion after requesting merge.
 * `--fail-fast`: Stop scheduling remaining merge queue work after the first branch failure.
 * `--branch=NAME,...`: Branches to merge. May be repeated.
 
-**Configuration**: [spice.merge.command](/cli/config.md#spicemergecommand), [spice.merge.mergeTimeout](/cli/config.md#spicemergemergetimeout), [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.readyCommand](/cli/config.md#spicemergereadycommand), [spice.merge.readyTimeout](/cli/config.md#spicemergereadytimeout)
+**Configuration**: [spice.merge.command](/cli/config.md#spicemergecommand), [spice.merge.method](/cli/config.md#spicemergemethod), [spice.merge.ready.command](/cli/config.md#spicemergereadycommand), [spice.merge.ready.timeout](/cli/config.md#spicemergereadytimeout), [spice.merge.timeout](/cli/config.md#spicemergetimeout)
 
 ### git-spice branch submit {#gs-branch-submit}
 

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -471,7 +471,7 @@ whether the branch is in sync with its pushed counterpart.
   show the number of outgoing and incoming commits in the form `⇡1⇣2`,
   where `⇡` indicates outgoing commits and `⇣` indicates incoming commits
 
-### spice.merge.readyTimeout
+### spice.merge.ready.timeout
 
 <!-- gs:version v0.30.0 -->
 
@@ -479,7 +479,7 @@ Maximum time that the merge commands wait
 for a CR to be ready to merge after enqueued.
 
 Whether a CR is ready is determined by the forge and repository configuration,
-or by $$spice.merge.readyCommand$$ if configured.
+or by $$spice.merge.ready.command$$ if configured.
 
 The value must be a duration string such as
 `30m`, `1h`, `90s`, etc.
@@ -489,7 +489,7 @@ that aren't already ready to merge.
 
 Defaults to `30m`.
 
-### spice.merge.readyCommand
+### spice.merge.ready.command
 
 <!-- gs:version unreleased -->
 
@@ -516,7 +516,7 @@ for the variables passed to the command.
 
 git-spice may run the command concurrently for different CRs.
 
-### spice.merge.mergeTimeout
+### spice.merge.timeout
 
 <!-- gs:version v0.30.0 -->
 
@@ -557,7 +557,7 @@ If unset, git-spice requests the merge through the forge API.
 git-spice waits for the CR to be reported as ready-to-merge
 before attempting a merge.
 Ready-to-merge is defined by the forge and repository settings,
-or by $$spice.merge.readyCommand$$ if configured.
+or by $$spice.merge.ready.command$$ if configured.
 
 Exit status `0` means the command requested the merge.
 Any non-zero exit status means the merge request failed for that CR.

--- a/doc/src/guide/merge.md
+++ b/doc/src/guide/merge.md
@@ -114,7 +114,7 @@ This can include CI checks, required approvals, or other requirements.
 git-spice will poll the forge until the CR is reported as mergeable,
 waiting up to 30 minutes for the CR to become ready.
 The wait time can be changed
-with the $$spice.merge.readyTimeout$$ configuration option.
+with the $$spice.merge.ready.timeout$$ configuration option.
 
 If a CR is not ready to merge after the configured timeout,
 that CR is assumed to be blocked and it, and its upstack branches,
@@ -123,7 +123,7 @@ will not be merged.
 ### Custom merge readiness
 
 If a repository's configured definition of "ready to merge" is not sufficient,
-git-spice offers a $$spice.merge.readyCommand$$ configuration option
+git-spice offers a $$spice.merge.ready.command$$ configuration option
 to customize it.
 
 If set, git-spice will run the configured command to poll for a CR's readiness.
@@ -144,7 +144,7 @@ with at least one approval and no blocking reviews.
 
 ```bash title="Configuration"
 git config \
-  spice.merge.readyCommand \
+  spice.merge.ready.command \
   "$HOME/bin/merge-ready.sh"
 ```
 
@@ -200,7 +200,7 @@ exit 1
 </details>
 
 See [Command environment](#command-environment)
-for the variables passed to $$spice.merge.readyCommand$$.
+for the variables passed to $$spice.merge.ready.command$$.
 
 ## Merging multiple stacks
 
@@ -338,7 +338,7 @@ git-spice waits for the CR to be ready to merge
 before running the configured command,
 and waits for the CR to finish merging before moving upstack.
 If the merge workflow is slow,
-the $$spice.merge.mergeTimeout$$ configuration option
+the $$spice.merge.timeout$$ configuration option
 can be used to increase the wait time.
 
 If the command exits with a non-zero exit code,
@@ -350,7 +350,7 @@ for the variables passed to $$spice.merge.command$$.
 
 ## Command environment
 
-$$spice.merge.readyCommand$$ and $$spice.merge.command$$
+$$spice.merge.ready.command$$ and $$spice.merge.command$$
 receive the following environment variables when executed:
 
 - `GIT_SPICE_FORGE_ID`

--- a/internal/handler/merge/handler.go
+++ b/internal/handler/merge/handler.go
@@ -82,16 +82,16 @@ type Options struct {
 
 	// ReadyCommand checks merge readiness through a user-defined command.
 	// Empty means use forge readiness.
-	ReadyCommand string `hidden:"" config:"merge.readyCommand" help:"Command to check merge readiness instead of using the forge."`
+	ReadyCommand string `hidden:"" config:"merge.ready.command" help:"Command to check merge readiness instead of using the forge."`
 
 	// ReadyTimeout is the maximum time to wait
 	// for the configured readiness provider.
 	// Zero means check once and fail if merge readiness is not reached.
-	ReadyTimeout time.Duration `name:"ready-timeout" config:"merge.readyTimeout" default:"30m" help:"Max time to wait for merge readiness before each merge. 0 means check once."`
+	ReadyTimeout time.Duration `name:"ready-timeout" config:"merge.ready.timeout" default:"30m" help:"Max time to wait for merge readiness before each merge. 0 means check once."`
 
 	// MergeTimeout is the maximum time to wait for the forge
 	// to report that a change is merged after requesting merge.
-	MergeTimeout time.Duration `name:"merge-timeout" config:"merge.mergeTimeout" default:"2m" help:"Max time to wait for merge completion after requesting merge."`
+	MergeTimeout time.Duration `name:"merge-timeout" config:"merge.timeout" default:"2m" help:"Max time to wait for merge completion after requesting merge."`
 
 	// FailFast stops scheduling remaining merge queue work
 	// after the first branch failure.

--- a/merge.go
+++ b/merge.go
@@ -8,7 +8,7 @@ When those are ready to merge, they are merged in turn, and the process repeats.
 
 A branch is considered ready to merge when the forge reports it as mergeable,
 based on the forge and the repository configuration.
-Override this with the 'spice.merge.readyCommand' configuration option.
+Override this with the 'spice.merge.ready.command' configuration option.
 
 Branches are merged using the forge's merge API.
 Override this with the 'spice.merge.command' configuration option.

--- a/testdata/help/branch_merge.txt
+++ b/testdata/help/branch_merge.txt
@@ -31,7 +31,7 @@ to merge, they are merged in turn, and the process repeats.
 
 A branch is considered ready to merge when the forge reports it as mergeable,
 based on the forge and the repository configuration. Override this with the
-'spice.merge.readyCommand' configuration option.
+'spice.merge.ready.command' configuration option.
 
 Branches are merged using the forge's merge API. Override this with the
 'spice.merge.command' configuration option.
@@ -45,9 +45,9 @@ Flags:
   --method=METHOD        Preferred merge method. One of 'merge', 'squash',
                          and 'rebase'. (🔧 spice.merge.method)
   --ready-timeout=30m    Max time to wait for merge readiness before each merge.
-                         0 means check once. (🔧 spice.merge.readyTimeout)
+                         0 means check once. (🔧 spice.merge.ready.timeout)
   --merge-timeout=2m     Max time to wait for merge completion after requesting
-                         merge. (🔧 spice.merge.mergeTimeout)
+                         merge. (🔧 spice.merge.timeout)
   --fail-fast            Stop scheduling remaining merge queue work after the
                          first branch failure.
   --branch=NAME,...      Branches to merge. May be repeated.
@@ -60,7 +60,7 @@ Global Flags:
       --[no-]prompt    Whether to prompt for missing information
 
 Configuration (🔧):
-  spice.merge.command         Command to request merge instead of using the
-                              forge merge API.
-  spice.merge.readyCommand    Command to check merge readiness instead of using
-                              the forge.
+  spice.merge.command          Command to request merge instead of using the
+                               forge merge API.
+  spice.merge.ready.command    Command to check merge readiness instead of using
+                               the forge.

--- a/testdata/help/downstack_merge.txt
+++ b/testdata/help/downstack_merge.txt
@@ -32,7 +32,7 @@ to merge, they are merged in turn, and the process repeats.
 
 A branch is considered ready to merge when the forge reports it as mergeable,
 based on the forge and the repository configuration. Override this with the
-'spice.merge.readyCommand' configuration option.
+'spice.merge.ready.command' configuration option.
 
 Branches are merged using the forge's merge API. Override this with the
 'spice.merge.command' configuration option.
@@ -46,9 +46,9 @@ Flags:
   --method=METHOD        Preferred merge method. One of 'merge', 'squash',
                          and 'rebase'. (🔧 spice.merge.method)
   --ready-timeout=30m    Max time to wait for merge readiness before each merge.
-                         0 means check once. (🔧 spice.merge.readyTimeout)
+                         0 means check once. (🔧 spice.merge.ready.timeout)
   --merge-timeout=2m     Max time to wait for merge completion after requesting
-                         merge. (🔧 spice.merge.mergeTimeout)
+                         merge. (🔧 spice.merge.timeout)
   --fail-fast            Stop scheduling remaining merge queue work after the
                          first branch failure.
   --branch=NAME,...      Branches to start merging from. May be repeated.
@@ -61,7 +61,7 @@ Global Flags:
       --[no-]prompt    Whether to prompt for missing information
 
 Configuration (🔧):
-  spice.merge.command         Command to request merge instead of using the
-                              forge merge API.
-  spice.merge.readyCommand    Command to check merge readiness instead of using
-                              the forge.
+  spice.merge.command          Command to request merge instead of using the
+                               forge merge API.
+  spice.merge.ready.command    Command to check merge readiness instead of using
+                               the forge.

--- a/testdata/help/stack_merge.txt
+++ b/testdata/help/stack_merge.txt
@@ -28,7 +28,7 @@ to merge, they are merged in turn, and the process repeats.
 
 A branch is considered ready to merge when the forge reports it as mergeable,
 based on the forge and the repository configuration. Override this with the
-'spice.merge.readyCommand' configuration option.
+'spice.merge.ready.command' configuration option.
 
 Branches are merged using the forge's merge API. Override this with the
 'spice.merge.command' configuration option.
@@ -42,9 +42,9 @@ Flags:
   --method=METHOD        Preferred merge method. One of 'merge', 'squash',
                          and 'rebase'. (🔧 spice.merge.method)
   --ready-timeout=30m    Max time to wait for merge readiness before each merge.
-                         0 means check once. (🔧 spice.merge.readyTimeout)
+                         0 means check once. (🔧 spice.merge.ready.timeout)
   --merge-timeout=2m     Max time to wait for merge completion after requesting
-                         merge. (🔧 spice.merge.mergeTimeout)
+                         merge. (🔧 spice.merge.timeout)
   --fail-fast            Stop scheduling remaining merge queue work after the
                          first branch failure.
   --branch=NAME,...      Branches whose stacks to merge. May be repeated.
@@ -57,7 +57,7 @@ Global Flags:
       --[no-]prompt    Whether to prompt for missing information
 
 Configuration (🔧):
-  spice.merge.command         Command to request merge instead of using the
-                              forge merge API.
-  spice.merge.readyCommand    Command to check merge readiness instead of using
-                              the forge.
+  spice.merge.command          Command to request merge instead of using the
+                               forge merge API.
+  spice.merge.ready.command    Command to check merge readiness instead of using
+                               the forge.

--- a/testdata/script/branch_merge_readiness_and_merge_commands.txt
+++ b/testdata/script/branch_merge_readiness_and_merge_commands.txt
@@ -29,7 +29,7 @@ stderr 'Created #1'
 # configure separate readiness and merge commands
 chmod 755 $WORK/ready-command.sh
 chmod 755 $WORK/merge-command.sh
-git config spice.merge.readyCommand $WORK/ready-command.sh
+git config spice.merge.ready.command $WORK/ready-command.sh
 git config spice.merge.command $WORK/merge-command.sh
 
 # merge the current branch through both configured commands

--- a/testdata/script/branch_merge_readiness_command_waits.txt
+++ b/testdata/script/branch_merge_readiness_command_waits.txt
@@ -1,4 +1,4 @@
-# 'branch merge' polls spice.merge.readyCommand until it reports ready.
+# 'branch merge' polls spice.merge.ready.command until it reports ready.
 
 as 'Test <test@example.com>'
 at '2026-06-30T12:00:00Z'
@@ -28,8 +28,8 @@ stderr 'Created #1'
 
 # configure a readiness command that waits once and then reports ready
 chmod 755 $WORK/ready-command.sh
-git config spice.merge.readyCommand $WORK/ready-command.sh
-git config spice.merge.readyTimeout 11s
+git config spice.merge.ready.command $WORK/ready-command.sh
+git config spice.merge.ready.timeout 11s
 
 # merge the current branch after the readiness command allows the merge
 env ROBOT_INPUT=$WORK/robot-merge.golden ROBOT_OUTPUT=$WORK/robot-merge.actual

--- a/testdata/script/stack_merge_readiness_command_blocked.txt
+++ b/testdata/script/stack_merge_readiness_command_blocked.txt
@@ -31,7 +31,7 @@ stderr 'Created #2'
 
 # configure a readiness command that permanently blocks the base branch
 chmod 755 $WORK/ready-command.sh
-git config spice.merge.readyCommand $WORK/ready-command.sh
+git config spice.merge.ready.command $WORK/ready-command.sh
 
 # stack merge should skip the dependent upstack branch
 env ROBOT_INPUT=$WORK/robot-merge.golden ROBOT_OUTPUT=$WORK/robot-merge.actual


### PR DESCRIPTION
Merge configuration now keeps the existing `spice.merge.method`
and `spice.merge.command` names,
but moves timeout and readiness configuration under clearer nested keys.

The renamed keys are:

- `spice.merge.readyCommand` to `spice.merge.ready.command`
- `spice.merge.readyTimeout` to `spice.merge.ready.timeout`
- `spice.merge.mergeTimeout` to `spice.merge.timeout`

This keeps the readiness-specific settings grouped together
while avoiding repeated `merge` wording inside `spice.merge.*`.
Generated help, user documentation, script tests,
and unreleased changelog entries now use the new names.