### PR TITLE
fix: Heal branches changed outside git-spice

### DIFF
--- a/.changes/unreleased/Fixed-20260801-105400.yaml
+++ b/.changes/unreleased/Fixed-20260801-105400.yaml
@@ -1,0 +1,4 @@
+kind: Fixed
+body: >-
+  log: Automatically heal from branches changed manually to point to a commit in their base branch.
+time: 2026-08-01T10:54:00.492776-07:00

--- a/internal/handler/list/handler.go
+++ b/internal/handler/list/handler.go
@@ -256,22 +256,15 @@ func (h *Handler) ListBranches(ctx context.Context, req *BranchesRequest) (*Bran
 				// which will panic down below when consuming
 				// the result.
 
-				// Check restack status /before/ looking up
-				// the branch in git because VerifyRestacked
-				// might update the branch's base hash
-				// if the branch was manually restacked.
-				//
-				// TODO: This is a hack.
-				// The isn't a good abstraction.
+				// BranchGraph was loaded before restack reconciliation.
+				// When CheckRestacked heals a boundary, its error returns the
+				// reconciled value so this invocation does not render stale commits.
 				baseHash, err := h.Service.CheckRestacked(ctx, branch.Name)
 				if err != nil {
 					var needsRestack *spice.BranchNeedsRestackError
 					if errors.As(err, &needsRestack) {
-						// if the branch needs to be restacked,
-						// use the base hash stored in state
-						// so that the log doesn't show duplicated commits.
 						item.NeedsRestack = true
-						baseHash = branch.BaseHash
+						baseHash = needsRestack.Upstream
 					} else {
 						baseHash = git.ZeroHash
 					}

--- a/internal/spice/onto.go
+++ b/internal/spice/onto.go
@@ -71,11 +71,10 @@ func (s *Service) BranchOnto(ctx context.Context, req *BranchOntoRequest) error 
 		ontoHash = onto.Head
 	}
 
-	replayRange, err := s.resolveBranchReplayRange(ctx, req.Branch, branch)
+	replayRange, err := s.branchBaseInfo(ctx, req.Branch, branch)
 	if err != nil {
 		return fmt.Errorf("resolve branch replay range: %w", err)
 	}
-	fromHash := replayRange.Upstream
 
 	// The destination can already contain the resolved replay boundary.
 	// This is expected when two branches share a downstack
@@ -99,9 +98,7 @@ func (s *Service) BranchOnto(ctx context.Context, req *BranchOntoRequest) error 
 	// Using the destination as the exclusive boundary selects
 	// NewBase..Current. The first attempt excludes NewBase's commits,
 	// and a resumed attempt becomes a no-op before state is updated.
-	if s.repo.IsAncestor(ctx, fromHash, ontoHash) {
-		fromHash = ontoHash
-	}
+	fromHash := replayRange.ReplayBoundary(ctx, ontoHash)
 
 	s.log.Debug(
 		"Moving commits onto new base",

--- a/internal/spice/replay_range.go
+++ b/internal/spice/replay_range.go
@@ -8,9 +8,13 @@ import (
 	"go.abhg.dev/gs/internal/git"
 )
 
-// branchReplayRange relates a tracked branch to the current head of its base.
-// BaseHead is the rebase destination, MergeBase describes the current graph,
-// and Upstream is the exclusive boundary of the commits to replay.
+// branchBaseInfo relates a tracked branch to the current head of its base.
+// Commits in the range Upstream..HEAD are owned by the branch.
+//
+// # How this affects restacking
+//
+// During a restack operation, BaseHead is the rebase destination,
+// and MergeBase describes the current graph.
 //
 // A branch already restacked on its base has all three hashes at B:
 //
@@ -26,17 +30,24 @@ import (
 //	      P branch (MergeBase=B, Upstream=B)
 //
 // Restack detects this state because MergeBase differs from BaseHead,
-// then replays Upstream..branch-head onto BaseHead.
+// then replays the owned commits (Upstream..HEAD) onto BaseHead.
 //
-// A retarget without rebase is the exception to that equality check:
+// However, if a branch is retargeted without rebasing (e.g. branch onto),
+// things differ more.
 //
 //	A new-base (BaseHead=A, MergeBase=A)
 //	 \
-//	  B---P branch (Upstream=B, UpstreamDescendsFromBase=true)
+//	  B old-base
+//	   \
+//	    P branch (Upstream=B, UpstreamDescendsFromBase=true)
 //
 // Although BaseHead is the merge base, a later restack must still replay
-// Upstream..branch-head to remove the old downstack commit B.
-type branchReplayRange struct {
+// Upstream..HEAD to remove the old downstack commit B.
+type branchBaseInfo struct {
+	repo interface {
+		IsAncestor(ctx context.Context, a, b git.Hash) bool
+	} // required
+
 	// BaseHead is the current head of the tracked base branch
 	// and the destination of a rebase.
 	BaseHead git.Hash
@@ -45,40 +56,37 @@ type branchReplayRange struct {
 	// A different BaseHead means the branch is not currently restacked.
 	MergeBase git.Hash
 
-	// Upstream is the exclusive lower boundary of the commits to replay.
+	// Upstream is the exclusive lower boundary of the commits owned
+	// by the branch.
 	// It begins at the recorded base hash and may move to the merge base
 	// or fork point when the recorded hash is stale.
 	Upstream git.Hash
 
 	// UpstreamDescendsFromBase reports that BaseHead is an ancestor of Upstream.
-	// A retarget without rebase uses this relationship to leave replay work
-	// for a later restack.
+	// A retarget without rebase uses this relationship
+	// to leave replay work for a later restack.
 	UpstreamDescendsFromBase bool
 }
 
-func (r branchReplayRange) isRestacked() bool {
-	return r.MergeBase == r.BaseHead && !r.UpstreamDescendsFromBase
-}
-
-// resolveBranchReplayRange finds the commits owned by a tracked branch.
+// branchBaseInfo finds the commits owned by a tracked branch.
 // It reconciles the recorded boundary with the current Git graph
 // without changing git-spice state.
-func (s *Service) resolveBranchReplayRange(
+func (s *Service) branchBaseInfo(
 	ctx context.Context,
 	name string,
 	branch *LookupBranchResponse,
-) (branchReplayRange, error) {
+) (branchBaseInfo, error) {
 	baseHead, err := s.repo.PeelToCommit(ctx, branch.Base)
 	if err != nil {
 		if errors.Is(err, git.ErrNotExist) {
-			return branchReplayRange{}, fmt.Errorf("base branch %v does not exist", branch.Base)
+			return branchBaseInfo{}, fmt.Errorf("base branch %v does not exist", branch.Base)
 		}
-		return branchReplayRange{}, fmt.Errorf("find commit for %v: %w", branch.Base, err)
+		return branchBaseInfo{}, fmt.Errorf("find commit for %v: %w", branch.Base, err)
 	}
 
 	mergeBase, err := s.repo.MergeBase(ctx, baseHead.String(), branch.Head.String())
 	if err != nil {
-		return branchReplayRange{}, fmt.Errorf(
+		return branchBaseInfo{}, fmt.Errorf(
 			"find merge base of %q and %q: %w",
 			branch.Base,
 			name,
@@ -105,14 +113,46 @@ func (s *Service) resolveBranchReplayRange(
 	//	     \
 	//	      P branch (branch.Head=P)
 	//
-	// If branch.BaseHash is A and mergeBase is B, advancing Upstream to B
-	// prevents base commit B from being treated as a branch commit.
+	// If branch.BaseHash is A and mergeBase is B, advancing
+	// Upstream to B prevents base commit B from being treated as a
+	// branch commit.
 	if upstream != mergeBase && s.repo.IsAncestor(ctx, upstream, mergeBase) {
-		s.log.Debug("Recorded base hash is out of date. Using merge base as replay boundary.",
-			"base", branch.Base,
-			"branch", name,
-			"mergeBase", mergeBase)
-		upstream = mergeBase
+		if mergeBase != branch.Head {
+			s.log.Debug("Recorded base hash is out of date. Using merge base as ownership boundary.",
+				"base", branch.Base,
+				"branch", name,
+				"mergeBase", mergeBase)
+			upstream = mergeBase
+		} else {
+			// MergeBase == branch.Head has two different meanings.
+			//
+			// The branch may have been reset to a commit already on the base:
+			//
+			//	A---B---C base (BaseHead=C)
+			//	    |
+			//	    +--- branch (Head=B, MergeBase=B)
+			//
+			// ForkPoint is B, so Upstream advances to B. The branch is
+			// empty but still needs restacking onto C.
+			//
+			// The base may instead contain the branch through a merge side
+			// parent:
+			//
+			//	A---B---M base (BaseHead=M)
+			//	 \     /
+			//	  P---Q branch (Head=Q, MergeBase=Q)
+			//
+			// ForkPoint remains A, so Upstream remains A. Commits P and
+			// Q remain owned by the branch until it is restacked.
+			forkPoint, err := s.repo.ForkPoint(ctx, branch.Base, name)
+			if err == nil && upstream != forkPoint {
+				s.log.Debug("Recorded base hash is out of date. Using fork point as ownership boundary.",
+					"base", branch.Base,
+					"branch", name,
+					"forkPoint", forkPoint)
+				upstream = forkPoint
+			}
+		}
 	}
 
 	// A retarget without rebase deliberately records a reachable boundary
@@ -120,10 +160,12 @@ func (s *Service) resolveBranchReplayRange(
 	//
 	//	A new-base (BaseHead=A)
 	//	 \
-	//	  B---P branch (branch.Head=P)
+	//	  B---P branch (branch.Head=P, Upstream=B,
+	//	                UpstreamDescendsFromBase=true)
 	//
-	// If mergeBase is A and branch.BaseHash is B, preserving Upstream B makes
-	// a later restack replay only P onto A and remove old downstack commit B.
+	// If mergeBase is A and branch.BaseHash is B, preserving
+	// Upstream B makes a later restack replay only P onto A and remove
+	// old downstack commit B.
 	//
 	// A rewritten history can instead leave branch.BaseHash disconnected from
 	// branch.Head even when Git's reflogs retain the former fork point:
@@ -144,7 +186,7 @@ func (s *Service) resolveBranchReplayRange(
 		forkPoint, err := s.repo.ForkPoint(ctx, branch.Base, name)
 		if err == nil {
 			if upstream != forkPoint {
-				s.log.Debug("Recorded base hash is out of date. Restacking from fork point.",
+				s.log.Debug("Recorded base hash is out of date. Using fork point as ownership boundary.",
 					"base", branch.Base,
 					"branch", name,
 					"forkPoint", forkPoint)
@@ -153,10 +195,33 @@ func (s *Service) resolveBranchReplayRange(
 		}
 	}
 
-	return branchReplayRange{
+	return branchBaseInfo{
+		repo:                     s.repo,
 		BaseHead:                 baseHead,
 		MergeBase:                mergeBase,
 		Upstream:                 upstream,
 		UpstreamDescendsFromBase: upstreamDescendsFromBase,
 	}, nil
+}
+
+func (r *branchBaseInfo) IsRestacked() bool {
+	return r.MergeBase == r.BaseHead && !r.UpstreamDescendsFromBase
+}
+
+// ReplayBoundary returns the start of the range of commits
+// that should be replayed onto dest.
+//
+// While branchCommitRange owns Upstream..HEAD,
+// when replaying onto dest, not all commits might need to be replayed.
+func (r *branchBaseInfo) ReplayBoundary(ctx context.Context, dest git.Hash) git.Hash {
+	// Upstream refers to start of range of commits for a branch,
+	// and destination to commit we're replaying commits on top of.
+	//
+	// If upstream is reachable by destination,
+	// trying to replay upstream..HEAD will result in conflicts.
+	// So replay range is now destination..HEAD.
+	if r.repo.IsAncestor(ctx, r.Upstream, dest) {
+		return dest
+	}
+	return r.Upstream
 }

--- a/internal/spice/restack.go
+++ b/internal/spice/restack.go
@@ -28,18 +28,39 @@ func (s *Service) Restack(ctx context.Context, name string) (*RestackResponse, e
 		return nil, err // includes ErrNotExist
 	}
 
-	replayRange, err := s.resolveBranchReplayRange(ctx, name, b)
+	commitRange, err := s.branchBaseInfo(ctx, name, b)
 	if err != nil {
 		return nil, err
 	}
-	if replayRange.isRestacked() {
-		s.reconcileRecordedBaseHash(ctx, name, b, replayRange.BaseHead)
+	if commitRange.IsRestacked() {
+		s.reconcileRecordedBaseHash(ctx, name, b, commitRange.BaseHead)
 		return nil, ErrAlreadyRestacked
 	}
 
+	// The base can already contain some or all branch-owned commits after a
+	// Git operation outside git-spice:
+	//
+	//	A---B---M base (BaseHead=M)
+	//	 \     /
+	//	  P---Q branch (MergeBase=Q, Upstream=A)
+	//
+	// Using the base as the exclusive replay boundary selects BaseHead..Q,
+	// which excludes every commit reachable from the base. In this example,
+	// the range is empty, so Git moves the branch to M without replaying P or Q.
+	//
+	// When the base does not contain Upstream, retaining it preserves
+	// retarget-without-rebase behavior:
+	//
+	//	A base (BaseHead=A)
+	//	 \
+	//	  B---P branch (MergeBase=A, Upstream=B,
+	//	                UpstreamDescendsFromBase=true)
+	//
+	// Replaying B..P onto A drops the old downstack commit B.
+	replayBoundary := commitRange.ReplayBoundary(ctx, commitRange.BaseHead)
 	if err := s.wt.Rebase(ctx, git.RebaseRequest{
-		Onto:      replayRange.BaseHead.String(),
-		Upstream:  replayRange.Upstream.String(),
+		Onto:      commitRange.BaseHead.String(),
+		Upstream:  replayBoundary.String(),
 		Branch:    name,
 		Autostash: true,
 		Quiet:     true,
@@ -50,7 +71,7 @@ func (s *Service) Restack(ctx context.Context, name string) (*RestackResponse, e
 	tx := s.store.BeginBranchTx()
 	if err := tx.Upsert(ctx, state.UpsertRequest{
 		Name:     name,
-		BaseHash: replayRange.BaseHead,
+		BaseHash: commitRange.BaseHead,
 	}); err != nil {
 		return nil, fmt.Errorf("update base hash of %v: %w", name, err)
 	}
@@ -73,6 +94,10 @@ type BranchNeedsRestackError struct {
 	// BaseHash is the hash of the base branch.
 	// Note that this is the actual hash, not the hash stored in state.
 	BaseHash git.Hash
+
+	// Upstream is the exclusive boundary of the branch's commits
+	// after reconciling the recorded state with the Git graph.
+	Upstream git.Hash
 }
 
 func (e *BranchNeedsRestackError) Error() string {
@@ -87,8 +112,8 @@ func (s *Service) VerifyRestacked(ctx context.Context, name string) error {
 }
 
 // CheckRestacked verifies that the given branch is on top of its base branch.
-// It updates the base branch hash if the hash is out of date,
-// but the branch is restacked properly.
+// It reconciles the recorded base hash with the Git graph,
+// including when the branch still needs to be restacked.
 //
 // It returns the actual hash of the base branch on success,
 // [BranchNeedsRestackError] if the branch needs to be restacked,
@@ -100,38 +125,27 @@ func (s *Service) CheckRestacked(ctx context.Context, name string) (baseHash git
 		return git.ZeroHash, err
 	}
 
-	replayRange, err := s.resolveBranchReplayRange(ctx, name, b)
+	commitRange, err := s.branchBaseInfo(ctx, name, b)
 	if err != nil {
 		return git.ZeroHash, err
 	}
 
-	if !replayRange.isRestacked() {
-		// If the base branch has merged this branch without updating git-spice
-		// state, the current merge base is the branch head:
-		//
-		//	A---B---M base
-		//	 \     /
-		//	  P---Q branch
-		//
-		// Moving the recorded boundary to Q would make log commands report no
-		// commits for branch, even though branch still needs restack because M is
-		// the base head. Keep the earlier recorded boundary in that case.
-		if replayRange.Upstream != b.Head {
-			s.reconcileRecordedBaseHash(ctx, name, b, replayRange.Upstream)
-		}
+	if !commitRange.IsRestacked() {
+		s.reconcileRecordedBaseHash(ctx, name, b, commitRange.Upstream)
 		return git.ZeroHash, &BranchNeedsRestackError{
 			Base:     b.Base,
-			BaseHash: replayRange.BaseHead,
+			BaseHash: commitRange.BaseHead,
+			Upstream: commitRange.Upstream,
 		}
 	}
 
-	s.reconcileRecordedBaseHash(ctx, name, b, replayRange.BaseHead)
-	return replayRange.BaseHead, nil
+	s.reconcileRecordedBaseHash(ctx, name, b, commitRange.BaseHead)
+	return commitRange.BaseHead, nil
 }
 
-// reconcileRecordedBaseHash updates stale state after the Git graph proves
-// that a branch is already restacked. State failures are logged because they
-// do not change whether the branch needs a rebase.
+// reconcileRecordedBaseHash persists an ownership boundary recovered from Git.
+// State failures are logged because they do not change the graph-derived
+// restack status.
 func (s *Service) reconcileRecordedBaseHash(
 	ctx context.Context,
 	name string,

--- a/testdata/script/branch_restack_manually_merged.txt
+++ b/testdata/script/branch_restack_manually_merged.txt
@@ -1,0 +1,74 @@
+# Restacking a manually merged branch preserves its commit ownership.
+
+as 'Test <test@example.com>'
+at '2026-07-20T02:00:00Z'
+
+mkdir repo
+cd repo
+git init
+git add app.txt
+git commit -m 'Initial commit'
+gs repo init
+
+# Create feature1 -> feature2,
+# then merge feature2 into feature1.
+cp $WORK/extra/feature1.txt app.txt
+git add app.txt
+gs branch create feature1 --no-prompt -m 'test: Add feature1'
+cp $WORK/extra/feature2.txt app.txt
+git add app.txt
+gs branch create feature2 --no-prompt -m 'test: Add feature2'
+gs branch checkout feature1 --no-prompt
+cp $WORK/extra/feature1-advanced.txt feature1.txt
+git add feature1.txt
+gs commit create --no-restack --no-prompt -m 'test: Advance feature1'
+git merge feature2 -m 'test: Merge feature2 into feature1'
+
+# feature2's head is now reachable from feature1,
+# but feature2 still owns its commits because the merge reached them through a
+# side parent.
+
+# Move feature1 to require a restack.
+cp $WORK/extra/feature1-after-merge.txt app.txt
+git add app.txt
+gs commit create --no-restack --no-prompt -m 'test: Change merged feature on feature1'
+
+# Inspections must preserve feature2's commits
+# so that if it's moved onto another branch, it still owns its commits.
+gs log long --all --verbose --no-prompt
+cmp stderr $WORK/golden/before-restack.txt
+
+gs branch restack --branch feature2 --no-prompt
+cmp stderr $WORK/golden/restack.txt
+gs log long --all --verbose --no-prompt
+cmp stderr $WORK/golden/after-restack.txt
+
+-- golden/before-restack.txt --
+  ┏━□ feature2 (needs restack)
+  ┃   497aca1 test: Add feature2 (now)
+┏━┻■ feature1 ◀
+┃    c8bface test: Change merged feature on feature1 (now)
+┃    a97fc5e test: Merge feature2 into feature1 (now)
+┃    768a4ce test: Advance feature1 (now)
+┃    f95154c test: Add feature1 (now)
+main
+-- golden/restack.txt --
+INF feature2: restacked on feature1
+-- golden/after-restack.txt --
+  ┏━■ feature2 ◀
+┏━┻□ feature1
+┃    c8bface test: Change merged feature on feature1 (now)
+┃    a97fc5e test: Merge feature2 into feature1 (now)
+┃    768a4ce test: Advance feature1 (now)
+┃    f95154c test: Add feature1 (now)
+main
+-- repo/app.txt --
+initial
+-- extra/feature1.txt --
+feature1
+-- extra/feature2.txt --
+feature2
+-- extra/feature1-advanced.txt --
+feature1 advanced
+-- extra/feature1-after-merge.txt --
+feature1 after merge

--- a/testdata/script/issue1387_log_reset_branch_on_trunk.txt
+++ b/testdata/script/issue1387_log_reset_branch_on_trunk.txt
@@ -1,0 +1,47 @@
+# https://github.com/abhinav/git-spice/issues/1387
+# Repeated log inspections stop reporting a stale base after a tracked branch
+# is reset onto trunk.
+
+as 'Test <test@example.com>'
+at '2026-08-01T00:00:00Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# Track topic-one at A, then replace its topic commit by resetting the branch
+# to the newer trunk commit B. Trunk advances again after the reset.
+gs branch create topic-one --no-prompt -m 'Add topic-one change'
+gs branch checkout main --no-prompt
+gs commit create --allow-empty --no-restack --no-prompt -m 'Advance trunk to B'
+git branch -f topic-one main
+gs commit create --allow-empty --no-restack --no-prompt -m 'Advance trunk to E'
+
+# After one inspection, repeated inspection must not recover the same stale
+# boundary again.
+gs log long --all --no-prompt --verbose
+cmp stderr $WORK/golden/first-log.txt
+gs log long --all --no-prompt --verbose
+cmp stderr $WORK/golden/second-log.txt
+
+# Restacking a branch already contained by its base replays no commits.
+gs branch restack --branch topic-one --no-prompt
+cmp stderr $WORK/golden/restack.txt
+gs log long --all --no-prompt --verbose
+cmp stderr $WORK/golden/after-restack.txt
+
+-- golden/first-log.txt --
+DBG Recorded base hash is out of date. Using fork point as ownership boundary.  base=main branch=topic-one forkPoint=ed7b595
+DBG Updating recorded base hash  branch=topic-one base=main
+┏━□ topic-one (needs restack)
+main ◀
+-- golden/second-log.txt --
+┏━□ topic-one (needs restack)
+main ◀
+-- golden/restack.txt --
+INF topic-one: restacked on main
+-- golden/after-restack.txt --
+┏━■ topic-one ◀
+main

--- a/testdata/script/issue1387_log_track_branch_behind_trunk.txt
+++ b/testdata/script/issue1387_log_track_branch_behind_trunk.txt
@@ -1,0 +1,31 @@
+# https://github.com/abhinav/git-spice/issues/1387
+# Repeated log inspections stop reporting a stale base after an older trunk
+# commit is tracked as a branch.
+
+as 'Test <test@example.com>'
+at '2026-08-01T00:01:00Z'
+
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# Create topic-two at C after trunk reaches D. Tracking records D as the base
+# even though topic-two points to C. Trunk advances again after tracking.
+gs commit create --allow-empty --no-restack --no-prompt -m 'Advance trunk to C'
+gs commit create --allow-empty --no-restack --no-prompt -m 'Advance trunk to D'
+git branch topic-two main~1
+gs branch track --base main topic-two --no-prompt
+gs commit create --allow-empty --no-restack --no-prompt -m 'Advance trunk to E'
+
+# Reconciliation may happen during tracking or the first inspection. Repeated
+# inspection must not recover the same stale boundary again.
+gs log long --all --no-prompt --verbose
+cmp stderr $WORK/golden/log.txt
+gs log long --all --no-prompt --verbose
+cmp stderr $WORK/golden/log.txt
+
+-- golden/log.txt --
+┏━□ topic-two (needs restack)
+main ◀

--- a/testdata/script/log_short_reconciles_recovered_boundary.txt
+++ b/testdata/script/log_short_reconciles_recovered_boundary.txt
@@ -1,4 +1,4 @@
-# Regression test for 0.31.1: 'log short' persists recovered replay
+# Regression test for 0.31.1: 'log short' persists recovered ownership
 # boundaries while preserving restack state.
 
 as 'Test <test@example.com>'
@@ -19,11 +19,9 @@ git rebase main feature
 gs branch checkout main --no-prompt
 gs commit create --allow-empty --no-restack --no-prompt -m 'test: Advance trunk to C' -m 'Leave the externally rebased feature behind trunk.'
 
-# The first inspection recovers and persists the merge-base boundary.
+# The first inspection logs recovery; both render the recovered boundary.
 gs log short --all --no-prompt --verbose
 cmp stderr $WORK/golden/first-merge-base-list.txt
-# A second inspection still reports that the branch needs restack,
-# but does not have to recover the stale boundary again.
 gs log short --all --no-prompt --verbose
 cmp stderr $WORK/golden/second-merge-base-list.txt
 
@@ -33,16 +31,14 @@ git branch trunk-c main
 git rebase --onto trunk-b trunk-c feature-fork
 gs branch checkout main --no-prompt
 
-# The first inspection recovers and persists the fork-point boundary.
+# The first inspection logs recovery; both render the recovered boundary.
 gs log short --all --no-prompt --verbose
 cmp stderr $WORK/golden/first-fork-point-list.txt
-# A second inspection still reports that both branches need restack,
-# but does not have to recover either stale boundary again.
 gs log short --all --no-prompt --verbose
 cmp stderr $WORK/golden/second-fork-point-list.txt
 
 -- golden/first-merge-base-list.txt --
-DBG Recorded base hash is out of date. Using merge base as replay boundary.  base=main branch=feature mergeBase=a1d1c71
+DBG Recorded base hash is out of date. Using merge base as ownership boundary.  base=main branch=feature mergeBase=a1d1c71
 DBG Updating recorded base hash  branch=feature base=main
 ┏━□ feature (needs restack)
 main ◀
@@ -50,7 +46,7 @@ main ◀
 ┏━□ feature (needs restack)
 main ◀
 -- golden/first-fork-point-list.txt --
-DBG Recorded base hash is out of date. Restacking from fork point.  base=main branch=feature-fork forkPoint=a1d1c71
+DBG Recorded base hash is out of date. Using fork point as ownership boundary.  base=main branch=feature-fork forkPoint=a1d1c71
 DBG Updating recorded base hash  branch=feature-fork base=main
 ┏━□ feature (needs restack)
 ┣━□ feature-fork (needs restack)


### PR DESCRIPTION
Git operations outside git-spice can move tracked branches or bases without
updating their recorded base hashes. The first subsequent log inspection
previously rendered stale commits, then persisted a recovered boundary, so the
second inspection rendered a different stack.

Reconcile the ownership boundary before rendering. The first inspection reports
and persists the repair; later inspections retain the same layout without
repeating the repair message.

Keep branch ownership separate from the Git replay boundary. A restack skips
owned commits already reachable from its destination, while a retargeted branch
continues to exclude its old downstack commit.

Resolves #1387