### PR TITLE
refactor(shamhub): Split CLI admin client

### DIFF
--- a/internal/forge/shamhub/cli_admin_client.go
+++ b/internal/forge/shamhub/cli_admin_client.go
@@ -1,0 +1,142 @@
+package shamhub
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// shamhubCLIAdminClient is the CLI's REST transport for ShamHub admin routes.
+type shamhubCLIAdminClient struct {
+	apiURL string
+	gitURL string
+	token  string
+	client *http.Client
+}
+
+func newShamHubCLIAdminClient(
+	getenv func(string) string,
+) (*shamhubCLIAdminClient, error) {
+	apiURL := getenv("SHAMHUB_API_URL")
+	if apiURL == "" {
+		return nil, errors.New("SHAMHUB_API_URL is required")
+	}
+	if _, err := url.Parse(apiURL); err != nil {
+		return nil, fmt.Errorf("parse SHAMHUB_API_URL: %w", err)
+	}
+
+	gitURL := getenv("SHAMHUB_URL")
+	if gitURL == "" {
+		return nil, errors.New("SHAMHUB_URL is required")
+	}
+	if _, err := url.Parse(gitURL); err != nil {
+		return nil, fmt.Errorf("parse SHAMHUB_URL: %w", err)
+	}
+
+	token := getenv("SHAMHUB_ADMIN_TOKEN")
+	if token == "" {
+		return nil, errors.New("SHAMHUB_ADMIN_TOKEN is required")
+	}
+
+	return &shamhubCLIAdminClient{
+		apiURL: strings.TrimRight(apiURL, "/"),
+		gitURL: strings.TrimRight(gitURL, "/"),
+		token:  token,
+		client: http.DefaultClient,
+	}, nil
+}
+
+// Get sends an authenticated GET request to a ShamHub admin endpoint.
+func (c *shamhubCLIAdminClient) Get(
+	ctx context.Context,
+	path string,
+	res any,
+) error {
+	return c.do(ctx, http.MethodGet, path, nil, res)
+}
+
+// Post sends an authenticated POST request to a ShamHub admin endpoint.
+func (c *shamhubCLIAdminClient) Post(
+	ctx context.Context,
+	path string,
+	req any,
+	res any,
+) error {
+	return c.do(ctx, http.MethodPost, path, req, res)
+}
+
+// Patch sends an authenticated PATCH request to a ShamHub admin endpoint.
+func (c *shamhubCLIAdminClient) Patch(
+	ctx context.Context,
+	path string,
+	req any,
+	res any,
+) error {
+	return c.do(ctx, http.MethodPatch, path, req, res)
+}
+
+// Delete sends an authenticated DELETE request to a ShamHub admin endpoint.
+func (c *shamhubCLIAdminClient) Delete(
+	ctx context.Context,
+	path string,
+	res any,
+) error {
+	return c.do(ctx, http.MethodDelete, path, nil, res)
+}
+
+func (c *shamhubCLIAdminClient) do(
+	ctx context.Context,
+	method string,
+	path string,
+	req any,
+	res any,
+) error {
+	var body io.Reader
+	if req != nil {
+		bs, err := json.Marshal(req)
+		if err != nil {
+			return fmt.Errorf("marshal request: %w", err)
+		}
+		body = bytes.NewReader(bs)
+	}
+
+	httpReq, err := http.NewRequestWithContext(
+		ctx,
+		method,
+		c.apiURL+path,
+		body,
+	)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	httpReq.Header.Set("ShamHub-Admin-Token", c.token)
+
+	httpResp, err := c.client.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("send request: %w", err)
+	}
+	defer func() {
+		_ = httpResp.Body.Close()
+	}()
+
+	resBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+	if httpResp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %d: %s", httpResp.StatusCode, resBody)
+	}
+	if res == nil {
+		return nil
+	}
+	if err := json.Unmarshal(resBody, res); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
+}

--- a/internal/forge/shamhub/cli_main.go
+++ b/internal/forge/shamhub/cli_main.go
@@ -1,14 +1,12 @@
 package shamhub
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
-	"net/http"
 	"net/url"
 	"os"
 	"slices"
@@ -106,135 +104,6 @@ func (c *shamhubCLI) run(args []string) error {
 	default:
 		return fmt.Errorf("unknown command: %s", cmd)
 	}
