### PR TITLE
fix(glab): new glab auth token format support #1391

### DIFF
--- a/.changes/unreleased/Fixed-20260804-201917.yaml
+++ b/.changes/unreleased/Fixed-20260804-201917.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'GitLab: Fix CLI token extraction in newer versions of glab.'
+time: 2026-08-04T20:19:17.675451-07:00

--- a/internal/forge/gitlab/auth.go
+++ b/internal/forge/gitlab/auth.go
@@ -517,7 +517,7 @@ func (gc *glabCLI) Status(ctx context.Context, host string) (ok bool, err error)
 	return true, nil
 }
 
-var _tokenRe = regexp.MustCompile(`(?m)^\W+Token(?:\s+found)?:\s+([\w\.\-]+)\s*$`)
+var _tokenRe = regexp.MustCompile(`(?m)^\W+Token(?:\s+found)?(?:\s+in\s+[^:]+)?:\s+([\w.-]+)\s*$`)
 
 // Token returns the authentication token from the GitLab CLI.
 func (gc *glabCLI) Token(ctx context.Context, host string) (string, error) {

--- a/internal/forge/gitlab/auth_test.go
+++ b/internal/forge/gitlab/auth_test.go
@@ -585,6 +585,16 @@ func TestCLITokenParsing(t *testing.T) {
 			want: "glpat-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.01.0xxxxxxxx",
 		},
 		{
+			name: "LongKeyring",
+			give: "  ✓ Token found in operating system keyring: glpat-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.01.0xxxxxxxx\n",
+			want: "glpat-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.01.0xxxxxxxx",
+		},
+		{
+			name: "LongPlainText",
+			give: "  ✓ Token found in configuration file (plaintext): glpat-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.01.0xxxxxxxx\n",
+			want: "glpat-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.01.0xxxxxxxx",
+		},
+		{
 			name: "NoToken",
 			give: "  ✓ Token: \n",
 		},


### PR DESCRIPTION
Fix https://github.com/abhinav/git-spice/issues/1391

Update the regular expression to match the new glab cli auth output.

