### PR TITLE
doc: rewrite AGENTS.md

### DIFF
--- a/.agents/docs/cli.md
+++ b/.agents/docs/cli.md
@@ -1,0 +1,85 @@
+# Command-Line Interfaces
+
+Use this guide when changing command behavior, flags, configuration, output,
+or generated CLI documentation.
+
+## Commands Are Adapters
+
+A command parses command-line syntax, builds a typed request,
+calls a handler or domain operation, and translates the result
+into the command output contract.
+
+Do not make command implementations a second business-logic layer.
+Policy, state transitions, and reusable workflows belong
+in handlers or domain packages.
+
+```go
+// Good: command syntax is converted into a handler request.
+func (cmd *moveCmd) Run(ctx context.Context, h MoveHandler) error {
+	return h.MoveBranch(ctx, &move.MoveRequest{
+		Branch:  cmd.Branch,
+		Onto:    cmd.Onto,
+		Options: &cmd.MoveOptions,
+	})
+}
+```
+
+```go
+// Bad: command code owns workflow policy.
+func (cmd *moveCmd) Run(ctx context.Context, repo *git.Repository) error {
+	if cmd.Restack {
+		// ...
+	}
+	return repo.MoveBranch(ctx, cmd.Branch, cmd.Onto)
+}
+```
+
+## Handler Boundary
+
+Most command workflows should cross into `internal/handler/...`.
+Handlers coordinate user-facing operations
+between command code and lower-level repository behavior.
+
+Commands commonly embed handler option types,
+then pass the populated options through a request.
+Read `internal/handler/AGENTS.md`
+before adding or changing that pattern.
+
+## Typed Requests
+
+Convert flags, arguments, and configuration into typed values
+before leaving the command boundary.
+Do not pass parser structs, raw flag maps,
+or arbitrary command-line argument slices into lower layers.
+
+```go
+return h.MoveBranch(ctx, &handler.MoveRequest{
+	Branch:  cmd.Branch,
+	Onto:    cmd.Onto,
+	Options: &cmd.MoveOptions,
+})
+```
+
+## Output Contracts
+
+Treat standard output and standard error as separate interfaces.
+Use standard output for the requested result,
+especially data intended for pipes, files,
+or machine consumption.
+
+Use standard error for diagnostics, progress, and logs.
+Structured output must not contain incidental log lines.
+
+Rendering belongs at the command or handler boundary.
+Domain operations should not need to know
+whether a result will be printed as text, JSON, or another representation.
+
+## Generated Files
+
+Run `mise run generate`
+after changing commands, flags, configuration, or command help.
+This updates generated CLI references
+and related generated artifacts.
+
+Document user-facing command changes in `doc/src`
+when the website should explain the behavior.

--- a/.agents/docs/comments.md
+++ b/.agents/docs/comments.md
@@ -1,0 +1,98 @@
+# Comments
+
+Use this guide when adding, removing, or revising code comments,
+symbol documentation, field comments, or package documentation.
+
+## Choose The Reader
+
+Documentation is for callers, importers, and package users.
+It explains what a symbol promises, how to use it, and which constraints matter
+at the boundary.
+
+Implementation comments are for maintainers
+who need to change the code.
+They explain why code is shaped this way,
+which invariant must hold, or what would break if the code were simplified.
+
+Do not make callers read implementation comments
+to learn a public contract.
+Do not make maintainers infer hidden implementation constraints
+from public documentation alone.
+
+## What To Document
+
+Document a named concept when the name and type do not fully explain:
+
+- what the concept represents
+- valid values or units
+- ownership or lifetime
+- side effects or ordering requirements
+- error meanings
+- external systems, protocols, file formats, or domain concepts
+
+This applies to packages, exported symbols, request structs, state objects,
+modes, interfaces, and fields.
+
+## Field Comments
+
+Comment struct fields when the field's meaning, source, valid values,
+or caller obligation is not obvious from the name and type.
+
+Use inline `// required` on required fields
+when direct struct initialization is expected
+or required-field checking should enforce initialization.
+
+```go
+type MoveRequest struct {
+	Branch string // required
+	Onto   string // required
+
+	// ContinueCommand resumes this operation
+	// after an interrupted rebase.
+	ContinueCommand []string // required
+}
+```
+
+## Implementation Comments
+
+Use comments to reduce context a maintainer must reconstruct.
+Good comments explain:
+
+- why a non-obvious decision was made
+- which invariant must be preserved
+- which external behavior or compatibility rule matters
+- what stage of a long operation the reader is entering
+- what hidden state the next operations depend on
+
+```go
+// Flush queued writes before detaching transport state.
+if conn.hasBufferedWrites() {
+	conn.flush()
+}
+conn.stopWritePump()
+```
+
+## What To Avoid
+
+Do not keep comments that only repeat the code.
+
+```go
+// Bad: repeats the operation.
+count++ // increment count
+```
+
+Do not record chat history, discarded proposals, or implementation archaeology
+unless that history is necessary to safely change the code.
+
+If a comment cannot state the relevant invariant, boundary,
+or reader obligation clearly,
+reconsider the code shape before adding more prose.
+
+## Formatting
+
+Use `//` comments.
+Do not use block comments.
+
+Use full sentences for standalone comments.
+Use sentence fragments for inline comments.
+Use semantic line breaks for multi-line comments.

