### PR TITLE
fix: Exclude stale base commits from replays

### DIFF
--- a/.changes/unreleased/Fixed-20260718-090808.yaml
+++ b/.changes/unreleased/Fixed-20260718-090808.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: >-
+  branch restack, branch onto: Conflicting rebases caused by replayed base
+  commits are avoided after a branch is rebased outside git-spice.
+time: 2026-07-18T09:08:08.569856-07:00

--- a/internal/spice/onto.go
+++ b/internal/spice/onto.go
@@ -20,7 +20,7 @@ const (
 	// BranchOntoRetargetOnly updates state
 	// without rebasing the branch's commits.
 	//
-	// The old upstream boundary is preserved
+	// The resolved upstream boundary is preserved
 	// so a future restack can replay the branch correctly.
 	BranchOntoRetargetOnly
 )
@@ -46,7 +46,7 @@ type BranchOntoRequest struct {
 // BranchOnto moves the commits of a branch onto a different base branch,
 // updating internal state to reflect the new branch stack.
 // It DOES NOT modify the upstack branches of the branch being moved.
-// As this involves a rebase operation,
+// When Mode is [BranchOntoRebase],
 // the caller should be prepared to rescue the operation if it fails.
 func (s *Service) BranchOnto(ctx context.Context, req *BranchOntoRequest) error {
 	must.NotBeEqualf(req.Branch, s.store.Trunk(), "cannot move trunk")
@@ -71,36 +71,16 @@ func (s *Service) BranchOnto(ctx context.Context, req *BranchOntoRequest) error 
 		ontoHash = onto.Head
 	}
 
-	// The recorded base hash may be stale if the old base branch
-	// was advanced outside git-spice,
-	// and the branch being moved was restacked outside git-spice.
-	//
-	// For example:
-	//
-	//     o---A (RecordedBase)
-	//          \
-	//           B---C (ActualBase)
-	//                \
-	//                 D (Current)
-	//
-	// git-spice may still think Current is based on RecordedBase,
-	// but using RecordedBase..Current would replay B and C.
-	// If ActualBase is reachable from Current,
-	// use ActualBase..Current so only Current's own commits are replayed.
-	fromHash := branch.BaseHash
-	if actualBaseHash, err := s.repo.PeelToCommit(ctx, branch.Base); err == nil {
-		if s.repo.IsAncestor(ctx, actualBaseHash, branch.Head) {
-			fromHash = actualBaseHash
-		}
+	replayRange, err := s.resolveBranchReplayRange(ctx, req.Branch, branch)
+	if err != nil {
+		return fmt.Errorf("resolve branch replay range: %w", err)
 	}
+	fromHash := replayRange.Upstream
 
-	// We're trying to move the selected commit range onto OntoHash.
-	//
-	// However, there's a possibility that BaseHash is reachable from OntoHash
-	// because the old base is also the base of onto,
-	// and we've already partially rebased and handled a conflict.
-	//
-	// For example, suppose we have:
+	// The destination can already contain the resolved replay boundary.
+	// This is expected when two branches share a downstack
+	// and when a branch-onto operation resumes after a conflict.
+	// For example, before the first attempt:
 	//
 	//           C--D (Current)  (git-spice: base=OriginalBase)
 	//          /
@@ -108,9 +88,7 @@ func (s *Service) BranchOnto(ctx context.Context, req *BranchOntoRequest) error 
 	//          \
 	//           A--B (NewBase)  (git-spice: base=OriginalBase)
 	//
-	// If we run 'git-spice branch onto NewBase' from Current,
-	// and there's a conflict, the user will resolve the rebase conflict,
-	// but the git-spice state will not yet be updated.
+	// After Git has replayed Current but before git-spice state is updated:
 	//
 	//     o---X (OriginalBase)
 	//          \
@@ -118,20 +96,15 @@ func (s *Service) BranchOnto(ctx context.Context, req *BranchOntoRequest) error 
 	//               \
 	//                C--D (Current)  (git-spice: base=OriginalBase)
 	//
-	// At that point, 'git-spice rebase continue' will re-run the original command
-	// 'git-spice branch onto NewBase' from Current,
-	// except the commits it wants (OriginalBase..Current)
-	// now includes commits OriginalBase..NewBase,
-	// which will fail for obvious reasons.
-	//
-	// To catch this, if OriginalBase is reachable from NewBase,
-	// we'll change the commit range to NewBase..Current.
-	// This will turn the rebase into a no-op, but it'll correctly update state.
+	// Using the destination as the exclusive boundary selects
+	// NewBase..Current. The first attempt excludes NewBase's commits,
+	// and a resumed attempt becomes a no-op before state is updated.
 	if s.repo.IsAncestor(ctx, fromHash, ontoHash) {
 		fromHash = ontoHash
 	}
 
-	s.log.Debug("Moving commits onto new base",
+	s.log.Debug(
+		"Moving commits onto new base",
 		"branch", req.Branch,
 		"oldBase", branch.Base,
 		"newBase", req.Onto,

--- a/internal/spice/replay_range.go
+++ b/internal/spice/replay_range.go
@@ -1,0 +1,162 @@
+package spice
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.abhg.dev/gs/internal/git"
+)
+
+// branchReplayRange relates a tracked branch to the current head of its base.
+// BaseHead is the rebase destination, MergeBase describes the current graph,
+// and Upstream is the exclusive boundary of the commits to replay.
+//
+// A branch already restacked on its base has all three hashes at B:
+//
+//	A---B base (BaseHead=B, MergeBase=B, Upstream=B)
+//	     \
+//	      P branch
+//
+// After the base advances, or after an external rebase followed by a base
+// advance, BaseHead moves beyond the branch's current merge base:
+//
+//	A---B---C base (BaseHead=C)
+//	     \
+//	      P branch (MergeBase=B, Upstream=B)
+//
+// Restack detects this state because MergeBase differs from BaseHead,
+// then replays Upstream..branch-head onto BaseHead.
+//
+// A retarget without rebase is the exception to that equality check:
+//
+//	A new-base (BaseHead=A, MergeBase=A)
+//	 \
+//	  B---P branch (Upstream=B, UpstreamDescendsFromBase=true)
+//
+// Although BaseHead is the merge base, a later restack must still replay
+// Upstream..branch-head to remove the old downstack commit B.
+type branchReplayRange struct {
+	// BaseHead is the current head of the tracked base branch
+	// and the destination of a rebase.
+	BaseHead git.Hash
+
+	// MergeBase is the current common ancestor of BaseHead and the branch head.
+	// A different BaseHead means the branch is not currently restacked.
+	MergeBase git.Hash
+
+	// Upstream is the exclusive lower boundary of the commits to replay.
+	// It begins at the recorded base hash and may move to the merge base
+	// or fork point when the recorded hash is stale.
+	Upstream git.Hash
+
+	// UpstreamDescendsFromBase reports that BaseHead is an ancestor of Upstream.
+	// A retarget without rebase uses this relationship to leave replay work
+	// for a later restack.
+	UpstreamDescendsFromBase bool
+}
+
+func (r branchReplayRange) isRestacked() bool {
+	return r.MergeBase == r.BaseHead && !r.UpstreamDescendsFromBase
+}
+
+// resolveBranchReplayRange finds the commits owned by a tracked branch.
+// It reconciles the recorded boundary with the current Git graph
+// without changing git-spice state.
+func (s *Service) resolveBranchReplayRange(
+	ctx context.Context,
+	name string,
+	branch *LookupBranchResponse,
+) (branchReplayRange, error) {
+	baseHead, err := s.repo.PeelToCommit(ctx, branch.Base)
+	if err != nil {
+		if errors.Is(err, git.ErrNotExist) {
+			return branchReplayRange{}, fmt.Errorf("base branch %v does not exist", branch.Base)
+		}
+		return branchReplayRange{}, fmt.Errorf("find commit for %v: %w", branch.Base, err)
+	}
+
+	mergeBase, err := s.repo.MergeBase(ctx, baseHead.String(), branch.Head.String())
+	if err != nil {
+		return branchReplayRange{}, fmt.Errorf(
+			"find merge base of %q and %q: %w",
+			branch.Base,
+			name,
+			err,
+		)
+	}
+
+	upstream := branch.BaseHash
+
+	// An ordinary base advance keeps the recorded boundary
+	// because the branch still diverges there:
+	//
+	//	A---B base (BaseHead=B)
+	//	 \
+	//	  P branch (branch.Head=P)
+	//
+	// branch.BaseHash and mergeBase are both A, so Upstream remains A
+	// and the branch needs to be restacked onto BaseHead B.
+	//
+	// A branch rebased outside git-spice can instead have a merge base newer
+	// than its recorded boundary:
+	//
+	//	A---B---C base (BaseHead=C)
+	//	     \
+	//	      P branch (branch.Head=P)
+	//
+	// If branch.BaseHash is A and mergeBase is B, advancing Upstream to B
+	// prevents base commit B from being treated as a branch commit.
+	if upstream != mergeBase && s.repo.IsAncestor(ctx, upstream, mergeBase) {
+		s.log.Debug("Recorded base hash is out of date. Using merge base as replay boundary.",
+			"base", branch.Base,
+			"branch", name,
+			"mergeBase", mergeBase)
+		upstream = mergeBase
+	}
+
+	// A retarget without rebase deliberately records a reachable boundary
+	// newer than the merge base with the new base branch:
+	//
+	//	A new-base (BaseHead=A)
+	//	 \
+	//	  B---P branch (branch.Head=P)
+	//
+	// If mergeBase is A and branch.BaseHash is B, preserving Upstream B makes
+	// a later restack replay only P onto A and remove old downstack commit B.
+	//
+	// A rewritten history can instead leave branch.BaseHash disconnected from
+	// branch.Head even when Git's reflogs retain the former fork point:
+	//
+	//	R                 branch.BaseHash, no longer in branch history
+	//
+	//	F---P---H branch (branch.Head=H)
+	//	 \
+	//	  ...---B base (BaseHead=B)
+	//
+	// In that case, forkPoint F is the best available Upstream.
+	upstreamDescendsFromBase := upstream != baseHead &&
+		!upstream.IsZero() &&
+		s.repo.IsAncestor(ctx, baseHead, upstream) &&
+		s.repo.IsAncestor(ctx, upstream, branch.Head)
+
+	if !s.repo.IsAncestor(ctx, upstream, branch.Head) {
+		forkPoint, err := s.repo.ForkPoint(ctx, branch.Base, name)
+		if err == nil {
+			if upstream != forkPoint {
+				s.log.Debug("Recorded base hash is out of date. Restacking from fork point.",
+					"base", branch.Base,
+					"branch", name,
+					"forkPoint", forkPoint)
+			}
+			upstream = forkPoint
+		}
+	}
+
+	return branchReplayRange{
+		BaseHead:                 baseHead,
+		MergeBase:                mergeBase,
+		Upstream:                 upstream,
+		UpstreamDescendsFromBase: upstreamDescendsFromBase,
+	}, nil
+}

--- a/internal/spice/restack.go
+++ b/internal/spice/restack.go
@@ -28,64 +28,18 @@ func (s *Service) Restack(ctx context.Context, name string) (*RestackResponse, e
 		return nil, err // includes ErrNotExist
 	}
 
-	err = s.VerifyRestacked(ctx, name)
-	if err == nil {
-		// Case:
-		// The branch is already on top of its base branch
+	replayRange, err := s.resolveBranchReplayRange(ctx, name, b)
+	if err != nil {
+		return nil, err
+	}
+	if replayRange.isRestacked() {
+		s.reconcileRecordedBaseHash(ctx, name, b, replayRange.BaseHead)
 		return nil, ErrAlreadyRestacked
-	}
-	var restackErr *BranchNeedsRestackError
-	if !errors.As(err, &restackErr) {
-		return nil, fmt.Errorf("verify restacked: %w", err)
-	}
-
-	// The branch needs to be restacked on top of its base branch.
-	// We will proceed with the restack.
-
-	baseHash := restackErr.BaseHash
-	upstream := b.BaseHash
-
-	// Case:
-	// Recorded base hash is super out of date,
-	// and is not an ancestor of the current branch.
-	// In that case, use fork point as a hail mary
-	// to guess the upstream start point.
-	//
-	// For context, fork point attempts to find the point
-	// where the current branch diverged from the branch it
-	// was originally forked from.
-	// For example, given:
-	//
-	//  ---X---A'---o foo
-	//      \
-	//       A
-	//        \
-	//         B---o---o bar
-	//
-	// If bar branched from foo, when foo was at A,
-	// and then we amended foo to get A',
-	// bar will still refer to A.
-	//
-	// In this case, merge-base --fork-point will give us A,
-	// and that should be the upstream (commit to start rebasing from)
-	// if the recorded base hash is out of date
-	// because the user changed something externally.
-	if !s.repo.IsAncestor(ctx, upstream, b.Head) {
-		forkPoint, err := s.repo.ForkPoint(ctx, b.Base, name)
-		if err == nil {
-			if upstream != forkPoint {
-				s.log.Debug("Recorded base hash is out of date. Restacking from fork point.",
-					"base", b.Base,
-					"branch", name,
-					"forkPoint", forkPoint)
-			}
-			upstream = forkPoint
-		}
 	}
 
 	if err := s.wt.Rebase(ctx, git.RebaseRequest{
-		Onto:      baseHash.String(),
-		Upstream:  upstream.String(),
+		Onto:      replayRange.BaseHead.String(),
+		Upstream:  replayRange.Upstream.String(),
 		Branch:    name,
 		Autostash: true,
 		Quiet:     true,
@@ -96,7 +50,7 @@ func (s *Service) Restack(ctx context.Context, name string) (*RestackResponse, e
 	tx := s.store.BeginBranchTx()
 	if err := tx.Upsert(ctx, state.UpsertRequest{
 		Name:     name,
-		BaseHash: baseHash,
+		BaseHash: replayRange.BaseHead,
 	}); err != nil {
 		return nil, fmt.Errorf("update base hash of %v: %w", name, err)
 	}
@@ -136,69 +90,57 @@ func (s *Service) VerifyRestacked(ctx context.Context, name string) error {
 // It updates the base branch hash if the hash is out of date,
 // but the branch is restacked properly.
 //
-// It returns the actual hash of the base branch in case of succses,
-// [ErrNeedsRestack] if the branch needs to be restacked,
+// It returns the actual hash of the base branch on success,
+// [BranchNeedsRestackError] if the branch needs to be restacked,
 // [state.ErrNotExist] if the branch is not tracked.
 // Any other error indicates a problem with checking the branch.
 func (s *Service) CheckRestacked(ctx context.Context, name string) (baseHash git.Hash, err error) {
-	// A branch needs to be restacked if
-	// its merge base with its base branch
-	// is not its base branch's head.
-	//
-	// That is, the branch is not on top of its base branch's current head.
 	b, err := s.LookupBranch(ctx, name)
 	if err != nil {
 		return git.ZeroHash, err
 	}
 
-	baseHash, err = s.repo.PeelToCommit(ctx, b.Base)
+	replayRange, err := s.resolveBranchReplayRange(ctx, name, b)
 	if err != nil {
-		if errors.Is(err, git.ErrNotExist) {
-			return git.ZeroHash, fmt.Errorf("base branch %v does not exist", b.Base)
-		}
-		return git.ZeroHash, fmt.Errorf("find commit for %v: %w", b.Base, err)
+		return git.ZeroHash, err
 	}
 
-	if !s.repo.IsAncestor(ctx, baseHash, b.Head) {
+	if !replayRange.isRestacked() {
 		return git.ZeroHash, &BranchNeedsRestackError{
 			Base:     b.Base,
-			BaseHash: baseHash,
+			BaseHash: replayRange.BaseHead,
 		}
 	}
 
-	// A branch retargeted without rebasing preserves its old base hash
-	// as the upstream boundary for the next explicit restack.
-	// Do not treat that as stale metadata just because the new base
-	// is already an ancestor of the branch head.
-	if b.BaseHash != baseHash &&
-		!b.BaseHash.IsZero() &&
-		s.repo.IsAncestor(ctx, baseHash, b.BaseHash) &&
-		s.repo.IsAncestor(ctx, b.BaseHash, b.Head) {
-		return git.ZeroHash, &BranchNeedsRestackError{
-			Base:     b.Base,
-			BaseHash: baseHash,
-		}
+	s.reconcileRecordedBaseHash(ctx, name, b, replayRange.BaseHead)
+	return replayRange.BaseHead, nil
+}
+
+// reconcileRecordedBaseHash updates stale state after the Git graph proves
+// that a branch is already restacked. State failures are logged because they
+// do not change whether the branch needs a rebase.
+func (s *Service) reconcileRecordedBaseHash(
+	ctx context.Context,
+	name string,
+	b *LookupBranchResponse,
+	baseHash git.Hash,
+) {
+	if b.BaseHash == baseHash {
+		return
 	}
 
-	// Branch does not need to be restacked
-	// but the base hash stored in state may be out of date.
-	if b.BaseHash != baseHash {
-		s.log.Debug("Updating recorded base hash", "branch", name, "base", b.Base)
+	s.log.Debug("Updating recorded base hash", "branch", name, "base", b.Base)
 
-		tx := s.store.BeginBranchTx()
-		if err := tx.Upsert(ctx, state.UpsertRequest{
-			Name:     name,
-			BaseHash: baseHash,
-		}); err != nil {
-			s.log.Warn("Failed to update recorded base hash", "error", err)
-			return git.ZeroHash, nil
-		}
-
-		if err := tx.Commit(ctx, fmt.Sprintf("%v: branch was restacked externally", name)); err != nil {
-			// This isn't a critical error. Just log it.
-			s.log.Warn("Failed to update state", "error", err)
-		}
+	tx := s.store.BeginBranchTx()
+	if err := tx.Upsert(ctx, state.UpsertRequest{
+		Name:     name,
+		BaseHash: baseHash,
+	}); err != nil {
+		s.log.Warn("Failed to update recorded base hash", "error", err)
+		return
 	}
 
-	return baseHash, nil
+	if err := tx.Commit(ctx, fmt.Sprintf("%v: branch was restacked externally", name)); err != nil {
+		s.log.Warn("Failed to update state", "error", err)
+	}
 }

--- a/testdata/script/branch_onto_stale_ancestral_base.txt
+++ b/testdata/script/branch_onto_stale_ancestral_base.txt
@@ -1,0 +1,61 @@
+# 'branch onto' excludes commits from an externally advanced base branch.
+
+as 'Test <test@example.com>'
+at '2026-07-18T16:00:00Z'
+
+cd repo
+git init
+git add shared.txt
+git commit -m 'Initial commit'
+gs repo init
+
+# Create an independent destination whose conflicting edit does not contain
+# commits from the feature's base branch.
+cp $WORK/extra/shared-from-target.txt shared.txt
+git add shared.txt
+gs branch create target -m 'Change target file'
+
+# Create the feature from the initial trunk commit.
+git checkout main
+git add feature-one.txt
+gs branch create feature -m 'Add first feature file'
+git add feature-two.txt
+gs commit create -m 'Add second feature file'
+
+# Advance trunk, then rebase the feature with plain Git. This leaves the
+# recorded base at the initial commit while the current merge base moves ahead.
+git checkout main
+cp $WORK/extra/shared-from-first-trunk.txt shared.txt
+git add shared.txt
+git commit -m 'Change unrelated file'
+git rebase --onto main feature~2 feature
+
+# Advance trunk again so its head is no longer an ancestor of the feature.
+git checkout main
+cp $WORK/extra/shared-from-second-trunk.txt shared.txt
+git add shared.txt
+git commit -m 'Change unrelated file again'
+git checkout feature
+
+gs branch onto target
+
+# Moving the feature should replay only its own commits onto target.
+git log --format=%s target..feature
+cmp stdout $WORK/golden/feature-commits.txt
+cmp shared.txt $WORK/extra/shared-from-target.txt
+
+-- repo/shared.txt --
+initial
+-- repo/feature-one.txt --
+first feature
+-- repo/feature-two.txt --
+second feature
+-- extra/shared-from-target.txt --
+target version
+-- extra/shared-from-first-trunk.txt --
+first trunk version
+-- extra/shared-from-second-trunk.txt --
+second trunk version
+-- golden/feature-commits.txt --
+Add second feature file
+Add first feature file

--- a/testdata/script/branch_restack_stale_ancestral_base.txt
+++ b/testdata/script/branch_restack_stale_ancestral_base.txt
@@ -1,0 +1,55 @@
+# 'branch restack' excludes commits from an externally advanced base branch.
+
+as 'Test <test@example.com>'
+at '2026-07-18T12:00:00Z'
+
+cd repo
+git init
+git add shared.txt
+git commit -m 'Initial commit'
+gs repo init
+
+# Create two feature commits from the initial trunk commit.
+git add feature-one.txt
+gs branch create feature -m 'Add first feature file'
+git add feature-two.txt
+gs commit create -m 'Add second feature file'
+
+# Advance trunk, then rebase the feature with plain Git. This leaves
+# git-spice's recorded base at the initial commit even though the feature's
+# current merge base is the first trunk commit.
+git checkout main
+cp $WORK/extra/shared-from-first-trunk.txt shared.txt
+git add shared.txt
+git commit -m 'Change unrelated file'
+git rebase --onto main feature~2 feature
+
+# Advance trunk again with an incompatible edit to the same unrelated file.
+# Restacking from the recorded base would try to replay the first trunk commit
+# and conflict before reaching either feature commit.
+git checkout main
+cp $WORK/extra/shared-from-second-trunk.txt shared.txt
+git add shared.txt
+git commit -m 'Change unrelated file again'
+git checkout feature
+
+gs branch restack
+
+# Restack should replay only the feature's commits onto the current trunk.
+git log --format=%s main..feature
+cmp stdout $WORK/golden/feature-commits.txt
+cmp shared.txt $WORK/extra/shared-from-second-trunk.txt
+
+-- repo/shared.txt --
+initial
+-- repo/feature-one.txt --
+first feature
+-- repo/feature-two.txt --
+second feature
+-- extra/shared-from-first-trunk.txt --
+first trunk version
+-- extra/shared-from-second-trunk.txt --
+second trunk version
+-- golden/feature-commits.txt --
+Add second feature file
+Add first feature file

--- a/testdata/script/stack_edit_stale_ancestral_base.txt
+++ b/testdata/script/stack_edit_stale_ancestral_base.txt
@@ -1,0 +1,77 @@
+# 'stack edit' excludes commits from an externally advanced base branch.
+
+as 'Test <test@example.com>'
+at '2026-07-18T16:00:00Z'
+
+cd repo
+git init
+git add shared.txt
+git commit -m 'Initial commit'
+gs repo init
+
+# Create a two-branch stack whose base owns the shared file.
+cp $WORK/extra/shared-from-base-a.txt shared.txt
+git add shared.txt
+gs branch create base -m 'Set base version'
+git add feature-one.txt
+gs branch create feature -m 'Add first feature file'
+git add feature-two.txt
+gs commit create -m 'Add second feature file'
+
+# Advance the base, then rebase the feature with plain Git. This leaves the
+# feature's recorded boundary at base~1 while its current merge base is base.
+git checkout base
+cp $WORK/extra/shared-from-base-b.txt shared.txt
+git add shared.txt
+git commit -m 'Change unrelated file'
+git rebase --onto base feature~2 feature
+
+# Advance the base again with another unrelated-file edit.
+git checkout base
+cp $WORK/extra/shared-from-base-c.txt shared.txt
+git add shared.txt
+git commit -m 'Change unrelated file again'
+git checkout feature
+
+# Reverse the stack so feature moves directly onto main.
+env MOCKEDIT_GIVE=$WORK/edit/give.txt MOCKEDIT_RECORD=$WORK/edit/got.txt
+gs stack edit
+cmp $WORK/edit/got.txt $WORK/edit/want.txt
+
+# Stack edit should move only the feature commits onto main.
+git checkout feature
+git log --format=%s main..feature
+cmp stdout $WORK/golden/feature-commits.txt
+cmp shared.txt $WORK/extra/shared-from-main.txt
+
+-- repo/shared.txt --
+main version
+-- repo/feature-one.txt --
+first feature
+-- repo/feature-two.txt --
+second feature
+-- extra/shared-from-base-a.txt --
+base version a
+-- extra/shared-from-base-b.txt --
+base version b
+-- extra/shared-from-base-c.txt --
+base version c
+-- extra/shared-from-main.txt --
+main version
+-- edit/give.txt --
+base
+feature
+-- edit/want.txt --
+feature
+base
+
+# Edit the order of branches by modifying the list above.
+# The branch at the bottom of the list will be merged into trunk first.
+# Branches above that will be stacked on top of it in the order they appear.
+# Branches deleted from the list will not be modified.
+#
+# Save and quit the editor to apply the changes.
+# Delete all lines in the editor to abort the operation.
+-- golden/feature-commits.txt --
+Add second feature file
+Add first feature file


### PR DESCRIPTION
Branch restack and branch onto now replay only commits owned by the branch when a tracked branch was rebased outside git-spice onto a newer base.

An external rebase can leave the recorded base as an older ancestor of the branch. If the base advances again, replaying from that recorded hash includes base-branch commits and can conflict before reaching the branch commits.

Resolve each replay boundary from the recorded base, current merge base, and branch head. Advance stale ancestral boundaries, preserve newer boundaries from retarget-without-rebase, and use fork-point recovery only when the recorded boundary is disconnected. Restack checks, restack execution, and `BranchOnto` share this decision.

Stack edit coverage exercises the same behavior through `BranchOnto`. It is evidence for that consumer path, not a separately changed replay surface.

## Validation

- The branch-restack regression externally rebases a two-commit branch, advances its base with a conflicting edit, and protects both commits.
- The branch-onto regression moves the same stale-boundary shape to an independent destination and rejects replay of the old base commit.
- The stack-edit regression reorders a stack through `BranchOnto` and protects only the feature commits and destination content.
- Compatibility cases protect ordinary base advances from a poisoned fork point and retain newer retarget-without-rebase boundaries.