### PR TITLE
release: Sign checksums with cosign

### DIFF
--- a/.changes/unreleased/Added-20260720-043120.yaml
+++ b/.changes/unreleased/Added-20260720-043120.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Release artifacts are now signed with cosign.
+time: 2026-07-20T04:31:20.229508-07:00

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -123,9 +123,6 @@ jobs:
       env:
         TAG: v${{ env.VERSION }}
 
-    - uses: sigstore/cosign-installer@v4.1.2
-      if: inputs.skip_goreleaser == false
-
     - name: Release
       if: inputs.skip_goreleaser == false
       uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -65,6 +65,9 @@ jobs:
     name: Publish Release
     runs-on: ubuntu-latest
     environment: release
+    permissions:
+      contents: write
+      id-token: write # for Cosigning
 
     steps:
     - uses: actions/checkout@v6
@@ -119,6 +122,9 @@ jobs:
         git push origin "$TAG"
       env:
         TAG: v${{ env.VERSION }}
+
+    - uses: sigstore/cosign-installer@v4.1.2
+      if: inputs.skip_goreleaser == false
 
     - name: Release
       if: inputs.skip_goreleaser == false

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,6 +41,16 @@ builds:
     flags:
       - -trimpath
 
+signs:
+  - artifacts: checksum
+    signature: ${artifact}.sigstore.json
+    cmd: cosign
+    args:
+      - sign-blob
+      - --bundle=${signature}
+      - --yes
+      - ${artifact}
+
 archives:
   - ids: [git-spice]
     formats: tar.gz

--- a/mise.lock
+++ b/mise.lock
@@ -42,6 +42,52 @@ checksum = "sha256:4a90748c1da0179afe282599b562e75ef2cb5ce34e25d5f67e70ef20725b9
 url = "https://github.com/miniscruff/changie/releases/download/v1.24.0/changie_1.24.0_windows_amd64.zip"
 url_api = "https://api.github.com/repos/miniscruff/changie/releases/assets/319542125"
 
+[[tools.cosign]]
+version = "3.1.2"
+backend = "aqua:sigstore/cosign"
+
+[tools.cosign."platforms.linux-arm64"]
+checksum = "sha256:90e7ae0b5dfd60f20816b52c012addf7fc055ebcc7bea4ce81c428ca8518c302"
+url = "https://github.com/sigstore/cosign/releases/download/v3.1.2/cosign-linux-arm64"
+url_api = "https://api.github.com/repos/sigstore/cosign/releases/assets/480496294"
+provenance = "cosign"
+
+[tools.cosign."platforms.linux-arm64-musl"]
+checksum = "sha256:90e7ae0b5dfd60f20816b52c012addf7fc055ebcc7bea4ce81c428ca8518c302"
+url = "https://github.com/sigstore/cosign/releases/download/v3.1.2/cosign-linux-arm64"
+url_api = "https://api.github.com/repos/sigstore/cosign/releases/assets/480496294"
+provenance = "cosign"
+
+[tools.cosign."platforms.linux-x64"]
+checksum = "sha256:f7622ed3cf22e55e1ae6377c080979ff77a22da9981c11df222a2e444991e7cf"
+url = "https://github.com/sigstore/cosign/releases/download/v3.1.2/cosign-linux-amd64"
+url_api = "https://api.github.com/repos/sigstore/cosign/releases/assets/480496709"
+provenance = "cosign"
+
+[tools.cosign."platforms.linux-x64-musl"]
+checksum = "sha256:f7622ed3cf22e55e1ae6377c080979ff77a22da9981c11df222a2e444991e7cf"
+url = "https://github.com/sigstore/cosign/releases/download/v3.1.2/cosign-linux-amd64"
+url_api = "https://api.github.com/repos/sigstore/cosign/releases/assets/480496709"
+provenance = "cosign"
+
+[tools.cosign."platforms.macos-arm64"]
+checksum = "sha256:dec1c3f802320b19c2fbcf2dc7bcfb3f258e1c181a046c23a1a074bdf932f10a"
+url = "https://github.com/sigstore/cosign/releases/download/v3.1.2/cosign-darwin-arm64"
+url_api = "https://api.github.com/repos/sigstore/cosign/releases/assets/480497116"
+provenance = "cosign"
+
+[tools.cosign."platforms.macos-x64"]
+checksum = "sha256:acd180f8b015be25240ca33abee8a1e564eb65cdf1a3cee4725456d2dceb7da6"
+url = "https://github.com/sigstore/cosign/releases/download/v3.1.2/cosign-darwin-amd64"
+url_api = "https://api.github.com/repos/sigstore/cosign/releases/assets/480496599"
+provenance = "cosign"
+
+[tools.cosign."platforms.windows-x64"]
+checksum = "sha256:fe4d621d7ae5e900ee62089837c00f996ae9acb82027d573d1d157b6ee875cb2"
+url = "https://github.com/sigstore/cosign/releases/download/v3.1.2/cosign-windows-amd64.exe"
+url_api = "https://api.github.com/repos/sigstore/cosign/releases/assets/480497219"
+provenance = "cosign"
+
 [[tools."github:abhinav/gotestsum"]]
 version = "v1.14.0-beta.1+github-actions-fails"
 backend = "github:abhinav/gotestsum"

--- a/mise.toml
+++ b/mise.toml
@@ -26,6 +26,7 @@ golangci-lint = "latest"
 # Changelog manager.
 changie = "latest"
 requiredfield = "0.9.0"
+cosign = "latest"
 
 [tasks.generate]
 depends = ["tools"]


### PR DESCRIPTION
Refs

- https://www.sigstore.dev
- https://docs.sigstore.dev/cosign/signing/overview/
- https://github.com/sigstore/cosign
- https://goreleaser.com/customization/sign/sign/#signing-with-cosign

This yields a `checksums.txt.sigstore.json` in release assets, which can be used to verify the checksums file and thus transitively files listed in it. This can be done manually using cosign, and software such as [aqua](https://aquaproj.github.io/) and [mise](https://mise.jdx.dev/) can do it automatically on install.

Untested, but I believe it could work.

Re aqua and mise, https://github.com/aquaproj/aqua-registry/pull/57300