-}
-
-// shamhubCLIAdminClient is the CLI's REST transport for ShamHub admin routes.
-type shamhubCLIAdminClient struct {
-	apiURL string
-	gitURL string
-	token  string
-	client *http.Client
-}
-
-func newShamHubCLIAdminClient(
-	getenv func(string) string,
-) (*shamhubCLIAdminClient, error) {
-	apiURL := getenv("SHAMHUB_API_URL")
-	if apiURL == "" {
-		return nil, errors.New("SHAMHUB_API_URL is required")
-	}
-	if _, err := url.Parse(apiURL); err != nil {
-		return nil, fmt.Errorf("parse SHAMHUB_API_URL: %w", err)
-	}
-
-	gitURL := getenv("SHAMHUB_URL")
-	if gitURL == "" {
-		return nil, errors.New("SHAMHUB_URL is required")
-	}
-	if _, err := url.Parse(gitURL); err != nil {
-		return nil, fmt.Errorf("parse SHAMHUB_URL: %w", err)
-	}
-
-	token := getenv("SHAMHUB_ADMIN_TOKEN")
-	if token == "" {
-		return nil, errors.New("SHAMHUB_ADMIN_TOKEN is required")
-	}
-
-	return &shamhubCLIAdminClient{
-		apiURL: strings.TrimRight(apiURL, "/"),
-		gitURL: strings.TrimRight(gitURL, "/"),
-		token:  token,
-		client: http.DefaultClient,
-	}, nil
-}
-
-// Get sends an authenticated GET request to a ShamHub admin endpoint.
-func (c *shamhubCLIAdminClient) Get(
-	ctx context.Context,
-	path string,
-	res any,
-) error {
-	return c.do(ctx, http.MethodGet, path, nil, res)
-}
-
-// Post sends an authenticated POST request to a ShamHub admin endpoint.
-func (c *shamhubCLIAdminClient) Post(
-	ctx context.Context,
-	path string,
-	req any,
-	res any,
-) error {
-	return c.do(ctx, http.MethodPost, path, req, res)
-}
-
-// Patch sends an authenticated PATCH request to a ShamHub admin endpoint.
-func (c *shamhubCLIAdminClient) Patch(
-	ctx context.Context,
-	path string,
-	req any,
-	res any,
-) error {
-	return c.do(ctx, http.MethodPatch, path, req, res)
-}
-
-// Delete sends an authenticated DELETE request to a ShamHub admin endpoint.
-func (c *shamhubCLIAdminClient) Delete(
-	ctx context.Context,
-	path string,
-	res any,
-) error {
-	return c.do(ctx, http.MethodDelete, path, nil, res)
-}
-
-func (c *shamhubCLIAdminClient) do(
-	ctx context.Context,
-	method string,
-	path string,
-	req any,
-	res any,
-) error {
-	var body io.Reader
-	if req != nil {
-		bs, err := json.Marshal(req)
-		if err != nil {
-			return fmt.Errorf("marshal request: %w", err)
-		}
-		body = bytes.NewReader(bs)
-	}
-
-	httpReq, err := http.NewRequestWithContext(
-		ctx,
-		method,
-		c.apiURL+path,
-		body,
-	)
-	if err != nil {
-		return fmt.Errorf("create request: %w", err)
-	}
-	httpReq.Header.Set("ShamHub-Admin-Token", c.token)
-
-	httpResp, err := c.client.Do(httpReq)
-	if err != nil {
-		return fmt.Errorf("send request: %w", err)
-	}
-	defer func() {
-		_ = httpResp.Body.Close()
-	}()
-
-	resBody, err := io.ReadAll(httpResp.Body)
-	if err != nil {
-		return fmt.Errorf("read response: %w", err)
-	}
-	if httpResp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status %d: %s", httpResp.StatusCode, resBody)
-	}
-	if res == nil {
-		return nil
-	}
-	if err := json.Unmarshal(resBody, res); err != nil {
-		return fmt.Errorf("decode response: %w", err)
-	}
-	return nil
 }
 
 // Comment commands seed and mutate review comments for test scenarios.


### PR DESCRIPTION
The ShamHub CLI keeps command dispatch, command implementations, and its admin REST transport in one package. Move the transport client into cli_admin_client.go so changes to endpoint communication are local to the client file while cli_main.go stays centered on command dispatch and command behavior.

This is a package-local file organization change. Command syntax, environment variables, endpoint paths, request bodies, and response handling remain unchanged.

[skip changelog]