--- a/.agents/docs/design.md
+++ b/.agents/docs/design.md
@@ -1,0 +1,251 @@
+# Design
+
+Use this guide when changing package boundaries, handler responsibilities,
+dependencies, constructors, or cross-package APIs.
+
+## Package Responsibility
+
+Organize Go packages by domain responsibility.
+Each package should own one cohesive part of git-spice
+and expose operations in that domain's vocabulary.
+
+Avoid packages that collect unrelated helpers, declaration kinds,
+or framework wiring without owning a domain.
+Purpose-scoped utility packages are permitted
+when the domain is otherwise taken or misleading,
+such as `sliceutil` when `slices` would conflict
+with the standard library package.
+
+Good package names describe the responsibility:
+
+```text
+internal/branch
+internal/forge/github
+internal/handler/submit
+```
+
+Weak package names hide the responsibility:
+
+```text
+internal/helper
+internal/service
+internal/type
+```
+
+## File Organization
+
+Organize files by granular domain responsibility.
+Keep a concept near the constructors,
+methods, private interfaces, and helpers that make the concept useful.
+
+Do not split files merely by declaration kind
+or by arbitrary size targets.
+Move code when the move improves context-locality for a future change.
+
+## Dependency Direction
+
+Abstractions flow in one direction:
+
+```text
+command syntax -> handler workflow -> domain operation -> infrastructure
+```
+
+Command packages parse command-line syntax
+and build typed requests.
+Handler packages coordinate command workflows.
+Domain packages own state transitions and invariants.
+Infrastructure packages wrap Git, forges, filesystems, processes,
+and other external systems.
+
+Lower layers must not depend on command parser types,
+generated command structs, process environment lookups,
+or caller-specific output formats.
+
+## Handler Packages
+
+Handler packages are command-workflow coordinators.
+They load command-level context, call lower-level services or Git APIs,
+compose other handlers when a workflow needs another workflow,
+emit user-facing log messages, and arrange rescue or continuation behavior.
+
+Read `internal/handler/AGENTS.md`
+before adding or changing handler code.
+In summary:
+
+- Handler fields hold dependencies.
+- Handler requests hold values for one invocation.
+- Handler `Options` types represent optional flags or configuration.
+- Handlers define narrow local interfaces
+  for the dependency behavior they call directly.
+- Lower-level packages still own their local invariants.
+
+## Dependency Wiring
+
+Use Kong bindings for application-scoped dependencies.
+An application-scoped dependency is any abstraction whose identity is fixed
+after CLI arguments are parsed:
+repositories, worktrees, stores, services, handlers, forge registries,
+loggers, and other process-lifetime collaborators.
+
+Kong initializes bindings lazily,
+so register application-scoped dependencies with Kong
+even when only some commands use them.
+
+Use command-local providers only when construction depends on parsed command
+arguments or command-specific setup.
+
+Kong belongs at the command and application wiring boundary.
+Do not pass Kong contexts, parser values,
+or provider mechanics into handlers, domain packages,
+or infrastructure packages.
+
+Handlers may define narrow local interfaces.
+Kong provider functions connect concrete implementations to those interfaces.
+
+## Process Boundaries
+
+Do not shell out casually.
+When git-spice needs another process,
+wrap that process behind a concrete library-like API.
+Callers should invoke domain-shaped methods,
+not construct arbitrary command-line argument slices.
+
+```go
+// Good: callers express the operation.
+branch, err := repo.LookupBranch(ctx, name)
+if err != nil {
+	return fmt.Errorf("lookup branch %q: %w", name, err)
+}
+```
+
+```go
+// Bad: callers leak process construction across the boundary.
+out, err := runner.Run(ctx, "git", "branch", "--list", name)
+```
+
+If a lower layer accepts raw arguments,
+the caller must understand process syntax, escaping, output parsing,
+and error interpretation.
+That is a boundary failure.
+
+## Configuration And Global State
+
+Do not introduce mutable global state.
+Read environment variables, configuration files,
+and other external process state at an entry point
+or explicit infrastructure boundary.
+
+Pass typed values or dependencies to the component
+that owns their lifetime.
+Values that change per operation belong on a request or parameter.
+Values that stay fixed for an object lifetime belong on the object.
+
+## Constructors And Dependencies
+
+Use a constructor when construction establishes behavior:
+validation, normalization, implementation selection, resource acquisition,
+or another invariant.
+
+Do not add a constructor that only copies dependencies into fields.
+When no construction behavior is needed,
+prefer direct struct initialization
+with required dependencies marked inline.
+
+```go
+type Handler struct {
+	Log     *silog.Logger // required
+	Service Service       // required
+}
+```
+
+When construction needs several required inputs
+or the input set is likely to grow,
+use a `Config` struct and a `New(Config)` constructor.
+Mark required `Config` fields inline.
+
+```go
+type Config struct {
+	Log     *silog.Logger // required
+	Service Service       // required
+}
+
+func New(config Config) (*Handler, error) {
+	if config.Log == nil {
+		return nil, errors.New("log is required")
+	}
+	return &Handler{
+		Log:     config.Log,
+		Service: config.Service,
+	}, nil
+}
+```
+
+When a constructor has fewer than three required dependencies,
+positional parameters are acceptable.
+If optional inputs are also needed, accept a trailing `*Options`.
+
+```go
+type OpenOptions struct {
+	Log *silog.Logger
+}
+
+func Open(path string, opts *OpenOptions) (*Repository, error) {
+	opts = cmp.Or(opts, &OpenOptions{})
+	return openRepository(path, opts.Log)
+}
+```
+
+Use `Options` only for optional inputs.
+A nil `*Options` means defaults.
+If a field is required, the type is not an `Options` type.
+
+## Boolean Overuse
+
+Avoid boolean API knobs for behavior choices.
+Model finite choices as named modes
+and open-ended behavior as an explicit interface.
+
+```go
+type RestackMode int
+
+const (
+	RestackModeAsk RestackMode = iota
+	RestackModeAlways
+	RestackModeNever
+)
+```
+
+## Interfaces
+
+Accept the smallest useful interface at the consumer boundary
+when behavior must vary.
+Return concrete structs by default.
+
+Do not introduce an interface only to hide one implementation
+or make dependencies look uniform.
+Concrete dependencies are acceptable
+when the concrete API is already the relevant contract,
+the value is cheap to construct or pass,
+and callers do not need behavioral substitution.
+
+This includes `*silog.Logger`, immutable configuration values,
+standard-library values,
+and small stateless collaborators.
+
+```go
+type BranchLookup interface {
+	LookupBranch(ctx context.Context, name string) (*spice.Branch, error)
+}
+
+type Handler struct {
+	Branches BranchLookup // required
+}
+```
+
+## Boundary Objects
+
+Prefer parameter and result objects
+for package, service, handler, or domain boundaries whose inputs
+or outputs are likely to grow.
+Keep request and result types next to the operation
+that consumes or produces them.

