### PR TITLE
github: Batch identity lookups

### DIFF
--- a/.changes/unreleased/Fixed-20260712-114841.yaml
+++ b/.changes/unreleased/Fixed-20260712-114841.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'github: Reviewer and assignee IDs are resolved in batches instead of one API call per identity.'
+time: 2026-07-12T11:48:41.655769-07:00

--- a/internal/forge/github/assignee.go
+++ b/internal/forge/github/assignee.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"go.abhg.dev/gs/internal/gateway/github"
 )
@@ -12,10 +13,12 @@ func (r *Repository) addAssigneesToPullRequest(ctx context.Context, assignees []
 		return nil
 	}
 
-	assigneeIDs, err := r.assigneeIDs(ctx, assignees)
+	assigneeIDs, _, err := r.identityIDs(ctx, assignees, nil)
 	if err != nil {
 		return fmt.Errorf("get assignee IDs: %w", err)
 	}
+	slices.Sort(assigneeIDs)
+	assigneeIDs = slices.Compact(assigneeIDs)
 
 	if err := r.gateway.AddAssigneesToAssignable(
 		ctx,
@@ -26,25 +29,4 @@ func (r *Repository) addAssigneesToPullRequest(ctx context.Context, assignees []
 	}
 
 	return nil
-}
-
-// assigneeIDs resolves assignee logins to GitHub user IDs.
-// The returned slice may be shorter than the input
-// because duplicate logins are automatically deduplicated.
-func (r *Repository) assigneeIDs(ctx context.Context, assignees []string) ([]github.ID, error) {
-	ids := make([]github.ID, 0, len(assignees))
-	seen := make(map[string]struct{}, len(assignees))
-	for _, assignee := range assignees {
-		if _, ok := seen[assignee]; ok {
-			continue
-		}
-		seen[assignee] = struct{}{}
-
-		id, err := r.userID(ctx, assignee)
-		if err != nil {
-			return nil, fmt.Errorf("resolve assignee %q: %w", assignee, err)
-		}
-		ids = append(ids, id)
-	}
-	return ids, nil
 }

--- a/internal/forge/github/assignee_test.go
+++ b/internal/forge/github/assignee_test.go
@@ -1,0 +1,71 @@
+package github
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/silog/silogtest"
+)
+
+func TestRepository_addAssigneesToPullRequest_batchesDistinctUncachedUsers(t *testing.T) {
+	var requests int
+	var identityRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		var request struct {
+			Query     string         `json:"query"`
+			Variables map[string]any `json:"variables"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+		switch {
+		case strings.Contains(request.Query, "user0:user"):
+			identityRequests++
+			assert.Equal(t, "alice", request.Variables["user0"])
+			assert.Equal(t, "bob", request.Variables["user1"])
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"user0": map[string]any{"id": "U_2"},
+					"user1": map[string]any{"id": "U_1"},
+				},
+			}))
+
+		case strings.Contains(request.Query, "addAssigneesToAssignable"):
+			input, ok := request.Variables["input"].(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, "PR_1", input["assignableId"])
+			assert.Equal(t, []any{"U_1", "U_2"}, input["assigneeIds"])
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"addAssigneesToAssignable": map[string]any{},
+				},
+			}))
+
+		default:
+			t.Fatalf("unexpected query: %s", request.Query)
+		}
+	}))
+	defer server.Close()
+
+	repo, err := newRepository(
+		t.Context(), new(Forge),
+		"acme", "warp-drive",
+		silogtest.New(t),
+		newTestGateway(t, server.URL),
+		"R_1",
+	)
+	require.NoError(t, err)
+
+	err = repo.addAssigneesToPullRequest(
+		t.Context(),
+		[]string{"alice", "bob", "alice"},
+		"PR_1",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, identityRequests)
+	assert.Equal(t, 2, requests)
+}

--- a/internal/forge/github/identity.go
+++ b/internal/forge/github/identity.go
@@ -1,0 +1,103 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.abhg.dev/gs/internal/gateway/github"
+)
+
+// userID looks up a user's GraphQL ID by login.
+func (r *Repository) userID(ctx context.Context, login string) (github.ID, error) {
+	userIDs, _, err := r.identityIDs(ctx, []string{login}, nil)
+	if err != nil {
+		return "", err
+	}
+	return userIDs[0], nil
+}
+
+// identityIDs returns user and team IDs aligned with the supplied identities.
+// Successful lookups are cached, including successes from a batch that also
+// contains identities GitHub does not recognize.
+func (r *Repository) identityIDs(
+	ctx context.Context,
+	users []string,
+	teams []github.TeamName,
+) ([]github.ID, []github.ID, error) {
+	r.identityIDsMu.RLock()
+	userIDs, missingUsers := cachedIdentityIDs(r.userIDsCache, users)
+	teamIDs, missingTeams := cachedIdentityIDs(r.teamIDsCache, teams)
+	r.identityIDsMu.RUnlock()
+
+	if len(missingUsers) == 0 && len(missingTeams) == 0 {
+		return userIDs, teamIDs, nil
+	}
+
+	r.identityIDsMu.Lock()
+	defer r.identityIDsMu.Unlock()
+
+	// Recheck missing items after write lock is acquired
+	// in case another goroutine already cached them.
+	_, missingUsers = cachedIdentityIDs(r.userIDsCache, missingUsers)
+	_, missingTeams = cachedIdentityIDs(r.teamIDsCache, missingTeams)
+
+	if len(missingUsers) > 0 || len(missingTeams) > 0 {
+		var err error
+		resolvedUserIDs, resolvedTeamIDs, err := r.gateway.IdentityIDs(
+			ctx, missingUsers, missingTeams,
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		for i, user := range missingUsers {
+			if resolvedUserIDs[i] != "" {
+				r.userIDsCache[user] = resolvedUserIDs[i]
+			}
+		}
+		for i, team := range missingTeams {
+			if resolvedTeamIDs[i] != "" {
+				r.teamIDsCache[team] = resolvedTeamIDs[i]
+			}
+		}
+	}
+
+	// Anything still uncached after miss resolution does not exist.
+	// Return one error for each distinct missing identity.
+	userIDs, missingUsers = cachedIdentityIDs(r.userIDsCache, users)
+	teamIDs, missingTeams = cachedIdentityIDs(r.teamIDsCache, teams)
+
+	var errs []error
+	for _, user := range missingUsers {
+		errs = append(errs, fmt.Errorf("user not found: %q", user))
+	}
+	for _, team := range missingTeams {
+		errs = append(errs, fmt.Errorf("team not found: %q/%q", team.Organization, team.Slug))
+	}
+
+	return userIDs, teamIDs, errors.Join(errs...)
+}
+
+// cachedIdentityIDs returns IDs aligned with identities and the distinct
+// identities absent from cache. The caller owns synchronization for cache.
+func cachedIdentityIDs[T comparable](
+	cache map[T]github.ID,
+	identities []T,
+) ([]github.ID, []T) {
+	ids := make([]github.ID, len(identities))
+	missingSeen := make(map[T]struct{}, len(identities))
+	var missing []T
+	for i, item := range identities {
+		id, ok := cache[item]
+		if ok {
+			ids[i] = id
+			continue
+		}
+		if _, seen := missingSeen[item]; !seen {
+			missing = append(missing, item)
+			missingSeen[item] = struct{}{}
+		}
+	}
+	return ids, missing
+}

--- a/internal/forge/github/identity_test.go
+++ b/internal/forge/github/identity_test.go
@@ -1,0 +1,51 @@
+package github
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/gateway/github"
+	"go.abhg.dev/gs/internal/silog/silogtest"
+)
+
+func TestRepository_identityIDsCachesSuccessesFromPartialLookup(t *testing.T) {
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		var request struct {
+			Query string `json:"query"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+		assert.Contains(t, request.Query, "user0:user(login: $user0){id}")
+		assert.Contains(t, request.Query, "user1:user(login: $user1){id}")
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"user0": map[string]any{"id": "U_1"},
+				"user1": nil,
+			},
+		}))
+	}))
+	defer server.Close()
+
+	repo, err := newRepository(
+		t.Context(), new(Forge),
+		"acme", "warp-drive",
+		silogtest.New(t),
+		newTestGateway(t, server.URL),
+		"R_1",
+	)
+	require.NoError(t, err)
+
+	userIDs, _, err := repo.identityIDs(t.Context(), []string{"alice", "missing"}, nil)
+	require.EqualError(t, err, `user not found: "missing"`)
+	assert.Equal(t, []github.ID{"U_1", ""}, userIDs)
+
+	id, err := repo.userID(t.Context(), "alice")
+	require.NoError(t, err)
+	assert.Equal(t, github.ID("U_1"), id)
+	assert.Equal(t, 1, requests)
+}

