### PR TITLE
log: Persist recovered replay boundaries during restack checks

### DIFF
--- a/.changes/unreleased/Fixed-20260720-170705.yaml
+++ b/.changes/unreleased/Fixed-20260720-170705.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'log: Recovered replay boundaries are persisted so repeated inspections do not emit stale-boundary diagnostics.'
+time: 2026-07-20T17:07:05.781716353Z

--- a/internal/spice/restack.go
+++ b/internal/spice/restack.go
@@ -106,7 +106,13 @@ func (s *Service) CheckRestacked(ctx context.Context, name string) (baseHash git
 	}
 
 	if !replayRange.isRestacked() {
-		s.reconcileRecordedBaseHash(ctx, name, b, replayRange.Upstream)
+		// A recovered replay boundary can match the branch head when the branch
+		// has already been merged into its base. Keeping the previous boundary
+		// lets log commands continue to show the branch commits while marking the
+		// branch as needing restack.
+		if replayRange.Upstream != b.Head {
+			s.reconcileRecordedBaseHash(ctx, name, b, replayRange.Upstream)
+		}
 		return git.ZeroHash, &BranchNeedsRestackError{
 			Base:     b.Base,
 			BaseHash: replayRange.BaseHead,

--- a/internal/spice/restack.go
+++ b/internal/spice/restack.go
@@ -106,6 +106,7 @@ func (s *Service) CheckRestacked(ctx context.Context, name string) (baseHash git
 	}
 
 	if !replayRange.isRestacked() {
+		s.reconcileRecordedBaseHash(ctx, name, b, replayRange.Upstream)
 		return git.ZeroHash, &BranchNeedsRestackError{
 			Base:     b.Base,
 			BaseHash: replayRange.BaseHead,

--- a/internal/spice/restack.go
+++ b/internal/spice/restack.go
@@ -106,10 +106,16 @@ func (s *Service) CheckRestacked(ctx context.Context, name string) (baseHash git
 	}
 
 	if !replayRange.isRestacked() {
-		// A recovered replay boundary can match the branch head when the branch
-		// has already been merged into its base. Keeping the previous boundary
-		// lets log commands continue to show the branch commits while marking the
-		// branch as needing restack.
+		// If the base branch has merged this branch without updating git-spice
+		// state, the current merge base is the branch head:
+		//
+		//	A---B---M base
+		//	 \     /
+		//	  P---Q branch
+		//
+		// Moving the recorded boundary to Q would make log commands report no
+		// commits for branch, even though branch still needs restack because M is
+		// the base head. Keep the earlier recorded boundary in that case.
 		if replayRange.Upstream != b.Head {
 			s.reconcileRecordedBaseHash(ctx, name, b, replayRange.Upstream)
 		}

--- a/testdata/script/log_short_reconciles_recovered_boundary.txt
+++ b/testdata/script/log_short_reconciles_recovered_boundary.txt
@@ -1,0 +1,47 @@
+# Regression test for 0.31.1: 'log short' persists recovered replay
+# boundaries while preserving restack state.
+
+as 'Test <test@example.com>'
+at '2026-07-20T00:00:00Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# Case 1: the recorded base is older than the current merge base.
+gs branch create feature --no-prompt -m 'test: Add feature commit' -m 'Create the tracked branch used by the reproducer.'
+gs branch checkout main --no-prompt
+gs commit create --allow-empty --no-restack --no-prompt -m 'test: Advance trunk to B' -m 'Create the first trunk advance for the reproducer.'
+git branch trunk-b main
+git rebase main feature
+gs branch checkout main --no-prompt
+gs commit create --allow-empty --no-restack --no-prompt -m 'test: Advance trunk to C' -m 'Leave the externally rebased feature behind trunk.'
+
+# Case 2: the recorded base is disconnected and fork-point recovery succeeds.
+gs branch create feature-fork --no-prompt -m 'test: Add fork-point feature' -m 'Create the disconnected-boundary reproducer branch.'
+git branch trunk-c main
+git rebase --onto trunk-b trunk-c feature-fork
+gs branch checkout main --no-prompt
+
+# The first inspection recovers and persists both replay boundaries.
+gs log short --all --no-prompt --verbose
+cmp stderr $WORK/golden/first-list.txt
+# A second inspection still reports that the branches need restack,
+# but does not have to recover either stale boundary again.
+gs log short --all --no-prompt --verbose
+cmp stderr $WORK/golden/second-list.txt
+
+-- golden/first-list.txt --
+DBG Recorded base hash is out of date. Using merge base as replay boundary.  base=main branch=feature mergeBase=a1d1c71
+DBG Updating recorded base hash  branch=feature base=main
+DBG Recorded base hash is out of date. Restacking from fork point.  base=main branch=feature-fork forkPoint=a1d1c71
+DBG Updating recorded base hash  branch=feature-fork base=main
+┏━□ feature (needs restack)
+┣━□ feature-fork (needs restack)
+main ◀
+-- golden/second-list.txt --
+┏━□ feature (needs restack)
+┣━□ feature-fork (needs restack)
+main ◀

--- a/testdata/script/log_short_reconciles_recovered_boundary.txt
+++ b/testdata/script/log_short_reconciles_recovered_boundary.txt
@@ -19,29 +19,43 @@ git rebase main feature
 gs branch checkout main --no-prompt
 gs commit create --allow-empty --no-restack --no-prompt -m 'test: Advance trunk to C' -m 'Leave the externally rebased feature behind trunk.'
 
+# The first inspection recovers and persists the merge-base boundary.
+gs log short --all --no-prompt --verbose
+cmp stderr $WORK/golden/first-merge-base-list.txt
+# A second inspection still reports that the branch needs restack,
+# but does not have to recover the stale boundary again.
+gs log short --all --no-prompt --verbose
+cmp stderr $WORK/golden/second-merge-base-list.txt
+
 # Case 2: the recorded base is disconnected and fork-point recovery succeeds.
 gs branch create feature-fork --no-prompt -m 'test: Add fork-point feature' -m 'Create the disconnected-boundary reproducer branch.'
 git branch trunk-c main
 git rebase --onto trunk-b trunk-c feature-fork
 gs branch checkout main --no-prompt
 
-# The first inspection recovers and persists both replay boundaries.
+# The first inspection recovers and persists the fork-point boundary.
 gs log short --all --no-prompt --verbose
-cmp stderr $WORK/golden/first-list.txt
-# A second inspection still reports that the branches need restack,
+cmp stderr $WORK/golden/first-fork-point-list.txt
+# A second inspection still reports that both branches need restack,
 # but does not have to recover either stale boundary again.
 gs log short --all --no-prompt --verbose
-cmp stderr $WORK/golden/second-list.txt
+cmp stderr $WORK/golden/second-fork-point-list.txt
 
--- golden/first-list.txt --
+-- golden/first-merge-base-list.txt --
 DBG Recorded base hash is out of date. Using merge base as replay boundary.  base=main branch=feature mergeBase=a1d1c71
 DBG Updating recorded base hash  branch=feature base=main
+┏━□ feature (needs restack)
+main ◀
+-- golden/second-merge-base-list.txt --
+┏━□ feature (needs restack)
+main ◀
+-- golden/first-fork-point-list.txt --
 DBG Recorded base hash is out of date. Restacking from fork point.  base=main branch=feature-fork forkPoint=a1d1c71
 DBG Updating recorded base hash  branch=feature-fork base=main
 ┏━□ feature (needs restack)
 ┣━□ feature-fork (needs restack)
 main ◀
--- golden/second-list.txt --
+-- golden/second-fork-point-list.txt --
 ┏━□ feature (needs restack)
 ┣━□ feature-fork (needs restack)
 main ◀


### PR DESCRIPTION
Fix regression in `gs ls` automatic healing introduced in 0.31.1.