--- a/.agents/docs/docs-and-release.md
+++ b/.agents/docs/docs-and-release.md
@@ -1,0 +1,125 @@
+# Documentation And Release Notes
+
+Use this guide when changing Markdown documentation,
+generated CLI reference content, changelog entries, release notes,
+or other user-facing prose.
+
+## Documentation
+
+Website documentation lives in `doc/src`.
+The website layout is configured by `doc/mkdocs.yml`.
+
+Document user-facing behavior when users need the website
+to understand a command, configuration value, workflow, or limitation.
+
+When documenting an unreleased feature, add the placeholder:
+
+```markdown
+<!-- gs:version unreleased -->
+```
+
+The release process converts this placeholder
+into the released version number at release time.
+
+Use `$$...$$` only for command names
+and configuration names that `doc/hooks/cliref.py` can link.
+Do not include flags inside `$$...$$`.
+
+```markdown
+Use $$gs repo sync$$ to update tracked branches.
+Run `gs repo sync --restack` to restack after syncing.
+```
+
+## Prose Style
+
+Write external prose for readers
+who do not have the conversation, tool output, or implementation history.
+
+State the user-visible behavior first.
+Use implementation details only when readers need them
+to understand, evaluate, or safely change the result.
+
+Use semantic line breaks in Markdown, multi-line comments, commit messages,
+and changelog prose.
+Keep Markdown prose near 80 columns
+and never exceed 100 columns
+unless a link or code span requires it.
+
+## Generated Reference
+
+Run `mise run generate`
+after changing commands, flags, configuration, or help text.
+Generated outputs include CLI reference content
+such as `doc/includes/cli-reference.md`.
+
+## Changelog Entries
+
+git-spice uses Changie.
+Unreleased entries live under `.changes/unreleased`.
+
+Create entries through the repository wrapper:
+
+```bash
+mise run changie new --kind $kind --body $body
+```
+
+Do not hand-write a Changie file
+unless the wrapper cannot be used
+and the user approves the fallback.
+
+Add a changelog entry for user-facing changes:
+
+- new features
+- changes to existing behavior
+- bug fixes with visible user impact
+- deprecations
+- removals
+- security fixes
+
+Do not add a changelog entry for internal-only changes:
+
+- refactors with no behavior change
+- test-only changes
+- CI or tooling-only changes
+- code movement with no user-facing effect
+
+## Changelog Kinds
+
+Choose the kind from `.changie.yaml`
+based on the user-visible outcome:
+
+| Kind | Use for |
+| --- | --- |
+| `Added` | New user-facing capability |
+| `Changed` | Changed behavior or workflow |
+| `Deprecated` | Newly discouraged capability |
+| `Removed` | Removed capability |
+| `Fixed` | Bug fix with visible user impact |
+| `Security` | Security fix |
+
+## Changelog Body
+
+Describe the user-facing effect, not the implementation.
+Use passive voice.
+
+For component-specific changes, prefix the body with the command or domain,
+such as `submit:`, `repo sync:`, or `github:`.
+
+Good:
+
+```text
+repo sync: Branches are restacked after syncing when restack is enabled.
+```
+
+Weak:
+
+```text
+refactor repo sync restack helper
+```
+
+If a PR has no changelog entry because the change is internal,
+include a trailer in the PR description:
+
+```text
+[skip changelog]: Internal refactor with no user-facing behavior change.
+```

--- a/.agents/docs/git-workflow.md
+++ b/.agents/docs/git-workflow.md
@@ -1,0 +1,53 @@
+# Git Workflow
+
+Use this guide when changing Git state:
+branches, commits, stack operations, rebases, pushes,
+or pull request publishing.
+
+## Preserve User State
+
+Do not treat incidental repository state as part of the task.
+Dirty files, staged hunks, untracked files,
+and mixed staged or unstaged paths may be intentional.
+
+Inspect only the state needed for the requested operation.
+Stage only the intended files.
+Report unrelated state instead of rearranging it.
+
+## Branches And Commits
+
+Use git-spice commands for stack, branch,
+and commit operations in this repository.
+Do not create commits with raw `git commit`.
+
+Before committing, confirm the current branch.
+Do not commit new work directly on `main`
+unless the user explicitly asks for that.
+
+After branch or commit operations, verify state with the relevant commands:
+
+```bash
+git status --short --branch
+git branch --show-current
+git log -1 --oneline --decorate
+git-spice ls --no-prompt
+```
+
+## Pull Requests
+
+Local commits and pull request updates are separate operations.
+Do not push, publish, submit, or update a pull request
+unless the user asks for that action.
+
+If the user asks only for a local commit, leave the PR untouched.
+
+## Recovery
+
+If a git-spice operation is interrupted,
+inspect the current branch, rebase state, and stack state before continuing.
+Use the non-interactive git-spice recovery path
+that matches the operation in progress.
+
+Do not use destructive Git commands
+unless the user explicitly requested the destructive operation
+or approved the recovery step.

