### PR TITLE
fix(uitest): Classify each RunScripts input

### DIFF
--- a/internal/ui/uitest/script.go
+++ b/internal/ui/uitest/script.go
@@ -64,7 +64,7 @@ func RunScripts(
 	}
 
 	for _, file := range files {
-		info, err := os.Stat(files[0])
+		info, err := os.Stat(file)
 		require.NoError(t, err)
 		if !info.IsDir() {
 			params.Files = append(params.Files, file)
@@ -174,7 +174,7 @@ func RunScripts(
 //		Print a copy of the screen to the script's stdout.
 //	feed [-r N] txt
 //		Post the given text to the command's stdin.
-//		If -count is given, the input is repeated N times.
+//		If -r is given, the input is repeated N times.
 func SetupScript(params *testscript.Params) (setEmulator func(*testscript.TestScript, Emulator)) {
 	type stateKey struct{}
 	type stateValue struct{ V *scriptState }
@@ -282,7 +282,7 @@ type Emulator interface {
 
 var _ Emulator = (*EmulatorView)(nil)
 
-// ScriptOptions are options for running a script against
+// ScriptOptions are options for running a script against a terminal emulator.
 type ScriptOptions struct {
 	// Logf is a function that logs messages.
 	//

--- a/internal/ui/uitest/script_test.go
+++ b/internal/ui/uitest/script_test.go
@@ -1,0 +1,54 @@
+package uitest
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/rogpeppe/go-internal/testscript"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/ui"
+)
+
+func TestRunScripts_mixedFileAndDirectoryInputs(t *testing.T) {
+	dir := t.TempDir()
+	fileScript := filepath.Join(dir, "file.txt")
+	scriptDir := filepath.Join(dir, "scripts")
+
+	require.NoError(t, os.WriteFile(fileScript, []byte("record file\n"), 0o644))
+	require.NoError(t, os.Mkdir(scriptDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(scriptDir, "dir.txt"), []byte("record dir\n"), 0o644))
+
+	var (
+		mu  sync.Mutex
+		got []string
+	)
+	t.Cleanup(func() {
+		mu.Lock()
+		defer mu.Unlock()
+		assert.ElementsMatch(t, []string{"file", "dir"}, got)
+	})
+
+	RunScripts(
+		t,
+		func(testing.TB, *testscript.TestScript, ui.InteractiveView) {},
+		&RunScriptsOptions{
+			Cmds: map[string]func(*testscript.TestScript, bool, []string){
+				"record": func(ts *testscript.TestScript, neg bool, args []string) {
+					if neg || len(args) != 1 {
+						ts.Fatalf("usage: record value")
+					}
+
+					mu.Lock()
+					defer mu.Unlock()
+					got = append(got, strings.Join(args, " "))
+				},
+			},
+		},
+		fileScript,
+		scriptDir,
+	)
+}


### PR DESCRIPTION
RunScripts promises that each input path can be a script file or a directory containing script files. The input scan now stats the current path instead of reusing the first path, so mixed file and directory inputs both enter testscript with the intended script files.

The regression covers a file argument followed by a directory argument and fails when the directory is classified from the first file. The nearby SetupScript and ScriptOptions documentation now matches the script API.

[skip changelog]