--- a/internal/forge/github/repository.go
+++ b/internal/forge/github/repository.go
@@ -8,7 +8,6 @@ import (
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/gateway/github"
 	"go.abhg.dev/gs/internal/silog"
-	"golang.org/x/sync/singleflight"
 )
 
 // Repository is a GitHub repository.
@@ -19,14 +18,15 @@ type Repository struct {
 	gateway     *github.Gateway
 	forge       *Forge
 
-	userIDsMu sync.Mutex // guards userIDs
-	// userIDs caches successful login lookups for this repository.
+	identityIDsMu sync.RWMutex // guards userIDsCache and teamIDsCache
+	// userIDsCache caches successful login lookups for this repository.
 	//
 	// Pull request metadata operations can resolve the same login
 	// through reviewers, assignees, or follow-up edits in one command.
-	userIDs map[string]github.ID
-	// userIDGroup coalesces concurrent misses for the same login.
-	userIDGroup singleflight.Group
+	userIDsCache map[string]github.ID
+
+	// teamIDsCache caches successful organization and team slug lookups.
+	teamIDsCache map[github.TeamName]github.ID
 }
 
 var _ forge.Repository = (*Repository)(nil)
@@ -50,68 +50,16 @@ func newRepository(
 	}
 
 	return &Repository{
-		owner:   owner,
-		repo:    repo,
-		log:     log,
-		gateway: gateway,
-		repoID:  repoID,
-		forge:   forge,
-		userIDs: make(map[string]github.ID),
+		owner:        owner,
+		repo:         repo,
+		log:          log,
+		gateway:      gateway,
+		repoID:       repoID,
+		forge:        forge,
+		userIDsCache: make(map[string]github.ID),
+		teamIDsCache: make(map[github.TeamName]github.ID),
 	}, nil
 }
 
 // Forge returns the forge this repository belongs to.
 func (r *Repository) Forge() forge.Forge { return r.forge }
-
-// userID looks up a user's GraphQL ID by login.
-func (r *Repository) userID(ctx context.Context, login string) (github.ID, error) {
-	r.userIDsMu.Lock()
-	id, ok := r.userIDs[login]
-	r.userIDsMu.Unlock()
-	if ok {
-		// Another goroutine resolved this login
-		// while the singleflight call was waiting for the lock.
-		return id, nil
-	}
-
-	idAny, err, _ := r.userIDGroup.Do(login, func() (any, error) {
-		r.userIDsMu.Lock()
-		id, ok := r.userIDs[login]
-		r.userIDsMu.Unlock()
-		if ok {
-			// Another goroutine resolved this login
-			// while the singleflight call was waiting for the lock.
-			return id, nil
-		}
-
-		id, err := r.queryUserID(ctx, login)
-		if err != nil {
-			return "", err
-		}
-
-		r.userIDsMu.Lock()
-		if r.userIDs == nil {
-			r.userIDs = make(map[string]github.ID)
-		}
-		r.userIDs[login] = id
-		r.userIDsMu.Unlock()
-
-		return id, nil
-	})
-	if err != nil {
-		return "", err
-	}
-	return idAny.(github.ID), nil
-}
-
-func (r *Repository) queryUserID(ctx context.Context, login string) (github.ID, error) {
-	id, err := r.gateway.UserID(ctx, login)
-	if err != nil {
-		return "", err
-	}
-	if id == "" {
-		return "", fmt.Errorf("user not found: %q", login)
-	}
-
-	return id, nil
-}

