### PR TITLE
git: Quote variable values in git error context

### DIFF
--- a/internal/git/hook.go
+++ b/internal/git/hook.go
@@ -38,7 +38,7 @@ func (r *Repository) HookRun(
 		cmd = cmd.AppendEnv(opts.Env...)
 	}
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("hook run %s: %w", hook, err)
+		return fmt.Errorf("hook run %q: %w", hook, err)
 	}
 	return nil
 }

--- a/internal/git/hook_test.go
+++ b/internal/git/hook_test.go
@@ -93,8 +93,8 @@ func TestRepository_HookRun(t *testing.T) {
 			Run(gomock.Any()).
 			Return(errors.New("git command failed"))
 
-		err := repo.HookRun(ctx, "commit-msg", nil)
+		err := repo.HookRun(ctx, "commit msg", nil)
 		assert.Error(t, err)
-		assert.ErrorContains(t, err, "hook run commit-msg")
+		assert.ErrorContains(t, err, `hook run "commit msg"`)
 	})
 }

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -53,7 +53,7 @@ func (r *Repository) RemoteURL(ctx context.Context, remote string) (string, erro
 func (r *Repository) RemoteConfigURL(ctx context.Context, remote string) (string, error) {
 	url, err := r.gitCmd(ctx, "config", "--get", "remote."+remote+".url").OutputChomp()
 	if err != nil {
-		return "", fmt.Errorf("config get remote.%s.url: %w", remote, err)
+		return "", fmt.Errorf("config get remote.%q.url: %w", remote, err)
 	}
 	return url, nil
 }
@@ -82,7 +82,7 @@ func (r *Repository) RemoteFetchRefspecs(ctx context.Context, remote string) ([]
 		ctx, "config", "--get-all", "remote."+remote+".fetch").
 		OutputChomp()
 	if err != nil {
-		return nil, fmt.Errorf("config get-all remote.%s.fetch: %w", remote, err)
+		return nil, fmt.Errorf("config get-all remote.%q.fetch: %w", remote, err)
 	}
 
 	var refspecs []Refspec

--- a/internal/git/remote_test.go
+++ b/internal/git/remote_test.go
@@ -1,6 +1,7 @@
 package git_test
 
 import (
+	"errors"
 	"io"
 	"os/exec"
 	"sync"
@@ -92,4 +93,38 @@ func TestRepositoryListRemoteRefsOptions(t *testing.T) {
 		}, ref)
 		break
 	}
+}
+
+func TestRepository_RemoteConfigURL_errorQuotesRemote(t *testing.T) {
+	mockExecer := git.NewMockExecer(gomock.NewController(t))
+	repo, _ := git.NewFakeRepository(t, "", mockExecer)
+
+	mockExecer.EXPECT().
+		Output(gomock.Any()).
+		DoAndReturn(func(cmd *exec.Cmd) ([]byte, error) {
+			assert.Equal(t, []string{
+				"git", "config", "--get", "remote.up stream.url",
+			}, cmd.Args)
+			return nil, errors.New("git command failed")
+		})
+
+	_, err := repo.RemoteConfigURL(t.Context(), "up stream")
+	assert.ErrorContains(t, err, `config get remote."up stream".url`)
+}
+
+func TestRepository_RemoteFetchRefspecs_errorQuotesRemote(t *testing.T) {
+	mockExecer := git.NewMockExecer(gomock.NewController(t))
+	repo, _ := git.NewFakeRepository(t, "", mockExecer)
+
+	mockExecer.EXPECT().
+		Output(gomock.Any()).
+		DoAndReturn(func(cmd *exec.Cmd) ([]byte, error) {
+			assert.Equal(t, []string{
+				"git", "config", "--get-all", "remote.up stream.fetch",
+			}, cmd.Args)
+			return nil, errors.New("git command failed")
+		})
+
+	_, err := repo.RemoteFetchRefspecs(t.Context(), "up stream")
+	assert.ErrorContains(t, err, `config get-all remote."up stream".fetch`)
 }

--- a/internal/git/var.go
+++ b/internal/git/var.go
@@ -11,7 +11,7 @@ func (r *Repository) Var(ctx context.Context, name string) (string, error) {
 	cmd := newGitCmd(ctx, r.log, r.exec, "var", name)
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("git var %s: %w", name, err)
+		return "", fmt.Errorf("git var %q: %w", name, err)
 	}
 	return strings.TrimSpace(string(out)), nil
 }

--- a/internal/git/var_test.go
+++ b/internal/git/var_test.go
@@ -1,0 +1,41 @@
+package git_test
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.abhg.dev/gs/internal/git"
+	"go.uber.org/mock/gomock"
+)
+
+func TestRepository_Var_errorQuotesName(t *testing.T) {
+	mockExecer := git.NewMockExecer(gomock.NewController(t))
+	repo, _ := git.NewFakeRepository(t, "", mockExecer)
+
+	mockExecer.EXPECT().
+		Output(gomock.Any()).
+		DoAndReturn(func(cmd *exec.Cmd) ([]byte, error) {
+			assert.Equal(t, []string{"git", "var", " "}, cmd.Args)
+			return nil, errors.New("git command failed")
+		})
+
+	_, err := repo.Var(t.Context(), " ")
+	assert.ErrorContains(t, err, `git var " "`)
+}
+
+func TestWorktree_Var_errorQuotesName(t *testing.T) {
+	mockExecer := git.NewMockExecer(gomock.NewController(t))
+	_, wt := git.NewFakeRepository(t, "", mockExecer)
+
+	mockExecer.EXPECT().
+		Output(gomock.Any()).
+		DoAndReturn(func(cmd *exec.Cmd) ([]byte, error) {
+			assert.Equal(t, []string{"git", "var", " "}, cmd.Args)
+			return nil, errors.New("git command failed")
+		})
+
+	_, err := wt.Var(t.Context(), " ")
+	assert.ErrorContains(t, err, `git var " "`)
+}

--- a/internal/git/var_wt.go
+++ b/internal/git/var_wt.go
@@ -11,7 +11,7 @@ import (
 func (w *Worktree) Var(ctx context.Context, name string) (string, error) {
 	out, err := w.gitCmd(ctx, "var", name).Output()
 	if err != nil {
-		return "", fmt.Errorf("git var %s: %w", name, err)
+		return "", fmt.Errorf("git var %q: %w", name, err)
 	}
 	return strings.TrimSpace(string(out)), nil
 }


### PR DESCRIPTION
Make internal/git error messages quote caller-supplied hook, variable, and remote names when those values are embedded in local Git command context. Quoting these values keeps empty or whitespace-containing inputs visible in diagnostics.

The regression coverage exercises hook names, repository and worktree Git variables, and remote configuration lookups so the diagnostic shape stays protected.

[skip changelog]