--- a/.agents/docs/style.md
+++ b/.agents/docs/style.md
@@ -1,0 +1,130 @@
+# Style
+
+Use this guide when changing Go implementation code.
+Prefer local clarity over broad cleanup.
+
+## Context-Locality
+
+Readable code keeps the context for a change near the code being changed.
+A future contributor should not have to cross unrelated files,
+helpers, or declarations to understand one operation.
+
+Keep request and result types near their operation.
+Keep private interfaces near the consumer.
+Keep helper functions near the code they support.
+Move shared code only when the shared boundary has the same meaning
+for every caller.
+
+## Symbol Ordering
+
+Order Go symbols by narrative dependency, not declaration kind.
+A reader should encounter a symbol close to the code
+that first makes the symbol useful.
+
+Preferred order:
+
+1. File-wide constants or variables
+   that configure the whole file.
+2. A cohesive type block:
+   type declaration, constructor, then methods.
+3. Request, result, mode, and local interface types
+   immediately before the operation that uses them.
+4. Helper machinery immediately after the operation or group it supports.
+
+Do not collect all constants, interfaces, types, or helpers at the top
+of a file
+unless they are genuinely file-wide concepts.
+
+## Naming
+
+Use one stable term for one domain concept.
+Do not vary names for style.
+If two names exist, they should describe a real distinction.
+
+Package names should be singular or compound domain names.
+Avoid plural package names unless the name is an established external term.
+
+## Required Fields
+
+Put required dependencies in struct fields
+and mark each required field inline with `// required`
+when direct initialization is the right construction path.
+
+```go
+type Runner struct {
+	Log  *silog.Logger // required
+	Repo Repository    // required
+}
+```
+
+Do not add a constructor
+only to copy those fields into a struct.
+
+## Errors
+
+Wrap errors with context for the immediate sub-operation.
+Do not use `failed to`, `error doing`,
+or the current function name as error context.
+
+```go
+data, err := os.ReadFile(path)
+if err != nil {
+	return fmt.Errorf("read %q: %w", path, err)
+}
+```
+
+Use `%q` for variable strings in errors
+so empty strings and whitespace are visible.
+
+Never use string matching
+to detect a specific error type or condition.
+
+## Control Flow
+
+Use early returns for invalid or failure states.
+Converge successful branches before shared work.
+Model mutually exclusive behavior as a named mode
+instead of a combination of booleans.
+
+Keep mutation close to the operation that depends on it.
+A longer visible sequence is better than a compressed expression
+when the sequence makes state transitions easier to verify.
+
+## Variables
+
+Limit variable scope to the smallest useful block.
+Declare variables close to first use.
+Inline variables that are used only once
+unless the expression is complex enough
+that a name improves readability.
+
+Initialize an empty slice with `var`:
+
+```go
+var items []Item
+```
+
+Use `make` for slices only when specifying length or capacity.
+
+## Logging
+
+Use `internal/silog.Logger`.
+In tests, use `silogtest.New(t)` by default
+so log output is attached to the test.
+Use `silog.Nop()` only when the test needs to suppress logging entirely.
+When asserting log output, capture logs with `silog.New(&buffer, nil)`.
+
+## Imports
+
+Avoid import aliases unless Go requires them
+or local precedent already uses the alias.
+Use a named import only for a real conflict,
+such as two imported packages with the same package name.
+The current file's package name is not a conflict
+because code inside the package does not reference that package name.
+
+## Exits
+
+Do not call `log.Fatal`, `os.Exit`,
+or similar hard exits outside `main`.
+Return errors and let the caller decide how to report them.

