### PR TITLE
refactor(forge): Build forges from definitions

### DIFF
--- a/.agents/docs/style.md
+++ b/.agents/docs/style.md
@@ -35,6 +35,13 @@ Do not collect all constants, interfaces, types, or helpers at the top
 of a file
 unless they are genuinely file-wide concepts.
 
+### Embedding
+
+For structs and interfaces,
+put embedded fields or embedded interfaces at the top of the type body.
+Separate embedded entries from explicitly declared fields or methods
+with a blank line.
+
 ## Naming
 
 Use one stable term for one domain concept.

--- a/.changes/unreleased/Fixed-20260706-193908.yaml
+++ b/.changes/unreleased/Fixed-20260706-193908.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'forge: `spice.forge.kind` now works with remotes that use `url.*.insteadOf` rewriting.'
+time: 2026-07-06T19:39:08.631966-07:00

--- a/auth.go
+++ b/auth.go
@@ -57,67 +57,74 @@ func resolveForge(
 	forgeID string,
 	configuredKind string,
 ) (forge.Forge, error) {
-	if forgeID != "" {
-		f, ok := forges.Lookup(forgeID)
-		if !ok {
+	remoteURL, rawRemoteURL, err := currentRemoteURL(ctx, log)
+	if err != nil {
+		return nil, err
+	}
+
+	if wantForge := cmp.Or(forgeID, configuredKind); wantForge != "" {
+		f, err := forges.New(wantForge, remoteURL)
+		if errors.Is(err, forge.ErrUnknown) {
 			var available []string
-			for f := range forges.All() {
-				available = append(available, f.ID())
+			for d := range forges.All() {
+				available = append(available, d.ID())
 			}
 			slices.Sort(available)
 
 			log.Errorf("Forge ID must be one of: %s", strings.Join(available, ", "))
-			return nil, fmt.Errorf("unknown forge: %s", forgeID)
+			return nil, fmt.Errorf("unknown forge: %q", wantForge)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("construct forge %q: %w", wantForge, err)
 		}
 		return f, nil
 	}
 
-	if configuredKind != "" {
-		return lookupForgeKind(forges, configuredKind)
-	}
-
-	f, _, err := guessCurrentForge(ctx, forges, log)
-	if err == nil {
+	f, _, ok := forge.InferFromRemoteURL(forges, remoteURL)
+	if ok {
 		return f, nil
 	}
 
-	var opts []ui.SelectOption[forge.Forge]
-	for f := range forges.All() {
-		opts = append(opts, ui.SelectOption[forge.Forge]{
-			Label: forge.GetDisplayName(f),
-			Value: f,
+	var opts []ui.SelectOption[forge.Definition]
+	for d := range forges.All() {
+		opts = append(opts, ui.SelectOption[forge.Definition]{
+			Label: forge.GetDisplayName(d),
+			Value: d,
 		})
 	}
-	slices.SortFunc(opts, func(a, b ui.SelectOption[forge.Forge]) int {
+	slices.SortFunc(opts, func(a, b ui.SelectOption[forge.Definition]) int {
 		return cmp.Compare(a.Label, b.Label)
 	})
 
 	// If there's only one known Forge, there's no need to prompt.
 	if len(opts) == 1 {
-		return opts[0].Value, nil
+		return opts[0].Value.New(remoteURL)
 	}
 
 	if !ui.Interactive(view) {
+		err := fmt.Errorf("no forge found for %s", rawRemoteURL)
 		log.Error("No Forge specified, and could not guess one from the repository", "error", err)
 		return nil, fmt.Errorf("%w: please use the --forge flag", errNoPrompt)
 	}
 
-	field := ui.NewSelect[forge.Forge]().
+	var selected forge.Definition
+	field := ui.NewSelect[forge.Definition]().
 		WithTitle("Select a Forge").
 		WithOptions(opts...).
-		WithValue(&f)
+		WithValue(&selected)
 	err = ui.Run(view, field)
-	return f, err
+	if err != nil {
+		return nil, err
+	}
+	return selected.New(remoteURL)
 }
 
-// guessCurrentForge attempts to guess the current forge based on the
-// current directory.
-func guessCurrentForge(ctx context.Context, forges *forge.Registry, log *silog.Logger) (forge.Forge, forge.RepositoryID, error) {
+func currentRemoteURL(ctx context.Context, log *silog.Logger) (*giturl.URL, string, error) {
 	repo, err := git.Open(ctx, ".", git.OpenOptions{
 		Log: log,
 	})
 	if err != nil {
-		return nil, nil, errors.New("not in a Git repository")
+		return nil, "", errors.New("not in a Git repository")
 	}
 
 	// If the repository is already initialized with git-spice,
@@ -133,11 +140,11 @@ func guessCurrentForge(ctx context.Context, forges *forge.Registry, log *silog.L
 	if remote == "" {
 		remotes, err := repo.ListRemotes(ctx)
 		if err != nil {
-			return nil, nil, fmt.Errorf("list remotes: %w", err)
+			return nil, "", fmt.Errorf("list remotes: %w", err)
 		}
 		switch len(remotes) {
 		case 0:
-			return nil, nil, errors.New("no remote set for repository")
+			return nil, "", errors.New("no remote set for repository")
 
 		case 1:
 			remote = remotes[0]
@@ -146,24 +153,19 @@ func guessCurrentForge(ctx context.Context, forges *forge.Registry, log *silog.L
 			// Repository not initialized with git-spice
 			// and has multiple remotes.
 			// We can't guess the forge in this case.
-			return nil, nil, fmt.Errorf("multiple remotes found: initialize with %s first", cli.Name())
+			return nil, "", fmt.Errorf("multiple remotes found: initialize with %s first", cli.Name())
 		}
 	}
 
 	remoteURL, err := repo.RemoteURL(ctx, remote)
 	if err != nil {
-		return nil, nil, fmt.Errorf("get remote URL: %w", err)
+		return nil, "", fmt.Errorf("get remote URL: %w", err)
 	}
 
 	parsedRemoteURL, err := giturl.Parse(remoteURL)
 	if err != nil {
-		return nil, nil, fmt.Errorf("parse remote URL: %w", err)
+		return nil, "", fmt.Errorf("parse remote URL: %w", err)
 	}
 
-	forge, repoID, ok := forge.FromRemoteURL(forges, parsedRemoteURL)
-	if !ok {
-		return nil, nil, fmt.Errorf("no forge found for %s", remoteURL)
-	}
-
-	return forge, repoID, nil
+	return parsedRemoteURL, remoteURL, nil
 }

--- a/auth.go
+++ b/auth.go
@@ -57,14 +57,9 @@ func resolveForge(
 	forgeID string,
 	configuredKind string,
 ) (forge.Forge, error) {
-	remoteURL, rawRemoteURL, err := currentRemoteURL(ctx, log)
-	if err != nil {
-		return nil, err
-	}
-
 	if wantForge := cmp.Or(forgeID, configuredKind); wantForge != "" {
-		f, err := forges.New(wantForge, remoteURL)
-		if errors.Is(err, forge.ErrUnknown) {
+		d, ok := forges.Lookup(wantForge)
+		if !ok {
 			var available []string
 			for d := range forges.All() {
 				available = append(available, d.ID())
@@ -74,10 +69,25 @@ func resolveForge(
 			log.Errorf("Forge ID must be one of: %s", strings.Join(available, ", "))
 			return nil, fmt.Errorf("unknown forge: %q", wantForge)
 		}
+
+		remoteURL, _, err := currentRemoteURL(ctx, log)
+		if err != nil {
+			remoteURL, err = giturl.Parse(d.BaseURL())
+			if err != nil {
+				return nil, fmt.Errorf("parse forge base URL: %w", err)
+			}
+		}
+
+		f, err := d.New(remoteURL)
 		if err != nil {
 			return nil, fmt.Errorf("construct forge %q: %w", wantForge, err)
 		}
 		return f, nil
+	}
+
+	remoteURL, rawRemoteURL, err := currentRemoteURL(ctx, log)
+	if err != nil {
+		return nil, err
 	}
 
 	f, _, ok := forge.InferFromRemoteURL(forges, remoteURL)

--- a/auth_test.go
+++ b/auth_test.go
@@ -22,8 +22,8 @@ func TestResolveForge_explicitForgeWins(t *testing.T) {
 	gitlab.EXPECT().ID().Return("gitlab").AnyTimes()
 
 	var forges forge.Registry
-	forges.Register(github)
-	forges.Register(gitlab)
+	registerTestForge(&forges, "github", github)
+	registerTestForge(&forges, "gitlab", gitlab)
 
 	got, err := resolveForge(
 		t.Context(),
@@ -47,8 +47,8 @@ func TestResolveForge_configuredKind(t *testing.T) {
 	gitlab.EXPECT().ID().Return("gitlab").AnyTimes()
 
 	var forges forge.Registry
-	forges.Register(github)
-	forges.Register(gitlab)
+	registerTestForge(&forges, "github", github)
+	registerTestForge(&forges, "gitlab", gitlab)
 
 	got, err := resolveForge(
 		t.Context(),
@@ -63,20 +63,10 @@ func TestResolveForge_configuredKind(t *testing.T) {
 	assert.Same(t, github, got)
 }
 
-func TestResolveForge_noForgeSignalPreservesNoninteractiveError(t *testing.T) {
+func TestResolveForge_requiresGitRemote(t *testing.T) {
 	t.Chdir(t.TempDir())
 
-	ctrl := gomock.NewController(t)
-
-	github := forgetest.NewMockForge(ctrl)
-	github.EXPECT().ID().Return("github").AnyTimes()
-	gitlab := forgetest.NewMockForge(ctrl)
-	gitlab.EXPECT().ID().Return("gitlab").AnyTimes()
-
 	var forges forge.Registry
-	forges.Register(github)
-	forges.Register(gitlab)
-
 	_, err := resolveForge(
 		t.Context(),
 		&forges,
@@ -87,5 +77,5 @@ func TestResolveForge_noForgeSignalPreservesNoninteractiveError(t *testing.T) {
 	)
 	require.Error(t, err)
 
-	assert.ErrorIs(t, err, errNoPrompt)
+	assert.ErrorContains(t, err, "not in a Git repository")
 }

--- a/auth_test.go
+++ b/auth_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/forge/forgetest"
+	"go.abhg.dev/gs/internal/git/giturl"
 	"go.abhg.dev/gs/internal/silog/silogtest"
 	"go.abhg.dev/gs/internal/ui"
 	"go.uber.org/mock/gomock"
@@ -36,6 +37,39 @@ func TestResolveForge_explicitForgeWins(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Same(t, gitlab, got)
+}
+
+func TestResolveForge_explicitForgeWithoutRepositoryRemote(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	ctrl := gomock.NewController(t)
+
+	github := forgetest.NewMockForge(ctrl)
+	github.EXPECT().ID().Return("github").AnyTimes()
+
+	var gotRemoteURL *giturl.URL
+	var forges forge.Registry
+	forges.Register(testDefinition{
+		id: "github",
+		new: func(remoteURL *giturl.URL) (forge.Forge, error) {
+			gotRemoteURL = remoteURL
+			return github, nil
+		},
+	})
+
+	got, err := resolveForge(
+		t.Context(),
+		&forges,
+		silogtest.New(t),
+		ui.NewFileView(io.Discard),
+		"github",
+		"",
+	)
+	require.NoError(t, err)
+
+	assert.Same(t, github, got)
+	require.NotNil(t, gotRemoteURL)
+	assert.Equal(t, "https://example.com", gotRemoteURL.Raw)
 }
 
 func TestResolveForge_configuredKind(t *testing.T) {

--- a/internal/forge/bitbucket/forge.go
+++ b/internal/forge/bitbucket/forge.go
@@ -8,11 +8,15 @@ import (
 
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/gateway/bitbucket"
+	"go.abhg.dev/gs/internal/git/giturl"
 	"go.abhg.dev/gs/internal/silog"
 )
 
-// Forge builds a Bitbucket Forge.
-type Forge struct {
+// Definition configures Bitbucket forge instances.
+type Definition struct {
+	changeMetadataCodec
+
+	// Options stores CLI and environment configuration.
 	Options Options
 
 	// Log specifies the logger to use.
@@ -20,9 +24,45 @@ type Forge struct {
 }
 
 var (
+	_ forge.Definition        = (*Definition)(nil)
 	_ forge.Forge             = (*Forge)(nil)
 	_ forge.WithCommentFormat = (*Forge)(nil)
 )
+
+// ID reports a unique key for this forge.
+func (*Definition) ID() string { return "bitbucket" }
+
+// BaseURL reports the Bitbucket web URL used for host matching.
+func (d *Definition) BaseURL() string {
+	return cmp.Or(d.Options.URL, DefaultURL)
+}
+
+// CLIPlugin returns the CLI plugin for the Bitbucket Forge.
+func (d *Definition) CLIPlugin() any { return &d.Options }
+
+// New constructs a Bitbucket Forge from the configured options.
+func (d *Definition) New(remoteURL *giturl.URL) (forge.Forge, error) {
+	if err := forge.ValidateRemoteURL(d.Options.URL, remoteURL); err != nil {
+		return nil, err
+	}
+
+	return &Forge{
+		Options: d.Options,
+		baseURL: d.BaseURL(),
+		Log:     d.Log,
+	}, nil
+}
+
+// Forge provides a Bitbucket forge instance.
+type Forge struct {
+	changeMetadataCodec
+
+	Options Options
+	baseURL string
+
+	// Log specifies the logger to use.
+	Log *silog.Logger
+}
 
 func (f *Forge) logger() *silog.Logger {
 	if f.Log == nil {
@@ -39,7 +79,7 @@ func (f *Forge) URL() string {
 
 // BaseURL reports the Bitbucket web URL used for host matching and links.
 func (f *Forge) BaseURL() string {
-	return f.URL()
+	return f.baseURL
 }
 
 // APIURL returns the base API URL configured for the Bitbucket Forge
@@ -62,9 +102,6 @@ func (*Forge) CommentFormat() forge.CommentFormat {
 		Marker: "[gs]: # (navigation comment)",
 	}
 }
-
-// CLIPlugin returns the CLI plugin for the Bitbucket Forge.
-func (f *Forge) CLIPlugin() any { return &f.Options }
 
 // ChangeTemplatePaths reports the paths at which change templates
 // can be found in a Bitbucket repository.

--- a/internal/forge/bitbucket/types.go
+++ b/internal/forge/bitbucket/types.go
@@ -95,13 +95,15 @@ func (m *PRMetadata) SetNavigationCommentID(id forge.ChangeCommentID) {
 	m.NavigationComment = mustPRComment(id)
 }
 
+type changeMetadataCodec struct{}
+
 // MarshalChangeMetadata serializes a PRMetadata into JSON.
-func (*Forge) MarshalChangeMetadata(md forge.ChangeMetadata) (json.RawMessage, error) {
+func (changeMetadataCodec) MarshalChangeMetadata(md forge.ChangeMetadata) (json.RawMessage, error) {
 	return json.Marshal(md)
 }
 
 // UnmarshalChangeMetadata deserializes a PRMetadata from JSON.
-func (*Forge) UnmarshalChangeMetadata(data json.RawMessage) (forge.ChangeMetadata, error) {
+func (changeMetadataCodec) UnmarshalChangeMetadata(data json.RawMessage) (forge.ChangeMetadata, error) {
 	var md PRMetadata
 	if err := json.Unmarshal(data, &md); err != nil {
 		return nil, fmt.Errorf("unmarshal PR metadata: %w", err)

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"iter"
 
+	"go.abhg.dev/gs/internal/git/giturl"
 	"go.abhg.dev/gs/internal/secret"
 	"go.abhg.dev/gs/internal/ui"
 )
@@ -18,18 +19,41 @@ import (
 // Forge should become a struct with multiple interfaces or funcctions
 // that it depends on in the underlying implementation.
 
-// Forge is a forge that hosts Git repositories.
-type Forge interface {
-	// ID reports a unique identifier for the forge, e.g. "github".
-	ID() string // TODO: Rename to "slug" or "name" as that's more correct
+// Definition describes a forge implementation before it is bound
+// to a particular repository remote.
+type Definition interface {
+	ChangeMetadataCodec
 
-	// CLIPlugin returns a Kong plugin for this Forge.
+	// ID reports a unique identifier for the forge, e.g. "github".
+	ID() string
+
+	// BaseURL reports the configured forge web URL.
+	//
+	// Remote URL inference uses the host and optional port from this URL.
+	BaseURL() string
+
+	// CLIPlugin returns a Kong plugin for this forge.
 	//
 	// This will be installed into the application to provide
 	// additional Forge-specific flags or environment variable overrides.
 	//
 	// Return nil if the forge does not require any extra CLI flags.
 	CLIPlugin() any
+
+	// New constructs a forge instance for the given remote URL.
+	//
+	// The remote URL must be non-nil.
+	// Implementations may use it to derive instance configuration
+	// that is not known when command-line options are registered.
+	New(remoteURL *giturl.URL) (Forge, error)
+}
+
+// Forge is a forge that hosts Git repositories.
+type Forge interface {
+	ChangeMetadataCodec
+
+	// ID reports a unique identifier for the forge, e.g. "github".
+	ID() string // TODO: Rename to "slug" or "name" as that's more correct
 
 	// BaseURL reports the configured forge web URL.
 	//
@@ -67,14 +91,6 @@ type Forge interface {
 	// UnmarshalChangeID deserializes the given JSON blob into a change ID.
 	UnmarshalChangeID(json.RawMessage) (ChangeID, error)
 
-	// MarshalChangeMetadata serializes the given change metadata
-	// into a valid JSON blob.
-	MarshalChangeMetadata(ChangeMetadata) (json.RawMessage, error)
-
-	// UnmarshalChangeMetadata deserializes the given JSON blob
-	// into change metadata.
-	UnmarshalChangeMetadata(json.RawMessage) (ChangeMetadata, error)
-
 	// AuthenticationFlow runs the authentication flow for the forge.
 	// This may prompt the user, perform network requests, etc.
 	//
@@ -95,25 +111,33 @@ type Forge interface {
 	ClearAuthenticationToken(secret.Stash) error
 }
 
-// WithDisplayName is an optional interface that forges can implement
-// to provide a human-friendly display name for the UI.
-// If not implemented, the forge's ID is used as the display name.
-type WithDisplayName interface {
-	Forge
+// ChangeMetadataCodec serializes persisted forge change metadata.
+type ChangeMetadataCodec interface {
+	// MarshalChangeMetadata serializes the given change metadata
+	// into a valid JSON blob.
+	MarshalChangeMetadata(ChangeMetadata) (json.RawMessage, error)
 
+	// UnmarshalChangeMetadata deserializes the given JSON blob
+	// into change metadata.
+	UnmarshalChangeMetadata(json.RawMessage) (ChangeMetadata, error)
+}
+
+// WithDisplayName is an optional interface for values with UI display names.
+// If not implemented, the value's ID is used as the display name.
+type WithDisplayName interface {
 	// DisplayName returns a human-friendly name for the forge,
 	// e.g. "Bitbucket (Atlassian)" instead of just "bitbucket".
 	DisplayName() string
 }
 
-// GetDisplayName returns the display name for a forge.
-// If the forge implements WithDisplayName, it returns DisplayName().
-// Otherwise, it returns the forge's ID.
-func GetDisplayName(f Forge) string {
-	if fd, ok := f.(WithDisplayName); ok {
+// GetDisplayName returns the display name for a forge or forge definition.
+// If the value implements WithDisplayName, it returns DisplayName().
+// Otherwise, it returns the value's ID.
+func GetDisplayName(v interface{ ID() string }) string {
+	if fd, ok := v.(WithDisplayName); ok {
 		return fd.DisplayName()
 	}
-	return f.ID()
+	return v.ID()
 }
 
 // AuthenticationToken is a secret that results from a successful login.
@@ -142,6 +166,9 @@ type RepositoryID interface {
 // ErrUnsubmittedBase indicates that a change cannot be submitted
 // because the base branch has not been pushed yet.
 var ErrUnsubmittedBase = errors.New("base branch has not been submitted yet")
+
+// ErrUnknown indicates that a requested forge is not registered.
+var ErrUnknown = errors.New("unknown forge")
 
 // Repository is a Git repository hosted on a forge.
 type Repository interface {

--- a/internal/forge/forge_test.go
+++ b/internal/forge/forge_test.go
@@ -1,14 +1,20 @@
 package forge_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/forge/bitbucket"
 	"go.abhg.dev/gs/internal/forge/forgejo"
 	"go.abhg.dev/gs/internal/forge/forgetest"
+	"go.abhg.dev/gs/internal/forge/gitea"
+	"go.abhg.dev/gs/internal/forge/github"
+	"go.abhg.dev/gs/internal/forge/gitlab"
+	"go.abhg.dev/gs/internal/forge/shamhub"
 	"go.abhg.dev/gs/internal/git/giturl"
 	"go.uber.org/mock/gomock"
 )
@@ -32,7 +38,12 @@ func TestRegister(t *testing.T) {
 		}).AnyTimes()
 
 	var registry forge.Registry
-	defer registry.Register(mockForge)()
+	defer registry.Register(testDefinition{
+		id: "a",
+		new: func(*giturl.URL) (forge.Forge, error) {
+			return mockForge, nil
+		},
+	})()
 
 	t.Run("All", func(t *testing.T) {
 		var ok bool
@@ -57,20 +68,119 @@ func TestRegister(t *testing.T) {
 	})
 }
 
-func TestFromRemoteURL_codebergForgejo(t *testing.T) {
+func TestRegistry_New(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	remoteURL, err := giturl.Parse("https://example.com/foo")
+	require.NoError(t, err)
+
+	var gotRemoteURL *giturl.URL
 	var registry forge.Registry
-	defer registry.Register(new(forgejo.Forge))()
+	defer registry.Register(testDefinition{
+		id: "a",
+		new: func(remoteURL *giturl.URL) (forge.Forge, error) {
+			gotRemoteURL = remoteURL
+
+			mockForge := forgetest.NewMockForge(ctrl)
+			mockForge.EXPECT().ID().Return("a").AnyTimes()
+			return mockForge, nil
+		},
+	})()
+
+	first, err := registry.New("a", remoteURL)
+	require.NoError(t, err)
+	second, err := registry.New("a", remoteURL)
+	require.NoError(t, err)
+
+	assert.Same(t, remoteURL, gotRemoteURL)
+	assert.NotSame(t, first, second)
+}
+
+func TestRegistry_New_requiresRemoteURL(t *testing.T) {
+	var registry forge.Registry
+	defer registry.Register(testDefinition{
+		id:      "a",
+		baseURL: "https://example.com",
+		new: func(*giturl.URL) (forge.Forge, error) {
+			t.Fatal("New should reject before calling the definition")
+			return nil, nil
+		},
+	})()
+
+	_, err := registry.New("a", nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, forge.ErrUnsupportedURL)
+}
+
+func TestInferFromRemoteURL_codebergForgejo(t *testing.T) {
+	var registry forge.Registry
+	defer registry.Register(new(forgejo.Definition))()
 
 	remoteURL, err := giturl.Parse("git@codeberg.org:example/repo.git")
 	require.NoError(t, err)
 
-	f, rid, ok := forge.FromRemoteURL(&registry, remoteURL)
+	f, rid, ok := forge.InferFromRemoteURL(&registry, remoteURL)
 	require.True(t, ok, "forge not found")
 	assert.Equal(t, "forgejo", f.ID())
 	assert.Equal(t, "example/repo", rid.String())
 }
 
-func TestFromRemoteURL(t *testing.T) {
+func TestDefinition_New_rejectsMismatchedConfiguredURL(t *testing.T) {
+	remoteURL, err := giturl.Parse("https://other.example.com/owner/repo")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		def  forge.Definition
+	}{
+		{
+			name: "Bitbucket",
+			def: &bitbucket.Definition{
+				Options: bitbucket.Options{URL: "https://bitbucket.example.com"},
+			},
+		},
+		{
+			name: "Forgejo",
+			def: &forgejo.Definition{
+				Options: forgejo.Options{URL: "https://forgejo.example.com"},
+			},
+		},
+		{
+			name: "Gitea",
+			def: &gitea.Definition{
+				Options: gitea.Options{URL: "https://gitea.example.com"},
+			},
+		},
+		{
+			name: "GitHub",
+			def: &github.Definition{
+				Options: github.Options{URL: "https://github.example.com"},
+			},
+		},
+		{
+			name: "GitLab",
+			def: &gitlab.Definition{
+				Options: gitlab.Options{URL: "https://gitlab.example.com"},
+			},
+		},
+		{
+			name: "ShamHub",
+			def: &shamhub.Definition{
+				Options: shamhub.Options{URL: "https://shamhub.example.com"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.def.New(remoteURL)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, forge.ErrUnsupportedURL)
+		})
+	}
+}
+
+func TestInferFromRemoteURL(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	tests := []struct {
@@ -105,18 +215,23 @@ func TestFromRemoteURL(t *testing.T) {
 			mockHandle := forgetest.NewMockRepositoryID(ctrl)
 			mockForge := forgetest.NewMockForge(ctrl)
 			mockForge.EXPECT().ID().Return("a").AnyTimes()
-			mockForge.EXPECT().BaseURL().Return(tt.baseURL)
 			mockForge.EXPECT().
 				ParseRepositoryPath("/foo").
 				Return(mockHandle, nil)
 
 			var registry forge.Registry
-			defer registry.Register(mockForge)()
+			defer registry.Register(testDefinition{
+				id:      "a",
+				baseURL: tt.baseURL,
+				new: func(*giturl.URL) (forge.Forge, error) {
+					return mockForge, nil
+				},
+			})()
 
 			remoteURL, err := giturl.Parse(tt.remoteURL)
 			require.NoError(t, err)
 
-			f, h, ok := forge.FromRemoteURL(&registry, remoteURL)
+			f, h, ok := forge.InferFromRemoteURL(&registry, remoteURL)
 			assert.True(t, ok, "forge not found")
 			assert.Equal(t, "a", f.ID(), "forge ID mismatch")
 			assert.Same(t, mockHandle, h, "repository ID mismatch")
@@ -124,7 +239,7 @@ func TestFromRemoteURL(t *testing.T) {
 	}
 }
 
-func TestFromRemoteURL_noMatch(t *testing.T) {
+func TestInferFromRemoteURL_noMatch(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	tests := []struct {
@@ -158,37 +273,47 @@ func TestFromRemoteURL_noMatch(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockForge := forgetest.NewMockForge(ctrl)
 			mockForge.EXPECT().ID().Return("a").AnyTimes()
-			mockForge.EXPECT().BaseURL().Return(tt.baseURL)
 
 			var registry forge.Registry
-			defer registry.Register(mockForge)()
+			defer registry.Register(testDefinition{
+				id:      "a",
+				baseURL: tt.baseURL,
+				new: func(*giturl.URL) (forge.Forge, error) {
+					return mockForge, nil
+				},
+			})()
 
 			remoteURL, err := giturl.Parse(tt.remoteURL)
 			require.NoError(t, err)
 
-			_, _, ok := forge.FromRemoteURL(&registry, remoteURL)
+			_, _, ok := forge.InferFromRemoteURL(&registry, remoteURL)
 			assert.False(t, ok, "unexpected forge match")
 		})
 	}
 }
 
-func TestFromRemoteURL_unsupportedRepositoryPath(t *testing.T) {
+func TestInferFromRemoteURL_unsupportedRepositoryPath(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockForge := forgetest.NewMockForge(ctrl)
 	mockForge.EXPECT().ID().Return("a").AnyTimes()
-	mockForge.EXPECT().BaseURL().Return("https://example.com")
 	mockForge.EXPECT().
 		ParseRepositoryPath("/foo").
 		Return(nil, fmt.Errorf("%w: unexpected path", forge.ErrUnsupportedURL))
 
 	var registry forge.Registry
-	defer registry.Register(mockForge)()
+	defer registry.Register(testDefinition{
+		id:      "a",
+		baseURL: "https://example.com",
+		new: func(*giturl.URL) (forge.Forge, error) {
+			return mockForge, nil
+		},
+	})()
 
 	remoteURL, err := giturl.Parse("https://example.com/foo")
 	require.NoError(t, err)
 
-	_, _, ok := forge.FromRemoteURL(&registry, remoteURL)
+	_, _, ok := forge.InferFromRemoteURL(&registry, remoteURL)
 	assert.False(t, ok, "unexpected forge match")
 }
 
@@ -275,6 +400,31 @@ func TestSplitRepositoryPath_noMatch(t *testing.T) {
 			assert.False(t, ok)
 		})
 	}
+}
+
+type testDefinition struct {
+	id      string
+	baseURL string
+	plugin  any
+	new     func(*giturl.URL) (forge.Forge, error)
+}
+
+func (d testDefinition) ID() string { return d.id }
+
+func (d testDefinition) BaseURL() string { return d.baseURL }
+
+func (d testDefinition) CLIPlugin() any { return d.plugin }
+
+func (testDefinition) MarshalChangeMetadata(forge.ChangeMetadata) (json.RawMessage, error) {
+	return nil, nil
+}
+
+func (testDefinition) UnmarshalChangeMetadata(json.RawMessage) (forge.ChangeMetadata, error) {
+	return nil, nil
+}
+
+func (d testDefinition) New(remoteURL *giturl.URL) (forge.Forge, error) {
+	return d.new(remoteURL)
 }
 
 func TestChangeState(t *testing.T) {

--- a/internal/forge/forgejo/change_meta.go
+++ b/internal/forge/forgejo/change_meta.go
@@ -77,15 +77,17 @@ func (m *PRMetadata) SetNavigationCommentID(id forge.ChangeCommentID) {
 	m.NavigationComment = mustPRComment(id)
 }
 
+type changeMetadataCodec struct{}
+
 // MarshalChangeMetadata serializes a PRMetadata into JSON.
-func (*Forge) MarshalChangeMetadata(
+func (changeMetadataCodec) MarshalChangeMetadata(
 	md forge.ChangeMetadata,
 ) (json.RawMessage, error) {
 	return json.Marshal(md)
 }
 
 // UnmarshalChangeMetadata deserializes a PRMetadata from JSON.
-func (*Forge) UnmarshalChangeMetadata(
+func (changeMetadataCodec) UnmarshalChangeMetadata(
 	data json.RawMessage,
 ) (forge.ChangeMetadata, error) {
 	var md PRMetadata

--- a/internal/forge/forgejo/forge.go
+++ b/internal/forge/forgejo/forge.go
@@ -9,6 +9,7 @@ import (
 
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/gateway/forgejo"
+	"go.abhg.dev/gs/internal/git/giturl"
 	"go.abhg.dev/gs/internal/silog"
 )
 
@@ -34,15 +35,56 @@ type Options struct {
 	Token string `name:"forgejo-token" hidden:"" env:"FORGEJO_TOKEN" help:"Forgejo API token"`
 }
 
-// Forge builds a Forgejo Forge.
-type Forge struct {
+// Definition configures Forgejo forge instances.
+type Definition struct {
+	changeMetadataCodec
+
+	// Options stores CLI and environment configuration.
 	Options Options
 
 	// Log specifies the logger to use.
 	Log *silog.Logger
 }
 
-var _ forge.Forge = (*Forge)(nil)
+var (
+	_ forge.Definition = (*Definition)(nil)
+	_ forge.Forge      = (*Forge)(nil)
+)
+
+// ID reports a unique key for this forge.
+func (*Definition) ID() string { return "forgejo" }
+
+// BaseURL reports the Forgejo web URL used for host matching.
+func (d *Definition) BaseURL() string {
+	return cmp.Or(d.Options.URL, DefaultURL)
+}
+
+// CLIPlugin returns the CLI plugin for the Forgejo Forge.
+func (d *Definition) CLIPlugin() any { return &d.Options }
+
+// New constructs a Forgejo Forge from the configured options.
+func (d *Definition) New(remoteURL *giturl.URL) (forge.Forge, error) {
+	if err := forge.ValidateRemoteURL(d.Options.URL, remoteURL); err != nil {
+		return nil, err
+	}
+
+	return &Forge{
+		Options: d.Options,
+		baseURL: d.BaseURL(),
+		Log:     d.Log,
+	}, nil
+}
+
+// Forge provides a Forgejo forge instance.
+type Forge struct {
+	changeMetadataCodec
+
+	Options Options
+	baseURL string
+
+	// Log specifies the logger to use.
+	Log *silog.Logger
+}
 
 func (f *Forge) logger() *silog.Logger {
 	if f.Log == nil {
@@ -59,7 +101,7 @@ func (f *Forge) URL() string {
 
 // BaseURL reports the Forgejo web URL used for host matching and links.
 func (f *Forge) BaseURL() string {
-	return f.URL()
+	return f.baseURL
 }
 
 // APIURL returns the base API URL configured for the Forgejo Forge
@@ -70,9 +112,6 @@ func (f *Forge) APIURL() string {
 
 // ID reports a unique key for this forge.
 func (*Forge) ID() string { return "forgejo" }
-
-// CLIPlugin returns the CLI plugin for the Forgejo Forge.
-func (f *Forge) CLIPlugin() any { return &f.Options }
 
 // ParseRepositoryPath parses a Forgejo repository path and returns
 // a [forge.RepositoryID] for the repository it identifies.

--- a/internal/forge/forgetest/mocks.go
+++ b/internal/forge/forgetest/mocks.go
@@ -122,44 +122,6 @@ func (c *MockForgeBaseURLCall) DoAndReturn(f func() string) *MockForgeBaseURLCal
 	return c
 }
 
-// CLIPlugin mocks base method.
-func (m *MockForge) CLIPlugin() any {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CLIPlugin")
-	ret0, _ := ret[0].(any)
-	return ret0
-}
-
-// CLIPlugin indicates an expected call of CLIPlugin.
-func (mr *MockForgeMockRecorder) CLIPlugin() *MockForgeCLIPluginCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CLIPlugin", reflect.TypeOf((*MockForge)(nil).CLIPlugin))
-	return &MockForgeCLIPluginCall{Call: call}
-}
-
-// MockForgeCLIPluginCall wrap *gomock.Call
-type MockForgeCLIPluginCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockForgeCLIPluginCall) Return(arg0 any) *MockForgeCLIPluginCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockForgeCLIPluginCall) Do(f func() any) *MockForgeCLIPluginCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockForgeCLIPluginCall) DoAndReturn(f func() any) *MockForgeCLIPluginCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // ChangeTemplatePaths mocks base method.
 func (m *MockForge) ChangeTemplatePaths() []string {
 	m.ctrl.T.Helper()

--- a/internal/forge/gitea/change_meta.go
+++ b/internal/forge/gitea/change_meta.go
@@ -50,13 +50,15 @@ func (r *Repository) NewChangeMetadata(_ context.Context, id forge.ChangeID) (fo
 	return &PRMetadata{PR: mustPR(id)}, nil
 }
 
+type changeMetadataCodec struct{}
+
 // MarshalChangeMetadata serializes a PRMetadata into JSON.
-func (*Forge) MarshalChangeMetadata(md forge.ChangeMetadata) (json.RawMessage, error) {
+func (changeMetadataCodec) MarshalChangeMetadata(md forge.ChangeMetadata) (json.RawMessage, error) {
 	return json.Marshal(md)
 }
 
 // UnmarshalChangeMetadata deserializes a PRMetadata from JSON.
-func (*Forge) UnmarshalChangeMetadata(data json.RawMessage) (forge.ChangeMetadata, error) {
+func (changeMetadataCodec) UnmarshalChangeMetadata(data json.RawMessage) (forge.ChangeMetadata, error) {
 	var md PRMetadata
 	if err := json.Unmarshal(data, &md); err != nil {
 		return nil, fmt.Errorf("unmarshal PR metadata: %w", err)

--- a/internal/forge/gitea/forge.go
+++ b/internal/forge/gitea/forge.go
@@ -9,6 +9,7 @@ import (
 
 	"go.abhg.dev/gs/internal/forge"
 	giteagw "go.abhg.dev/gs/internal/gateway/gitea"
+	"go.abhg.dev/gs/internal/git/giturl"
 	"go.abhg.dev/gs/internal/silog"
 )
 
@@ -29,15 +30,56 @@ type Options struct {
 	Token string `name:"gitea-token" hidden:"" env:"GITEA_TOKEN" help:"Gitea API token"`
 }
 
-// Forge builds a Gitea Forge.
-type Forge struct {
+// Definition configures Gitea forge instances.
+type Definition struct {
+	changeMetadataCodec
+
+	// Options stores CLI and environment configuration.
 	Options Options
 
 	// Log specifies the logger to use.
 	Log *silog.Logger
 }
 
-var _ forge.Forge = (*Forge)(nil)
+var (
+	_ forge.Definition = (*Definition)(nil)
+	_ forge.Forge      = (*Forge)(nil)
+)
+
+// ID reports a unique key for this forge.
+func (*Definition) ID() string { return "gitea" }
+
+// BaseURL reports the Gitea web URL used for host matching.
+func (d *Definition) BaseURL() string {
+	return d.Options.URL
+}
+
+// CLIPlugin returns the CLI plugin for the Gitea Forge.
+func (d *Definition) CLIPlugin() any { return &d.Options }
+
+// New constructs a Gitea Forge from the configured options.
+func (d *Definition) New(remoteURL *giturl.URL) (forge.Forge, error) {
+	if err := forge.ValidateRemoteURL(d.Options.URL, remoteURL); err != nil {
+		return nil, err
+	}
+
+	return &Forge{
+		Options: d.Options,
+		baseURL: d.BaseURL(),
+		Log:     d.Log,
+	}, nil
+}
+
+// Forge provides a Gitea forge instance.
+type Forge struct {
+	changeMetadataCodec
+
+	Options Options
+	baseURL string
+
+	// Log specifies the logger to use.
+	Log *silog.Logger
+}
 
 func (f *Forge) logger() *silog.Logger {
 	if f.Log == nil {
@@ -54,7 +96,7 @@ func (f *Forge) URL() string {
 // BaseURL reports the Gitea instance URL used for host matching and links.
 // Returns an empty string if not configured.
 func (f *Forge) BaseURL() string {
-	return f.URL()
+	return f.baseURL
 }
 
 // apiURL returns the API URL to use for Gitea requests.
@@ -64,9 +106,6 @@ func (f *Forge) apiURL() string {
 
 // ID reports a unique key for this forge.
 func (*Forge) ID() string { return "gitea" }
-
-// CLIPlugin returns the CLI plugin for the Gitea Forge.
-func (f *Forge) CLIPlugin() any { return &f.Options }
 
 // ParseRepositoryPath parses a Gitea repository path and returns a [RepositoryID]
 // for the Gitea repository it identifies.

--- a/internal/forge/gitea/forge_test.go
+++ b/internal/forge/gitea/forge_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/git/giturl"
 )
 
 func TestForge_ID(t *testing.T) {
@@ -40,9 +41,14 @@ func TestForge_URLs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := &Forge{Options: tt.opts}
+			remoteURL, err := giturl.Parse("https://gitea.example.com/owner/repo")
+			require.NoError(t, err)
+
+			f, err := (&Definition{Options: tt.opts}).New(remoteURL)
+			require.NoError(t, err)
+
 			assert.Equal(t, tt.wantURL, f.BaseURL())
-			assert.Equal(t, tt.wantAPIURL, f.apiURL())
+			assert.Equal(t, tt.wantAPIURL, f.(*Forge).apiURL())
 		})
 	}
 }
@@ -106,7 +112,7 @@ func TestRepositoryID_ChangeURL(t *testing.T) {
 	)
 }
 
-func TestForge_CLIPlugin(t *testing.T) {
-	f := new(Forge)
-	assert.Equal(t, &f.Options, f.CLIPlugin())
+func TestDefinition_CLIPlugin(t *testing.T) {
+	d := new(Definition)
+	assert.Equal(t, &d.Options, d.CLIPlugin())
 }

--- a/internal/forge/github/change_meta.go
+++ b/internal/forge/github/change_meta.go
@@ -61,13 +61,15 @@ func (r *Repository) NewChangeMetadata(
 	return &PRMetadata{PR: pr}, nil
 }
 
+type changeMetadataCodec struct{}
+
 // MarshalChangeMetadata serializes a PRMetadata into JSON.
-func (*Forge) MarshalChangeMetadata(md forge.ChangeMetadata) (json.RawMessage, error) {
+func (changeMetadataCodec) MarshalChangeMetadata(md forge.ChangeMetadata) (json.RawMessage, error) {
 	return json.Marshal(md)
 }
 
 // UnmarshalChangeMetadata deserializes a PRMetadata from JSON.
-func (*Forge) UnmarshalChangeMetadata(data json.RawMessage) (forge.ChangeMetadata, error) {
+func (changeMetadataCodec) UnmarshalChangeMetadata(data json.RawMessage) (forge.ChangeMetadata, error) {
 	var md PRMetadata
 	if err := json.Unmarshal(data, &md); err != nil {
 		return nil, fmt.Errorf("unmarshal PR metadata: %w", err)

--- a/internal/forge/github/forge.go
+++ b/internal/forge/github/forge.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/git/giturl"
 	"go.abhg.dev/gs/internal/silog"
 	"golang.org/x/oauth2"
 )
@@ -37,15 +38,56 @@ type Options struct {
 	Token string `name:"github-token" hidden:"" env:"GITHUB_TOKEN" help:"GitHub API token"`
 }
 
-// Forge builds a GitHub Forge.
-type Forge struct {
+// Definition configures GitHub forge instances.
+type Definition struct {
+	changeMetadataCodec
+
+	// Options stores CLI and environment configuration.
 	Options Options
 
 	// Log specifies the logger to use.
 	Log *silog.Logger
 }
 
-var _ forge.Forge = (*Forge)(nil)
+var (
+	_ forge.Definition = (*Definition)(nil)
+	_ forge.Forge      = (*Forge)(nil)
+)
+
+// ID reports a unique key for this forge.
+func (*Definition) ID() string { return "github" }
+
+// BaseURL reports the GitHub web URL used for host matching.
+func (d *Definition) BaseURL() string {
+	return cmp.Or(d.Options.URL, DefaultURL)
+}
+
+// CLIPlugin returns the CLI plugin for the GitHub Forge.
+func (d *Definition) CLIPlugin() any { return &d.Options }
+
+// New constructs a GitHub Forge from the configured options.
+func (d *Definition) New(remoteURL *giturl.URL) (forge.Forge, error) {
+	if err := forge.ValidateRemoteURL(d.Options.URL, remoteURL); err != nil {
+		return nil, err
+	}
+
+	return &Forge{
+		Options: d.Options,
+		baseURL: d.BaseURL(),
+		Log:     d.Log,
+	}, nil
+}
+
+// Forge provides a GitHub forge instance.
+type Forge struct {
+	changeMetadataCodec
+
+	Options Options
+	baseURL string
+
+	// Log specifies the logger to use.
+	Log *silog.Logger
+}
 
 func (f *Forge) logger() *silog.Logger {
 	if f.Log == nil {
@@ -62,7 +104,7 @@ func (f *Forge) URL() string {
 
 // BaseURL reports the GitHub web URL used for host matching and links.
 func (f *Forge) BaseURL() string {
-	return f.URL()
+	return f.baseURL
 }
 
 // APIURL returns the base API URL configured for the GitHub Forge
@@ -86,9 +128,6 @@ func (f *Forge) APIURL() string {
 
 // ID reports a unique key for this forge.
 func (*Forge) ID() string { return "github" }
-
-// CLIPlugin returns the CLI plugin for the GitHub Forge.
-func (f *Forge) CLIPlugin() any { return &f.Options }
 
 // ParseRepositoryPath parses a GitHub repository path and returns a [RepositoryID]
 // if the path identifies a repository.

--- a/internal/forge/gitlab/change_meta.go
+++ b/internal/forge/gitlab/change_meta.go
@@ -54,13 +54,15 @@ func (r *Repository) NewChangeMetadata(_ context.Context, id forge.ChangeID) (fo
 	return &MRMetadata{MR: mr}, nil
 }
 
+type changeMetadataCodec struct{}
+
 // MarshalChangeMetadata serializes a MRMetadata into JSON.
-func (*Forge) MarshalChangeMetadata(md forge.ChangeMetadata) (json.RawMessage, error) {
+func (changeMetadataCodec) MarshalChangeMetadata(md forge.ChangeMetadata) (json.RawMessage, error) {
 	return json.Marshal(md)
 }
 
 // UnmarshalChangeMetadata deserializes a MRMetadata from JSON.
-func (*Forge) UnmarshalChangeMetadata(data json.RawMessage) (forge.ChangeMetadata, error) {
+func (changeMetadataCodec) UnmarshalChangeMetadata(data json.RawMessage) (forge.ChangeMetadata, error) {
 	var md MRMetadata
 	if err := json.Unmarshal(data, &md); err != nil {
 		return nil, fmt.Errorf("unmarshal MR metadata: %w", err)

--- a/internal/forge/gitlab/forge.go
+++ b/internal/forge/gitlab/forge.go
@@ -9,6 +9,7 @@ import (
 
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/gateway/gitlab"
+	"go.abhg.dev/gs/internal/git/giturl"
 	"go.abhg.dev/gs/internal/silog"
 )
 
@@ -42,15 +43,56 @@ type Options struct {
 	RemoveSourceBranch bool `name:"gitlab-remove-source-branch" hidden:"" config:"forge.gitlab.removeSourceBranch" default:"true" help:"Remove source branch after merging a merge request"`
 }
 
-// Forge builds a GitLab Forge.
-type Forge struct {
+// Definition configures GitLab forge instances.
+type Definition struct {
+	changeMetadataCodec
+
+	// Options stores CLI and environment configuration.
 	Options Options
 
 	// Log specifies the logger to use.
 	Log *silog.Logger
 }
 
-var _ forge.Forge = (*Forge)(nil)
+var (
+	_ forge.Definition = (*Definition)(nil)
+	_ forge.Forge      = (*Forge)(nil)
+)
+
+// ID reports a unique key for this forge.
+func (*Definition) ID() string { return "gitlab" }
+
+// BaseURL reports the GitLab web URL used for host matching.
+func (d *Definition) BaseURL() string {
+	return cmp.Or(d.Options.URL, DefaultURL)
+}
+
+// CLIPlugin returns the CLI plugin for the GitLab Forge.
+func (d *Definition) CLIPlugin() any { return &d.Options }
+
+// New constructs a GitLab Forge from the configured options.
+func (d *Definition) New(remoteURL *giturl.URL) (forge.Forge, error) {
+	if err := forge.ValidateRemoteURL(d.Options.URL, remoteURL); err != nil {
+		return nil, err
+	}
+
+	return &Forge{
+		Options: d.Options,
+		baseURL: d.BaseURL(),
+		Log:     d.Log,
+	}, nil
+}
+
+// Forge provides a GitLab forge instance.
+type Forge struct {
+	changeMetadataCodec
+
+	Options Options
+	baseURL string
+
+	// Log specifies the logger to use.
+	Log *silog.Logger
+}
 
 func (f *Forge) logger() *silog.Logger {
 	if f.Log == nil {
@@ -67,7 +109,7 @@ func (f *Forge) URL() string {
 
 // BaseURL reports the GitLab web URL used for host matching and links.
 func (f *Forge) BaseURL() string {
-	return f.URL()
+	return f.baseURL
 }
 
 // APIURL returns the base API URL configured for the GitHub Forge
@@ -78,9 +120,6 @@ func (f *Forge) APIURL() string {
 
 // ID reports a unique key for this forge.
 func (*Forge) ID() string { return "gitlab" }
-
-// CLIPlugin returns the CLI plugin for the GitLab Forge.
-func (f *Forge) CLIPlugin() any { return &f.Options }
 
 // ParseRepositoryPath parses a GitLab repository path and returns a [RepositoryID]
 // for the GitLab repository it identifies.

--- a/internal/forge/registry.go
+++ b/internal/forge/registry.go
@@ -1,75 +1,72 @@
 package forge
 
 import (
+	"fmt"
 	"iter"
-	"net/url"
 	"strings"
 	"sync"
 
 	"go.abhg.dev/gs/internal/git/giturl"
 )
 
-// Registry is a collection of known code forges.
+// Registry is a collection of known code forge definitions.
 type Registry struct {
 	m sync.Map
 }
 
-// All returns an iterator over items in the Forge
+// All returns an iterator over definitions in the Registry
 // in an unspecified order.
-func (r *Registry) All() iter.Seq[Forge] {
-	return func(yield func(Forge) bool) {
+func (r *Registry) All() iter.Seq[Definition] {
+	return func(yield func(Definition) bool) {
 		r.m.Range(func(_, value any) bool {
-			return yield(value.(Forge))
+			return yield(value.(Definition))
 		})
 	}
 }
 
-// Register registers a Forge with the Registry.
-// The Forge may be unregistered by calling the returned function.
-func (r *Registry) Register(f Forge) (unregister func()) {
-	id := f.ID()
-	r.m.Store(id, f)
+// Register registers a forge definition with the Registry.
+// The definition may be unregistered by calling the returned function.
+func (r *Registry) Register(d Definition) (unregister func()) {
+	id := d.ID()
+	r.m.Store(id, d)
 	return func() {
 		r.m.Delete(id)
 	}
 }
 
-// Lookup searches for a registered Forge by ID.
+// Lookup searches for a registered forge definition by ID.
 // It returns false if a forge with that ID is not known.
-func (r *Registry) Lookup(id string) (Forge, bool) {
-	f, ok := r.m.Load(id)
+func (r *Registry) Lookup(id string) (Definition, bool) {
+	d, ok := r.m.Load(id)
 	if !ok {
 		return nil, false
 	}
-	return f.(Forge), true
+	return d.(Definition), true
 }
 
-// FromRemoteURL attempts to match the given remote URL with a registered forge.
+// New constructs a registered forge by ID.
+func (r *Registry) New(id string, remoteURL *giturl.URL) (Forge, error) {
+	if remoteURL == nil {
+		return nil, fmt.Errorf("%w: remote URL is required", ErrUnsupportedURL)
+	}
+
+	d, ok := r.Lookup(id)
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrUnknown, id)
+	}
+	return d.New(remoteURL)
+}
+
+// InferFromRemoteURL attempts to infer the forge for the given remote URL.
 // It returns the matched forge and information about the matched repository.
-func FromRemoteURL(r *Registry, remoteURL *giturl.URL) (forge Forge, rid RepositoryID, ok bool) {
-	for f := range r.All() {
-		baseURL, err := url.Parse(f.BaseURL())
+func InferFromRemoteURL(r *Registry, remoteURL *giturl.URL) (forge Forge, rid RepositoryID, ok bool) {
+	for d := range r.All() {
+		if !remoteURLMatches(d.BaseURL(), remoteURL) {
+			continue
+		}
+
+		f, err := d.New(remoteURL)
 		if err != nil {
-			continue
-		}
-
-		baseHost := baseURL.Hostname()
-		remoteHost := remoteURL.Hostname
-		// Some forges advertise a base URL such as "https://github.com",
-		// while Git remotes use a related SSH hostname like "ssh.github.com".
-		// Accept subdomains so these documented SSH hosts still infer
-		// the same forge.
-		hostMatches := remoteHost == baseHost ||
-			strings.HasSuffix(remoteHost, "."+baseHost)
-		if !hostMatches {
-			continue
-		}
-
-		// A base URL without an explicit port describes the forge host,
-		// not one transport endpoint.
-		// In that case, allow the remote to specify its SSH port.
-		basePort := baseURL.Port()
-		if basePort != "" && remoteURL.Port != basePort {
 			continue
 		}
 

--- a/internal/forge/remote_url.go
+++ b/internal/forge/remote_url.go
@@ -1,0 +1,62 @@
+package forge
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"go.abhg.dev/gs/internal/git/giturl"
+)
+
+// ValidateRemoteURL verifies that remoteURL can be used with configuredURL.
+//
+// The configured URL is the provider URL supplied by configuration, flags,
+// or environment variables.
+// It may be empty when the provider uses its built-in default base URL.
+//
+// Validation requires a non-nil remote URL.
+// If configuredURL is set, validation also requires the remote host to match
+// the configured URL host or one of its subdomains.
+// If configuredURL includes a port, the remote URL must use the same port.
+func ValidateRemoteURL(configuredURL string, remoteURL *giturl.URL) error {
+	if remoteURL == nil {
+		return fmt.Errorf("%w: remote URL is required", ErrUnsupportedURL)
+	}
+	if configuredURL == "" {
+		return nil
+	}
+	if remoteURLMatches(configuredURL, remoteURL) {
+		return nil
+	}
+	return fmt.Errorf("%w: remote URL %q does not match configured forge URL %q",
+		ErrUnsupportedURL, remoteURL.Raw, configuredURL)
+}
+
+func remoteURLMatches(forgeURL string, remoteURL *giturl.URL) bool {
+	if remoteURL == nil {
+		return false
+	}
+
+	baseURL, err := url.Parse(forgeURL)
+	if err != nil {
+		return false
+	}
+
+	baseHost := baseURL.Hostname()
+	remoteHost := remoteURL.Hostname
+	// Some forges advertise a base URL such as "https://github.com",
+	// while Git remotes use a related SSH hostname like "ssh.github.com".
+	// Accept subdomains so these documented SSH hosts still infer
+	// the same forge.
+	hostMatches := remoteHost == baseHost ||
+		strings.HasSuffix(remoteHost, "."+baseHost)
+	if !hostMatches {
+		return false
+	}
+
+	// A base URL without an explicit port describes the forge host,
+	// not one transport endpoint.
+	// In that case, allow the remote to specify its SSH port.
+	basePort := baseURL.Port()
+	return basePort == "" || remoteURL.Port == basePort
+}

--- a/internal/forge/remote_url_test.go
+++ b/internal/forge/remote_url_test.go
@@ -1,0 +1,103 @@
+package forge
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/git/giturl"
+)
+
+func TestValidateRemoteURL(t *testing.T) {
+	remoteURL, err := giturl.Parse("ssh://git@ssh.example.com:2222/owner/repo")
+	require.NoError(t, err)
+
+	t.Run("EmptyConfiguredURL", func(t *testing.T) {
+		assert.NoError(t, ValidateRemoteURL("", remoteURL))
+	})
+
+	t.Run("MatchingSubdomain", func(t *testing.T) {
+		assert.NoError(t, ValidateRemoteURL("https://example.com", remoteURL))
+	})
+
+	t.Run("MatchingPort", func(t *testing.T) {
+		assert.NoError(t, ValidateRemoteURL("https://example.com:2222", remoteURL))
+	})
+
+	t.Run("MissingRemoteURL", func(t *testing.T) {
+		err := ValidateRemoteURL("https://example.com", nil)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrUnsupportedURL)
+	})
+
+	t.Run("WrongHost", func(t *testing.T) {
+		err := ValidateRemoteURL("https://example.org", remoteURL)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrUnsupportedURL)
+	})
+
+	t.Run("WrongPort", func(t *testing.T) {
+		err := ValidateRemoteURL("https://example.com:443", remoteURL)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrUnsupportedURL)
+	})
+}
+
+func TestRemoteURLMatches(t *testing.T) {
+	tests := []struct {
+		name      string
+		forgeURL  string
+		remoteURL string
+		want      bool
+	}{
+		{
+			name:      "SameHost",
+			forgeURL:  "https://example.com",
+			remoteURL: "https://example.com/owner/repo",
+			want:      true,
+		},
+		{
+			name:      "Subdomain",
+			forgeURL:  "https://example.com",
+			remoteURL: "ssh://git@ssh.example.com/owner/repo",
+			want:      true,
+		},
+		{
+			name:      "RemotePortAllowedWithoutBasePort",
+			forgeURL:  "https://example.com",
+			remoteURL: "ssh://git@example.com:2222/owner/repo",
+			want:      true,
+		},
+		{
+			name:      "BasePortMustMatch",
+			forgeURL:  "https://example.com:443",
+			remoteURL: "ssh://git@example.com:2222/owner/repo",
+			want:      false,
+		},
+		{
+			name:      "WrongHost",
+			forgeURL:  "https://example.com",
+			remoteURL: "https://example.org/owner/repo",
+			want:      false,
+		},
+		{
+			name:      "InvalidBaseURL",
+			forgeURL:  "NOT\tA\nVALID URL",
+			remoteURL: "https://example.com/owner/repo",
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			remoteURL, err := giturl.Parse(tt.remoteURL)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.want, remoteURLMatches(tt.forgeURL, remoteURL))
+		})
+	}
+
+	t.Run("NilRemoteURL", func(t *testing.T) {
+		assert.False(t, remoteURLMatches("https://example.com", nil))
+	})
+}

--- a/internal/forge/shamhub/change_meta.go
+++ b/internal/forge/shamhub/change_meta.go
@@ -50,13 +50,15 @@ func (r *forgeRepository) NewChangeMetadata(_ context.Context, id forge.ChangeID
 	}, nil
 }
 
+type changeMetadataCodec struct{}
+
 // MarshalChangeMetadata marshals the given change metadata to JSON.
-func (f *Forge) MarshalChangeMetadata(md forge.ChangeMetadata) (json.RawMessage, error) {
+func (changeMetadataCodec) MarshalChangeMetadata(md forge.ChangeMetadata) (json.RawMessage, error) {
 	return json.Marshal(md)
 }
 
 // UnmarshalChangeMetadata unmarshals the given JSON data to change metadata.
-func (f *Forge) UnmarshalChangeMetadata(data json.RawMessage) (forge.ChangeMetadata, error) {
+func (changeMetadataCodec) UnmarshalChangeMetadata(data json.RawMessage) (forge.ChangeMetadata, error) {
 	var md ChangeMetadata
 	if err := json.Unmarshal(data, &md); err != nil {
 		return nil, fmt.Errorf("unmarshal change metadata: %w", err)

--- a/internal/forge/shamhub/forge.go
+++ b/internal/forge/shamhub/forge.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 
 	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/git/giturl"
 	"go.abhg.dev/gs/internal/must"
 	"go.abhg.dev/gs/internal/silog"
 )
@@ -25,16 +26,57 @@ type Options struct {
 	APIURL string `name:"shamhub-api-url" hidden:"" env:"SHAMHUB_API_URL" help:"Base URL for ShamHub API requests"`
 }
 
-// Forge provides an implementation of [forge.Forge] backed by a ShamHub
-// server.
-type Forge struct {
+// Definition configures ShamHub forge instances.
+type Definition struct {
+	changeMetadataCodec
+
+	// Options stores CLI and environment configuration.
 	Options
 
 	// Log is the logger to use for logging.
 	Log *silog.Logger
 }
 
-var _ forge.Forge = (*Forge)(nil)
+var (
+	_ forge.Definition = (*Definition)(nil)
+	_ forge.Forge      = (*Forge)(nil)
+)
+
+// ID reports a unique identifier for this forge.
+func (*Definition) ID() string { return "shamhub" }
+
+// BaseURL reports the ShamHub web URL used for host matching.
+func (d *Definition) BaseURL() string {
+	return d.URL
+}
+
+// CLIPlugin registers additional CLI flags for the ShamHub forge.
+func (d *Definition) CLIPlugin() any { return &d.Options }
+
+// New constructs a ShamHub Forge from the configured options.
+func (d *Definition) New(remoteURL *giturl.URL) (forge.Forge, error) {
+	if err := forge.ValidateRemoteURL(d.URL, remoteURL); err != nil {
+		return nil, err
+	}
+
+	return &Forge{
+		Options: d.Options,
+		baseURL: d.BaseURL(),
+		Log:     d.Log,
+	}, nil
+}
+
+// Forge provides an implementation of [forge.Forge] backed by a ShamHub
+// server.
+type Forge struct {
+	changeMetadataCodec
+
+	Options
+	baseURL string
+
+	// Log is the logger to use for logging.
+	Log *silog.Logger
+}
 
 func (f *Forge) jsonHTTPClient() *jsonHTTPClient {
 	return &jsonHTTPClient{
@@ -46,12 +88,9 @@ func (f *Forge) jsonHTTPClient() *jsonHTTPClient {
 // ID reports a unique identifier for this forge.
 func (*Forge) ID() string { return "shamhub" }
 
-// CLIPlugin registers additional CLI flags for the ShamHub forge.
-func (f *Forge) CLIPlugin() any { return &f.Options }
-
 // BaseURL reports the ShamHub web URL used for host matching and links.
 func (f *Forge) BaseURL() string {
-	return f.URL
+	return f.baseURL
 }
 
 // ParseRepositoryPath parses a ShamHub repository path and returns

--- a/internal/handler/split/handler.go
+++ b/internal/handler/split/handler.go
@@ -50,13 +50,13 @@ var _ Service = (*spice.Service)(nil)
 
 // Handler handles git-spice's branch split commands.
 type Handler struct {
-	Log            *silog.Logger                            // required
-	View           ui.View                                  // required
-	Repository     GitRepository                            // required
-	Store          Store                                    // required
-	Service        Service                                  // required
-	FindForge      func(forgeID string) (forge.Forge, bool) // required
-	HighlightStyle ui.Style                                 // required
+	Log            *silog.Logger                                     // required
+	View           ui.View                                           // required
+	Repository     GitRepository                                     // required
+	Store          Store                                             // required
+	Service        Service                                           // required
+	FindForge      func(context.Context, string) (forge.Forge, bool) // required
+	HighlightStyle ui.Style                                          // required
 }
 
 // Options defines options for the SplitBranch method.
@@ -337,7 +337,7 @@ func (h *Handler) prepareChangeMetadataTransfer(
 	tx *state.BranchTx,
 ) (transfer func(), _ error) {
 	forgeID := meta.ForgeID()
-	f, ok := h.FindForge(forgeID)
+	f, ok := h.FindForge(ctx, forgeID)
 	if !ok {
 		return nil, fmt.Errorf("unknown forge: %v", forgeID)
 	}

--- a/internal/spice/branch_lookup.go
+++ b/internal/spice/branch_lookup.go
@@ -107,12 +107,12 @@ func (s *Service) LookupBranch(ctx context.Context, name string) (*LookupBranchR
 		}
 
 		if resp.ChangeMetadata != nil {
-			// TODO: This is ick. Service should have a Registry.
-			if f, ok := s.forges.Lookup(resp.ChangeForge); !ok {
+			codec, ok := s.forges.Lookup(resp.ChangeForge)
+			if !ok {
 				s.log.Warn("Ignoring unknown forge requested in change metadata",
 					"forge", resp.ChangeForge)
 			} else {
-				md, err := f.UnmarshalChangeMetadata(resp.ChangeMetadata)
+				md, err := codec.UnmarshalChangeMetadata(resp.ChangeMetadata)
 				if err != nil {
 					s.log.Warn("Corrupt change metadata associated with branch",
 						"branch", name,

--- a/internal/spice/branch_mutation.go
+++ b/internal/spice/branch_mutation.go
@@ -95,9 +95,9 @@ func (s *Service) RenameBranch(ctx context.Context, oldName, newName string) err
 		changeMetadata json.RawMessage
 	)
 	if md := oldBranch.Change; md != nil {
-		if f, ok := s.forges.Lookup(md.ForgeID()); ok {
-			changeForge = f.ID()
-			changeMetadata, err = f.MarshalChangeMetadata(md)
+		if codec, ok := s.forges.Lookup(md.ForgeID()); ok {
+			changeForge = codec.ID()
+			changeMetadata, err = codec.MarshalChangeMetadata(md)
 			if err != nil {
 				return fmt.Errorf("marshal change metadata: %w", err)
 			}

--- a/internal/spice/branch_test.go
+++ b/internal/spice/branch_test.go
@@ -46,7 +46,7 @@ func TestService_LookupBranch_changeAssociation(t *testing.T) {
 	}))
 	t.Cleanup(shamhubServer.Close)
 
-	shamhubForge := &shamhub.Forge{
+	shamhubForge := &shamhub.Definition{
 		Log: silogtest.New(t),
 		Options: shamhub.Options{
 			URL:    shamhubServer.URL,

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	"go.abhg.dev/gs/internal/forge/github"
 	"go.abhg.dev/gs/internal/forge/gitlab"
 	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/git/giturl"
 	"go.abhg.dev/gs/internal/handler/autostash"
 	"go.abhg.dev/gs/internal/handler/checkout"
 	"go.abhg.dev/gs/internal/handler/cherrypick"
@@ -63,7 +64,7 @@ var (
 	_browserLauncher browser.Launcher = new(browser.Browser)
 
 	// Forges to registry into main at startup besides the defaults.
-	_extraForges []func(*silog.Logger) forge.Forge
+	_extraForges []func(*silog.Logger) forge.Definition
 
 	_highlightStyle = ui.NewStyle().
 			Foreground(ui.Cyan).
@@ -124,11 +125,11 @@ func main() {
 
 	// Register supported forges.
 	var forges forge.Registry
-	forges.Register(&bitbucket.Forge{Log: logger})
-	forges.Register(&forgejo.Forge{Log: logger})
-	forges.Register(&gitea.Forge{Log: logger})
-	forges.Register(&github.Forge{Log: logger})
-	forges.Register(&gitlab.Forge{Log: logger})
+	forges.Register(&bitbucket.Definition{Log: logger})
+	forges.Register(&forgejo.Definition{Log: logger})
+	forges.Register(&gitea.Definition{Log: logger})
+	forges.Register(&github.Definition{Log: logger})
+	forges.Register(&gitlab.Definition{Log: logger})
 	for _, buildForge := range _extraForges {
 		forges.Register(buildForge(logger))
 	}
@@ -566,12 +567,30 @@ func (cmd *mainCmd) AfterApply(
 			forges *forge.Registry,
 		) (SplitHandler, error) {
 			return &split.Handler{
-				Log:            log,
-				View:           view,
-				Repository:     repo,
-				Store:          store,
-				Service:        svc,
-				FindForge:      forges.Lookup,
+				Log:        log,
+				View:       view,
+				Repository: repo,
+				Store:      store,
+				Service:    svc,
+				FindForge: func(ctx context.Context, id string) (forge.Forge, bool) {
+					remote, err := store.Remote()
+					if err != nil {
+						return nil, false
+					}
+
+					remoteURL, err := repo.RemoteURL(ctx, remote.Upstream)
+					if err != nil {
+						return nil, false
+					}
+
+					parsedRemoteURL, err := giturl.Parse(remoteURL)
+					if err != nil {
+						return nil, false
+					}
+
+					f, err := forges.New(id, parsedRemoteURL)
+					return f, err == nil
+				},
 				HighlightStyle: _highlightStyle,
 			}, nil
 		}),

--- a/main_test.go
+++ b/main_test.go
@@ -68,8 +68,8 @@ func TestMain(m *testing.M) {
 				}
 			}
 
-			_extraForges = append(_extraForges, func(log *silog.Logger) forge.Forge {
-				return &shamhub.Forge{Log: log}
+			_extraForges = append(_extraForges, func(log *silog.Logger) forge.Definition {
+				return &shamhub.Definition{Log: log}
 			})
 			main()
 		},

--- a/remote.go
+++ b/remote.go
@@ -32,14 +32,18 @@ func (e *notLoggedInError) Error() string {
 	return "not logged in to " + e.Forge.ID()
 }
 
-// remoteConfigURLer reads the remote URL before Git transport rewriting.
-type remoteConfigURLer interface {
+// remoteURLer reads configured and transport-resolved remote URLs.
+type remoteURLer interface {
 	// RemoteConfigURL accepts a Git remote name and returns the configured
 	// `remote.<name>.url` value before applying `url.*.insteadOf` rewriting.
 	RemoteConfigURL(context.Context, string) (string, error)
+
+	// RemoteURL accepts a Git remote name and returns the URL Git uses for
+	// transport after applying `url.*.insteadOf` rewriting.
+	RemoteURL(context.Context, string) (string, error)
 }
 
-var _ remoteConfigURLer = (*git.Repository)(nil)
+var _ remoteURLer = (*git.Repository)(nil)
 
 // remoteResolver resolves git-spice remotes to forge repository identities.
 type remoteResolver struct {
@@ -47,7 +51,7 @@ type remoteResolver struct {
 	Forges *forge.Registry // required
 
 	// Repository is the Git repository whose remotes should be resolved.
-	Repository remoteConfigURLer // required
+	Repository remoteURLer // required
 
 	// ForgeKind names the forge selected by configuration.
 	//
@@ -71,7 +75,17 @@ func (r *remoteResolver) Resolve(
 	}
 
 	if r.ForgeKind != "" {
-		f, err := r.Forges.New(r.ForgeKind, parsedRemoteURL)
+		resolvedRemoteURL, err := r.Repository.RemoteURL(ctx, remote)
+		if err != nil {
+			return nil, nil, fmt.Errorf("get resolved remote URL: %w", err)
+		}
+
+		parsedResolvedRemoteURL, err := giturl.Parse(resolvedRemoteURL)
+		if err != nil {
+			return nil, nil, fmt.Errorf("parse resolved remote URL: %w", err)
+		}
+
+		f, err := r.Forges.New(r.ForgeKind, parsedResolvedRemoteURL)
 		if err != nil {
 			if errors.Is(err, forge.ErrUnknown) {
 				var available []string

--- a/remote.go
+++ b/remote.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"slices"
 	"strings"
 
@@ -72,9 +71,22 @@ func (r *remoteResolver) Resolve(
 	}
 
 	if r.ForgeKind != "" {
-		f, err := lookupForgeKind(r.Forges, r.ForgeKind)
+		f, err := r.Forges.New(r.ForgeKind, parsedRemoteURL)
 		if err != nil {
-			return nil, nil, err
+			if errors.Is(err, forge.ErrUnknown) {
+				var available []string
+				for d := range r.Forges.All() {
+					available = append(available, d.ID())
+				}
+				slices.Sort(available)
+
+				return nil, nil, fmt.Errorf(
+					"unknown forge kind %q: expected one of: %s",
+					r.ForgeKind,
+					strings.Join(available, ", "),
+				)
+			}
+			return nil, nil, fmt.Errorf("construct forge %q: %w", r.ForgeKind, err)
 		}
 
 		repoID, err := f.ParseRepositoryPath(parsedRemoteURL.Path)
@@ -84,7 +96,7 @@ func (r *remoteResolver) Resolve(
 		return f, repoID, nil
 	}
 
-	f, repoID, ok := forge.FromRemoteURL(r.Forges, parsedRemoteURL)
+	f, repoID, ok := forge.InferFromRemoteURL(r.Forges, parsedRemoteURL)
 	if !ok {
 		return nil, nil, &unsupportedForgeError{
 			Remote:    remote,
@@ -92,23 +104,6 @@ func (r *remoteResolver) Resolve(
 		}
 	}
 	return f, repoID, nil
-}
-
-func lookupForgeKind(forges *forge.Registry, kind string) (forge.Forge, error) {
-	f, ok := forges.Lookup(kind)
-	if ok {
-		return f, nil
-	}
-
-	ids := make(map[string]struct{})
-	for f := range forges.All() {
-		ids[f.ID()] = struct{}{}
-	}
-	return nil, fmt.Errorf(
-		"unknown forge kind %q: expected one of: %s",
-		kind,
-		strings.Join(slices.Sorted(maps.Keys(ids)), ", "),
-	)
 }
 
 // ResolveID identifies the repository for a configured Git remote.

--- a/remote_test.go
+++ b/remote_test.go
@@ -86,6 +86,46 @@ func TestRemoteResolver_Resolve_configuredKind(t *testing.T) {
 	assert.Equal(t, repoID, gotRepoID)
 }
 
+func TestRemoteResolver_Resolve_configuredKindConstructsWithResolvedURL(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	repoID := forgetest.NewMockRepositoryID(ctrl)
+	testForge := forgetest.NewMockForge(ctrl)
+	testForge.EXPECT().ID().Return("github").AnyTimes()
+	testForge.EXPECT().
+		ParseRepositoryPath("/owner/repo.git").
+		Return(repoID, nil)
+
+	var gotRemoteURL *giturl.URL
+	var forges forge.Registry
+	forges.Register(testDefinition{
+		id: "github",
+		new: func(remoteURL *giturl.URL) (forge.Forge, error) {
+			gotRemoteURL = remoteURL
+			return testForge, nil
+		},
+	})
+
+	gotForge, gotRepoID, err := (&remoteResolver{
+		Forges: &forges,
+		Repository: remoteURLs{
+			config: map[string]string{
+				"origin": "ssh://githubalias/owner/repo.git",
+			},
+			resolved: map[string]string{
+				"origin": "https://example.com/owner/repo.git",
+			},
+		},
+		ForgeKind: "github",
+	}).Resolve(t.Context(), "origin")
+	require.NoError(t, err)
+
+	assert.Same(t, testForge, gotForge)
+	assert.Equal(t, repoID, gotRepoID)
+	require.NotNil(t, gotRemoteURL)
+	assert.Equal(t, "https://example.com/owner/repo.git", gotRemoteURL.Raw)
+}
+
 func TestRemoteResolver_Resolve_unknownConfiguredKind(t *testing.T) {
 	var forges forge.Registry
 	_, _, err := (&remoteResolver{
@@ -167,4 +207,21 @@ type remoteURLMap map[string]string
 
 func (m remoteURLMap) RemoteConfigURL(_ context.Context, remote string) (string, error) {
 	return m[remote], nil
+}
+
+func (m remoteURLMap) RemoteURL(ctx context.Context, remote string) (string, error) {
+	return m.RemoteConfigURL(ctx, remote)
+}
+
+type remoteURLs struct {
+	config   map[string]string
+	resolved map[string]string
+}
+
+func (m remoteURLs) RemoteConfigURL(_ context.Context, remote string) (string, error) {
+	return m.config[remote], nil
+}
+
+func (m remoteURLs) RemoteURL(_ context.Context, remote string) (string, error) {
+	return m.resolved[remote], nil
 }

--- a/remote_test.go
+++ b/remote_test.go
@@ -3,12 +3,14 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/forge/forgetest"
+	"go.abhg.dev/gs/internal/git/giturl"
 	"go.abhg.dev/gs/internal/silog"
 	"go.uber.org/mock/gomock"
 )
@@ -19,13 +21,12 @@ func TestRemoteResolver_Resolve(t *testing.T) {
 	repoID := forgetest.NewMockRepositoryID(ctrl)
 	testForge := forgetest.NewMockForge(ctrl)
 	testForge.EXPECT().ID().Return("test").AnyTimes()
-	testForge.EXPECT().BaseURL().Return("https://example.com")
 	testForge.EXPECT().
 		ParseRepositoryPath("/owner/repo").
 		Return(repoID, nil)
 
 	var forges forge.Registry
-	forges.Register(testForge)
+	registerTestForge(&forges, "test", testForge)
 
 	gotForge, gotRepoID, err := (&remoteResolver{
 		Forges:     &forges,
@@ -44,13 +45,12 @@ func TestRemoteResolver_ResolveID(t *testing.T) {
 	repoID := forgetest.NewMockRepositoryID(ctrl)
 	testForge := forgetest.NewMockForge(ctrl)
 	testForge.EXPECT().ID().Return("test").AnyTimes()
-	testForge.EXPECT().BaseURL().Return("https://example.com")
 	testForge.EXPECT().
 		ParseRepositoryPath("/owner/repo").
 		Return(repoID, nil)
 
 	var forges forge.Registry
-	forges.Register(testForge)
+	registerTestForge(&forges, "test", testForge)
 
 	gotRepoID, err := (&remoteResolver{
 		Forges:     &forges,
@@ -73,7 +73,7 @@ func TestRemoteResolver_Resolve_configuredKind(t *testing.T) {
 		Return(repoID, nil)
 
 	var forges forge.Registry
-	forges.Register(testForge)
+	registerTestForge(&forges, "github", testForge)
 
 	gotForge, gotRepoID, err := (&remoteResolver{
 		Forges:     &forges,
@@ -129,6 +129,38 @@ func TestResolveRemoteRepository_unsupportedRecommendsForgeKind(t *testing.T) {
 	require.Error(t, err)
 
 	assert.Contains(t, logBuffer.String(), "git config spice.forge.kind <forge>")
+}
+
+func registerTestForge(r *forge.Registry, id string, f forge.Forge) {
+	r.Register(testDefinition{
+		id: id,
+		new: func(*giturl.URL) (forge.Forge, error) {
+			return f, nil
+		},
+	})
+}
+
+type testDefinition struct {
+	id  string
+	new func(*giturl.URL) (forge.Forge, error)
+}
+
+func (d testDefinition) ID() string { return d.id }
+
+func (testDefinition) BaseURL() string { return "https://example.com" }
+
+func (d testDefinition) CLIPlugin() any { return nil }
+
+func (testDefinition) MarshalChangeMetadata(forge.ChangeMetadata) (json.RawMessage, error) {
+	return nil, nil
+}
+
+func (testDefinition) UnmarshalChangeMetadata(json.RawMessage) (forge.ChangeMetadata, error) {
+	return nil, nil
+}
+
+func (d testDefinition) New(remoteURL *giturl.URL) (forge.Forge, error) {
+	return d.new(remoteURL)
 }
 
 type remoteURLMap map[string]string

--- a/shamhub.go
+++ b/shamhub.go
@@ -17,8 +17,8 @@ func init() {
 		panic(err)
 	}
 
-	_extraForges = append(_extraForges, func(log *silog.Logger) forge.Forge {
-		return &shamhub.Forge{Log: log}
+	_extraForges = append(_extraForges, func(log *silog.Logger) forge.Definition {
+		return &shamhub.Definition{Log: log}
 	})
 }
 

--- a/testdata/script/auth_explicit_forge.txt
+++ b/testdata/script/auth_explicit_forge.txt
@@ -15,7 +15,7 @@ git push origin main
 gs repo init
 
 ! gs auth status --forge=unrecognized
-stderr 'unknown forge: unrecognized'
+stderr 'unknown forge: "unrecognized"'
 stderr 'must be one of'
 
 ! gs auth status --forge=shamhub

--- a/testdata/script/auth_prompt_forge.txt
+++ b/testdata/script/auth_prompt_forge.txt
@@ -7,6 +7,11 @@ shamhub-setup
 shamhub register alice
 env SHAMHUB_USERNAME=alice
 
+mkdir repo
+cd repo
+git init
+git remote add origin $SHAMHUB_URL/repo-only
+
 env ROBOT_INPUT=$WORK/robot.golden ROBOT_OUTPUT=$WORK/robot.actual
 gs auth login
 cmp $WORK/robot.actual $WORK/robot.golden


### PR DESCRIPTION
Forge construction now separates registry-time configuration from
remote-bound runtime behavior.
The old registry stored runtime forge values directly:

```go
registry.Register(&github.Forge{Log: log})
f, ok := registry.Lookup(kind)
f, repoID, ok := forge.FromRemoteURL(&registry, remoteURL)
```

That made the registered value carry CLI option storage, display metadata,
remote matching metadata, repository parsing, and repository-bound behavior at
once.
It also meant explicit selection returned the registered forge directly,
without a construction boundary that could validate the selected remote.

The new registry stores definitions instead:

```go
registry.Register(&github.Definition{Log: log})
f, err := registry.New(kind, remoteURL)
f, repoID, ok := forge.InferFromRemoteURL(&registry, remoteURL)
```

A `forge.Definition` owns CLI options, provider display metadata,
remote matching metadata, and persisted change metadata encoding.
A `forge.Forge` owns repository-bound behavior such as authentication,
repository opening, change operations, and URL generation.
`Definition.New(remoteURL)` is the boundary between those roles,
and `remoteURL` is required.

Remote inference now matches definitions by base URL before constructing a
forge.
Explicit forge selection, auth selection, split metadata transfer,
and remote resolution all construct forges with the parsed remote URL.
When a provider URL is configured, construction rejects remotes whose host or
required port does not match that URL.