### PR TITLE
release/ppa: allow opting out of orig.tar.gz upload

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -35,6 +35,13 @@ on:
         required: false
         default: '1'
         type: string
+      ppa_omit_orig:
+        description: >-
+          Omit the upstream orig tarball from every PPA upload.
+          Enable this when retrying an upstream version already in the PPA.
+        required: false
+        default: false
+        type: boolean
       ppa_series:
         description: >-
           Comma-separated Ubuntu series for PPA publishing.
@@ -235,6 +242,9 @@ jobs:
           -sign
           -dput
         )
+        if [[ "$PPA_OMIT_ORIG" == "true" ]]; then
+          args+=(-omit-orig)
+        fi
         if [[ -n "$PPA_SOURCE_DATE_EPOCH" ]]; then
           args+=(-source-date-epoch "$PPA_SOURCE_DATE_EPOCH")
         fi
@@ -243,6 +253,7 @@ jobs:
       env:
         LAUNCHPAD_GPG_KEY_ID: ${{ secrets.LAUNCHPAD_GPG_KEY_ID }}
         LAUNCHPAD_GPG_PASSPHRASE: ${{ secrets.LAUNCHPAD_GPG_PASSPHRASE }}
+        PPA_OMIT_ORIG: ${{ inputs.ppa_omit_orig }}
         PPA_REVISION: ${{ inputs.ppa_revision }}
         PPA_SERIES: ${{ inputs.ppa_series }}
         PPA_SOURCE_DATE_EPOCH: ${{ inputs.ppa_source_date_epoch }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -283,6 +283,8 @@ If a PPA upload must be retried for the same upstream version,
 rerun the release workflow with a higher `ppa_revision` value.
 For example,
 `ppa_revision=2` publishes `X.Y.Z-1~ppa2`.
+If Launchpad already has the upstream orig tarball,
+set `ppa_omit_orig=true` to omit it from every selected series.
 
 ## Backporting changes
 

--- a/tools/ci/launchpad-ppa/main.go
+++ b/tools/ci/launchpad-ppa/main.go
@@ -54,6 +54,9 @@ type publishRequest struct {
 	// PPARevision is the Debian package revision suffix for Launchpad retries.
 	PPARevision int
 
+	// OmitOrig excludes the upstream orig tarball from every source upload.
+	OmitOrig bool
+
 	// Sign controls whether source packages are signed before upload.
 	Sign bool
 
@@ -94,6 +97,8 @@ func main() {
 		"Unix timestamp to use for reproducible package outputs")
 	flag.Var(&req.Series, "series", "Ubuntu series to target")
 	flag.IntVar(&req.PPARevision, "ppa-revision", 1, "PPA revision number")
+	flag.BoolVar(&req.OmitOrig, "omit-orig", false,
+		"Omit the upstream orig tarball from every source upload")
 	flag.BoolVar(&req.Sign, "sign", false, "Sign packages with Launchpad GPG environment variables")
 	flag.BoolVar(&req.Dput, "dput", false, "Upload signed packages with dput")
 	flag.StringVar(&req.DputTarget, "dput-target", _defaultDputTarget, "dput upload target")
@@ -127,6 +132,7 @@ func run(log *silog.Logger, req publishRequest) error {
 		"sourceDateEpoch", sourceDateEpoch,
 		"series", strings.Join(plan.Series, ","),
 		"ppaRevision", plan.PPARevision,
+		"omitOrig", plan.OmitOrig,
 		"dput", plan.Dput,
 		"dputTarget", plan.DputTarget)
 
@@ -191,15 +197,10 @@ func run(log *silog.Logger, req publishRequest) error {
 
 	var dputCommands []string
 	for i, series := range plan.Series {
-		uploadMode := sourceUploadWithOrig
-		if i > 0 {
-			uploadMode = sourceUploadWithoutOrig
-		}
-
 		changes, err := buildSeries(
 			ctx, log,
 			root, sourceDir, workDir, origTar,
-			plan, series, uploadMode, mtime)
+			plan, series, plan.sourceUploadMode(i), mtime)
 		if err != nil {
 			return fmt.Errorf("build %s: %w", series, err)
 		}
@@ -306,6 +307,9 @@ type packagePlan struct {
 	// PPARevision is the Launchpad PPA source package revision.
 	PPARevision int
 
+	// OmitOrig excludes the upstream orig tarball from every source upload.
+	OmitOrig bool
+
 	// Ref is the Git object exported as upstream source.
 	Ref string
 
@@ -320,6 +324,13 @@ type packagePlan struct {
 
 	// DputTarget is the destination passed to dput.
 	DputTarget string
+}
+
+func (p packagePlan) sourceUploadMode(seriesIndex int) sourceUploadMode {
+	if p.OmitOrig || seriesIndex > 0 {
+		return sourceUploadWithoutOrig
+	}
+	return sourceUploadWithOrig
 }
 
 // sourceUploadMode controls whether the generated .changes upload manifest
@@ -409,6 +420,7 @@ func newPackagePlan(req publishRequest) (packagePlan, error) {
 		),
 		SourceModTime: sourceModTime,
 		PPARevision:   req.PPARevision,
+		OmitOrig:      req.OmitOrig,
 		Ref:           req.Ref,
 		Series:        series,
 		Sign:          sign,

--- a/tools/ci/launchpad-ppa/main_test.go
+++ b/tools/ci/launchpad-ppa/main_test.go
@@ -54,6 +54,7 @@ func TestNewPackagePlan_customValues(t *testing.T) {
 		SourceDateEpoch: 1_779_770_939,
 		Series:          seriesFlag{"noble", "plucky"},
 		PPARevision:     2,
+		OmitOrig:        true,
 		Dput:            true,
 		DputTarget:      "ppa:test/git-spice",
 	})
@@ -65,6 +66,7 @@ func TestNewPackagePlan_customValues(t *testing.T) {
 	assert.Equal(t,
 		time.Unix(1_779_770_939, 0).UTC(),
 		plan.SourceModTime)
+	assert.True(t, plan.OmitOrig)
 	assert.Nil(t, plan.Sign)
 	assert.True(t, plan.Dput)
 	assert.Equal(t, "ppa:test/git-spice", plan.DputTarget)
@@ -92,6 +94,22 @@ func TestNewPackagePlan_invalidSourceDateEpoch(t *testing.T) {
 
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "-source-date-epoch must be positive: -1")
+}
+
+func TestPackagePlan_sourceUploadMode(t *testing.T) {
+	t.Run("FirstSeriesIncludesOrig", func(t *testing.T) {
+		plan := packagePlan{}
+
+		assert.Equal(t, sourceUploadWithOrig, plan.sourceUploadMode(0))
+		assert.Equal(t, sourceUploadWithoutOrig, plan.sourceUploadMode(1))
+	})
+
+	t.Run("OmitOrigExcludesOrigFromAllSeries", func(t *testing.T) {
+		plan := packagePlan{OmitOrig: true}
+
+		assert.Equal(t, sourceUploadWithoutOrig, plan.sourceUploadMode(0))
+		assert.Equal(t, sourceUploadWithoutOrig, plan.sourceUploadMode(1))
+	})
 }
 
 func TestSignConfigFromEnv(t *testing.T) {


### PR DESCRIPTION
Re-publish attempts after initial upload should not include orig.tar.gz
because that's already published in the first attempt.
Add an option to opt out of it.

[skip changelog]: no user facing changes