### PR TITLE
test(mergequeue): Stabilize barrier coalescing test

### DIFF
--- a/internal/mergequeue/scheduler_test.go
+++ b/internal/mergequeue/scheduler_test.go
@@ -252,6 +252,7 @@ func TestScheduler_Run_barrierRunsBeforeDependentPrepare(t *testing.T) {
 func TestScheduler_Run_barrierCoalescesReadyRunResults(t *testing.T) {
 	rec := &recordingQueue{}
 	started := make(chan string, 2)
+	prepareStarted := make(chan struct{})
 	releaseRuns := make(chan struct{})
 	releasePrepare := make(chan struct{})
 
@@ -267,6 +268,7 @@ func TestScheduler_Run_barrierCoalescesReadyRunResults(t *testing.T) {
 			return nil
 		}),
 		newTestItem("block-prepare", rec).withPrepare(func(context.Context) error {
+			close(prepareStarted)
 			<-releasePrepare
 			return nil
 		}).withRunError(errors.New("stop after barrier")),
@@ -291,6 +293,11 @@ func TestScheduler_Run_barrierCoalescesReadyRunResults(t *testing.T) {
 		receiveStarted(t, started),
 		receiveStarted(t, started),
 	})
+	select {
+	case <-prepareStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for blocking Prepare to start")
+	}
 	close(releaseRuns)
 	require.Eventually(t, func() bool {
 		events := rec.events()


### PR DESCRIPTION
The barrier coalescing test needs `block-prepare` to be inside
`Prepare` before it releases the sibling `Run` calls.
Without that interlock, CI scheduling can let the barrier observe only
one completed sibling before the blocking prepare phase starts.

Wait for the blocking `Prepare` call to start before releasing sibling
runs.
The test now covers the intended scheduler state transition instead of
relying on goroutine timing.