--- a/.agents/docs/testing.md
+++ b/.agents/docs/testing.md
@@ -1,0 +1,145 @@
+# Testing
+
+Use this guide when adding, changing, or reviewing tests.
+
+## Regression Tests
+
+A bug fix requires a regression test
+that fails before the fix
+and passes after the fix.
+
+Prefer a unit test when the behavior can be exercised directly.
+Use a test script when the behavior is a command workflow, shell contract,
+or end-to-end user-visible interaction.
+
+When Git, forge, or process behavior matters,
+prefer a real-boundary probe or fixture-backed test
+over a mock that only proves the implementation called a helper.
+
+## Useful Tests
+
+A useful test protects an observable promise:
+what callers can rely on, what users can see,
+what state transition must happen, or what error means.
+
+Avoid tests that only detect private implementation shape.
+If a different correct implementation would fail the test,
+the test may be too coupled to mechanics.
+
+Keep the scenario visible in the test body.
+Helpers are useful when they name real setup operations.
+Helpers that only hide required fields, mock construction,
+or assertions make tests harder to inspect.
+
+## Unit Tests
+
+Use `t.Context()` instead of `context.Background()`.
+Use `testify/assert` and `testify/require`.
+Use `silogtest.New(t)` by default
+so log output is attached to the test.
+Use `silog.Nop()` only when the test needs to suppress logging entirely.
+
+When asserting log output, capture logs with a buffer:
+
+```go
+var logBuffer bytes.Buffer
+log := silog.New(&logBuffer, nil)
+```
+
+Use `defer` for cleanup.
+Inside deferred cleanup, use `assert.NoError`
+so cleanup can continue.
+
+## Test Organization
+
+Use table tests for simple scenarios
+that share setup and teardown.
+Use subtests when scenarios need different setup, different teardown,
+or enough local detail that a table would hide the case.
+
+Do not use test tables with `func` fields.
+
+Name tests with GoCase symbol names:
+
+```text
+Test{Name}
+Test{Type}_{Method}
+Test{Name}_{scenario}
+Test{Type}_{Method}_{scenario}
+```
+
+The scenario suffix starts with a lower-case letter.
+
+Use GoCase subtest names, such as `AlreadyRestacked` or `NeedsRestack`.
+
+```go
+t.Run("AlreadyRestacked", func(t *testing.T) {
+	// ...
+})
+```
+
+Place helper functions below all test functions.
+
+## Test Scripts
+
+Test scripts live in `testdata/script`.
+They use the txtar-based script format described in
+`testdata/script/README.md`.
+Read `.agents/skills/test-script/SKILL.md`
+before adding or changing a test script.
+
+Name scripts with the `<command>_<scenario>.txt` convention.
+Reserve `issueNNN_...` prefixes only for bug-fix regression scripts
+that are specifically tied to that issue.
+Do not use `issueNNN_...` names for feature scripts.
+
+Run a single script during development:
+
+```bash
+mise run test:script --run $name
+```
+
+Update a script's golden output only after verifying
+the new behavior is intended:
+
+```bash
+mise run test:script --run $name --update
+```
+
+## Mocks
+
+Use `gomock` only when a real dependency would make the test slower,
+less deterministic, or unable to isolate the behavior under test.
+
+Create the controller at the start of the test:
+
+```go
+mockCtrl := gomock.NewController(t)
+```
+
+Do not call `defer mockCtrl.Finish()`;
+the controller handles cleanup automatically.
+
+Declare mocks next to first use, especially when a test uses multiple mocks.
+Inline mocks with no expectations
+unless the mock value is used more than once.
+
+Format expectations in multi-line style:
+
+```go
+mockService.EXPECT().
+	MethodName(gomock.Any(), "param").
+	Return(expectedResult)
+```
+
+Generate mocks with `//go:generate mockgen`.
+Use `mocks_test.go` or `mock_foo_test.go`
+unless the destination package is a test-only package
+with a name ending in `test`.
+In test-only packages, use `mocks.go` or `mock_foo.go`.
+
+Example:
+
+```go
+//go:generate mockgen -destination mocks_test.go -package track -typed . GitRepository,Service
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,632 +1,82 @@
-# Development workflow
-
-## Quick reference
-
-| Step                     | Command                                         |
-|--------------------------|-------------------------------------------------|
-| Verify code compiles     | Use `mcp__gopls__go_diagnostics` (if available) |
-| Build project            | `mise run build`                                |
-| Update generated files   | `mise run generate`                             |
-| Run linters              | `mise run lint`                                 |
-| Format code              | `mise run fmt`                                  |
-| Run all tests            | `mise run test` (use sparingly; slow)           |
-| Run specific unit tests  | `go test ./path/to/package -run TestRegex`      |
-| Run all test scripts     | `mise run test:script` (use sparingly; slow)    |
-| Run specific test script | `mise run test:script --run $name`              |
-| Update test script       | `mise run test:script --run $name --update`     |
-| Add changelog entry      | `mise run changie new --kind $kind --body $body` |
-
-## Overview
-
-Features and bug fixes must always follow these steps
-unless explicitly stated otherwise:
-
-- **Core development loop**:
-  Use the following cycle during development:
-
-  1. Write tests
-
-     Test-driven development is preferred.
-     If not possible, discuss with the user before writing code.
-
-     - For features, propose a series of test scripts (see Skill(test-script))
-       that demonstrate the desired behavior before writing code.
-     - For bug fixes, write a regression test first:
-       prefer a unit test, but a test script is acceptable if necessary.
-
-     In both cases, verify test failure before writing code.
-
-  2. Write code
-
-      Use `mcp__gopls__go_diagnostics` to verify code compiles,
-      fixing issues as they arise.
-      It is acceptable to have temporary compilation errors
-      during refactoring if planned changes will resolve them.
-
-  3. Get tests passing
-
-      Run only the new or modified tests during development to save time.
-
-- **Finishing up**:
-  When the user indicates that the change is ready to be finalized
-  (ask if unsure), perform these steps:
-
-    1. Format
-
-        Run the following command and accept its changes:
-
-        ```bash
-        mise run fmt
-        ```
-
-    2. Lint
-
-        Run the following command and fix any issues reported:
-
-        ```bash
-        mise run lint
-        ```
-
-    3. Build
-
-        Verify the project builds successfully:
-
-        ```bash
-        mise run build
-        ```
-
-    4. Generate
-
-        If the change adds or modifies CLI commands, flags, or
-        configuration options (e.g., adding a new forge),
-        regenerate documentation and other generated files:
-
-        ```bash
-        mise run generate
-        ```
-
-        This updates `doc/includes/cli-reference.md` and other generated files.
-
-    5. Changelog
-
-        If the change is user-facing, that is,
-        it adds or modifies functionality visible to end users,
-        add a changelog entry.
-        Internal changes, refactors, and test-only changes
-        do not require changelog entries.
-        Ask if unsure.
-
-        ```bash
-        mise run changie new --kind $kind --body $body
-        ```
-
-    6. Commit
-
-        Create a commit with a descriptive message.
-        Follow user-specified guidelines for commit messages if provided.
-
-## Testing
-
-This project has two kinds of tests:
-
-- **Unit tests**:
-  Written as regular Go tests using the `testing` package.
-  These are fast to run and should be used for most testing.
-- **Test scripts**:
-  Written inside testdata/script/ directory as a series of `*.txt` files
-  in a shell-like syntax (note: NOT actual shell scripts).
-  The syntax for these is described in testdata/script/README.md.
-
-  Name test scripts using the `<command>_<scenario>.txt` convention.
-  Reserve `issue123_...` prefixes for regression tests
-  that are specifically tied to that issue.
-
-### Unit tests
-
-#### Testing best practices
-
-Always follow these best practices
-when writing or modifying unit tests:
-
-- **Context**:
-  Use `t.Context()` instead of `context.Background()`.
-- **Assertions**:
-  Use `testify/assert` and `testify/require` for assertions.
-- **Logging**:
-  - Use `silog.Nop()` when log output is not being tested.
-  - When the log output is being tested (e.g., verifying log messages),
-    use `silog.New(&logBuffer, nil)` with a `bytes.Buffer` to capture log output.
-    Verify important log messages with
-    `assert.Contains(t, logBuffer.String(), "message")`.
-- **Cleanup**:
-  When tests create resources (branches, files, etc.),
-  use `defer` with proper error handling to clean up.
-  In deferred cleanup functions, use `assert.NoError`
-  rather than `require.NoError` to avoid stopping cleanup.
-
-#### Test organization
-
-- Use table tests for simple scenarios
-  where all test cases share the same setup and teardown logic.
-- Use subtests instead of table tests
-  when scenarios are complex and require different setup/teardown logic.
-- Use separate test functions for simple, independent scenarios.
-- Group related test cases under a common parent test function
-  using subtests.
-- NEVER use test tables with `func` fields
-  (i.e., anonymous functions inside test case structs).
-
-#### Test naming
-
-- Use `Test{Name}` for tests for specific symbols.
-  `{Name}` always starts with a capital letter (e.g. `TestFoo`).
-- Use `Test{Type}_{Method}` for tests for methods.
-  `{Type}` and `{Method}` start with capital letters (e.g. `TestBar_Baz`).
-- Use `Test{Name}_{scenario}` or `Test{Name}_{Method}_{scenario}`
-  for tests for specific scenarios under a symbol or method.
-  `{scenario}` starts with a lowercase letter
-  (e.g. `TestFoo_invalidInput` or `TestBar_Baz_edgeCase`).
-- Use GoCase for subtest names
-  (e.g., "AlreadyRestacked", "NeedsRestack").
-
-#### Test function ordering
-
-- Order test functions with related tests together.
-- Add new test functions below existing test functions
-- Helper functions must always go at the bottom of the file
-  below all test functions.
-
-### Mocks
-
-Unit tests that require interfaces to be mocked
-make use of the `gomock` library
-and the accompanying `mockgen` tool.
-
-#### Generating mocks
-
-If a test requires a mock of an interface,
-add a `//go:generate mockgen` comment as follows:
-
-```go
-//go:generate mockgen -destination=<destination> -package=<package-name> -write_package_comment=false -typed=true <import-path> <Iface1,Iface2,...>
-```
-
-Explanation:
-
-- `<destination>`:
-  Path to the generated mock file.
-  Use a name ending in `*_test.go`, e.g. `mocks_test.go`.
-  This ensures the mock is only included in test builds.
-  - Exception: The package is a test utility package
-    (name ending in `test`, e.g. `footest`).
-- `<package-name>`:
-  Name of the package for the generated mock file.
-  Matches package name used in source files in the same directory,
-  or the name of the directory.
-- `<import-path>`:
-  Full import path of the package containing the interfaces to be mocked.
-  This will usually be `.` for interfaces defined in the same package
-  as the test using the mock.
-- `<Iface1,Iface2,...>`:
-  Comma-separated list of interface names to be mocked.
-
-After adding or modifying a `//go:generate mockgen` comment,
-run `go generate` in the package directory
-or run `mise run generate` to regenerate all mocks in the codebase.
-
-#### Using mocks
-
-At the start of a test function that uses mocks, set up a `gomock.Controller`:
-
-```go
-mockCtrl := gomock.NewController(t)
-// DO NOT use `defer ctrl.Finish()`; this is handled automatically.
-```
-
-Instantiate mocks using the generated mock types
-next to the first use of the mock:
-
-```go
-mockService := NewMockService(mockCtrl)
-```
-
-
-Format mock expectations using multi-line style for readability:
-
-```go
-mockService.EXPECT().
-    MethodName(gomock.Any(), "param").
-    Return(expectedResult)
-```
-
-#### Common mistakes with mocks
-
-- **Mistake**: Declaring all mocks at the start of the test function.
-  **Fix**: Declare mocks next to their first use.
-
-  ```go
-  // Bad: mocks are declared at start of function
-  func TestSomething(t *testing.T) {
-      mockCtrl := gomock.NewController(t)
-      mockService := NewMockService(mockCtrl)
-      mockRepo := NewMockRepo(mockCtrl)
-
-      // ...
-
-      mockService.EXPECT().
-          DoSomething(gomock.Any()).
-          Return(nil)
-      doStuff(mockService)
-
-      // ...
-
-      mockRepo.EXPECT().
-          GetData("id").
-          Return(&Data{}, nil)
-      data, err := fetchData(mockRepo, "id")
-  }
-
-  // Good: mocks are declared next to first use
-  func TestSomething(t *testing.T) {
-      mockCtrl := gomock.NewController(t)
-
-      // ...
-
-      mockService := NewMockService(mockCtrl)
-      mockService.EXPECT().
-          DoSomething(gomock.Any()).
-          Return(nil)
-      doStuff(mockService)
-
-      // ...
-      mockRepo := NewMockRepo(mockCtrl)
-      mockRepo.EXPECT().
-          GetData("id").
-          Return(&Data{}, nil)
-      data, err := fetchData(mockRepo, "id")
-  }
-  ```
-
-- **Mistake**: Creating mock variables for mocks without expectations.
-  **Fix**: Inline mocks without expectations directly where they are used.
-  **Exception**: If the mock is used multiple times in the test, don't inline.
-
-  ```go
-  // Bad: mock variable created for mock without expectations
-  func TestSomething(t *testing.T) {
-      mockCtrl := gomock.NewController(t)
-      mockService := NewMockService(mockCtrl)
-      doStuff(mockService)
-  }
-
-  // Good: mock inlined directly where used
-  func TestSomething(t *testing.T) {
-      mockCtrl := gomock.NewController(t)
-      doStuff(NewMockService(mockCtrl))
-  }
-
-  // Exception: mock used multiple times
-  func TestSomething(t *testing.T) {
-      mockCtrl := gomock.NewController(t)
-      mockService := NewMockService(mockCtrl)
-      doStuff(mockService)
-      verifyStuff(mockService)
-  }
-  ```
-
-## Keeping the changelog
-
-We use the `changie` tool to manage the changelog.
-Unreleased changes are stored in the .changes/unreleased directory.
-
-To add a changelog entry for a user-facing change, run:
-
-```
-mise run changie new --kind $kind --body $body
-```
-
-Where:
-
-- `$kind` is one of:
-  - Added: a new feature
-  - Changed: a change to existing functionality
-  - Deprecated: a feature that is deprecated
-  - Removed: a removed feature
-  - Fixed: a bug fix
-  - Security: a security fix
-- `$body` is a description of the change in passive voice.
-  - **IMPORTANT**: Describe the user-facing change,
-    not the internal implementation detail.
-    If there are no user-facing changes, do not add a changelog entry.
-  - For component-specific changes,
-    prefix the description with the component name,
-    e.g., "submit: Add 'config.option' to enable feature".
-  - Components can be command names (e.g., "repo sync")
-    or command domains (e.g., "submit", "github").
-  - See CHANGELOG.md for existing patterns.
-
-To skip the changelog check for internal changes, refactors,
-or test-only changes, include `[skip changelog]: <cause description>` in the PR description as a trailer.
-
-# Code Quality
-
-- Never introduce new third-party dependencies.
-
-## Code style
-
-- **Line length**
-
-  Prefer a soft limit of 80 characters per line.
-  This includes code, comments, and documentation.
-  Aim to keep lines within this limit for readability.
-
-  Never exceed 120 characters per line.
-
-- **Package naming**
-
-  Do not pluralize package names.
-  Use singular nouns or compound names instead.
-
-  ```
-  // BAD: pluralized package names
-  urls
-  utils
-  helpers
-
-  // GOOD: singular or compound names
-  forgeurl
-  stringutil
-  testhelper
-  ```
-
-- **Logical grouping with comments**
-
-  Use descriptive section headers to group related operations
-
-- **Reduce variable scope**
-
-  Limit variable scope to the smallest possible block.
-  Declare variables closest to their first use.
-
-- **Minimize variable declarations**
-
-  Do not create variables that are used only once.
-  Inline such values directly where they are used.
-
-  ```go
-  // BAD: unnecessary variable declaration
-  result := computeValue()
-  process(result)
-
-  // GOOD: inline value directly
-  process(computeValue())
-  ```
-
-  ```go
-  // BAD: unnecessary variable declaration
-  handler := RequestHandler{
-      Field: value,
-  }
-  handler.HandleRequest(request)
-
-  // GOOD: inline value directly
-  (&RequestHandler{
-      Field: value,
-  }).HandleRequest(request)
-  ```
-
-  Exceptions:
-
-  - The variable is used multiple times.
-  - The expression is already complex and inlining would reduce readability.
-
-- **Initializing slices**
-
-  To initialize an empty slice, always use `var` form:
-
-  ```go
-  // GOOD
-  var items []Item
-  ```
-
-  Use `make` only for slices with a non-zero length or capacity:
-
-  ```go
-  // GOOD
-  items := make([]Item, length)
-  items := make([]Item, length, capacity)
-  ```
-
-- **String concatenation**
-
-  For simple string concatenation, use `+`:
-
-  ```go
-  // GOOD
-  fullName := firstName + " " + lastName
-
-  // BAD
-  fullName := fmt.Sprintf("%s %s", firstName, lastName)
-  ```
-
-## Code patterns
-
-- **Immediately-invoked functions for short-lived defer**
-
-  If a function needs a `defer` that is only relevant within a small scope,
-  encapsulate that logic in an immediately-invoked function.
-
-  ```go
-  err := func() error {
-      res, err := doSomething()
-      if err != nil {
-          return err
-      }
-      defer res.Close()
-
-      // ...
-
-      return nil
-  }()
-  if err != nil {
-      return // ...
-  }
-
-  // ...
-  ```
-
-- **Error wrapping**
-
-  - Always add context when propagating errors up the call stack.
-
-    ```go
-    // BAD: no context added
-    data, err := fetchData()
-    if err != nil {
-        return err
-    }
-
-
-    // GOOD: context added
-    data, err := fetchData()
-    if err != nil {
-        return fmt.Errorf("fetch data: %w", err)
-    }
-    ```
-
-  - Add context for only the current sub-operation that failed.
-
-    ```go
-    // BAD: context for entire operation repeated
-    func process(input string) error {
-        data, err := fetchData(input)
-        if err != nil {
-            return fmt.Errorf("process input %q: fetch data: %w", input, err)
-        }
-        // ...
-    }
-
-    // GOOD: context only for failing sub-operation
-    func process(input string) error {
-        data, err := fetchData(input)
-        if err != nil {
-            return fmt.Errorf("fetch data: %w", err)
-        }
-        // ...
-    }
-    ```
-
-    Rationale:
-    The higher-level context will be added by the caller.
-
-  - Do not add "failed to x", "error doing y", or similar phrases
-    to wrapped error context.
-
-    ```go
-    // BAD: redundant failure indication
-    if err != nil {
-        return fmt.Errorf("failed to fetch data: %w", err)
-    }
-
-    // GOOD: no redundant failure indication
-    if err != nil {
-        return fmt.Errorf("fetch data: %w", err)
-    }
-    ```
-
-    Rationale: The presence of an error already indicates failure.
-
-## Code Anti-patterns
-
-NEVER do the following:
-
-- NEVER use string matching to check for specific error types or conditions.
-
-## Comment style
-
-- Use full sentences for standalone comments
-  (i.e., comments that are not inline with code).
-
-  ```go
-  # BAD
-  // initialize the user repository
-
-  # GOOD
-  // Initialize the user repository.
-  ```
-
-- Use sentence fragments for inline comments
-  (i.e., comments that are on the same line as code).
-
-  ```go
-  # BAD
-  value := computeValue() // This computes the value
-
-  # GOOD
-  value := computeValue() // compute the value
-  ```
-
-- Add comments to struct fields
-  when the field's meaning,
-  source,
-  valid values,
-  or caller obligations are not obvious
-  from its name and type.
-
-- For request structs,
-  handler structs,
-  and other structs with required fields,
-  use inline `// required` comments
-  when that contract is useful to callers
-  or enforced by tooling.
-
-- Never add comments that merely repeat the code.
-
-  ```go
-  # BAD
-  count := len(items) // get the length of items
-
-  # GOOD
-  count := len(items)
-  ```
-
-- Always use `//`-style comments.
-  Never use `/* ... */`-style comments.
-
-- Use semantic line breaks in comments.
-  This requires breaking lines at natural grammatical boundaries
-  (such as after complete sentences, clauses, or list items),
-  while remaining within the 80-character limit.
-
-# Documentation
-
-Markdown documentation resides inside `doc/src`.
-The layout and structure of the documentation
-is described in `doc/mkdocs.yml`.
-This content powers the website,
-so document user-facing changes there when appropriate.
-
-When documenting unreleased features, add the following placeholder:
-
-```markdown
-<!-- gs:version unreleased -->
-```
-
-On the website,
-this renders a badge indicating that the feature is unreleased.
-The placeholder will be automatically updated to the correct version
-on the next release.
-
-## Documentation style
-
-- Wrap lines at 80 characters.
-- Always follow semantic line breaks in documentation.
-  This requires breaking lines at natural grammatical boundaries
-  (such as after complete sentences, clauses, or list items),
-  while remaining within the 80-character limit.
-- Use the `$$...$$` shorthand only for command names
-  and configuration names that `doc/hooks/cliref.py` can link.
-  Examples: `$$gs repo sync$$` and `$$spice.repoSync.restack$$`.
-  Never include flags inside `$$...$$`;
-  write full command invocations with flags as inline code instead.
-  For example, write `gs repo sync --restack`.
+# Development Workflow
+
+## Task Guides
+
+Read the relevant guide before editing that kind of code or prose:
+
+| Task | Guide |
+| --- | --- |
+| Package boundaries, dependencies, constructors, APIs | `.agents/docs/design.md` |
+| Go implementation style and symbol ordering | `.agents/docs/style.md` |
+| Code comments and symbol documentation | `.agents/docs/comments.md` |
+| Command behavior, flags, output, generated CLI docs | `.agents/docs/cli.md` |
+| Unit tests, test scripts, mocks, regression tests | `.agents/docs/testing.md` |
+| Documentation, changelog, release-facing prose | `.agents/docs/docs-and-release.md` |
+| Branches, commits, stacks, PR publishing boundaries | `.agents/docs/git-workflow.md` |
+
+Before changing files or Git state,
+verify the working directory
+and preserve unrelated dirty,
+staged,
+and untracked files.
+
+`internal/handler/AGENTS.md` contains additional rules
+for handler packages.
+Read it before adding or changing handler code.
+
+## Quick Reference
+
+| Step | Command |
+| --- | --- |
+| Verify code compiles | Use `mcp__gopls__go_diagnostics` if available |
+| Build project | `mise run build` |
+| Update generated files | `mise run generate` |
+| Run linters | `mise run lint` |
+| Format code | `mise run fmt` |
+| Run all tests | `mise run test` |
+| Run specific unit tests | `go test ./path/to/package -run TestRegex` |
+| Run all test scripts | `mise run test:script` |
+| Run specific test script | `mise run test:script --run $name` |
+| Update test script | `mise run test:script --run $name --update` |
+| Add changelog entry | `mise run changie new --kind $kind --body $body` |
+
+Use broad test commands sparingly during development.
+Prefer the smallest command that exercises the changed behavior.
+
+## Development Loop
+
+For features and bug fixes:
+
+1. Add or update the test first.
+   For a bug, verify that the regression test fails before the fix.
+2. Implement the change.
+3. Run the narrowest relevant test command.
+4. Run `mise run fmt`.
+5. Run `mise run lint`.
+6. Run `mise run build`.
+7. Run `mise run generate`
+   when commands, flags, configuration, or generated docs change.
+8. Add a changelog entry when the change is user-facing.
+
+## Design Summary
+
+Organize packages by domain responsibility.
+A package should expose operations in its domain vocabulary,
+not collect unrelated helpers or framework wiring.
+
+Handler packages coordinate user-facing command workflows.
+Command packages parse syntax and construct typed requests.
+Lower-level packages own local invariants and domain operations.
+
+Keep infrastructure concerns at boundaries.
+Read environment variables, configuration files,
+and process state at explicit entry points.
+Pass typed values or dependencies to the component
+that owns their lifetime.
+
+Do not shell out as an implementation shortcut.
+When behavior depends on another process,
+wrap that process behind a concrete API
+whose methods describe git-spice operations.
+
+Do not introduce new third-party dependencies without explicit approval.


### PR DESCRIPTION
Rewrite AGENTS.md guidance with more instructions around coding practices.
Root file is kept lean and points to reference files for detailed guidance.

[skip changelog]: no user facing changes