--- a/internal/forge/github/reviewer.go
+++ b/internal/forge/github/reviewer.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -48,9 +47,8 @@ func (r *Repository) reviewersIDs(
 	ctx context.Context,
 	reviewers []string,
 ) (userIDs []github.ID, teamIDs []github.ID, err error) {
-	var errs []error
-
-	// TODO: parallelize lookups or combine into one GQL query.
+	var users []string
+	var teams []github.TeamName
 	for _, reviewer := range reviewers {
 		reviewer = strings.TrimSpace(reviewer)
 		if reviewer == "" {
@@ -60,36 +58,28 @@ func (r *Repository) reviewersIDs(
 		// Team reviewer in the form "org/team",
 		// where "org" must match the repository owner.
 		if org, teamSlug, ok := strings.Cut(reviewer, "/"); ok {
-			id, err := r.teamID(ctx, org, teamSlug)
-			if err != nil {
-				errs = append(errs, fmt.Errorf("lookup team %q: %w", reviewer, err))
-				continue
-			}
-			teamIDs = append(teamIDs, id)
-			r.log.Debug("Resolved team reviewer ID", "team", reviewer, "id", id)
+			teams = append(teams, github.TeamName{
+				Organization: org,
+				Slug:         teamSlug,
+			})
 		} else {
-			id, err := r.userID(ctx, reviewer)
-			if err != nil {
-				errs = append(errs, fmt.Errorf("lookup user %q: %w", reviewer, err))
-				continue
-			}
-			userIDs = append(userIDs, id)
-			r.log.Debug("Resolved user reviewer ID", "username", reviewer, "id", id)
+			users = append(users, reviewer)
 		}
 	}
 
-	return userIDs, teamIDs, errors.Join(errs...)
-}
-
-// teamID looks up a team's GraphQL ID by organization and team slug.
-func (r *Repository) teamID(ctx context.Context, org, teamSlug string) (github.ID, error) {
-	id, err := r.gateway.TeamID(ctx, org, teamSlug)
+	userIDs, teamIDs, err = r.identityIDs(ctx, users, teams)
 	if err != nil {
-		return "", err
+		return nil, nil, err
 	}
-	if id == "" {
-		return "", fmt.Errorf("team not found: %q/%q", org, teamSlug)
+	for i, user := range users {
+		r.log.Debug("Resolved user reviewer ID", "username", user, "id", userIDs[i])
 	}
-
-	return id, nil
+	for i, team := range teams {
+		r.log.Debug(
+			"Resolved team reviewer ID",
+			"team", team.Organization+"/"+team.Slug,
+			"id", teamIDs[i],
+		)
+	}
+	return userIDs, teamIDs, nil
 }

--- a/internal/forge/github/reviewer_test.go
+++ b/internal/forge/github/reviewer_test.go
@@ -1,0 +1,64 @@
+package github
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/gateway/github"
+	"go.abhg.dev/gs/internal/silog/silogtest"
+)
+
+func TestRepository_reviewersIDs_batchesUncachedIdentities(t *testing.T) {
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		var request struct {
+			Variables json.RawMessage `json:"variables"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+		assert.JSONEq(t, `{
+			"teamOrg0": "acme",
+			"teamSlug0": "platform",
+			"user0": "alice",
+			"user1": "bob"
+		}`, string(request.Variables))
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"user0": map[string]any{"id": "U_1"},
+				"user1": map[string]any{"id": "U_2"},
+				"team0": map[string]any{
+					"team": map[string]any{"id": "T_1"},
+				},
+			},
+		}))
+	}))
+	defer server.Close()
+
+	repo, err := newRepository(
+		t.Context(), new(Forge),
+		"acme", "warp-drive",
+		silogtest.New(t),
+		newTestGateway(t, server.URL),
+		"R_1",
+	)
+	require.NoError(t, err)
+
+	userIDs, teamIDs, err := repo.reviewersIDs(
+		t.Context(),
+		[]string{
+			"alice",
+			"acme/platform",
+			"bob",
+			"alice",
+			"acme/platform",
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []github.ID{"U_1", "U_2", "U_1"}, userIDs)
+	assert.Equal(t, []github.ID{"T_1", "T_1"}, teamIDs)
+	assert.Equal(t, 1, requests)
+}

--- a/internal/forge/github/submit_test.go
+++ b/internal/forge/github/submit_test.go
@@ -115,20 +115,20 @@ func TestRepository_prMetadataCachesUserIDs(t *testing.T) {
 		var body struct {
 			Query     string `json:"query"`
 			Variables struct {
-				Login string         `json:"login"`
+				User0 string         `json:"user0"`
 				Input map[string]any `json:"input"`
 			} `json:"variables"`
 		}
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
 
 		switch {
-		case strings.Contains(body.Query, "user(login: $login)"):
+		case strings.Contains(body.Query, "user0:user(login: $user0)"):
 			userQueries++
-			assert.Equal(t, "alice", body.Variables.Login)
+			assert.Equal(t, "alice", body.Variables.User0)
 
 			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
 				"data": map[string]any{
-					"user": map[string]any{
+					"user0": map[string]any{
 						"id": "aliceID",
 					},
 				},
@@ -209,12 +209,12 @@ func TestRepository_userIDCoalescesConcurrentMisses(t *testing.T) {
 		var body struct {
 			Query     string `json:"query"`
 			Variables struct {
-				Login string `json:"login"`
+				User0 string `json:"user0"`
 			} `json:"variables"`
 		}
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		require.Contains(t, body.Query, "user(login: $login)")
-		assert.Equal(t, "alice", body.Variables.Login)
+		require.Contains(t, body.Query, "user0:user(login: $user0)")
+		assert.Equal(t, "alice", body.Variables.User0)
 
 		if userQueries.Add(1) == 1 {
 			close(firstQueryStarted)
@@ -226,7 +226,7 @@ func TestRepository_userIDCoalescesConcurrentMisses(t *testing.T) {
 		<-releaseQuery
 		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
 			"data": map[string]any{
-				"user": map[string]any{
+				"user0": map[string]any{
 					"id": "aliceID",
 				},
 			},

--- a/internal/forge/github/testdata/TestIntegration/SubmitEditAssignees/AddAssignee/branch-no-assignee
+++ b/internal/forge/github/testdata/TestIntegration/SubmitEditAssignees/AddAssignee/branch-no-assignee
@@ -1,1 +1,1 @@
-"YzGo60Kw"
+"ZyMDPhV1"

--- a/internal/forge/github/testdata/TestIntegration/SubmitEditAssignees/SubmitWithAssignee/branch-with-assignee
+++ b/internal/forge/github/testdata/TestIntegration/SubmitEditAssignees/SubmitWithAssignee/branch-with-assignee
@@ -1,1 +1,1 @@
-"KbHQmhqp"
+"D7eU16mu"

--- a/internal/forge/github/testdata/TestIntegration/SubmitEditReviewers/AddReviewer/branch-no-reviewer
+++ b/internal/forge/github/testdata/TestIntegration/SubmitEditReviewers/AddReviewer/branch-no-reviewer
@@ -1,1 +1,1 @@
-"f4fqEb9C"
+"sMCSMgpe"

--- a/internal/forge/github/testdata/TestIntegration/SubmitEditReviewers/SubmitWithReviewer/branch-with-reviewer
+++ b/internal/forge/github/testdata/TestIntegration/SubmitEditReviewers/SubmitWithReviewer/branch-with-reviewer
@@ -1,1 +1,1 @@
-"4IUzIjwL"
+"fWMkS7CC"

--- a/internal/forge/github/testdata/fixtures/TestIntegration/SubmitEditAssignees/AddAssignee.yaml
+++ b/internal/forge/github/testdata/fixtures/TestIntegration/SubmitEditAssignees/AddAssignee.yaml
@@ -20,14 +20,13 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: -1
-        uncompressed: true
         body: '{"data":{"repository":{"id":"R_kgDOMVd0xg"}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 226.9605ms
+        duration: 328.176417ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -36,7 +35,7 @@ interactions:
         content_length: 277
         host: api.github.com
         body: |
-            {"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"main","headRefName":"YzGo60Kw","title":"Testing YzGo60Kw","body":"Test PR without assignees"}}}
+            {"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"main","headRefName":"ZyMDPhV1","title":"Testing ZyMDPhV1","body":"Test PR without assignees"}}}
         headers:
             Content-Type:
                 - application/json
@@ -48,22 +47,22 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs7XrmCc","number":82,"url":"https://github.com/test-owner/test-repo/pull/82"}}}}'
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs7wz5zl","number":104,"url":"https://github.com/test-owner/test-repo/pull/104"}}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 825.8385ms
+        duration: 1.085099416s
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 426
+        content_length: 427
         host: api.github.com
         body: |
-            {"query":"query($number:Int!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){pullRequest(number: $number){id,number,url,title,state,headRefOid,baseRefName,isDraft,headRepository{owner{login},name},labels(first: 100){nodes{name}},reviewRequests(first: 100){nodes{requestedReviewer{... on Actor{login}}}},assignees(first: 100){nodes{login}}}}}","variables":{"number":82,"owner":"test-owner","repo":"test-repo"}}
+            {"query":"query($number:Int!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){pullRequest(number: $number){id,number,url,title,state,headRefOid,baseRefName,isDraft,headRepository{owner{login},name},labels(first: 100){nodes{name}},reviewRequests(first: 100){nodes{requestedReviewer{... on Actor{login}}}},assignees(first: 100){nodes{login}}}}}","variables":{"number":104,"owner":"test-owner","repo":"test-repo"}}
         headers:
             Content-Type:
                 - application/json
@@ -75,22 +74,22 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"data":{"repository":{"pullRequest":{"id":"PR_kwDOMVd0xs7XrmCc","number":82,"url":"https://github.com/test-owner/test-repo/pull/82","title":"Testing YzGo60Kw","state":"OPEN","headRefOid":"5283cc32fb924518fe9608b2bcdfe76b59f2a315","baseRefName":"main","isDraft":false,"headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"labels":{"nodes":[]},"reviewRequests":{"nodes":[]},"assignees":{"nodes":[]}}}}}'
+        body: '{"data":{"repository":{"pullRequest":{"id":"PR_kwDOMVd0xs7wz5zl","number":104,"url":"https://github.com/test-owner/test-repo/pull/104","title":"Testing ZyMDPhV1","state":"OPEN","headRefOid":"dbf5c1205081137e33d99870a1260c91a1e9f1f2","baseRefName":"main","isDraft":false,"headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"labels":{"nodes":[]},"reviewRequests":{"nodes":[]},"assignees":{"nodes":[]}}}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 263.56125ms
+        duration: 377.980417ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 91
+        content_length: 97
         host: api.github.com
         body: |
-            {"query":"query($login:String!){user(login: $login){id}}","variables":{"login":"test-owner"}}
+            {"query":"query($user0:String!){user0:user(login: $user0){id}}","variables":{"user0":"test-owner"}}
         headers:
             Content-Type:
                 - application/json
@@ -101,14 +100,13 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: -1
-        uncompressed: true
-        body: '{"data":{"user":{"id":"MDQ6VXNlcjQxNzMw"}}}'
+        body: '{"data":{"user0":{"id":"MDQ6VXNlcjQxNzMw"}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 181.914417ms
+        duration: 342.161625ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -117,7 +115,7 @@ interactions:
         content_length: 215
         host: api.github.com
         body: |
-            {"query":"mutation($input:AddAssigneesToAssignableInput!){addAssigneesToAssignable(input: $input){clientMutationId}}","variables":{"input":{"assignableId":"PR_kwDOMVd0xs7XrmCc","assigneeIds":["MDQ6VXNlcjQxNzMw"]}}}
+            {"query":"mutation($input:AddAssigneesToAssignableInput!){addAssigneesToAssignable(input: $input){clientMutationId}}","variables":{"input":{"assignableId":"PR_kwDOMVd0xs7wz5zl","assigneeIds":["MDQ6VXNlcjQxNzMw"]}}}
         headers:
             Content-Type:
                 - application/json
@@ -135,16 +133,16 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 664.769625ms
+        duration: 614.212708ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 426
+        content_length: 427
         host: api.github.com
         body: |
-            {"query":"query($number:Int!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){pullRequest(number: $number){id,number,url,title,state,headRefOid,baseRefName,isDraft,headRepository{owner{login},name},labels(first: 100){nodes{name}},reviewRequests(first: 100){nodes{requestedReviewer{... on Actor{login}}}},assignees(first: 100){nodes{login}}}}}","variables":{"number":82,"owner":"test-owner","repo":"test-repo"}}
+            {"query":"query($number:Int!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){pullRequest(number: $number){id,number,url,title,state,headRefOid,baseRefName,isDraft,headRepository{owner{login},name},labels(first: 100){nodes{name}},reviewRequests(first: 100){nodes{requestedReviewer{... on Actor{login}}}},assignees(first: 100){nodes{login}}}}}","variables":{"number":104,"owner":"test-owner","repo":"test-repo"}}
         headers:
             Content-Type:
                 - application/json
@@ -156,10 +154,10 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"data":{"repository":{"pullRequest":{"id":"PR_kwDOMVd0xs7XrmCc","number":82,"url":"https://github.com/test-owner/test-repo/pull/82","title":"Testing YzGo60Kw","state":"OPEN","headRefOid":"5283cc32fb924518fe9608b2bcdfe76b59f2a315","baseRefName":"main","isDraft":false,"headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"labels":{"nodes":[]},"reviewRequests":{"nodes":[]},"assignees":{"nodes":[{"login":"test-owner"}]}}}}}'
+        body: '{"data":{"repository":{"pullRequest":{"id":"PR_kwDOMVd0xs7wz5zl","number":104,"url":"https://github.com/test-owner/test-repo/pull/104","title":"Testing ZyMDPhV1","state":"OPEN","headRefOid":"dbf5c1205081137e33d99870a1260c91a1e9f1f2","baseRefName":"main","isDraft":false,"headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"labels":{"nodes":[]},"reviewRequests":{"nodes":[]},"assignees":{"nodes":[{"login":"test-owner"}]}}}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 375.316875ms
+        duration: 291.110875ms

--- a/internal/forge/github/testdata/fixtures/TestIntegration/SubmitEditAssignees/SubmitWithAssignee.yaml
+++ b/internal/forge/github/testdata/fixtures/TestIntegration/SubmitEditAssignees/SubmitWithAssignee.yaml
@@ -20,14 +20,13 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: -1
-        uncompressed: true
         body: '{"data":{"repository":{"id":"R_kgDOMVd0xg"}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 321.043625ms
+        duration: 221.388792ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -36,7 +35,7 @@ interactions:
         content_length: 273
         host: api.github.com
         body: |
-            {"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"main","headRefName":"KbHQmhqp","title":"Testing KbHQmhqp","body":"Test PR with assignee"}}}
+            {"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"main","headRefName":"D7eU16mu","title":"Testing D7eU16mu","body":"Test PR with assignee"}}}
         headers:
             Content-Type:
                 - application/json
@@ -48,22 +47,22 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs7XrmCS","number":81,"url":"https://github.com/test-owner/test-repo/pull/81"}}}}'
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs7wz5zs","number":105,"url":"https://github.com/test-owner/test-repo/pull/105"}}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.006462875s
+        duration: 826.788375ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 91
+        content_length: 97
         host: api.github.com
         body: |
-            {"query":"query($login:String!){user(login: $login){id}}","variables":{"login":"test-owner"}}
+            {"query":"query($user0:String!){user0:user(login: $user0){id}}","variables":{"user0":"test-owner"}}
         headers:
             Content-Type:
                 - application/json
@@ -75,13 +74,13 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"data":{"user":{"id":"MDQ6VXNlcjQxNzMw"}}}'
+        body: '{"data":{"user0":{"id":"MDQ6VXNlcjQxNzMw"}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 215.445709ms
+        duration: 224.845625ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -90,7 +89,7 @@ interactions:
         content_length: 215
         host: api.github.com
         body: |
-            {"query":"mutation($input:AddAssigneesToAssignableInput!){addAssigneesToAssignable(input: $input){clientMutationId}}","variables":{"input":{"assignableId":"PR_kwDOMVd0xs7XrmCS","assigneeIds":["MDQ6VXNlcjQxNzMw"]}}}
+            {"query":"mutation($input:AddAssigneesToAssignableInput!){addAssigneesToAssignable(input: $input){clientMutationId}}","variables":{"input":{"assignableId":"PR_kwDOMVd0xs7wz5zs","assigneeIds":["MDQ6VXNlcjQxNzMw"]}}}
         headers:
             Content-Type:
                 - application/json
@@ -108,16 +107,16 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 826.706834ms
+        duration: 890.443708ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 426
+        content_length: 427
         host: api.github.com
         body: |
-            {"query":"query($number:Int!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){pullRequest(number: $number){id,number,url,title,state,headRefOid,baseRefName,isDraft,headRepository{owner{login},name},labels(first: 100){nodes{name}},reviewRequests(first: 100){nodes{requestedReviewer{... on Actor{login}}}},assignees(first: 100){nodes{login}}}}}","variables":{"number":81,"owner":"test-owner","repo":"test-repo"}}
+            {"query":"query($number:Int!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){pullRequest(number: $number){id,number,url,title,state,headRefOid,baseRefName,isDraft,headRepository{owner{login},name},labels(first: 100){nodes{name}},reviewRequests(first: 100){nodes{requestedReviewer{... on Actor{login}}}},assignees(first: 100){nodes{login}}}}}","variables":{"number":105,"owner":"test-owner","repo":"test-repo"}}
         headers:
             Content-Type:
                 - application/json
@@ -129,13 +128,13 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"data":{"repository":{"pullRequest":{"id":"PR_kwDOMVd0xs7XrmCS","number":81,"url":"https://github.com/test-owner/test-repo/pull/81","title":"Testing KbHQmhqp","state":"OPEN","headRefOid":"78103ab8c69e880a4b7c85bfac02743eb0d63c48","baseRefName":"main","isDraft":false,"headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"labels":{"nodes":[]},"reviewRequests":{"nodes":[]},"assignees":{"nodes":[{"login":"test-owner"}]}}}}}'
+        body: '{"data":{"repository":{"pullRequest":{"id":"PR_kwDOMVd0xs7wz5zs","number":105,"url":"https://github.com/test-owner/test-repo/pull/105","title":"Testing D7eU16mu","state":"OPEN","headRefOid":"0d5ff62488713ddcf5e15d68f6a438cc05cd2283","baseRefName":"main","isDraft":false,"headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"labels":{"nodes":[]},"reviewRequests":{"nodes":[]},"assignees":{"nodes":[{"login":"test-owner"}]}}}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 275.43125ms
+        duration: 284.744334ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -144,7 +143,7 @@ interactions:
         content_length: 615
         host: api.github.com
         body: |
-            {"query":"query($branch:String!$limit:Int!$owner:String!$repo:String!$states:[PullRequestState!]!){repository(owner: $owner, name: $repo){pullRequests(first: $limit, headRefName: $branch, states: $states, orderBy: {field: UPDATED_AT, direction: DESC}){nodes{id,number,url,title,state,headRefOid,baseRefName,isDraft,headRepository{owner{login},name},labels(first: 100){nodes{name}},reviewRequests(first: 100){nodes{requestedReviewer{... on Actor{login}}}},assignees(first: 100){nodes{login}}}}}}","variables":{"branch":"KbHQmhqp","limit":10,"owner":"test-owner","repo":"test-repo","states":["OPEN","CLOSED","MERGED"]}}
+            {"query":"query($branch:String!$limit:Int!$owner:String!$repo:String!$states:[PullRequestState!]!){repository(owner: $owner, name: $repo){pullRequests(first: $limit, headRefName: $branch, states: $states, orderBy: {field: UPDATED_AT, direction: DESC}){nodes{id,number,url,title,state,headRefOid,baseRefName,isDraft,headRepository{owner{login},name},labels(first: 100){nodes{name}},reviewRequests(first: 100){nodes{requestedReviewer{... on Actor{login}}}},assignees(first: 100){nodes{login}}}}}}","variables":{"branch":"D7eU16mu","limit":10,"owner":"test-owner","repo":"test-repo","states":["OPEN","CLOSED","MERGED"]}}
         headers:
             Content-Type:
                 - application/json
@@ -156,10 +155,10 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"data":{"repository":{"pullRequests":{"nodes":[{"id":"PR_kwDOMVd0xs7XrmCS","number":81,"url":"https://github.com/test-owner/test-repo/pull/81","title":"Testing KbHQmhqp","state":"OPEN","headRefOid":"78103ab8c69e880a4b7c85bfac02743eb0d63c48","baseRefName":"main","isDraft":false,"headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"labels":{"nodes":[]},"reviewRequests":{"nodes":[]},"assignees":{"nodes":[{"login":"test-owner"}]}}]}}}}'
+        body: '{"data":{"repository":{"pullRequests":{"nodes":[{"id":"PR_kwDOMVd0xs7wz5zs","number":105,"url":"https://github.com/test-owner/test-repo/pull/105","title":"Testing D7eU16mu","state":"OPEN","headRefOid":"0d5ff62488713ddcf5e15d68f6a438cc05cd2283","baseRefName":"main","isDraft":false,"headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"labels":{"nodes":[]},"reviewRequests":{"nodes":[]},"assignees":{"nodes":[{"login":"test-owner"}]}}]}}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 419.090792ms
+        duration: 270.396ms

--- a/internal/forge/github/testdata/fixtures/TestIntegration/SubmitEditReviewers/AddReviewer.yaml
+++ b/internal/forge/github/testdata/fixtures/TestIntegration/SubmitEditReviewers/AddReviewer.yaml
@@ -20,14 +20,13 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: -1
-        uncompressed: true
         body: '{"data":{"repository":{"id":"R_kgDOMVd0xg"}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 234.461333ms
+        duration: 302.593375ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -36,7 +35,7 @@ interactions:
         content_length: 277
         host: api.github.com
         body: |
-            {"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"main","headRefName":"f4fqEb9C","title":"Testing f4fqEb9C","body":"Test PR without reviewers"}}}
+            {"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"main","headRefName":"sMCSMgpe","title":"Testing sMCSMgpe","body":"Test PR without reviewers"}}}
         headers:
             Content-Type:
                 - application/json
@@ -48,22 +47,22 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs7XrljJ","number":75,"url":"https://github.com/test-owner/test-repo/pull/75"}}}}'
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs7wz5zf","number":103,"url":"https://github.com/test-owner/test-repo/pull/103"}}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 787.09375ms
+        duration: 837.778875ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 426
+        content_length: 427
         host: api.github.com
         body: |
-            {"query":"query($number:Int!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){pullRequest(number: $number){id,number,url,title,state,headRefOid,baseRefName,isDraft,headRepository{owner{login},name},labels(first: 100){nodes{name}},reviewRequests(first: 100){nodes{requestedReviewer{... on Actor{login}}}},assignees(first: 100){nodes{login}}}}}","variables":{"number":75,"owner":"test-owner","repo":"test-repo"}}
+            {"query":"query($number:Int!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){pullRequest(number: $number){id,number,url,title,state,headRefOid,baseRefName,isDraft,headRepository{owner{login},name},labels(first: 100){nodes{name}},reviewRequests(first: 100){nodes{requestedReviewer{... on Actor{login}}}},assignees(first: 100){nodes{login}}}}}","variables":{"number":103,"owner":"test-owner","repo":"test-repo"}}
         headers:
             Content-Type:
                 - application/json
@@ -75,22 +74,22 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"data":{"repository":{"pullRequest":{"id":"PR_kwDOMVd0xs7XrljJ","number":75,"url":"https://github.com/test-owner/test-repo/pull/75","title":"Testing f4fqEb9C","state":"OPEN","headRefOid":"9ca0860d6f10b375b4d5d57cf43d445d07522341","baseRefName":"main","isDraft":false,"headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"labels":{"nodes":[]},"reviewRequests":{"nodes":[]},"assignees":{"nodes":[]}}}}}'
+        body: '{"data":{"repository":{"pullRequest":{"id":"PR_kwDOMVd0xs7wz5zf","number":103,"url":"https://github.com/test-owner/test-repo/pull/103","title":"Testing sMCSMgpe","state":"OPEN","headRefOid":"bfea7ec1178c722e894a4eb2920fbdec7f21a219","baseRefName":"main","isDraft":false,"headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"labels":{"nodes":[]},"reviewRequests":{"nodes":[]},"assignees":{"nodes":[]}}}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 243.585583ms
+        duration: 295.408334ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 97
+        content_length: 103
         host: api.github.com
         body: |
-            {"query":"query($login:String!){user(login: $login){id}}","variables":{"login":"test-owner-robot"}}
+            {"query":"query($user0:String!){user0:user(login: $user0){id}}","variables":{"user0":"test-owner-robot"}}
         headers:
             Content-Type:
                 - application/json
@@ -102,13 +101,13 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"data":{"user":{"id":"U_kgDOCzNVWQ"}}}'
+        body: '{"data":{"user0":{"id":"U_kgDOCzNVWQ"}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 182.531959ms
+        duration: 200.18575ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -117,7 +116,7 @@ interactions:
         content_length: 201
         host: api.github.com
         body: |
-            {"query":"mutation($input:RequestReviewsInput!){requestReviews(input: $input){clientMutationId}}","variables":{"input":{"pullRequestId":"PR_kwDOMVd0xs7XrljJ","userIds":["U_kgDOCzNVWQ"],"union":true}}}
+            {"query":"mutation($input:RequestReviewsInput!){requestReviews(input: $input){clientMutationId}}","variables":{"input":{"pullRequestId":"PR_kwDOMVd0xs7wz5zf","userIds":["U_kgDOCzNVWQ"],"union":true}}}
         headers:
             Content-Type:
                 - application/json
@@ -128,23 +127,22 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: -1
-        uncompressed: true
         body: '{"data":{"requestReviews":{"clientMutationId":null}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 531.640792ms
+        duration: 685.6325ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 426
+        content_length: 427
         host: api.github.com
         body: |
-            {"query":"query($number:Int!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){pullRequest(number: $number){id,number,url,title,state,headRefOid,baseRefName,isDraft,headRepository{owner{login},name},labels(first: 100){nodes{name}},reviewRequests(first: 100){nodes{requestedReviewer{... on Actor{login}}}},assignees(first: 100){nodes{login}}}}}","variables":{"number":75,"owner":"test-owner","repo":"test-repo"}}
+            {"query":"query($number:Int!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){pullRequest(number: $number){id,number,url,title,state,headRefOid,baseRefName,isDraft,headRepository{owner{login},name},labels(first: 100){nodes{name}},reviewRequests(first: 100){nodes{requestedReviewer{... on Actor{login}}}},assignees(first: 100){nodes{login}}}}}","variables":{"number":103,"owner":"test-owner","repo":"test-repo"}}
         headers:
             Content-Type:
                 - application/json
@@ -155,11 +153,10 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: -1
-        uncompressed: true
-        body: '{"data":{"repository":{"pullRequest":{"id":"PR_kwDOMVd0xs7XrljJ","number":75,"url":"https://github.com/test-owner/test-repo/pull/75","title":"Testing f4fqEb9C","state":"OPEN","headRefOid":"9ca0860d6f10b375b4d5d57cf43d445d07522341","baseRefName":"main","isDraft":false,"headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"labels":{"nodes":[]},"reviewRequests":{"nodes":[{"requestedReviewer":{"login":"test-owner-robot"}}]},"assignees":{"nodes":[]}}}}}'
+        body: '{"data":{"repository":{"pullRequest":{"id":"PR_kwDOMVd0xs7wz5zf","number":103,"url":"https://github.com/test-owner/test-repo/pull/103","title":"Testing sMCSMgpe","state":"OPEN","headRefOid":"bfea7ec1178c722e894a4eb2920fbdec7f21a219","baseRefName":"main","isDraft":false,"headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"labels":{"nodes":[]},"reviewRequests":{"nodes":[{"requestedReviewer":{"login":"test-owner-robot"}}]},"assignees":{"nodes":[]}}}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 264.140542ms
+        duration: 293.648666ms

--- a/internal/forge/github/testdata/fixtures/TestIntegration/SubmitEditReviewers/SubmitWithReviewer.yaml
+++ b/internal/forge/github/testdata/fixtures/TestIntegration/SubmitEditReviewers/SubmitWithReviewer.yaml
@@ -20,14 +20,13 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: -1
-        uncompressed: true
         body: '{"data":{"repository":{"id":"R_kgDOMVd0xg"}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 244.771ms
+        duration: 246.258041ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -36,7 +35,7 @@ interactions:
         content_length: 273
         host: api.github.com
         body: |
-            {"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"main","headRefName":"4IUzIjwL","title":"Testing 4IUzIjwL","body":"Test PR with reviewer"}}}
+            {"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"main","headRefName":"fWMkS7CC","title":"Testing fWMkS7CC","body":"Test PR with reviewer"}}}
         headers:
             Content-Type:
                 - application/json
@@ -47,23 +46,22 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: -1
-        uncompressed: true
-        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs7Xrli3","number":73,"url":"https://github.com/test-owner/test-repo/pull/73"}}}}'
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs7wz5zq","number":106,"url":"https://github.com/test-owner/test-repo/pull/106"}}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 915.4875ms
+        duration: 1.039112125s
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 97
+        content_length: 103
         host: api.github.com
         body: |
-            {"query":"query($login:String!){user(login: $login){id}}","variables":{"login":"test-owner-robot"}}
+            {"query":"query($user0:String!){user0:user(login: $user0){id}}","variables":{"user0":"test-owner-robot"}}
         headers:
             Content-Type:
                 - application/json
@@ -75,13 +73,13 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"data":{"user":{"id":"U_kgDOCzNVWQ"}}}'
+        body: '{"data":{"user0":{"id":"U_kgDOCzNVWQ"}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 222.630666ms
+        duration: 244.439167ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -90,7 +88,7 @@ interactions:
         content_length: 201
         host: api.github.com
         body: |
-            {"query":"mutation($input:RequestReviewsInput!){requestReviews(input: $input){clientMutationId}}","variables":{"input":{"pullRequestId":"PR_kwDOMVd0xs7Xrli3","userIds":["U_kgDOCzNVWQ"],"union":true}}}
+            {"query":"mutation($input:RequestReviewsInput!){requestReviews(input: $input){clientMutationId}}","variables":{"input":{"pullRequestId":"PR_kwDOMVd0xs7wz5zq","userIds":["U_kgDOCzNVWQ"],"union":true}}}
         headers:
             Content-Type:
                 - application/json
@@ -101,14 +99,13 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: -1
-        uncompressed: true
         body: '{"data":{"requestReviews":{"clientMutationId":null}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 623.937333ms
+        duration: 804.647792ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -117,7 +114,7 @@ interactions:
         content_length: 615
         host: api.github.com
         body: |
-            {"query":"query($branch:String!$limit:Int!$owner:String!$repo:String!$states:[PullRequestState!]!){repository(owner: $owner, name: $repo){pullRequests(first: $limit, headRefName: $branch, states: $states, orderBy: {field: UPDATED_AT, direction: DESC}){nodes{id,number,url,title,state,headRefOid,baseRefName,isDraft,headRepository{owner{login},name},labels(first: 100){nodes{name}},reviewRequests(first: 100){nodes{requestedReviewer{... on Actor{login}}}},assignees(first: 100){nodes{login}}}}}}","variables":{"branch":"4IUzIjwL","limit":10,"owner":"test-owner","repo":"test-repo","states":["OPEN","CLOSED","MERGED"]}}
+            {"query":"query($branch:String!$limit:Int!$owner:String!$repo:String!$states:[PullRequestState!]!){repository(owner: $owner, name: $repo){pullRequests(first: $limit, headRefName: $branch, states: $states, orderBy: {field: UPDATED_AT, direction: DESC}){nodes{id,number,url,title,state,headRefOid,baseRefName,isDraft,headRepository{owner{login},name},labels(first: 100){nodes{name}},reviewRequests(first: 100){nodes{requestedReviewer{... on Actor{login}}}},assignees(first: 100){nodes{login}}}}}}","variables":{"branch":"fWMkS7CC","limit":10,"owner":"test-owner","repo":"test-repo","states":["OPEN","CLOSED","MERGED"]}}
         headers:
             Content-Type:
                 - application/json
@@ -129,10 +126,10 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"data":{"repository":{"pullRequests":{"nodes":[{"id":"PR_kwDOMVd0xs7Xrli3","number":73,"url":"https://github.com/test-owner/test-repo/pull/73","title":"Testing 4IUzIjwL","state":"OPEN","headRefOid":"90ec1928f53d0d67eff62f828c471c935f7d9660","baseRefName":"main","isDraft":false,"headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"labels":{"nodes":[]},"reviewRequests":{"nodes":[{"requestedReviewer":{"login":"test-owner-robot"}}]},"assignees":{"nodes":[]}}]}}}}'
+        body: '{"data":{"repository":{"pullRequests":{"nodes":[{"id":"PR_kwDOMVd0xs7wz5zq","number":106,"url":"https://github.com/test-owner/test-repo/pull/106","title":"Testing fWMkS7CC","state":"OPEN","headRefOid":"05b56904cea77e58da729b916cd574cf7b7d35ab","baseRefName":"main","isDraft":false,"headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"labels":{"nodes":[]},"reviewRequests":{"nodes":[{"requestedReviewer":{"login":"test-owner-robot"}}]},"assignees":{"nodes":[]}}]}}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 302.3805ms
+        duration: 306.905459ms

--- a/internal/gateway/github/identity.go
+++ b/internal/gateway/github/identity.go
@@ -3,50 +3,104 @@ package github
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 )
 
-// UserID looks up a user's GraphQL node ID by login.
-func (c *Gateway) UserID(ctx context.Context, login string) (ID, error) {
-	var result struct {
-		User struct {
-			ID ID `json:"id"`
-		} `json:"user"`
-	}
-	query := compactGraphQL(`
-		query($login:String!){
-			user(login: $login){id}
-		}
-	`)
-	if err := c.execute(ctx, query, struct {
-		Login string `json:"login"`
-	}{login}, &result); err != nil {
-		return "", fmt.Errorf("query user: %w", err)
-	}
-	return result.User.ID, nil
+// TeamName identifies a GitHub team within an organization.
+type TeamName struct {
+	// Organization is the login of the organization that owns the team.
+	Organization string
+
+	// Slug is the team's URL slug within the organization.
+	Slug string
 }
 
-// TeamID looks up a team's GraphQL node ID by organization and slug.
-func (c *Gateway) TeamID(ctx context.Context, org, slug string) (ID, error) {
-	var result struct {
-		Organization struct {
-			Team struct {
-				ID ID `json:"id"`
-			} `json:"team"`
-		} `json:"organization"`
+// IdentityIDs looks up GitHub users and teams in one GraphQL operation.
+// The returned slices match the length and order of users and teams.
+// If GitHub successfully executes the query,
+// an identity that does not exist has an empty ID in its result position,
+// other identities remain populated,
+// and IdentityIDs returns a nil error.
+// A transport or GraphQL error returns nil result slices and a non-nil error.
+func (c *Gateway) IdentityIDs(
+	ctx context.Context,
+	users []string,
+	teams []TeamName,
+) ([]ID, []ID, error) {
+	userIDs := make([]ID, len(users))
+	teamIDs := make([]ID, len(teams))
+	if len(users) == 0 && len(teams) == 0 {
+		return userIDs, teamIDs, nil
 	}
-	vars := struct {
-		Org  string `json:"org"`
-		Slug string `json:"slug"`
-	}{org, slug}
-	query := compactGraphQL(`
-		query($org:String!$slug:String!){
-			organization(login: $org){
-				team(slug: $slug){id}
-			}
+
+	variables := make(map[string]any, len(users)+2*len(teams))
+
+	// Build one root selection per identity:
+	//
+	// query($user0:String!$teamOrg0:String!$teamSlug0:String!) {
+	//   user0: user(login: $user0) { id }
+	//   team0: organization(login: $teamOrg0) {
+	//     team(slug: $teamSlug0) { id }
+	//   }
+	// }
+	var variableDefinitions strings.Builder
+	var selections strings.Builder
+	for i, user := range users {
+		alias := "user" + strconv.Itoa(i)
+		fmt.Fprintf(&variableDefinitions, "$%s:String!", alias)
+		if selections.Len() > 0 {
+			selections.WriteByte(',')
 		}
-	`)
-	if err := c.execute(ctx, query, vars, &result); err != nil {
-		return "", fmt.Errorf("query team: %w", err)
+		fmt.Fprintf(&selections, "%s:user(login: $%s){id}", alias, alias)
+		variables[alias] = user
 	}
-	return result.Organization.Team.ID, nil
+	for i, team := range teams {
+		alias := "team" + strconv.Itoa(i)
+		organizationVariable := "teamOrg" + strconv.Itoa(i)
+		slugVariable := "teamSlug" + strconv.Itoa(i)
+		fmt.Fprintf(
+			&variableDefinitions,
+			"$%s:String!$%s:String!",
+			organizationVariable,
+			slugVariable,
+		)
+		if selections.Len() > 0 {
+			selections.WriteByte(',')
+		}
+		fmt.Fprintf(
+			&selections,
+			"%s:organization(login: $%s){team(slug: $%s){id}}",
+			alias,
+			organizationVariable,
+			slugVariable,
+		)
+		variables[organizationVariable] = team.Organization
+		variables[slugVariable] = team.Slug
+	}
+
+	query := compactGraphQL(
+		"query(" + variableDefinitions.String() + "){" +
+			selections.String() + "}",
+	)
+	var result map[string]struct {
+		ID   ID `json:"id"`
+		Team *struct {
+			ID ID `json:"id"`
+		} `json:"team"`
+	}
+	if err := c.execute(ctx, query, variables, &result); err != nil {
+		return nil, nil, fmt.Errorf("query identities: %w", err)
+	}
+
+	for i := range users {
+		userIDs[i] = result["user"+strconv.Itoa(i)].ID
+	}
+	for i := range teams {
+		team := result["team"+strconv.Itoa(i)].Team
+		if team != nil {
+			teamIDs[i] = team.ID
+		}
+	}
+	return userIDs, teamIDs, nil
 }

--- a/internal/gateway/github/identity_test.go
+++ b/internal/gateway/github/identity_test.go
@@ -1,22 +1,69 @@
 package github
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestGateway_UserID(t *testing.T) {
-	gateway := newResponseGateway(t, `{"data":{"user":{"id":"U_1"}}}`)
-	id, err := gateway.UserID(t.Context(), "alice")
+func TestGateway_IdentityIDs(t *testing.T) {
+	gateway := newTestGateway(t, roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		var request struct {
+			Query     string          `json:"query"`
+			Variables json.RawMessage `json:"variables"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+		assert.Equal(t, compactGraphQL(`
+			query($user0:String!$user1:String!$teamOrg0:String!$teamSlug0:String!){
+				user0:user(login: $user0){id},
+				user1:user(login: $user1){id},
+				team0:organization(login: $teamOrg0){
+					team(slug: $teamSlug0){id}
+				}
+			}
+		`), request.Query)
+		assert.JSONEq(t, `{
+			"teamOrg0": "acme",
+			"teamSlug0": "platform",
+			"user0": "alice",
+			"user1": "bob"
+		}`, string(request.Variables))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body: io.NopCloser(strings.NewReader(`{
+				"data": {
+					"user0": {"id": "U_1"},
+					"user1": null,
+					"team0": {"team": {"id": "T_1"}}
+				}
+			}`)),
+		}, nil
+	}))
+
+	userIDs, teamIDs, err := gateway.IdentityIDs(
+		t.Context(),
+		[]string{"alice", "bob"},
+		[]TeamName{{Organization: "acme", Slug: "platform"}},
+	)
 	require.NoError(t, err)
-	assert.Equal(t, ID("U_1"), id)
+	assert.Equal(t, []ID{"U_1", ""}, userIDs)
+	assert.Equal(t, []ID{"T_1"}, teamIDs)
 }
 
-func TestGateway_TeamID(t *testing.T) {
-	gateway := newResponseGateway(t, `{"data":{"organization":{"team":{"id":"T_1"}}}}`)
-	id, err := gateway.TeamID(t.Context(), "acme", "platform")
+func TestGateway_IdentityIDs_empty(t *testing.T) {
+	gateway := newTestGateway(t, roundTripFunc(func(*http.Request) (*http.Response, error) {
+		t.Fatal("unexpected request")
+		return nil, nil
+	}))
+
+	userIDs, teamIDs, err := gateway.IdentityIDs(t.Context(), nil, nil)
 	require.NoError(t, err)
-	assert.Equal(t, ID("T_1"), id)
+	assert.Empty(t, userIDs)
+	assert.Empty(t, teamIDs)
 }


### PR DESCRIPTION
Resolve uncached reviewer and assignee identities with one aliased
GraphQL query per metadata operation. Cache successful user and team
lookups while preserving ordered results and missing-identity errors.

Single-identity requests use the same batching path. Recorded reviewer
and assignee fixtures cover the new wire representation.