### PR TITLE
github: Hide GraphQL pagination in gateway

### DIFF
--- a/internal/forge/github/checks.go
+++ b/internal/forge/github/checks.go
@@ -26,23 +26,11 @@ func (r *Repository) queryChecksRollup(
 	ctx context.Context, gqlID github.ID,
 ) ([]forge.ChangeCheck, error) {
 	var contexts []github.StatusCheck
-	var after *string
-	for {
-		page, err := r.gateway.StatusChecks(ctx, gqlID, after)
+	for check, err := range r.gateway.StatusChecks(ctx, gqlID, nil) {
 		if err != nil {
 			return nil, fmt.Errorf("query status checks: %w", err)
 		}
-
-		if !page.Present {
-			return nil, nil
-		}
-
-		contexts = append(contexts, page.Contexts...)
-
-		if !page.HasNextPage {
-			break
-		}
-		after = &page.EndCursor
+		contexts = append(contexts, check)
 	}
 
 	return checksFromGatewayContexts(contexts), nil

--- a/internal/forge/github/comment.go
+++ b/internal/forge/github/comment.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"slices"
 
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/gateway/github"
@@ -139,45 +140,29 @@ func (r *Repository) ListChangeComments(
 	}
 
 	return func(yield func(*forge.ListChangeCommentItem, error) bool) {
-		var after *string
-
-		for pageNum := 1; true; pageNum++ {
-			page, err := r.gateway.PullRequestComments(ctx, gqlID, _listChangeCommentsPageSize, after)
+		for node, err := range r.gateway.PullRequestComments(ctx, gqlID, &github.PaginationOptions{
+			ItemsPerPage: _listChangeCommentsPageSize,
+		}) {
 			if err != nil {
-				yield(nil, fmt.Errorf("list comments (page %d): %w", pageNum, err))
+				yield(nil, err)
 				return
 			}
 
-			for _, node := range page.Nodes {
-				match := true
-				for _, filter := range filters {
-					if !filter(node) {
-						match = false
-						break
-					}
-				}
-				if !match {
-					continue
-				}
-
-				item := &forge.ListChangeCommentItem{
-					ID: &PRComment{
-						GQLID: node.ID,
-						URL:   node.URL,
-					},
-					Body: node.Body,
-				}
-
-				if !yield(item, nil) {
-					return
-				}
+			if slices.ContainsFunc(filters, func(keep func(*github.Comment) bool) bool {
+				return !keep(node)
+			}) {
+				continue
 			}
 
-			if !page.HasNextPage {
+			if !yield(&forge.ListChangeCommentItem{
+				ID: &PRComment{
+					GQLID: node.ID,
+					URL:   node.URL,
+				},
+				Body: node.Body,
+			}, nil) {
 				return
 			}
-
-			after = &page.EndCursor
 		}
 	}
 }

--- a/internal/forge/github/comment_counts.go
+++ b/internal/forge/github/comment_counts.go
@@ -22,28 +22,17 @@ func (r *Repository) CommentCountsByChange(
 		return nil, err
 	}
 
-	threadsByChange, err := r.gateway.PullRequestReviewThreads(ctx, gqlIDs)
+	countsByChange, err := r.gateway.PullRequestReviewThreadCounts(ctx, gqlIDs, nil)
 	if err != nil {
-		return nil, fmt.Errorf("query review threads: %w", err)
+		return nil, err
 	}
 
-	results := make([]*forge.CommentCounts, len(threadsByChange))
-	for i, threads := range threadsByChange {
-		resolved := countResolved(threads.Nodes)
-
-		// If there are more threads than the first page,
-		// paginate to count all resolved threads.
-		if threads.HasNextPage {
-			remaining, err := r.countRemainingResolved(ctx, gqlIDs[i], threads.EndCursor)
-			if err != nil {
-				return nil, err
-			}
-			resolved += remaining
-		}
+	results := make([]*forge.CommentCounts, len(countsByChange))
+	for i, counts := range countsByChange {
 		results[i] = &forge.CommentCounts{
-			Total:      threads.TotalCount,
-			Resolved:   resolved,
-			Unresolved: threads.TotalCount - resolved,
+			Total:      counts.Total,
+			Resolved:   counts.Resolved,
+			Unresolved: counts.Total - counts.Resolved,
 		}
 	}
 	return results, nil
@@ -63,45 +52,4 @@ func (r *Repository) resolveGraphQLIDs(
 		gqlIDs[i] = gqlID
 	}
 	return gqlIDs, nil
-}
-
-// _reviewThreadsPageSize is the number of review threads
-// fetched per page when counting comment resolutions.
-const _reviewThreadsPageSize = 100
-
-// countRemainingResolved paginates through the remaining
-// review threads for a single PR and counts resolved ones.
-func (r *Repository) countRemainingResolved(
-	ctx context.Context,
-	gqlID github.ID,
-	cursor string,
-) (int, error) {
-	resolved := 0
-	for pageNum := 2; ; pageNum++ {
-		threads, err := r.gateway.PullRequestReviewThreadsPage(ctx, gqlID, _reviewThreadsPageSize, cursor)
-		if err != nil {
-			return 0, fmt.Errorf(
-				"review threads (page %d): %w", pageNum, err,
-			)
-		}
-
-		resolved += countResolved(threads.Nodes)
-
-		if !threads.HasNextPage {
-			break
-		}
-		cursor = threads.EndCursor
-	}
-
-	return resolved, nil
-}
-
-func countResolved(nodes []bool) int {
-	count := 0
-	for _, n := range nodes {
-		if n {
-			count++
-		}
-	}
-	return count
 }

--- a/internal/gateway/github/comment.go
+++ b/internal/gateway/github/comment.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"iter"
 	"time"
 )
 
@@ -30,22 +31,59 @@ type Comment struct {
 	UpdatedAt time.Time `json:"updatedAt"`
 }
 
-// CommentsPage is one page from a pull request's comments connection.
-type CommentsPage struct {
-	// Nodes contains the comments on this page.
-	Nodes []*Comment
+// GitHub charges GraphQL rate limits by queried nodes.
+// Comments usually appear near the start of the ascending connection, so a
+// small page avoids over-fetching while retaining useful request granularity.
+const pullRequestCommentsPageSize = 10
 
-	// EndCursor is usable as after when HasNextPage is true.
-	EndCursor string
+// PullRequestComments yields pull request comments in GitHub's ascending order.
+// The gateway traverses every page and yields a pagination error once before
+// stopping. A nil opts or zero [PaginationOptions.ItemsPerPage] requests 10
+// comments per page.
+func (c *Gateway) PullRequestComments(ctx context.Context, id ID, opts *PaginationOptions) iter.Seq2[*Comment, error] {
+	return func(yield func(*Comment, error) bool) {
+		itemsPerPage, err := paginationItemsPerPage(opts, pullRequestCommentsPageSize)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
 
-	// HasNextPage reports whether another page follows EndCursor.
-	HasNextPage bool
+		var after *string
+		for pageNum := 1; ; pageNum++ {
+			page, err := c.pullRequestCommentsPage(ctx, id, itemsPerPage, after)
+			if err != nil {
+				yield(nil, fmt.Errorf("list comments (page %d): %w", pageNum, err))
+				return
+			}
+			for _, comment := range page.nodes {
+				if !yield(comment, nil) {
+					return
+				}
+			}
+			if !page.hasNextPage {
+				return
+			}
+			after = &page.endCursor
+		}
+	}
 }
 
-// PullRequestComments loads one page with first entries.
-// A nil after selects the first page; a non-nil after continues after that
-// cursor. First must be from 1 through 100.
-func (c *Gateway) PullRequestComments(ctx context.Context, id ID, first int, after *string) (*CommentsPage, error) {
+// commentsPage is one response page from GitHub's comments connection.
+type commentsPage struct {
+	// The page contains these comments in GitHub's response order.
+	nodes []*Comment
+
+	// The cursor identifies the page boundary when another page follows.
+	endCursor string
+
+	// This value reports whether GitHub has another page after the cursor.
+	hasNextPage bool
+}
+
+// pullRequestCommentsPage requests one comments page.
+// The first request declares a nullable cursor while continuation requests
+// declare a non-null cursor to preserve the existing GraphQL documents.
+func (c *Gateway) pullRequestCommentsPage(ctx context.Context, id ID, first int, after *string) (*commentsPage, error) {
 	var result struct {
 		Node struct {
 			Comments struct {
@@ -82,7 +120,11 @@ func (c *Gateway) PullRequestComments(ctx context.Context, id ID, first int, aft
 		return nil, fmt.Errorf("query pull request comments: %w", err)
 	}
 	comments := result.Node.Comments
-	return &CommentsPage{Nodes: comments.Nodes, EndCursor: comments.PageInfo.EndCursor, HasNextPage: comments.PageInfo.HasNextPage}, nil
+	return &commentsPage{
+		nodes:       comments.Nodes,
+		endCursor:   comments.PageInfo.EndCursor,
+		hasNextPage: comments.PageInfo.HasNextPage,
+	}, nil
 }
 
 // AddedComment identifies a comment returned after creation.

--- a/internal/gateway/github/comment_test.go
+++ b/internal/gateway/github/comment_test.go
@@ -1,6 +1,11 @@
 package github
 
 import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,16 +13,97 @@ import (
 )
 
 func TestGateway_PullRequestComments(t *testing.T) {
-	gateway := newResponseGateway(t, `{
-		"data": {"node": {"comments": {
-			"pageInfo": {"endCursor": "next", "hasNextPage": true},
-			"nodes": [{"id": "C_1", "body": "hello"}]
-		}}}
-	}`)
-	page, err := gateway.PullRequestComments(t.Context(), "PR_1", 10, nil)
-	require.NoError(t, err)
-	assert.Equal(t, "next", page.EndCursor)
-	require.Len(t, page.Nodes, 1)
+	requestNum := 0
+	gateway := newTestGateway(t, roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		var request struct {
+			Query     string          `json:"query"`
+			Variables json.RawMessage `json:"variables"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+
+		requestNum++
+		var response string
+		switch requestNum {
+		case 1:
+			assert.Equal(t, "query($after:String$first:Int!$id:ID!){node(id: $id){... on PullRequest{comments(first: $first, after: $after){pageInfo{endCursor,hasNextPage},nodes{id,body,url,viewerCanUpdate,viewerDidAuthor,createdAt,updatedAt}}}}}", request.Query)
+			assert.JSONEq(t, `{
+				"after": null,
+				"first": 10,
+				"id": "PR_1"
+			}`, string(request.Variables))
+			response = `{
+				"data": {"node": {"comments": {
+					"pageInfo": {"endCursor": "next", "hasNextPage": true},
+					"nodes": [{"id": "C_1", "body": "hello"}]
+				}}}
+			}`
+		case 2:
+			assert.Equal(t, "query($after:String!$first:Int!$id:ID!){node(id: $id){... on PullRequest{comments(first: $first, after: $after){pageInfo{endCursor,hasNextPage},nodes{id,body,url,viewerCanUpdate,viewerDidAuthor,createdAt,updatedAt}}}}}", request.Query)
+			assert.JSONEq(t, `{
+				"after": "next",
+				"first": 10,
+				"id": "PR_1"
+			}`, string(request.Variables))
+			response = `{
+				"data": {"node": {"comments": {
+					"pageInfo": {"endCursor": "", "hasNextPage": false},
+					"nodes": [{"id": "C_2", "body": "world"}]
+				}}}
+			}`
+		default:
+			t.Fatalf("unexpected request %d", requestNum)
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body:       io.NopCloser(strings.NewReader(response)),
+		}, nil
+	}))
+
+	var comments []*Comment
+	for comment, err := range gateway.PullRequestComments(t.Context(), "PR_1", nil) {
+		require.NoError(t, err)
+		comments = append(comments, comment)
+	}
+	require.Len(t, comments, 2)
+	assert.Equal(t, ID("C_1"), comments[0].ID)
+	assert.Equal(t, ID("C_2"), comments[1].ID)
+	assert.Equal(t, 2, requestNum)
+}
+
+func TestGateway_PullRequestComments_yieldsContinuationError(t *testing.T) {
+	want := errors.New("continuation unavailable")
+	requestNum := 0
+	gateway := newTestGateway(t, roundTripFunc(func(*http.Request) (*http.Response, error) {
+		requestNum++
+		if requestNum == 2 {
+			return nil, want
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body: io.NopCloser(strings.NewReader(`{
+				"data": {"node": {"comments": {
+					"pageInfo": {"endCursor": "next", "hasNextPage": true},
+					"nodes": [{"id": "C_1", "body": "hello"}]
+				}}}
+			}`)),
+		}, nil
+	}))
+
+	var comments []*Comment
+	var gotErr error
+	for comment, err := range gateway.PullRequestComments(t.Context(), "PR_1", nil) {
+		if err != nil {
+			gotErr = err
+			continue
+		}
+		comments = append(comments, comment)
+	}
+	require.Len(t, comments, 1)
+	assert.ErrorIs(t, gotErr, want)
+	assert.ErrorContains(t, gotErr, "list comments (page 2)")
 }
 
 func TestGateway_AddComment(t *testing.T) {

--- a/internal/gateway/github/pagination.go
+++ b/internal/gateway/github/pagination.go
@@ -1,0 +1,21 @@
+package github
+
+import "fmt"
+
+// PaginationOptions configures the page requests behind a gateway iterator.
+type PaginationOptions struct {
+	// ItemsPerPage is the number of connection items requested from GitHub.
+	// Zero selects the operation's default; other values must be from 1 through
+	// 100.
+	ItemsPerPage int
+}
+
+func paginationItemsPerPage(opts *PaginationOptions, defaultValue int) (int, error) {
+	if opts == nil || opts.ItemsPerPage == 0 {
+		return defaultValue, nil
+	}
+	if opts.ItemsPerPage < 1 || opts.ItemsPerPage > 100 {
+		return 0, fmt.Errorf("items per page must be from 1 through 100: %d", opts.ItemsPerPage)
+	}
+	return opts.ItemsPerPage, nil
+}

--- a/internal/gateway/github/pagination_test.go
+++ b/internal/gateway/github/pagination_test.go
@@ -1,0 +1,23 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPaginationItemsPerPage(t *testing.T) {
+	got, err := paginationItemsPerPage(nil, 10)
+	require.NoError(t, err)
+	assert.Equal(t, 10, got)
+
+	got, err = paginationItemsPerPage(&PaginationOptions{ItemsPerPage: 3}, 10)
+	require.NoError(t, err)
+	assert.Equal(t, 3, got)
+}
+
+func TestPaginationItemsPerPage_rejectsOutOfRange(t *testing.T) {
+	_, err := paginationItemsPerPage(&PaginationOptions{ItemsPerPage: 101}, 10)
+	assert.ErrorContains(t, err, "items per page must be from 1 through 100: 101")
+}

--- a/internal/gateway/github/review_thread.go
+++ b/internal/gateway/github/review_thread.go
@@ -3,27 +3,73 @@ package github
 import (
 	"context"
 	"fmt"
+	"strconv"
 )
 
-// ReviewThreads is one pull request's review-thread connection.
-type ReviewThreads struct {
-	// TotalCount is the number of review threads in the connection.
-	TotalCount int
+// ReviewThreadCounts summarizes all review threads for one pull request.
+type ReviewThreadCounts struct {
+	// Total is the number of review threads reported by GitHub.
+	Total int
 
-	// Nodes contains the IsResolved value for each thread on this page.
-	Nodes []bool
-
-	// EndCursor is usable as after when HasNextPage is true.
-	EndCursor string
-
-	// HasNextPage reports whether another page follows EndCursor.
-	HasNextPage bool
+	// Resolved is the number of threads marked resolved across every page.
+	Resolved int
 }
 
-// PullRequestReviewThreads loads up to 100 review threads for each ID.
-// Each result has the same position as its input ID and exposes continuation
-// metadata when more than 100 threads exist.
-func (c *Gateway) PullRequestReviewThreads(ctx context.Context, ids []ID) ([]*ReviewThreads, error) {
+// PullRequestReviewThreadCounts returns one complete count for each input ID.
+// Results have the same length and order as ids. The gateway retains the
+// batched first-page request, then traverses each pull request's continuation
+// pages. A nil opts or zero [PaginationOptions.ItemsPerPage] requests 100
+// threads per page.
+func (c *Gateway) PullRequestReviewThreadCounts(ctx context.Context, ids []ID, opts *PaginationOptions) ([]*ReviewThreadCounts, error) {
+	itemsPerPage, err := paginationItemsPerPage(opts, 100)
+	if err != nil {
+		return nil, err
+	}
+
+	pages, err := c.pullRequestReviewThreadsFirstPages(ctx, ids, itemsPerPage)
+	if err != nil {
+		return nil, fmt.Errorf("query review threads: %w", err)
+	}
+	if len(pages) != len(ids) {
+		return nil, fmt.Errorf("match review thread results: got %d nodes for %d IDs", len(pages), len(ids))
+	}
+
+	results := make([]*ReviewThreadCounts, len(ids))
+	for i, page := range pages {
+		total := page.totalCount
+		resolved := countResolvedReviewThreads(page.nodes)
+		cursor := page.endCursor
+		for pageNum := 2; page.hasNextPage; pageNum++ {
+			page, err = c.pullRequestReviewThreadsPage(ctx, ids[i], itemsPerPage, cursor)
+			if err != nil {
+				return nil, fmt.Errorf("review threads (page %d): %w", pageNum, err)
+			}
+			resolved += countResolvedReviewThreads(page.nodes)
+			cursor = page.endCursor
+		}
+
+		results[i] = &ReviewThreadCounts{Total: total, Resolved: resolved}
+	}
+	return results, nil
+}
+
+// reviewThreadsPage is one pull request's review-thread connection page.
+type reviewThreadsPage struct {
+	// The total covers the full connection rather than only this page.
+	totalCount int
+
+	// The page contains these resolved states in GitHub's response order.
+	nodes []bool
+
+	// The cursor identifies the page boundary when another page follows.
+	endCursor string
+
+	// This value reports whether GitHub has another page after the cursor.
+	hasNextPage bool
+}
+
+// pullRequestReviewThreadsFirstPages loads one review-thread page for each ID.
+func (c *Gateway) pullRequestReviewThreadsFirstPages(ctx context.Context, ids []ID, first int) ([]*reviewThreadsPage, error) {
 	var result struct {
 		Nodes []struct {
 			ReviewThreads reviewThreadsConnection `json:"reviewThreads"`
@@ -33,7 +79,7 @@ func (c *Gateway) PullRequestReviewThreads(ctx context.Context, ids []ID) ([]*Re
 		query($ids:[ID!]!){
 			nodes(ids: $ids){
 				... on PullRequest{
-					reviewThreads(first: 100){
+					reviewThreads(first: ` + strconv.Itoa(first) + `){
 						totalCount,
 						pageInfo{endCursor,hasNextPage},
 						nodes{isResolved}
@@ -47,16 +93,16 @@ func (c *Gateway) PullRequestReviewThreads(ctx context.Context, ids []ID) ([]*Re
 	}{ids}, &result); err != nil {
 		return nil, fmt.Errorf("query pull request review threads: %w", err)
 	}
-	threads := make([]*ReviewThreads, len(result.Nodes))
+	threads := make([]*reviewThreadsPage, len(result.Nodes))
 	for i, node := range result.Nodes {
 		threads[i] = reviewThreads(&node.ReviewThreads)
 	}
 	return threads, nil
 }
 
-// PullRequestReviewThreadsPage loads first review threads after a non-empty
+// pullRequestReviewThreadsPage loads first review threads after a non-empty
 // cursor. First must be from 1 through 100.
-func (c *Gateway) PullRequestReviewThreadsPage(ctx context.Context, id ID, first int, after string) (*ReviewThreads, error) {
+func (c *Gateway) pullRequestReviewThreadsPage(ctx context.Context, id ID, first int, after string) (*reviewThreadsPage, error) {
 	var result struct {
 		Node struct {
 			ReviewThreads reviewThreadsConnection `json:"reviewThreads"`
@@ -97,15 +143,25 @@ type reviewThreadsConnection struct {
 	} `json:"nodes"`
 }
 
-func reviewThreads(connection *reviewThreadsConnection) *ReviewThreads {
+func reviewThreads(connection *reviewThreadsConnection) *reviewThreadsPage {
 	resolved := make([]bool, len(connection.Nodes))
 	for i, node := range connection.Nodes {
 		resolved[i] = node.IsResolved
 	}
-	return &ReviewThreads{
-		TotalCount:  connection.TotalCount,
-		Nodes:       resolved,
-		EndCursor:   connection.PageInfo.EndCursor,
-		HasNextPage: connection.PageInfo.HasNextPage,
+	return &reviewThreadsPage{
+		totalCount:  connection.TotalCount,
+		nodes:       resolved,
+		endCursor:   connection.PageInfo.EndCursor,
+		hasNextPage: connection.PageInfo.HasNextPage,
 	}
+}
+
+func countResolvedReviewThreads(nodes []bool) int {
+	count := 0
+	for _, resolved := range nodes {
+		if resolved {
+			count++
+		}
+	}
+	return count
 }

--- a/internal/gateway/github/review_thread_test.go
+++ b/internal/gateway/github/review_thread_test.go
@@ -1,31 +1,95 @@
 package github
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestGateway_PullRequestReviewThreads(t *testing.T) {
-	gateway := newResponseGateway(t, `{
-		"data": {"nodes": [{"reviewThreads": {
-			"totalCount": 1, "nodes": [{"isResolved": true}], "pageInfo": {}
-		}}]}
-	}`)
-	got, err := gateway.PullRequestReviewThreads(t.Context(), []ID{"PR_1"})
+func TestGateway_PullRequestReviewThreadCounts(t *testing.T) {
+	requestNum := 0
+	gateway := newTestGateway(t, roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		var request struct {
+			Query     string          `json:"query"`
+			Variables json.RawMessage `json:"variables"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+
+		requestNum++
+		var response string
+		switch requestNum {
+		case 1:
+			assert.Equal(t, "query($ids:[ID!]!){nodes(ids: $ids){... on PullRequest{reviewThreads(first: 2){totalCount,pageInfo{endCursor,hasNextPage},nodes{isResolved}}}}}", request.Query)
+			assert.JSONEq(t, `{
+				"ids": ["PR_1", "PR_2"]
+			}`, string(request.Variables))
+			response = `{
+				"data": {"nodes": [
+					{"reviewThreads": {
+						"totalCount": 3,
+						"nodes": [{"isResolved": true}, {"isResolved": false}],
+						"pageInfo": {"endCursor": "next", "hasNextPage": true}
+					}},
+					{"reviewThreads": {
+						"totalCount": 1,
+						"nodes": [{"isResolved": false}],
+						"pageInfo": {"endCursor": "", "hasNextPage": false}
+					}}
+				]}
+			}`
+		case 2:
+			assert.Equal(t, "query($after:String!$first:Int!$id:ID!){node(id: $id){... on PullRequest{reviewThreads(first: $first, after: $after){totalCount,pageInfo{endCursor,hasNextPage},nodes{isResolved}}}}}", request.Query)
+			assert.JSONEq(t, `{
+				"after": "next",
+				"first": 2,
+				"id": "PR_1"
+			}`, string(request.Variables))
+			response = `{
+				"data": {"node": {"reviewThreads": {
+					"totalCount": 3,
+					"nodes": [{"isResolved": true}],
+					"pageInfo": {"endCursor": "", "hasNextPage": false}
+				}}}
+			}`
+		default:
+			t.Fatalf("unexpected request %d", requestNum)
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(response)),
+		}, nil
+	}))
+	got, err := gateway.PullRequestReviewThreadCounts(
+		t.Context(), []ID{"PR_1", "PR_2"},
+		&PaginationOptions{ItemsPerPage: 2},
+	)
 	require.NoError(t, err)
-	require.Len(t, got, 1)
-	assert.Equal(t, []bool{true}, got[0].Nodes)
+	assert.Equal(t, []*ReviewThreadCounts{
+		{Total: 3, Resolved: 2},
+		{Total: 1, Resolved: 0},
+	}, got)
+	assert.Equal(t, 2, requestNum)
 }
 
-func TestGateway_PullRequestReviewThreadsPage(t *testing.T) {
+func TestGateway_PullRequestReviewThreadCounts_rejectsMismatchedNodeCount(t *testing.T) {
 	gateway := newResponseGateway(t, `{
-		"data": {"node": {"reviewThreads": {
-			"totalCount": 1, "nodes": [{"isResolved": false}], "pageInfo": {}
-		}}}
+		"data": {"nodes": [
+			{"reviewThreads": {
+				"totalCount": 1,
+				"nodes": [{"isResolved": true}],
+				"pageInfo": {"endCursor": "", "hasNextPage": false}
+			}}
+		]}
 	}`)
-	got, err := gateway.PullRequestReviewThreadsPage(t.Context(), "PR_1", 100, "next")
-	require.NoError(t, err)
-	assert.Equal(t, []bool{false}, got.Nodes)
+
+	_, err := gateway.PullRequestReviewThreadCounts(
+		t.Context(), []ID{"PR_1", "PR_2"}, nil,
+	)
+	assert.ErrorContains(t, err, "got 1 nodes for 2 IDs")
 }

--- a/internal/gateway/github/status_check.go
+++ b/internal/gateway/github/status_check.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
+	"strconv"
 	"time"
 )
 
 // StatusCheck is one gateway-normalized member of GitHub's status-check union.
 // Its dynamic type is either [StatusContext] or [CheckRun].
 // Future union members that the gateway does not recognize are omitted from
-// [StatusChecksPage.Contexts] so known checks remain available.
+// the sequence returned by [Gateway.StatusChecks] so known checks remain
+// available.
 type StatusCheck interface {
 	isStatusCheck()
 }
@@ -65,33 +68,66 @@ type CheckRun struct {
 
 func (*CheckRun) isStatusCheck() {}
 
-// StatusChecksPage is one page of a pull request's status-check rollup.
-type StatusChecksPage struct {
-	// Contexts contains the known status and check-run members on this page.
-	// Future unknown union members are omitted for forward compatibility.
-	Contexts []StatusCheck
+// StatusChecks yields every known status-check rollup context for a pull request.
+// Future union members that the gateway does not recognize are omitted.
+// A pagination or decoding error is yielded once before the sequence stops.
+// A nil opts or zero [PaginationOptions.ItemsPerPage] requests 100 contexts per
+// page.
+func (c *Gateway) StatusChecks(ctx context.Context, id ID, opts *PaginationOptions) iter.Seq2[StatusCheck, error] {
+	return func(yield func(StatusCheck, error) bool) {
+		itemsPerPage, err := paginationItemsPerPage(opts, 100)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
 
-	// EndCursor is usable as after when HasNextPage is true.
-	EndCursor string
-
-	// HasNextPage reports whether another page follows EndCursor.
-	HasNextPage bool
-
-	// Present reports whether the pull request has a status-check rollup.
-	Present bool
+		var after *string
+		for {
+			page, err := c.statusChecksPage(ctx, id, itemsPerPage, after)
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+			if !page.present {
+				return
+			}
+			for _, check := range page.contexts {
+				if !yield(check, nil) {
+					return
+				}
+			}
+			if !page.hasNextPage {
+				return
+			}
+			after = &page.endCursor
+		}
+	}
 }
 
-// StatusChecks loads up to 100 status-check rollup contexts.
-// A nil after selects the first page; a non-nil after continues after that
-// cursor. Present is false when the pull request has no status-check rollup.
-func (c *Gateway) StatusChecks(ctx context.Context, id ID, after *string) (*StatusChecksPage, error) {
+// statusChecksPage is one response page from GitHub's status-check connection.
+type statusChecksPage struct {
+	// The page contains these known status and check-run union members.
+	contexts []StatusCheck
+
+	// The cursor identifies the page boundary when another page follows.
+	endCursor string
+
+	// This value reports whether GitHub has another page after the cursor.
+	hasNextPage bool
+
+	// This value reports whether the pull request has a status-check rollup.
+	present bool
+}
+
+// statusChecksPage requests and normalizes one status-check connection page.
+func (c *Gateway) statusChecksPage(ctx context.Context, id ID, first int, after *string) (*statusChecksPage, error) {
 	query := compactGraphQL(`
 		query($after:String$id:ID!){
 			node(id: $id){
 				... on PullRequest{
 					commits(last: 1){
 						nodes{commit{statusCheckRollup{
-							contexts(first: 100, after: $after){
+							contexts(first: ` + strconv.Itoa(first) + `, after: $after){
 								nodes{
 									... on StatusContext{context,state,createdAt},
 									... on CheckRun{
@@ -119,17 +155,17 @@ func (c *Gateway) StatusChecks(ctx context.Context, id ID, after *string) (*Stat
 
 	contexts, ok := result.statusCheckContexts()
 	if !ok {
-		return &StatusChecksPage{}, nil
+		return &statusChecksPage{}, nil
 	}
 	normalized, err := normalizeStatusChecks(contexts.Nodes)
 	if err != nil {
 		return nil, err
 	}
-	return &StatusChecksPage{
-		Contexts:    normalized,
-		EndCursor:   contexts.PageInfo.EndCursor,
-		HasNextPage: contexts.PageInfo.HasNextPage,
-		Present:     true,
+	return &statusChecksPage{
+		contexts:    normalized,
+		endCursor:   contexts.PageInfo.EndCursor,
+		hasNextPage: contexts.PageInfo.HasNextPage,
+		present:     true,
 	}, nil
 }
 

--- a/internal/gateway/github/status_check_test.go
+++ b/internal/gateway/github/status_check_test.go
@@ -48,8 +48,11 @@ func TestGateway_StatusChecks_rejectsUnknownEnumValue(t *testing.T) {
 		}
 	}`)
 
-	_, err := gateway.StatusChecks(t.Context(), "PR_1", nil)
-	assert.ErrorContains(t, err, `unknown github.StatusState: "RECALIBRATING"`)
+	var gotErr error
+	for _, err := range gateway.StatusChecks(t.Context(), "PR_1", nil) {
+		gotErr = err
+	}
+	assert.ErrorContains(t, gotErr, `unknown github.StatusState: "RECALIBRATING"`)
 }
 
 func TestGateway_StatusChecks_normalizesKnownMembers(t *testing.T) {
@@ -89,16 +92,19 @@ func TestGateway_StatusChecks_normalizesKnownMembers(t *testing.T) {
 		}
 	}`)
 
-	page, err := gateway.StatusChecks(t.Context(), "PR_1", nil)
-	require.NoError(t, err)
-	require.Len(t, page.Contexts, 2)
+	var checks []StatusCheck
+	for check, err := range gateway.StatusChecks(t.Context(), "PR_1", nil) {
+		require.NoError(t, err)
+		checks = append(checks, check)
+	}
+	require.Len(t, checks, 2)
 
-	status, ok := page.Contexts[0].(*StatusContext)
+	status, ok := checks[0].(*StatusContext)
 	require.True(t, ok)
 	assert.Equal(t, "build", status.Context)
 	assert.Equal(t, StatusStateSuccess, status.State)
 
-	checkRun, ok := page.Contexts[1].(*CheckRun)
+	checkRun, ok := checks[1].(*CheckRun)
 	require.True(t, ok)
 	assert.Equal(t, "test", checkRun.Name)
 	assert.Equal(t, CheckConclusionStateSuccess, *checkRun.Conclusion)
@@ -108,8 +114,11 @@ func TestGateway_StatusChecks_normalizesKnownMembers(t *testing.T) {
 func TestGateway_StatusChecks_rejectsAmbiguousUnionMember(t *testing.T) {
 	gateway := newResponseGateway(t, `{"data":{"node":{"commits":{"nodes":[{"commit":{"statusCheckRollup":{"contexts":{"nodes":[{"context":"status","name":"check"}],"pageInfo":{}}}}}]}}}}`)
 
-	_, err := gateway.StatusChecks(t.Context(), "PR_1", nil)
-	assert.ErrorContains(t, err, "ambiguous union member")
+	var gotErr error
+	for _, err := range gateway.StatusChecks(t.Context(), "PR_1", nil) {
+		gotErr = err
+	}
+	assert.ErrorContains(t, gotErr, "ambiguous union member")
 }
 
 func TestGateway_StatusChecks_ignoresUnknownUnionMember(t *testing.T) {
@@ -131,8 +140,73 @@ func TestGateway_StatusChecks_ignoresUnknownUnionMember(t *testing.T) {
 		}, nil
 	}))
 
-	page, err := gateway.StatusChecks(t.Context(), "PR_1", nil)
-	require.NoError(t, err)
-	assert.Empty(t, page.Contexts)
-	assert.True(t, page.Present)
+	for _, err := range gateway.StatusChecks(t.Context(), "PR_1", nil) {
+		require.NoError(t, err)
+	}
+}
+
+func TestGateway_StatusChecks_paginates(t *testing.T) {
+	requestNum := 0
+	gateway := newTestGateway(t, roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		var request struct {
+			Query     string          `json:"query"`
+			Variables json.RawMessage `json:"variables"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+		assert.Equal(t, "query($after:String$id:ID!){node(id: $id){... on PullRequest{commits(last: 1){nodes{commit{statusCheckRollup{contexts(first: 2, after: $after){nodes{... on StatusContext{context,state,createdAt},... on CheckRun{name,checkSuite{workflowRun{event,workflow{name}}},status,conclusion,startedAt,completedAt}},pageInfo{endCursor,hasNextPage}}}}}}}}}", request.Query)
+
+		requestNum++
+		var response string
+		switch requestNum {
+		case 1:
+			assert.JSONEq(t, `{
+				"after": null,
+				"id": "PR_1"
+			}`, string(request.Variables))
+			response = `{
+				"data": {"node": {"commits": {"nodes": [{"commit": {
+					"statusCheckRollup": {"contexts": {
+						"nodes": [{
+							"context": "build",
+							"state": "SUCCESS",
+							"createdAt": "2026-07-11T00:00:00Z"
+						}],
+						"pageInfo": {"endCursor": "next", "hasNextPage": true}
+					}}
+				}}]}}}
+			}`
+		case 2:
+			assert.JSONEq(t, `{
+				"after": "next",
+				"id": "PR_1"
+			}`, string(request.Variables))
+			response = `{
+				"data": {"node": {"commits": {"nodes": [{"commit": {
+					"statusCheckRollup": {"contexts": {
+						"nodes": [{
+							"context": "test",
+							"state": "SUCCESS",
+							"createdAt": "2026-07-11T00:01:00Z"
+						}],
+						"pageInfo": {"endCursor": "", "hasNextPage": false}
+					}}
+				}}]}}}
+			}`
+		default:
+			t.Fatalf("unexpected request %d", requestNum)
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(response)),
+		}, nil
+	}))
+
+	var contexts []string
+	for check, err := range gateway.StatusChecks(t.Context(), "PR_1", &PaginationOptions{ItemsPerPage: 2}) {
+		require.NoError(t, err)
+		contexts = append(contexts, check.(*StatusContext).Context)
+	}
+	assert.Equal(t, []string{"build", "test"}, contexts)
+	assert.Equal(t, 2, requestNum)
 }


### PR DESCRIPTION
Move comment and status-check traversal behind gateway iterators, and make batched review-thread counts traverse continuation pages internally. Forge callers no longer own cursors or continuation loops.

Preserve the existing GraphQL documents, variables, default page sizes, and request order. `PaginationOptions` permits smaller pages for callers and tests without exposing cursors.

Validation strengthens gateway coverage for multi-page request documents, cursor variables, result order, cardinality, and continuation errors. The existing GitHub forge replay passes without fixture changes.