### PR TITLE
Pad leaf connectors in tree view to fix sibling branch label alignment

### DIFF
--- a/.changes/unreleased/Fixed-20260805-113924.yaml
+++ b/.changes/unreleased/Fixed-20260805-113924.yaml
@@ -1,3 +1,5 @@
 kind: Fixed
-body: 'tree: Pad leaf node connectors to match width of junction glyphs, aligning sibling branch labels.'
+body: >-
+  Sibling branches in rendered branch trees are no longer unaligned
+  when one of them has upstack branches and the other does not.
 time: 2026-08-05T11:39:24+00:00

--- a/.changes/unreleased/Fixed-20260805-113924.yaml
+++ b/.changes/unreleased/Fixed-20260805-113924.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'tree: Pad leaf node connectors to match width of junction glyphs, aligning sibling branch labels.'
+time: 2026-08-05T11:39:24+00:00

--- a/internal/ui/branchtree/tree_test.go
+++ b/internal/ui/branchtree/tree_test.go
@@ -47,7 +47,7 @@ func TestWrite(t *testing.T) {
 				Roots: []int{0},
 			},
 			want: joinLines(
-				"  ┏━□ feat2",
+				"  ┏━━□ feat2",
 				"┏━┻□ feat1",
 				"main",
 			),
@@ -63,8 +63,8 @@ func TestWrite(t *testing.T) {
 				Roots: []int{0},
 			},
 			want: joinLines(
-				"┏━□ feat1",
-				"┣━□ feat2",
+				"┏━━□ feat1",
+				"┣━━□ feat2",
 				"main",
 			),
 		},
@@ -81,9 +81,9 @@ func TestWrite(t *testing.T) {
 				Roots: []int{0},
 			},
 			want: joinLines(
-				"  ┏━□ feat1.1",
+				"  ┏━━□ feat1.1",
 				"┏━┻□ feat1",
-				"┃ ┏━□ feat2.1",
+				"┃ ┏━━□ feat2.1",
 				"┣━┻□ feat2",
 				"main",
 			),
@@ -100,9 +100,9 @@ func TestWrite(t *testing.T) {
 				Roots: []int{0, 2},
 			},
 			want: joinLines(
-				"┏━□ feat1",
+				"┏━━□ feat1",
 				"main",
-				"┏━□ hotfix",
+				"┏━━□ hotfix",
 				"develop",
 			),
 		},

--- a/internal/ui/fliptree/testdata/write.yaml
+++ b/internal/ui/fliptree/testdata/write.yaml
@@ -7,13 +7,6 @@
     b: [c]
     c: [d]
     d: [e]
-  want: |2
-            ┏━□ e
-          ┏━┻□ d
-        ┏━┻□ c
-      ┏━┻□ b
-    ┏━┻□ a
-    main
   wantOffsets:
     a: 4
     b: 3
@@ -21,21 +14,19 @@
     d: 1
     e: 0
     main: 5
+  want: |2
+            ┏━━□ e
+          ┏━┻□ d
+        ┏━┻□ c
+      ┏━┻□ b
+    ┏━┻□ a
+    main
 
 - name: multiple roots
   roots: [foo, bar]
   graph:
     foo: [a, b, c]
     bar: [d, e, f]
-  want: |
-    ┏━□ a
-    ┣━□ b
-    ┣━□ c
-    foo
-    ┏━□ d
-    ┣━□ e
-    ┣━□ f
-    bar
   wantOffsets:
     a: 0
     b: 1
@@ -45,6 +36,32 @@
     e: 5
     f: 6
     foo: 3
+  want: |
+    ┏━━□ a
+    ┣━━□ b
+    ┣━━□ c
+    foo
+    ┏━━□ d
+    ┣━━□ e
+    ┣━━□ f
+    bar
+
+- name: leaf and parent siblings
+  roots: [root]
+  graph:
+    root: [parent, leaf]
+    parent: [child]
+    leaf: []
+  wantOffsets:
+    parent: 0
+    leaf: 0
+    child: 2
+    root: 8
+  want: |2
+      ┏━━□ child
+    ┏━┻□ parent
+    ┣━━□ leaf
+    root
 
 - name: linear multline
   roots: [main]
@@ -59,9 +76,15 @@
     b: "b\n|\nmore stuff"
     c: "c\n\nboop"
     d: "d\nbeep"
+  wantOffsets:
+    a: 8
+    b: 5
+    c: 2
+    d: 0
+    main: 11
   want: |2
-          ┏━□ d
-          ┃   beep
+          ┏━━□ d
+          ┃    beep
         ┏━┻□ c
         ┃
         ┃    boop
@@ -73,12 +96,6 @@
     ┃    stuff
     main
     main stuff
-  wantOffsets:
-    a: 8
-    b: 5
-    c: 2
-    d: 0
-    main: 11
 
 - name: many lines
   roots: [main]
@@ -90,50 +107,50 @@
     d: "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl\nm\nn\no\np\nq\nr\ns\nt\nu\nv\nw\nx"
   graph:
     main: [a, b, c, d]
-  want: |
-    ┏━□ x
-    ┃   y
-    ┃   z
-    ┣━□ b	1
-    ┃   	2
-    ┃   	3
-    ┣━□ i
-    ┃   ii
-    ┃   iii
-    ┃   iiii
-    ┃   iiiii
-    ┃   iiiiii
-    ┣━□ a
-    ┃   b
-    ┃   c
-    ┃   d
-    ┃   e
-    ┃   f
-    ┃   g
-    ┃   h
-    ┃   i
-    ┃   j
-    ┃   k
-    ┃   l
-    ┃   m
-    ┃   n
-    ┃   o
-    ┃   p
-    ┃   q
-    ┃   r
-    ┃   s
-    ┃   t
-    ┃   u
-    ┃   v
-    ┃   w
-    ┃   x
-    main
   wantOffsets:
     a: 0
     b: 3
     c: 6
     d: 12
     main: 36
+  want: |
+    ┏━━□ x
+    ┃    y
+    ┃    z
+    ┣━━□ b	1
+    ┃    	2
+    ┃    	3
+    ┣━━□ i
+    ┃    ii
+    ┃    iii
+    ┃    iiii
+    ┃    iiiii
+    ┃    iiiiii
+    ┣━━□ a
+    ┃    b
+    ┃    c
+    ┃    d
+    ┃    e
+    ┃    f
+    ┃    g
+    ┃    h
+    ┃    i
+    ┃    j
+    ┃    k
+    ┃    l
+    ┃    m
+    ┃    n
+    ┃    o
+    ┃    p
+    ┃    q
+    ┃    r
+    ┃    s
+    ┃    t
+    ┃    u
+    ┃    v
+    ┃    w
+    ┃    x
+    main
 
 - name: big graph
   roots: [main]
@@ -151,86 +168,6 @@
     j: [aq, ar, as, at, au, av, aw, ax, ay, az]
     k: [ba, bb, bc, bd, be, bf, bg, bh, bi, bj, bk, bl]
     l: [bm, bn, bo, bp, bq, br, bs, bt, bu, bv, bw, bx, by, bz]
-  want: |2
-        ┏━□ m
-        ┣━□ n
-        ┣━□ o
-      ┏━┻□ d
-      ┃ ┏━□ p
-      ┃ ┣━□ q
-      ┃ ┣━□ r
-      ┣━┻□ e
-      ┃ ┏━□ s
-      ┃ ┣━□ t
-      ┃ ┣━□ u
-      ┃ ┣━□ v
-      ┃ ┣━□ w
-      ┃ ┣━□ x
-      ┣━┻□ f
-    ┏━┻□ a
-    ┃   ┏━□ y
-    ┃   ┣━□ z
-    ┃   ┣━□ aa
-    ┃   ┣━□ ab
-    ┃ ┏━┻□ g
-    ┃ ┃ ┏━□ ac
-    ┃ ┃ ┣━□ ad
-    ┃ ┃ ┣━□ ae
-    ┃ ┃ ┣━□ af
-    ┃ ┃ ┣━□ ag
-    ┃ ┃ ┣━□ ah
-    ┃ ┣━┻□ h
-    ┣━┻□ b
-    ┃   ┏━□ ai
-    ┃   ┣━□ aj
-    ┃   ┣━□ ak
-    ┃   ┣━□ al
-    ┃   ┣━□ am
-    ┃   ┣━□ an
-    ┃   ┣━□ ao
-    ┃   ┣━□ ap
-    ┃ ┏━┻□ i
-    ┃ ┃ ┏━□ aq
-    ┃ ┃ ┣━□ ar
-    ┃ ┃ ┣━□ as
-    ┃ ┃ ┣━□ at
-    ┃ ┃ ┣━□ au
-    ┃ ┃ ┣━□ av
-    ┃ ┃ ┣━□ aw
-    ┃ ┃ ┣━□ ax
-    ┃ ┃ ┣━□ ay
-    ┃ ┃ ┣━□ az
-    ┃ ┣━┻□ j
-    ┃ ┃ ┏━□ ba
-    ┃ ┃ ┣━□ bb
-    ┃ ┃ ┣━□ bc
-    ┃ ┃ ┣━□ bd
-    ┃ ┃ ┣━□ be
-    ┃ ┃ ┣━□ bf
-    ┃ ┃ ┣━□ bg
-    ┃ ┃ ┣━□ bh
-    ┃ ┃ ┣━□ bi
-    ┃ ┃ ┣━□ bj
-    ┃ ┃ ┣━□ bk
-    ┃ ┃ ┣━□ bl
-    ┃ ┣━┻□ k
-    ┃ ┃ ┏━□ bm
-    ┃ ┃ ┣━□ bn
-    ┃ ┃ ┣━□ bo
-    ┃ ┃ ┣━□ bp
-    ┃ ┃ ┣━□ bq
-    ┃ ┃ ┣━□ br
-    ┃ ┃ ┣━□ bs
-    ┃ ┃ ┣━□ bt
-    ┃ ┃ ┣━□ bu
-    ┃ ┃ ┣━□ bv
-    ┃ ┃ ┣━□ bw
-    ┃ ┃ ┣━□ bx
-    ┃ ┃ ┣━□ by
-    ┃ ┃ ┣━□ bz
-    ┃ ┣━┻□ l
-    ┣━┻□ c
-    main
   wantOffsets:
     a: 15
     aa: 18
@@ -311,3 +248,83 @@
     x: 13
     "y": 16
     z: 17
+  want: |2
+        ┏━━□ m
+        ┣━━□ n
+        ┣━━□ o
+      ┏━┻□ d
+      ┃ ┏━━□ p
+      ┃ ┣━━□ q
+      ┃ ┣━━□ r
+      ┣━┻□ e
+      ┃ ┏━━□ s
+      ┃ ┣━━□ t
+      ┃ ┣━━□ u
+      ┃ ┣━━□ v
+      ┃ ┣━━□ w
+      ┃ ┣━━□ x
+      ┣━┻□ f
+    ┏━┻□ a
+    ┃   ┏━━□ y
+    ┃   ┣━━□ z
+    ┃   ┣━━□ aa
+    ┃   ┣━━□ ab
+    ┃ ┏━┻□ g
+    ┃ ┃ ┏━━□ ac
+    ┃ ┃ ┣━━□ ad
+    ┃ ┃ ┣━━□ ae
+    ┃ ┃ ┣━━□ af
+    ┃ ┃ ┣━━□ ag
+    ┃ ┃ ┣━━□ ah
+    ┃ ┣━┻□ h
+    ┣━┻□ b
+    ┃   ┏━━□ ai
+    ┃   ┣━━□ aj
+    ┃   ┣━━□ ak
+    ┃   ┣━━□ al
+    ┃   ┣━━□ am
+    ┃   ┣━━□ an
+    ┃   ┣━━□ ao
+    ┃   ┣━━□ ap
+    ┃ ┏━┻□ i
+    ┃ ┃ ┏━━□ aq
+    ┃ ┃ ┣━━□ ar
+    ┃ ┃ ┣━━□ as
+    ┃ ┃ ┣━━□ at
+    ┃ ┃ ┣━━□ au
+    ┃ ┃ ┣━━□ av
+    ┃ ┃ ┣━━□ aw
+    ┃ ┃ ┣━━□ ax
+    ┃ ┃ ┣━━□ ay
+    ┃ ┃ ┣━━□ az
+    ┃ ┣━┻□ j
+    ┃ ┃ ┏━━□ ba
+    ┃ ┃ ┣━━□ bb
+    ┃ ┃ ┣━━□ bc
+    ┃ ┃ ┣━━□ bd
+    ┃ ┃ ┣━━□ be
+    ┃ ┃ ┣━━□ bf
+    ┃ ┃ ┣━━□ bg
+    ┃ ┃ ┣━━□ bh
+    ┃ ┃ ┣━━□ bi
+    ┃ ┃ ┣━━□ bj
+    ┃ ┃ ┣━━□ bk
+    ┃ ┃ ┣━━□ bl
+    ┃ ┣━┻□ k
+    ┃ ┃ ┏━━□ bm
+    ┃ ┃ ┣━━□ bn
+    ┃ ┃ ┣━━□ bo
+    ┃ ┃ ┣━━□ bp
+    ┃ ┃ ┣━━□ bq
+    ┃ ┃ ┣━━□ br
+    ┃ ┃ ┣━━□ bs
+    ┃ ┃ ┣━━□ bt
+    ┃ ┃ ┣━━□ bu
+    ┃ ┃ ┣━━□ bv
+    ┃ ┃ ┣━━□ bw
+    ┃ ┃ ┣━━□ bx
+    ┃ ┃ ┣━━□ by
+    ┃ ┃ ┣━━□ bz
+    ┃ ┣━┻□ l
+    ┣━┻□ c
+    main

--- a/internal/ui/fliptree/tree.go
+++ b/internal/ui/fliptree/tree.go
@@ -282,6 +282,12 @@ func (tw *treeWriter[T]) writeTree(nodeIdx int, path []int, pathNodeIxes []int) 
 	titlePrefix := tw.style.NodeMarker(nodeValue).String() + " "
 	if hasChildren {
 		titlePrefix = tw.style.Joint.Render(string(_horizontalUp)) + titlePrefix
+	} else if len(path) > 0 {
+		// The node is a leaf sibling: it has no upward joint to
+		// children, but we emit a horizontal segment anyway so its
+		// marker lines up with siblings that do have children
+		// and carry a ┻ joint there.
+		titlePrefix = tw.style.Joint.Render(string(_horizontal)) + titlePrefix
 	}
 	bodyPrefix := strings.Repeat(" ", lipgloss.Width(titlePrefix))
 

--- a/internal/ui/fliptree/tree_test.go
+++ b/internal/ui/fliptree/tree_test.go
@@ -382,7 +382,7 @@ func TestWrite_resolvesThemeAtRenderTime(t *testing.T) {
 	require.NoError(t, Write(&out, g, opts))
 
 	got := out.String()
-	assert.Equal(t, "┏━■ feat\nmain\n", ansi.Strip(got))
+	assert.Equal(t, "┏━━■ feat\nmain\n", ansi.Strip(got))
 	assert.Contains(t, got, "\x1b[96m■\x1b[m")
 }
 

--- a/internal/ui/widget/testdata/script/branch_tree_select/change_id.txt
+++ b/internal/ui/widget/testdata/script/branch_tree_select/change_id.txt
@@ -21,14 +21,14 @@ feed 7 <Enter>
 ]
 -- prompt --
 Select a branch:
-      ┏━■ qux ◀
+      ┏━━■ qux ◀
     ┏━┻□ baz
   ┏━┻□ bar (#127)
 ┏━┻□ foo (#123)
 main
 -- filter --
 Select a branch:
-┏━■ bar (#127) ◀
+┏━━■ bar (#127) ◀
 foo (#123)
 -- want --
 bar

--- a/internal/ui/widget/testdata/script/branch_tree_select/linear.txt
+++ b/internal/ui/widget/testdata/script/branch_tree_select/linear.txt
@@ -25,7 +25,7 @@ We have many branches to choose from.
 bar
 -- prompt --
 Select a branch:
-      ┏━■ qux ◀
+      ┏━━■ qux ◀
     ┏━┻□ baz
   ┏━┻□ bar
 ┏━┻□ foo
@@ -34,7 +34,7 @@ main
 We have many branches to choose from.
 -- hover --
 Select a branch:
-      ┏━□ qux
+      ┏━━□ qux
     ┏━┻□ baz
   ┏━┻■ bar ◀
 ┏━┻□ foo

--- a/internal/ui/widget/testdata/script/branch_tree_select/linear_filter.txt
+++ b/internal/ui/widget/testdata/script/branch_tree_select/linear_filter.txt
@@ -23,12 +23,12 @@ feed <Enter>
 baz
 -- prompt --
 Select a branch:
-      ┏━■ qux ◀
+      ┏━━■ qux ◀
     ┏━┻□ baz
   ┏━┻□ bar
 ┏━┻□ foo
 main
 -- filter --
 Select a branch:
-┏━■ baz ◀
+┏━━■ baz ◀
 bar

--- a/internal/ui/widget/testdata/script/branch_tree_select/unselectable_base.txt
+++ b/internal/ui/widget/testdata/script/branch_tree_select/unselectable_base.txt
@@ -38,7 +38,7 @@ feed <Down> <Enter>
 bar
 -- prompt --
 Select a branch:
-  ┏━■ baz ◀
+  ┏━━■ baz ◀
 ┏━┻□ bar
 foo
 -- filter --

--- a/internal/ui/widget/testdata/script/branch_tree_select/worktree.txt
+++ b/internal/ui/widget/testdata/script/branch_tree_select/worktree.txt
@@ -25,9 +25,9 @@ feed <Enter>
 ]
 -- prompt --
 Select a branch:
-  ┏━■ feat2 (#456) [wt: /tmp/wt2] ◀
+  ┏━━■ feat2 (#456) [wt: /tmp/wt2] ◀
 ┏━┻□ feat1 [wt: /home/user/wt1]
-┃ ┏━□ feat4 (#789)
+┃ ┏━━□ feat4 (#789)
 ┣━┻□ feat3
 main
 -- filter --

--- a/internal/ui/widget/testdata/script/branch_tree_select/worktree_filter_current.txt
+++ b/internal/ui/widget/testdata/script/branch_tree_select/worktree_filter_current.txt
@@ -27,8 +27,8 @@ feed <Enter>
 ]
 -- prompt --
 Select a branch:
-┏━■ feat1 [wt: /home/user/wt1] ◀
-┣━□ feat4
+┏━━■ feat1 [wt: /home/user/wt1] ◀
+┣━━□ feat4
 main
 -- filter --
 Select a branch:

--- a/internal/ui/widget/testdata/script/branch_tree_select/worktree_filter_other.txt
+++ b/internal/ui/widget/testdata/script/branch_tree_select/worktree_filter_other.txt
@@ -24,8 +24,8 @@ feed <Enter>
 ]
 -- prompt --
 Select a branch:
-┏━■ feat1 [wt: /home/user/other-wt] ◀
-┣━□ feat2
+┏━━■ feat1 [wt: /home/user/other-wt] ◀
+┣━━□ feat2
 main
 -- filter --
 Select a branch:

--- a/internal/ui/widget/testdata/script/commit_pick/basic.txt
+++ b/internal/ui/widget/testdata/script/commit_pick/basic.txt
@@ -53,8 +53,8 @@ def
 Pick a commit to cherry-pick
 -- prompt --
 Select a commit:
-  ┏━□ feat2
-  ┃   ▶ ghi feat: add another feature (11 hours ago)
+  ┏━━□ feat2
+  ┃    ▶ ghi feat: add another feature (11 hours ago)
 ┏━┻□ feat1
 ┃      abc feat: add feature (11 hours ago)
 ┃      def refac: unrelated change (11 hours ago)
@@ -63,8 +63,8 @@ main
 Pick a commit to cherry-pick
 -- commit_2 --
 Select a commit:
-  ┏━□ feat2
-  ┃     ghi feat: add another feature (11 hours ago)
+  ┏━━□ feat2
+  ┃      ghi feat: add another feature (11 hours ago)
 ┏━┻□ feat1
 ┃    ▶ abc feat: add feature (11 hours ago)
 ┃      def refac: unrelated change (11 hours ago)
@@ -73,8 +73,8 @@ main
 Pick a commit to cherry-pick
 -- commit_3 --
 Select a commit:
-  ┏━□ feat2
-  ┃     ghi feat: add another feature (11 hours ago)
+  ┏━━□ feat2
+  ┃      ghi feat: add another feature (11 hours ago)
 ┏━┻□ feat1
 ┃      abc feat: add feature (11 hours ago)
 ┃    ▶ def refac: unrelated change (11 hours ago)

--- a/internal/ui/widget/testdata/script/commit_pick/branch_without_commit.txt
+++ b/internal/ui/widget/testdata/script/commit_pick/branch_without_commit.txt
@@ -44,9 +44,9 @@ ghi
 
 -- prompt --
 Select a commit:
-    ┏━□ feat3
-    ┃   ▶ abc feat: add another feature (1 day ago)
-    ┃     def refac: unrelated change (17 hours ago)
+    ┏━━□ feat3
+    ┃    ▶ abc feat: add another feature (1 day ago)
+    ┃      def refac: unrelated change (17 hours ago)
   ┏━┻□ feat2
 ┏━┻□ feat1
 ┃      ghi feat: add feature (11 hours ago)

--- a/internal/ui/widget/testdata/script/commit_pick/preselected.txt
+++ b/internal/ui/widget/testdata/script/commit_pick/preselected.txt
@@ -31,7 +31,7 @@ def
 ]
 -- prompt --
 Select a commit:
-┏━□ feat1
-┃     abc feat: add another feature (1 day ago)
-┃   ▶ def refac: unrelated change (17 hours ago)
+┏━━□ feat1
+┃      abc feat: add another feature (1 day ago)
+┃    ▶ def refac: unrelated change (17 hours ago)
 main

--- a/log_graph_test.go
+++ b/log_graph_test.go
@@ -38,7 +38,7 @@ func TestGraphLogPresenter_Present(t *testing.T) {
 	err := presenter.Present(res, "feature")
 	require.NoError(t, err)
 
-	assert.Equal(t, "┏━■ feature ◀\nmain\n", buf.String())
+	assert.Equal(t, "┏━━■ feature ◀\nmain\n", buf.String())
 }
 
 func TestGraphLogPresenter_Present_preservesColor(t *testing.T) {

--- a/testdata/script/branch_checkout_prompt.txt
+++ b/testdata/script/branch_checkout_prompt.txt
@@ -68,15 +68,15 @@ whatever
 -- robot.golden --
 ===
 > Select a branch to checkout: 
-> ┏━□ bar
-> ┣━□ foo
+> ┏━━□ bar
+> ┣━━□ foo
 > main ◀
 "bar"
 ===
 > Select a branch to checkout: 
 > baz
-> ┏━□ bar
-> ┣━□ foo
+> ┏━━□ bar
+> ┣━━□ foo
 > main ◀
 > quux
 > qux
@@ -87,8 +87,8 @@ true
 ===
 > Select a branch to checkout: 
 > baz
-> ┏━□ bar
-> ┣━□ foo
+> ┏━━□ bar
+> ┣━━□ foo
 > main ◀
 > quux
 > qux

--- a/testdata/script/branch_checkout_prompt_detach_worktrees.txt
+++ b/testdata/script/branch_checkout_prompt_detach_worktrees.txt
@@ -65,7 +65,7 @@ feat1
 -- robot-unix.golden --
 ===
 > Select a branch to checkout: 
-> ┏━□ feat1 [wt: ~/repo]
+> ┏━━□ feat1 [wt: ~/repo]
 > main ◀
 "feat1"
 -- robot-windows.golden --
@@ -77,7 +77,7 @@ feat1
 -- robot-name-unix.golden --
 ===
 > Select a branch to checkout: 
-> ┏━■ feat1 [wt: ~/repo] ◀
+> ┏━━■ feat1 [wt: ~/repo] ◀
 > main
 "feat1"
 -- robot-name-windows.golden --

--- a/testdata/script/branch_checkout_prompt_sort_order.txt
+++ b/testdata/script/branch_checkout_prompt_sort_order.txt
@@ -76,14 +76,14 @@ whatever
 > bcd
 > ccc
 > ddd
-> ┏━□ aaa
-> ┣━□ bbb
+> ┏━━□ aaa
+> ┣━━□ bbb
 > main ◀
 "bbb"
 ===
 > Select a branch to checkout: 
-> ┏━□ aaa
-> ┣━□ bbb
+> ┏━━□ aaa
+> ┣━━□ bbb
 > main ◀
 > ccc
 > ddd
@@ -94,7 +94,7 @@ whatever
 > bcd
 > ddd
 > ccc
-> ┏━□ bbb
-> ┣━□ aaa
+> ┏━━□ bbb
+> ┣━━□ aaa
 > main ◀
 "bbb"

--- a/testdata/script/branch_checkout_prompt_trunk.txt
+++ b/testdata/script/branch_checkout_prompt_trunk.txt
@@ -25,6 +25,6 @@ feature
 -- robot.golden --
 ===
 > Select a branch to checkout: 
-> ┏━■ feature ◀
+> ┏━━■ feature ◀
 > main
 "main"

--- a/testdata/script/branch_checkout_remote.txt
+++ b/testdata/script/branch_checkout_remote.txt
@@ -68,8 +68,8 @@ true
 > Do you want to track this branch now?: [Y/n]
 false
 -- golden/ls-feat1.txt --
-┏━■ feat1 ◀
+┏━━■ feat1 ◀
 main
 -- golden/ls-feat2.txt --
-┏━□ feat1
+┏━━□ feat1
 main

--- a/testdata/script/branch_checkout_track_always.txt
+++ b/testdata/script/branch_checkout_track_always.txt
@@ -26,5 +26,5 @@ cmp stderr $WORK/golden/ls.txt
 -- repo/foo.txt --
 whatever
 -- golden/ls.txt --
-┏━■ feature ◀
+┏━━■ feature ◀
 main

--- a/testdata/script/branch_checkout_track_prompt.txt
+++ b/testdata/script/branch_checkout_track_prompt.txt
@@ -32,5 +32,5 @@ whatever
 true
 
 -- golden/ls.txt --
-┏━■ feature ◀
+┏━━■ feature ◀
 main

--- a/testdata/script/branch_create_below_with_downstack_history.txt
+++ b/testdata/script/branch_create_below_with_downstack_history.txt
@@ -61,12 +61,12 @@ feat 3
 -- repo/feat4.txt --
 feat 4
 -- golden/ls-before.txt --
-    ┏━■ feat3 (#3) ◀
+    ┏━━■ feat3 (#3) ◀
   ┏━┻□ feat2 (#2)
 ┏━┻□ feat1 (#1)
 main
 -- golden/ls-after.txt --
-    ┏━□ feat3 (#3)
+    ┏━━□ feat3 (#3)
   ┏━┻□ feat2 (#2)
 ┏━┻■ feat4 (#4) ◀
 main

--- a/testdata/script/branch_create_generate_name_limit.txt
+++ b/testdata/script/branch_create_generate_name_limit.txt
@@ -21,6 +21,6 @@ cmp stderr $WORK/golden/ll.txt
 -- repo/feature.txt --
 This is a feature file.
 -- golden/ll.txt --
-┏━■ add-a-very-long-and-descriptive-feature-name ◀
-┃   72d6161 Add a very long and descriptive feature name (now)
+┏━━■ add-a-very-long-and-descriptive-feature-name ◀
+┃    72d6161 Add a very long and descriptive feature name (now)
 main

--- a/testdata/script/branch_create_message_implies_commit.txt
+++ b/testdata/script/branch_create_message_implies_commit.txt
@@ -31,8 +31,8 @@ cmp stdout $WORK/golden/graph.txt
 foo
 
 -- golden/ll-feat1.txt --
-┏━■ feat1 ◀
-┃   aadd769 Add foo (now)
+┏━━■ feat1 ◀
+┃    aadd769 Add foo (now)
 main
 -- golden/graph.txt --
 * aadd769 (HEAD -> feat1) Add foo

--- a/testdata/script/branch_create_no_commit.txt
+++ b/testdata/script/branch_create_no_commit.txt
@@ -53,20 +53,20 @@ A  foo.txt
 A  bar.txt
 A  foo.txt
 -- golden/ls-feat1.txt --
-┏━■ feat1 ◀
+┏━━■ feat1 ◀
 main
 -- golden/ls-feat2.txt --
-  ┏━■ feat2 ◀
+  ┏━━■ feat2 ◀
 ┏━┻□ feat1
 main
 -- golden/ls-feat3.txt --
-    ┏━■ feat3 ◀
+    ┏━━■ feat3 ◀
   ┏━┻□ feat2
 ┏━┻□ feat1
 main
 -- golden/ll-feat3.txt --
-    ┏━■ feat3 ◀
-    ┃   2a17718 Add foo and bar (now)
+    ┏━━■ feat3 ◀
+    ┃    2a17718 Add foo and bar (now)
   ┏━┻□ feat2
 ┏━┻□ feat1
 main

--- a/testdata/script/branch_create_no_verify.txt
+++ b/testdata/script/branch_create_no_verify.txt
@@ -30,8 +30,8 @@ feature
 exit 1
 
 -- golden/ll.txt --
-┏━■ feature ◀
-┃   5648694 Add feature (now)
+┏━━■ feature ◀
+┃    5648694 Add feature (now)
 main
 -- golden/diff.txt --
 diff --git a/feature.txt b/feature.txt

--- a/testdata/script/branch_create_prefix.txt
+++ b/testdata/script/branch_create_prefix.txt
@@ -20,6 +20,6 @@ cmp stderr $WORK/golden/ll.txt
 feature
 
 -- golden/ll.txt --
-┏━■ myuser/feature ◀
-┃   eb4b3b8 Add feature (now)
+┏━━■ myuser/feature ◀
+┃    eb4b3b8 Add feature (now)
 main

--- a/testdata/script/branch_create_prefix_with_generated_name.txt
+++ b/testdata/script/branch_create_prefix_with_generated_name.txt
@@ -22,6 +22,6 @@ cmp stderr $WORK/golden/ll.txt
 -- repo/feature.txt --
 This is a feature file.
 -- golden/ll.txt --
-┏━■ myuser/add-feature-2 ◀
-┃   702c658 Add feature (now)
+┏━━■ myuser/add-feature-2 ◀
+┃    702c658 Add feature (now)
 main

--- a/testdata/script/branch_create_stage_all.txt
+++ b/testdata/script/branch_create_stage_all.txt
@@ -29,8 +29,8 @@ feature 2
 -- repo/feature1-new.txt --
 new feature 1
 -- golden/ll.txt --
-  ┏━■ y ◀
-  ┃   b903d8e Remove feature 2 and rename feature 1 (now)
+  ┏━━■ y ◀
+  ┃    b903d8e Remove feature 2 and rename feature 1 (now)
 ┏━┻□ x
 ┃    2840e92 Add features 1 and 2 (now)
 main

--- a/testdata/script/branch_create_target.txt
+++ b/testdata/script/branch_create_target.txt
@@ -53,19 +53,19 @@ feature 4
 feature 5
 
 -- golden/add-feature3.txt --
-  ┏━□ feature2
-  ┣━■ feature3 ◀
+  ┏━━□ feature2
+  ┣━━■ feature3 ◀
 ┏━┻□ feature1
 main
 -- golden/add-feature4.txt --
-    ┏━□ feature2
-    ┣━□ feature3
+    ┏━━□ feature2
+    ┣━━□ feature3
   ┏━┻■ feature4 ◀
 ┏━┻□ feature1
 main
 -- golden/add-feature5.txt --
-      ┏━□ feature2
-      ┣━□ feature3
+      ┏━━□ feature2
+      ┣━━□ feature3
     ┏━┻□ feature4
   ┏━┻□ feature1
 ┏━┻■ feature5 ◀

--- a/testdata/script/branch_delete_heal.txt
+++ b/testdata/script/branch_delete_heal.txt
@@ -66,6 +66,6 @@ feature 3
 * aa78494 feature1
 * 102a190 (HEAD -> main) Initial commit
 -- golden/ls.txt --
-┏━□ feature2
-┣━□ feature3
+┏━━□ feature2
+┣━━□ feature3
 main ◀

--- a/testdata/script/branch_delete_prompt_sort_order.txt
+++ b/testdata/script/branch_delete_prompt_sort_order.txt
@@ -64,14 +64,14 @@ whatever
 ===
 > Select a branch to delete: 
 > ccc ◀
-> ┏━□ aaa
-> ┣━□ bbb
+> ┏━━□ aaa
+> ┣━━□ bbb
 > main
 "ccc"
 ===
 > Select a branch to delete: 
-> ┏━■ bbb ◀
-> ┣━□ aaa
+> ┏━━■ bbb ◀
+> ┣━━□ aaa
 > main
 > ccc
 "bbb"

--- a/testdata/script/branch_fold.txt
+++ b/testdata/script/branch_fold.txt
@@ -46,9 +46,9 @@ bar
 * 588349e Add foo.txt
 * 9bad92b (main) Initial commit
 -- golden/ls-before.txt --
-  ┏━■ bar ◀
+  ┏━━■ bar ◀
 ┏━┻□ foo
 main
 -- golden/ls-after.txt --
-┏━■ foo ◀
+┏━━■ foo ◀
 main

--- a/testdata/script/branch_fold_trunk_protection.txt
+++ b/testdata/script/branch_fold_trunk_protection.txt
@@ -52,7 +52,7 @@ Feature 1 content
 Feature 2 content
 
 -- golden/ls-before.txt --
-  ┏━■ feature2 ◀
+  ┏━━■ feature2 ◀
 ┏━┻□ feature1
 main
 -- golden/robot-no.txt --
@@ -66,7 +66,7 @@ false
 false
 
 -- golden/ls-after-abort.txt --
-  ┏━□ feature2
+  ┏━━□ feature2
 ┏━┻■ feature1 ◀
 main
 -- golden/robot-yes.txt --
@@ -80,7 +80,7 @@ true
 true
 
 -- golden/ls-after-feature1-folded.txt --
-┏━□ feature2
+┏━━□ feature2
 main ◀
 -- golden/non-interactive-warning.txt --
 INF Branch feature2 has been folded into main

--- a/testdata/script/branch_onto_conflict_hell.txt
+++ b/testdata/script/branch_onto_conflict_hell.txt
@@ -135,8 +135,8 @@ DU feature.txt
 |/  
 * 53ec458 (main) Initial commit
 -- golden/list-short.txt --
-  ┏━□ feature1
+  ┏━━□ feature1
 ┏━┻□ feature0
-┣━□ feature2
-┣━■ feature3 ◀
+┣━━□ feature2
+┣━━■ feature3 ◀
 main

--- a/testdata/script/branch_onto_conflict_loop_repro.txt
+++ b/testdata/script/branch_onto_conflict_loop_repro.txt
@@ -73,24 +73,24 @@ cmp stderr $WORK/golden/ll-after-three-onto-two.txt
 -- extra/three.txt --
 3
 -- golden/ll-before.txt --
-┏━□ one
-┃   1cd0ae2 Add one (now)
-┃ ┏━□ three
-┃ ┃   41de4ed Add three (now)
+┏━━□ one
+┃    1cd0ae2 Add one (now)
+┃ ┏━━□ three
+┃ ┃    41de4ed Add three (now)
 ┣━┻□ two
 ┃    def1539 Add two (now)
 main ◀
 -- golden/ll-after-two-onto-one.txt --
-  ┏━■ two ◀
-  ┃   6f74174 Add two (now)
+  ┏━━■ two ◀
+  ┃    6f74174 Add two (now)
 ┏━┻□ one
 ┃    1cd0ae2 Add one (now)
-┣━□ three
-┃   dcd3b5d Add three (now)
+┣━━□ three
+┃    dcd3b5d Add three (now)
 main
 -- golden/ll-after-three-onto-two.txt --
-    ┏━■ three ◀
-    ┃   6b39879 Add three (now)
+    ┏━━■ three ◀
+    ┃    6b39879 Add three (now)
   ┏━┻□ two
   ┃    6f74174 Add two (now)
 ┏━┻□ one

--- a/testdata/script/branch_onto_diverged_from_base.txt
+++ b/testdata/script/branch_onto_diverged_from_base.txt
@@ -39,13 +39,13 @@ feature 1
 feature 2
 
 -- golden/ls-before.txt --
-  ┏━■ feat2 ◀
-  ┃   e3b0e7d Add feature 2 (now)
+  ┏━━■ feat2 ◀
+  ┃    e3b0e7d Add feature 2 (now)
 ┏━┻□ feat1
 main
 -- golden/ls-after.txt --
-  ┏━■ feat2 ◀
-  ┃   9995287 Add feature 2 (now)
+  ┏━━■ feat2 ◀
+  ┃    9995287 Add feature 2 (now)
 ┏━┻□ feat1
 ┃    c6747e9 Add feature 1 (now)
 main

--- a/testdata/script/branch_onto_prompt_sort_order.txt
+++ b/testdata/script/branch_onto_prompt_sort_order.txt
@@ -48,9 +48,9 @@ Feature 3
 -- robot.golden --
 ===
 > Select a branch to move onto: 
-> ┏━□ bbb
-> ┣━□ ccc
-> ┣━□ aaa
+> ┏━━□ bbb
+> ┣━━□ ccc
+> ┣━━□ aaa
 > main ◀
 >
 > Moving bbb onto another branch

--- a/testdata/script/branch_onto_restack_config.txt
+++ b/testdata/script/branch_onto_restack_config.txt
@@ -63,24 +63,24 @@ Move 2
 -- repo/above2.txt --
 Above 2
 -- golden/config-ll.txt --
-  ┏━□ above1
-  ┃   35e266d above1 (now)
+  ┏━━□ above1
+  ┃    35e266d above1 (now)
 ┏━┻□ base1
 ┃    18643f6 base1 (now)
-┣━■ move1 ◀
-┃   5ee462d move1 (now)
+┣━━■ move1 ◀
+┃    5ee462d move1 (now)
 main
 -- golden/override-ll.txt --
-  ┏━□ above1
-  ┃   35e266d above1 (now)
+  ┏━━□ above1
+  ┃    35e266d above1 (now)
 ┏━┻□ base1
 ┃    18643f6 base1 (now)
-┃ ┏━□ above2 (needs restack)
-┃ ┃   89eb1d3 above2 (now)
+┃ ┏━━□ above2 (needs restack)
+┃ ┃    89eb1d3 above2 (now)
 ┣━┻□ base2
 ┃    239cefd base2 (now)
-┣━□ move1
-┃   5ee462d move1 (now)
-┣━■ move2 ◀
-┃   122e24b move2 (now)
+┣━━□ move1
+┃    5ee462d move1 (now)
+┣━━■ move2 ◀
+┃    122e24b move2 (now)
 main

--- a/testdata/script/branch_onto_retarget_upstack.txt
+++ b/testdata/script/branch_onto_retarget_upstack.txt
@@ -43,18 +43,18 @@ Feature 2
 -- repo/feature3.txt --
 Feature 3
 -- golden/ll-after-onto.txt --
-  ┏━□ feature3 (needs restack)
-  ┃   cda485e feature3 (now)
+  ┏━━□ feature3 (needs restack)
+  ┃    cda485e feature3 (now)
 ┏━┻□ feature1
 ┃    33bdea5 feature1 (now)
-┣━■ feature2 ◀
-┃   879767a feature2 (now)
+┣━━■ feature2 ◀
+┃    879767a feature2 (now)
 main
 -- golden/ll-after-restack.txt --
-  ┏━■ feature3 ◀
-  ┃   4723867 feature3 (now)
+  ┏━━■ feature3 ◀
+  ┃    4723867 feature3 (now)
 ┏━┻□ feature1
 ┃    33bdea5 feature1 (now)
-┣━□ feature2
-┃   879767a feature2 (now)
+┣━━□ feature2
+┃    879767a feature2 (now)
 main

--- a/testdata/script/branch_onto_two_stacks_with_downstack_history.txt
+++ b/testdata/script/branch_onto_two_stacks_with_downstack_history.txt
@@ -125,20 +125,20 @@ feature2
 # Save and quit the editor to apply the changes.
 # Delete all lines in the editor to abort the operation.
 -- golden/ls-before-stack1.txt --
-    ┏━■ feature3 ◀
+    ┏━━■ feature3 ◀
   ┏━┻□ feature2
 ┏━┻□ feature1
 main
 -- golden/ls-before-stack2.txt --
-    ┏━□ feature3 (#3)
+    ┏━━□ feature3 (#3)
   ┏━┻□ feature2 (#2)
 ┏━┻□ feature1 (#1)
-┃ ┏━■ stack2feature2 ◀
+┃ ┏━━■ stack2feature2 ◀
 ┣━┻□ stack2feature1
 main
 -- golden/ls-after.txt --
-  ┏━□ feature3 (#3)
-  ┣━□ stack2feature2 (#5)
+  ┏━━□ feature3 (#3)
+  ┣━━□ stack2feature2 (#5)
 ┏━┻■ feature2 (#2) ◀
 main
 -- golden/submit-first-stack-comments.txt --

--- a/testdata/script/branch_prompt_worktree.txt
+++ b/testdata/script/branch_prompt_worktree.txt
@@ -46,21 +46,21 @@ gs ls -a
 -- robot-unix.golden --
 ===
 > Select a branch to checkout: 
->     ┏━□ feat3
+>     ┏━━□ feat3
 >   ┏━┻□ feat2 [wt: ~/feat2]
 > ┏━┻□ feat1 [wt: ~/feat1]
 > main ◀
 "feat3"
 ===
 > Select a branch to delete: 
->     ┏━■ feat3 ◀
+>     ┏━━■ feat3 ◀
 >   ┏━┻□ feat2 [wt: ~/feat2]
 > ┏━┻□ feat1 [wt: ~/feat1]
 > main
 "feat3"
 ===
 > Select a branch to move onto: 
->   ┏━□ feat2
+>   ┏━━□ feat2
 > ┏━┻■ feat1 [wt: ~/feat1] ◀
 > main
 >
@@ -90,8 +90,8 @@ gs ls -a
 > Moving feat2 onto another branch
 "main"
 -- golden/ls-unix.txt --
-┏━□ feat1 [wt: ~/feat1]
-┣━■ feat2 ◀
+┏━━□ feat1 [wt: ~/feat1]
+┣━━■ feat2 ◀
 main
 -- golden/ls-windows.txt --
 ┏━□ feat1 [wt: ~\feat1]

--- a/testdata/script/branch_restack_dirty_tree.txt
+++ b/testdata/script/branch_restack_dirty_tree.txt
@@ -58,5 +58,5 @@ another file
 * 31b0f28 (main) Diverge
 * 9315e88 Initial commit
 -- golden/ls.txt --
-┏━■ feature (needs restack) ◀
+┏━━■ feature (needs restack) ◀
 main

--- a/testdata/script/branch_restack_manually_merged.txt
+++ b/testdata/script/branch_restack_manually_merged.txt
@@ -44,8 +44,8 @@ gs log long --all --verbose --no-prompt
 cmp stderr $WORK/golden/after-restack.txt
 
 -- golden/before-restack.txt --
-  ┏━□ feature2 (needs restack)
-  ┃   497aca1 test: Add feature2 (now)
+  ┏━━□ feature2 (needs restack)
+  ┃    497aca1 test: Add feature2 (now)
 ┏━┻■ feature1 ◀
 ┃    c8bface test: Change merged feature on feature1 (now)
 ┃    a97fc5e test: Merge feature2 into feature1 (now)
@@ -55,7 +55,7 @@ main
 -- golden/restack.txt --
 INF feature2: restacked on feature1
 -- golden/after-restack.txt --
-  ┏━■ feature2 ◀
+  ┏━━■ feature2 ◀
 ┏━┻□ feature1
 ┃    c8bface test: Change merged feature on feature1 (now)
 ┃    a97fc5e test: Merge feature2 into feature1 (now)

--- a/testdata/script/branch_split.txt
+++ b/testdata/script/branch_split.txt
@@ -32,10 +32,10 @@ feature2
 -- repo/feature3.txt --
 feature3
 -- golden/before.txt --
-┏━■ features ◀
+┏━━■ features ◀
 main
 -- golden/after.txt --
-    ┏━■ features ◀
+    ┏━━■ features ◀
   ┏━┻□ feature2
 ┏━┻□ feature1
 main

--- a/testdata/script/branch_split_err.txt
+++ b/testdata/script/branch_split_err.txt
@@ -45,10 +45,10 @@ feature2
 -- repo/feature3.txt --
 feature3
 -- golden/before.txt --
-  ┏━■ features ◀
-  ┃   20c96d0 Add feature3 (now)
-  ┃   31bf33e Add feature2 (now)
-  ┃   97bc101 Add feature1 (now)
+  ┏━━■ features ◀
+  ┃    20c96d0 Add feature3 (now)
+  ┃    31bf33e Add feature2 (now)
+  ┃    97bc101 Add feature1 (now)
 ┏━┻□ feature0
 ┃    b28a94c Add feature0 (now)
 main

--- a/testdata/script/branch_split_prefix_at_literal.txt
+++ b/testdata/script/branch_split_prefix_at_literal.txt
@@ -35,7 +35,7 @@ feature2
 -- repo/feature3.txt --
 feature3
 -- golden/after.txt --
-    ┏━■ features ◀
+    ┏━━■ features ◀
   ┏━┻□ feature2
 ┏━┻□ feature1
 main

--- a/testdata/script/branch_split_prefix_prompt.txt
+++ b/testdata/script/branch_split_prefix_prompt.txt
@@ -33,8 +33,8 @@ feature2
 -- repo/feature3.txt --
 feature3
 -- golden/after.txt --
-    ┏━■ features ◀
-    ┃   1b17c72 Add feature3 (now)
+    ┏━━■ features ◀
+    ┃    1b17c72 Add feature3 (now)
   ┏━┻□ myuser/feature2
   ┃    0c7ed55 Add feature2 (now)
 ┏━┻□ myuser/feature1

--- a/testdata/script/branch_split_prefix_reuse_name.txt
+++ b/testdata/script/branch_split_prefix_reuse_name.txt
@@ -33,8 +33,8 @@ feature2
 -- repo/feature3.txt --
 feature3
 -- golden/after.txt --
-    ┏━■ feature3 ◀
-    ┃   1b17c72 Add feature3 (now)
+    ┏━━■ feature3 ◀
+    ┃    1b17c72 Add feature3 (now)
   ┏━┻□ feature2
   ┃    0c7ed55 Add feature2 (now)
 ┏━┻□ features

--- a/testdata/script/branch_split_prompt.txt
+++ b/testdata/script/branch_split_prompt.txt
@@ -30,14 +30,14 @@ feature2
 -- repo/feature3.txt --
 feature3
 -- golden/before.txt --
-┏━■ features ◀
-┃   1b17c72 Add feature3 (now)
-┃   0c7ed55 Add feature2 (now)
-┃   a3a4c59 Add feature1 (now)
+┏━━■ features ◀
+┃    1b17c72 Add feature3 (now)
+┃    0c7ed55 Add feature2 (now)
+┃    a3a4c59 Add feature1 (now)
 main
 -- golden/after.txt --
-    ┏━■ features ◀
-    ┃   1b17c72 Add feature3 (now)
+    ┏━━■ features ◀
+    ┃    1b17c72 Add feature3 (now)
   ┏━┻□ feature2
   ┃    0c7ed55 Add feature2 (now)
 ┏━┻□ feature1

--- a/testdata/script/branch_split_reassign_submitted.txt
+++ b/testdata/script/branch_split_reassign_submitted.txt
@@ -66,10 +66,10 @@ feat 3
 -- extra/feat1-new.txt --
 new feat 1
 -- golden/ll-before.txt --
-┏━■ features ◀
-┃   f460550 feat3 (now)
-┃   f9c1263 feat2 (now)
-┃   1578492 feat1 (now)
+┏━━■ features ◀
+┃    f460550 feat3 (now)
+┃    f9c1263 feat2 (now)
+┃    1578492 feat1 (now)
 main
 -- robot.golden --
 ===
@@ -88,16 +88,16 @@ WRN features: If you push this branch with 'git push' instead of 'gs branch subm
 WRN features: remember to use a different upstream branch name with the command:
 WRN     git push -u origin features:<new name>
 -- golden/ll-split.txt --
-    ┏━■ features ◀
-    ┃   f460550 feat3 (now)
+    ┏━━■ features ◀
+    ┃    f460550 feat3 (now)
   ┏━┻□ feat2
   ┃    f9c1263 feat2 (now)
 ┏━┻□ feat1 (#1) (needs push)
 ┃    1578492 feat1 (now)
 main
 -- golden/ll-commit-feat1.txt --
-    ┏━□ features
-    ┃   d543265 feat3 (now)
+    ┏━━□ features
+    ┃    d543265 feat3 (now)
   ┏━┻□ feat2
   ┃    4432c24 feat2 (now)
 ┏━┻■ feat1 (#1) (needs push) ◀
@@ -105,8 +105,8 @@ main
 ┃    1578492 feat1 (now)
 main
 -- golden/ll-final.txt --
-    ┏━□ features (#3)
-    ┃   d543265 feat3 (now)
+    ┏━━□ features (#3)
+    ┃    d543265 feat3 (now)
   ┏━┻□ feat2 (#2)
   ┃    4432c24 feat2 (now)
 ┏━┻■ feat1 (#1) ◀

--- a/testdata/script/branch_split_reuse_name.txt
+++ b/testdata/script/branch_split_reuse_name.txt
@@ -46,14 +46,14 @@ feature2
 -- repo/feature3.txt --
 feature3
 -- golden/before.txt --
-┏━■ features ◀
-┃   1b17c72 Add feature3 (now)
-┃   0c7ed55 Add feature2 (now)
-┃   a3a4c59 Add feature1 (now)
+┏━━■ features ◀
+┃    1b17c72 Add feature3 (now)
+┃    0c7ed55 Add feature2 (now)
+┃    a3a4c59 Add feature1 (now)
 main
 -- golden/after.txt --
-    ┏━■ feature3 ◀
-    ┃   1b17c72 Add feature3 (now)
+    ┏━━■ feature3 ◀
+    ┃    1b17c72 Add feature3 (now)
   ┏━┻□ feature2
   ┃    0c7ed55 Add feature2 (now)
 ┏━┻□ features

--- a/testdata/script/branch_split_reuse_name_non_interactive.txt
+++ b/testdata/script/branch_split_reuse_name_non_interactive.txt
@@ -43,14 +43,14 @@ feature2
 -- repo/feature3.txt --
 feature3
 -- golden/before.txt --
-┏━■ features ◀
-┃   1b17c72 Add feature3 (now)
-┃   0c7ed55 Add feature2 (now)
-┃   a3a4c59 Add feature1 (now)
+┏━━■ features ◀
+┃    1b17c72 Add feature3 (now)
+┃    0c7ed55 Add feature2 (now)
+┃    a3a4c59 Add feature1 (now)
 main
 -- golden/after.txt --
-    ┏━■ feature3 ◀
-    ┃   1b17c72 Add feature3 (now)
+    ┏━━■ feature3 ◀
+    ┃    1b17c72 Add feature3 (now)
   ┏━┻□ feature2
   ┃    0c7ed55 Add feature2 (now)
 ┏━┻□ features

--- a/testdata/script/branch_split_reuse_name_with_cr.txt
+++ b/testdata/script/branch_split_reuse_name_with_cr.txt
@@ -45,14 +45,14 @@ feature2
 -- repo/feature3.txt --
 feature3
 -- golden/before_split.txt --
-┏━■ features (#1) ◀
-┃   242e421 Add feature3 (now)
-┃   3c19fb9 Add feature2 (now)
-┃   569c763 Add feature1 (now)
+┏━━■ features (#1) ◀
+┃    242e421 Add feature3 (now)
+┃    3c19fb9 Add feature2 (now)
+┃    569c763 Add feature1 (now)
 main
 -- golden/after_split.txt --
-    ┏━■ feature3 ◀
-    ┃   242e421 Add feature3 (now)
+    ┏━━■ feature3 ◀
+    ┃    242e421 Add feature3 (now)
   ┏━┻□ feature2
   ┃    3c19fb9 Add feature2 (now)
 ┏━┻□ features (#1) (needs push)

--- a/testdata/script/branch_submit_config_no_publish.txt
+++ b/testdata/script/branch_submit_config_no_publish.txt
@@ -59,9 +59,9 @@ feature 1 v3
 -- golden/no-pulls.txt --
 []
 -- golden/log-long.txt --
-┏━■ feature1 (#1) ◀
-┃   5a09fe1 feature1 v3 (now)
-┃   293742b feature1 (now)
+┏━━■ feature1 (#1) ◀
+┃    5a09fe1 feature1 v3 (now)
+┃    293742b feature1 (now)
 main
 -- golden/post-publish.txt --
 [

--- a/testdata/script/branch_submit_create_update.txt
+++ b/testdata/script/branch_submit_create_update.txt
@@ -104,7 +104,7 @@ New contents of feature1
 ]
 
 -- golden/ls.txt --
-┏━■ feature1 (#1) ◀
+┏━━■ feature1 (#1) ◀
 main
 -- golden/ls.json --
 {"name":"feature1","current":true,"down":{"name":"main"},"change":{"id":"#1","url":"$SHAMHUB_URL/alice/example/change/1","status":"open"},"push":{"ahead":0,"behind":0}}

--- a/testdata/script/branch_submit_many_upstream_names_taken.txt
+++ b/testdata/script/branch_submit_many_upstream_names_taken.txt
@@ -53,8 +53,8 @@ cmpenvJSON stdout $WORK/golden/changes.json
 -- repo/feat1.txt --
 feature 1
 -- golden/ll.txt --
-┏━■ feature (#1) ◀
-┃   4af1d44 add feature (now)
+┏━━■ feature (#1) ◀
+┃    4af1d44 add feature (now)
 main
 -- golden/changes.json --
 [

--- a/testdata/script/branch_submit_rename_base.txt
+++ b/testdata/script/branch_submit_rename_base.txt
@@ -122,8 +122,8 @@ feature 3
   }
 ]
 -- golden/ll-before.txt --
-    ┏━■ feat3 (#3) ◀
-    ┃   dc2b288 feat3 (now)
+    ┏━━■ feat3 (#3) ◀
+    ┃    dc2b288 feat3 (now)
   ┏━┻□ feat2 (#2)
   ┃    3a03742 feat2 (now)
 ┏━┻□ feature (#1)
@@ -202,8 +202,8 @@ main
   }
 ]
 -- golden/ll-after.txt --
-    ┏━□ feat3 (#3)
-    ┃   dc2b288 feat3 (now)
+    ┏━━□ feat3 (#3)
+    ┃    dc2b288 feat3 (now)
   ┏━┻□ feat2 (#2)
   ┃    3a03742 feat2 (now)
 ┏━┻■ feat1 (#1) ◀

--- a/testdata/script/branch_submit_update_pr_is_closed.txt
+++ b/testdata/script/branch_submit_update_pr_is_closed.txt
@@ -51,13 +51,13 @@ Contents of feature 1
 New contents of feature 1
 
 -- golden/open.txt --
-┏━■ feat1 (#1) ◀
-┃   fabf34f feat1 (now)
+┏━━■ feat1 (#1) ◀
+┃    fabf34f feat1 (now)
 main
 -- golden/resubmit.txt --
-┏━■ feat1 (#2) ◀
-┃   03fced6 Update feature 1 (now)
-┃   fabf34f feat1 (now)
+┏━━■ feat1 (#2) ◀
+┃    03fced6 Update feature 1 (now)
+┃    fabf34f feat1 (now)
 main
 -- golden/changes.json --
 [

--- a/testdata/script/branch_submit_update_pr_is_merged.txt
+++ b/testdata/script/branch_submit_update_pr_is_merged.txt
@@ -57,12 +57,12 @@ Contents of feature 1
 New contents of feature 1
 
 -- golden/open.txt --
-┏━■ feat1 (#1) ◀
-┃   fabf34f feat1 (now)
+┏━━■ feat1 (#1) ◀
+┃    fabf34f feat1 (now)
 main
 -- golden/resubmit.txt --
-┏━■ feat1 (#2) ◀
-┃   514d04f Update feature 1 (now)
+┏━━■ feat1 (#2) ◀
+┃    514d04f Update feature 1 (now)
 main
 -- golden/changes.json --
 [

--- a/testdata/script/branch_submit_upstream_name.txt
+++ b/testdata/script/branch_submit_upstream_name.txt
@@ -44,9 +44,9 @@ feature 1
 feature 1 new
 
 -- golden/ll.txt --
-┏━■ feat1 (#1) ◀
-┃   b7f8335 update feature 1 (now)
-┃   6731361 Add feature 1 (now)
+┏━━■ feat1 (#1) ◀
+┃    b7f8335 update feature 1 (now)
+┃    6731361 Add feature 1 (now)
 main
 -- golden/pulls.json --
 [

--- a/testdata/script/branch_submit_upstream_name_wrong_remote.txt
+++ b/testdata/script/branch_submit_upstream_name_wrong_remote.txt
@@ -41,8 +41,8 @@ cmpenvJSON stdout $WORK/golden/pulls.json
 -- extra/feat1.txt --
 feature 1
 -- golden/ll.txt --
-┏━■ feat1 (#1) ◀
-┃   aa30b56 Add feature 1 (now)
+┏━━■ feat1 (#1) ◀
+┃    aa30b56 Add feature 1 (now)
 main
 -- golden/pulls.json --
 [

--- a/testdata/script/commit_fixup_prompt.txt
+++ b/testdata/script/commit_fixup_prompt.txt
@@ -67,8 +67,8 @@ Fixed file1 content
 -- robot.golden --
 ===
 > Pick a commit: 
->     ┏━□ feature3 
->     ┃   ▶ f0e8dfd Add file3 (now)
+>     ┏━━□ feature3 
+>     ┃    ▶ f0e8dfd Add file3 (now)
 >   ┏━┻□ feature2 
 >   ┃      47d73f5 Update feature2 (now) 
 >   ┃      a467257 Add file2 (now)

--- a/testdata/script/commit_pick_interactive.txt
+++ b/testdata/script/commit_pick_interactive.txt
@@ -55,9 +55,9 @@ feature 1 adjustment
 -- robot.golden --
 ===
 > Pick a commit: 
->     ┏━□ feat3 
->     ┃   ▶ f596d7f feature 1 adjustment (now) 
->     ┃     18a7878 feat3 (now)
+>     ┏━━□ feat3 
+>     ┃    ▶ f596d7f feature 1 adjustment (now) 
+>     ┃      18a7878 feat3 (now)
 >   ┏━┻□ feat2 
 >   ┃      54bd7cc feat2 (now)
 > ┏━┻□ feat1

--- a/testdata/script/commit_pick_trunk_prompt.txt
+++ b/testdata/script/commit_pick_trunk_prompt.txt
@@ -66,5 +66,5 @@ Feature content
 * d146e2e (HEAD -> main, feature) Add feature file
 * 63343e8 Initial commit
 -- golden/ls.txt --
-┏━□ feature
+┏━━□ feature
 main ◀

--- a/testdata/script/commit_split.txt
+++ b/testdata/script/commit_split.txt
@@ -149,8 +149,8 @@ Date:   Mon Jul 8 05:04:32 2024 +0000
 
     Initial commit
 -- golden/ll.txt --
-  ┏━□ feature3
-  ┃   be650d2 Add feature 3 (now)
+  ┏━━□ feature3
+  ┃    be650d2 Add feature 3 (now)
 ┏━┻■ features ◀
 ┃    d5849e7 Add features (now)
 ┃    5c5b54e Add feature 1 (now)

--- a/testdata/script/commit_split_no_verify.txt
+++ b/testdata/script/commit_split_no_verify.txt
@@ -157,8 +157,8 @@ Date:   Mon Jul 8 05:04:32 2024 +0000
 
     Initial commit
 -- golden/ll.txt --
-  ┏━□ feature3
-  ┃   be650d2 Add feature 3 (now)
+  ┏━━□ feature3
+  ┃    be650d2 Add feature 3 (now)
 ┏━┻■ features ◀
 ┃    d5849e7 Add features (now)
 ┃    5c5b54e Add feature 1 (now)

--- a/testdata/script/config_log_all.txt
+++ b/testdata/script/config_log_all.txt
@@ -38,32 +38,32 @@ gs ll
 cmp stderr $WORK/golden/ll-after.txt
 
 -- golden/ls-before.txt --
-    ┏━■ feat3 ◀
+    ┏━━■ feat3 ◀
   ┏━┻□ feat2
 ┏━┻□ feat1
 main
 -- golden/ll-before.txt --
-    ┏━■ feat3 ◀
-    ┃   7b5eba4 feat3 (now)
+    ┏━━■ feat3 ◀
+    ┃    7b5eba4 feat3 (now)
   ┏━┻□ feat2
   ┃    562c8c6 feat2 (now)
 ┏━┻□ feat1
 ┃    ecc906e feat1 (now)
 main
 -- golden/ls-after.txt --
-    ┏━■ feat3 ◀
+    ┏━━■ feat3 ◀
   ┏━┻□ feat2
-  ┃ ┏━□ feat5
+  ┃ ┏━━□ feat5
   ┣━┻□ feat4
 ┏━┻□ feat1
 main
 -- golden/ll-after.txt --
-    ┏━■ feat3 ◀
-    ┃   7b5eba4 feat3 (now)
+    ┏━━■ feat3 ◀
+    ┃    7b5eba4 feat3 (now)
   ┏━┻□ feat2
   ┃    562c8c6 feat2 (now)
-  ┃ ┏━□ feat5
-  ┃ ┃   874abc7 feat5 (now)
+  ┃ ┏━━□ feat5
+  ┃ ┃    874abc7 feat5 (now)
   ┣━┻□ feat4
   ┃    0eb14d6 feat4 (now)
 ┏━┻□ feat1

--- a/testdata/script/config_log_change_format.txt
+++ b/testdata/script/config_log_change_format.txt
@@ -43,13 +43,13 @@ gs ll
 cmpenv stderr $WORK/golden/ll-after-crformat-url.txt
 
 -- golden/ls-after-crformat-url.txt --
-    ┏━■ feat3 ◀
+    ┏━━■ feat3 ◀
   ┏━┻□ feat2
 ┏━┻□ feat1 ($SHAMHUB_URL/alice/example/change/1)
 main
 -- golden/ll-after-crformat-url.txt --
-    ┏━■ feat3 ◀
-    ┃   7b5eba4 feat3 (now)
+    ┏━━■ feat3 ◀
+    ┃    7b5eba4 feat3 (now)
   ┏━┻□ feat2
   ┃    562c8c6 feat2 (now)
 ┏━┻□ feat1 ($SHAMHUB_URL/alice/example/change/1)

--- a/testdata/script/config_log_combined_change_format.txt
+++ b/testdata/script/config_log_combined_change_format.txt
@@ -61,32 +61,32 @@ gs ll
 cmpenv stderr $WORK/golden/ll-fallback-id.txt
 
 -- golden/ls-general-url.txt --
-  ┏━■ feat2 ◀
+  ┏━━■ feat2 ◀
 ┏━┻□ feat1 ($SHAMHUB_URL/alice/example/change/1)
 main
 -- golden/ll-general-url.txt --
-  ┏━■ feat2 ◀
-  ┃   562c8c6 feat2 (now)
+  ┏━━■ feat2 ◀
+  ┃    562c8c6 feat2 (now)
 ┏━┻□ feat1 ($SHAMHUB_URL/alice/example/change/1)
 ┃    ecc906e feat1 (now)
 main
 -- golden/ls-specific-id.txt --
-  ┏━■ feat2 ◀
+  ┏━━■ feat2 ◀
 ┏━┻□ feat1 (#1)
 main
 -- golden/ll-specific-url.txt --
-  ┏━■ feat2 ◀
-  ┃   562c8c6 feat2 (now)
+  ┏━━■ feat2 ◀
+  ┃    562c8c6 feat2 (now)
 ┏━┻□ feat1 ($SHAMHUB_URL/alice/example/change/1)
 ┃    ecc906e feat1 (now)
 main
 -- golden/ls-fallback-id.txt --
-  ┏━■ feat2 ◀
+  ┏━━■ feat2 ◀
 ┏━┻□ feat1 (#1)
 main
 -- golden/ll-fallback-id.txt --
-  ┏━■ feat2 ◀
-  ┃   562c8c6 feat2 (now)
+  ┏━━■ feat2 ◀
+  ┃    562c8c6 feat2 (now)
 ┏━┻□ feat1 (#1)
 ┃    ecc906e feat1 (now)
 main

--- a/testdata/script/config_log_long_change_format.txt
+++ b/testdata/script/config_log_long_change_format.txt
@@ -59,32 +59,32 @@ gs ll
 cmpenv stderr $WORK/golden/ll-override-id.txt
 
 -- golden/ll-default.txt --
-  ┏━■ feat2 ◀
-  ┃   562c8c6 feat2 (now)
+  ┏━━■ feat2 ◀
+  ┃    562c8c6 feat2 (now)
 ┏━┻□ feat1 (#1)
 ┃    ecc906e feat1 (now)
 main
 -- golden/ll-loglong-url.txt --
-  ┏━■ feat2 ◀
-  ┃   562c8c6 feat2 (now)
+  ┏━━■ feat2 ◀
+  ┃    562c8c6 feat2 (now)
 ┏━┻□ feat1 ($SHAMHUB_URL/alice/example/change/1)
 ┃    ecc906e feat1 (now)
 main
 -- golden/ll-loglong-id.txt --
-  ┏━■ feat2 ◀
-  ┃   562c8c6 feat2 (now)
+  ┏━━■ feat2 ◀
+  ┃    562c8c6 feat2 (now)
 ┏━┻□ feat1 (#1)
 ┃    ecc906e feat1 (now)
 main
 -- golden/ll-fallback-url.txt --
-  ┏━■ feat2 ◀
-  ┃   562c8c6 feat2 (now)
+  ┏━━■ feat2 ◀
+  ┃    562c8c6 feat2 (now)
 ┏━┻□ feat1 ($SHAMHUB_URL/alice/example/change/1)
 ┃    ecc906e feat1 (now)
 main
 -- golden/ll-override-id.txt --
-  ┏━■ feat2 ◀
-  ┃   562c8c6 feat2 (now)
+  ┏━━■ feat2 ◀
+  ┃    562c8c6 feat2 (now)
 ┏━┻□ feat1 (#1)
 ┃    ecc906e feat1 (now)
 main

--- a/testdata/script/config_log_push_status_format.txt
+++ b/testdata/script/config_log_push_status_format.txt
@@ -81,42 +81,42 @@ feat3 new
 -- extra/feat2-new.txt --
 feat2 new
 -- golden/ls-feat3-default.txt --
-    ┏━■ feat3 (#3) (needs push) ◀
+    ┏━━■ feat3 (#3) (needs push) ◀
   ┏━┻□ feat2 (#2)
 ┏━┻□ feat1 (#1)
 main
 -- golden/ll-feat3-default.txt --
-    ┏━■ feat3 (#3) (needs push) ◀
-    ┃   e00a44b update feat3 (now)
-    ┃   61be7b8 feat3 (now)
+    ┏━━■ feat3 (#3) (needs push) ◀
+    ┃    e00a44b update feat3 (now)
+    ┃    61be7b8 feat3 (now)
   ┏━┻□ feat2 (#2)
   ┃    92d90ce feat2 (now)
 ┏━┻□ feat1 (#1)
 ┃    8761af2 feat1 (now)
 main
 -- golden/ls-feat3-disabled.txt --
-    ┏━■ feat3 (#3) ◀
+    ┏━━■ feat3 (#3) ◀
   ┏━┻□ feat2 (#2)
 ┏━┻□ feat1 (#1)
 main
 -- golden/ll-feat3-disabled.txt --
-    ┏━■ feat3 (#3) ◀
-    ┃   e00a44b update feat3 (now)
-    ┃   61be7b8 feat3 (now)
+    ┏━━■ feat3 (#3) ◀
+    ┃    e00a44b update feat3 (now)
+    ┃    61be7b8 feat3 (now)
   ┏━┻□ feat2 (#2)
   ┃    92d90ce feat2 (now)
 ┏━┻□ feat1 (#1)
 ┃    8761af2 feat1 (now)
 main
 -- golden/ls-feat2-enabled.txt --
-    ┏━□ feat3 (#3) (needs restack) (needs push)
+    ┏━━□ feat3 (#3) (needs restack) (needs push)
   ┏━┻■ feat2 (#2) (needs push) ◀
 ┏━┻□ feat1 (#1)
 main
 -- golden/ll-feat2-enabled.txt --
-    ┏━□ feat3 (#3) (needs restack) (needs push)
-    ┃   e00a44b update feat3 (now)
-    ┃   61be7b8 feat3 (now)
+    ┏━━□ feat3 (#3) (needs restack) (needs push)
+    ┃    e00a44b update feat3 (now)
+    ┃    61be7b8 feat3 (now)
   ┏━┻■ feat2 (#2) (needs push) ◀
   ┃    b5b29cc update feat2 (now)
   ┃    92d90ce feat2 (now)
@@ -124,14 +124,14 @@ main
 ┃    8761af2 feat1 (now)
 main
 -- golden/ls-feat2-aheadBehind.txt --
-    ┏━□ feat3 (#3) (needs restack) (⇡1)
+    ┏━━□ feat3 (#3) (needs restack) (⇡1)
   ┏━┻■ feat2 (#2) (⇡1) ◀
 ┏━┻□ feat1 (#1)
 main
 -- golden/ll-feat2-aheadBehind.txt --
-    ┏━□ feat3 (#3) (needs restack) (⇡1)
-    ┃   e00a44b update feat3 (now)
-    ┃   61be7b8 feat3 (now)
+    ┏━━□ feat3 (#3) (needs restack) (⇡1)
+    ┃    e00a44b update feat3 (now)
+    ┃    61be7b8 feat3 (now)
   ┏━┻■ feat2 (#2) (⇡1) ◀
   ┃    b5b29cc update feat2 (now)
   ┃    92d90ce feat2 (now)

--- a/testdata/script/config_log_short_change_format.txt
+++ b/testdata/script/config_log_short_change_format.txt
@@ -59,22 +59,22 @@ gs ls
 cmpenv stderr $WORK/golden/ls-override-id.txt
 
 -- golden/ls-default.txt --
-  ┏━■ feat2 ◀
+  ┏━━■ feat2 ◀
 ┏━┻□ feat1 (#1)
 main
 -- golden/ls-logshort-url.txt --
-  ┏━■ feat2 ◀
+  ┏━━■ feat2 ◀
 ┏━┻□ feat1 ($SHAMHUB_URL/alice/example/change/1)
 main
 -- golden/ls-logshort-id.txt --
-  ┏━■ feat2 ◀
+  ┏━━■ feat2 ◀
 ┏━┻□ feat1 (#1)
 main
 -- golden/ls-fallback-url.txt --
-  ┏━■ feat2 ◀
+  ┏━━■ feat2 ◀
 ┏━┻□ feat1 ($SHAMHUB_URL/alice/example/change/1)
 main
 -- golden/ls-override-id.txt --
-  ┏━■ feat2 ◀
+  ┏━━■ feat2 ◀
 ┏━┻□ feat1 (#1)
 main

--- a/testdata/script/downstack_track_join_existing.txt
+++ b/testdata/script/downstack_track_join_existing.txt
@@ -44,18 +44,18 @@ Feature 3 content
 -- repo/feat4.txt --
 Feature 4 content
 -- golden/before-ls.txt --
-  ┏━□ feat2
+  ┏━━□ feat2
 ┏━┻□ feat1
 main
 -- golden/after-ls.txt --
-      ┏━■ feat4 ◀
+      ┏━━■ feat4 ◀
     ┏━┻□ feat3
   ┏━┻□ feat2
 ┏━┻□ feat1
 main
 -- golden/after-ll.txt --
-      ┏━■ feat4 ◀
-      ┃   794d949 Add feat4 (now)
+      ┏━━■ feat4 ◀
+      ┃    794d949 Add feat4 (now)
     ┏━┻□ feat3
     ┃    5c7162f Add feat3 (now)
   ┏━┻□ feat2

--- a/testdata/script/downstack_track_linear.txt
+++ b/testdata/script/downstack_track_linear.txt
@@ -47,22 +47,22 @@ Feature 2 content
 -- repo/feat3.txt --
 Feature 3 content
 -- golden/linear-ls-feat3.txt --
-    ┏━■ feat3 ◀
+    ┏━━■ feat3 ◀
   ┏━┻□ feat2
 ┏━┻□ feat1
 main
 -- golden/linear-ll-feat3.txt --
-    ┏━■ feat3 ◀
-    ┃   dd76d28 Add feat3 (now)
+    ┏━━■ feat3 ◀
+    ┃    dd76d28 Add feat3 (now)
   ┏━┻□ feat2
   ┃    302dc4b Add feat2 (now)
 ┏━┻□ feat1
 ┃    79bb101 Add feat1 (now)
 main
 -- golden/linear-ls-feat1.txt --
-┏━□ feat1
+┏━━□ feat1
 main
 -- golden/linear-ll-feat1.txt --
-┏━□ feat1
-┃   79bb101 Add feat1 (now)
+┏━━□ feat1
+┃    79bb101 Add feat1 (now)
 main

--- a/testdata/script/downstack_track_linear_interactive.txt
+++ b/testdata/script/downstack_track_linear_interactive.txt
@@ -136,8 +136,8 @@ feature 8
 > We can track it as the base for feat3, or skip it.
 "feat1"
 -- golden/ll.txt --
-        ┏━■ feat8 ◀
-        ┃   ed87235 Add feat8 (now)
+        ┏━━■ feat8 ◀
+        ┃    ed87235 Add feat8 (now)
       ┏━┻□ feat7
       ┃    72d250a Add feat7 (now)
       ┃    67f3bad Add feat6 (now)

--- a/testdata/script/downstack_track_prompt_onto_tracked.txt
+++ b/testdata/script/downstack_track_prompt_onto_tracked.txt
@@ -67,13 +67,13 @@ Feature 3 content
 > We can track it as the base for feat2, or skip it.
 "feat1"
 -- golden/ls.txt --
-    ┏━■ feat3 ◀
+    ┏━━■ feat3 ◀
   ┏━┻□ feat2
 ┏━┻□ feat1
 main
 -- golden/ll.txt --
-    ┏━■ feat3 ◀
-    ┃   4daf884 Add feat3 (now)
+    ┏━━■ feat3 ◀
+    ┃    4daf884 Add feat3 (now)
   ┏━┻□ feat2
   ┃    f81ebba Add feat2 (now)
 ┏━┻□ feat1

--- a/testdata/script/issue1019_repo_sync_restack_drops_commits.txt
+++ b/testdata/script/issue1019_repo_sync_restack_drops_commits.txt
@@ -105,12 +105,12 @@ Contents of file1
 Contents of file2
 
 -- golden/ll-before.txt --
-┏━■ feature ◀
-┃   4bb9afa Second feature commit (now)
-┃   260e03c First feature commit (now)
+┏━━■ feature ◀
+┃    4bb9afa Second feature commit (now)
+┃    260e03c First feature commit (now)
 main
 -- golden/ll-after.txt --
-┏━■ feature ◀
-┃   28d574d Second feature commit (now)
-┃   8d031d0 First feature commit (now)
+┏━━■ feature ◀
+┃    28d574d Second feature commit (now)
+┃    8d031d0 First feature commit (now)
 main

--- a/testdata/script/issue1134_repo_sync_no_implicit_restack.txt
+++ b/testdata/script/issue1134_repo_sync_no_implicit_restack.txt
@@ -65,8 +65,8 @@ b
 -- repo/c.txt --
 c
 -- golden/ll-after-sync.txt --
-┏━■ c (#3) (needs restack) ◀
-┃   bd749dc Add c (now)
+┏━━■ c (#3) (needs restack) ◀
+┃    bd749dc Add c (now)
 main
 -- golden/graph-after-sync.txt --
 * bd749dc (HEAD -> c, origin/c) Add c
@@ -83,8 +83,8 @@ main
 |/  
 * b567761 Initial commit
 -- golden/ll-after-restack.txt --
-┏━■ c (#3) (needs push) ◀
-┃   9eaaa26 Add c (now)
+┏━━■ c (#3) (needs push) ◀
+┃    9eaaa26 Add c (now)
 main
 -- golden/graph-after-restack.txt --
 * 9eaaa26 (HEAD -> c) Add c

--- a/testdata/script/issue1387_log_reset_branch_on_trunk.txt
+++ b/testdata/script/issue1387_log_reset_branch_on_trunk.txt
@@ -51,13 +51,13 @@ trunk E
 -- golden/first-log.txt --
 DBG Recorded base hash is out of date. Using fork point as ownership boundary.  base=main branch=topic-one forkPoint=1dc006f
 DBG Updating recorded base hash  branch=topic-one base=main
-┏━□ topic-one (needs restack)
+┏━━□ topic-one (needs restack)
 main ◀
 -- golden/second-log.txt --
-┏━□ topic-one (needs restack)
+┏━━□ topic-one (needs restack)
 main ◀
 -- golden/restack.txt --
 INF topic-one: restacked on main
 -- golden/after-restack.txt --
-┏━■ topic-one ◀
+┏━━■ topic-one ◀
 main

--- a/testdata/script/issue1387_log_track_branch_behind_trunk.txt
+++ b/testdata/script/issue1387_log_track_branch_behind_trunk.txt
@@ -42,5 +42,5 @@ trunk D
 -- extra/trunk-e.txt --
 trunk E
 -- golden/log.txt --
-┏━□ topic-two (needs restack)
+┏━━□ topic-two (needs restack)
 main ◀

--- a/testdata/script/issue208_commit_no_restack_current.txt
+++ b/testdata/script/issue208_commit_no_restack_current.txt
@@ -63,5 +63,5 @@ part 2 of feature 1
 |/  
 * 43089bc Initial commit
 -- golden/ls.txt --
-┏━■ feature1 (needs restack) ◀
+┏━━■ feature1 (needs restack) ◀
 main

--- a/testdata/script/issue391_repo_sync_pull_unsupported_forge.txt
+++ b/testdata/script/issue391_repo_sync_pull_unsupported_forge.txt
@@ -77,8 +77,8 @@ feature 2
 * 1993921 (origin/main, main) feat1
 * 8b0535b Initial commit
 -- golden/repo-sync-ll.txt --
-┏━■ feat2 ◀
-┃   b3ed169 feat2 (now)
+┏━━■ feat2 ◀
+┃    b3ed169 feat2 (now)
 main
 -- golden/repo-sync-graph-2.txt --
 * b3ed169 (HEAD -> main, origin/main) feat2

--- a/testdata/script/issue398_repo_sync_many_merged.txt
+++ b/testdata/script/issue398_repo_sync_many_merged.txt
@@ -111,14 +111,14 @@ feat3 part2
 -- repo/feat4.part2.txt --
 feat4 part2
 -- golden/ll.start.txt --
-  ┏━□ feat1-part2
-  ┃   3b90c1c feat1.part2 (now)
-  ┃ ┏━□ feat2-part2
-  ┃ ┃   a252f85 feat2.part2 (now)
-  ┃ ┃ ┏━□ feat3-part2
-  ┃ ┃ ┃   9a90907 feat3.part2 (now)
-  ┃ ┃ ┃ ┏━□ feat4-part2
-  ┃ ┃ ┃ ┃   d568d96 feat4.part2 (now)
+  ┏━━□ feat1-part2
+  ┃    3b90c1c feat1.part2 (now)
+  ┃ ┏━━□ feat2-part2
+  ┃ ┃    a252f85 feat2.part2 (now)
+  ┃ ┃ ┏━━□ feat3-part2
+  ┃ ┃ ┃    9a90907 feat3.part2 (now)
+  ┃ ┃ ┃ ┏━━□ feat4-part2
+  ┃ ┃ ┃ ┃    d568d96 feat4.part2 (now)
   ┃ ┃ ┣━┻□ feat4
   ┃ ┃ ┃    267a7ec feat4 (now)
   ┃ ┣━┻□ feat3
@@ -129,10 +129,10 @@ feat4 part2
 ┃    fc49b37 feat1 (now)
 main ◀
 -- golden/ls.submit.txt --
-  ┏━□ feat1-part2 (#5)
-  ┃ ┏━□ feat2-part2 (#6)
-  ┃ ┃ ┏━□ feat3-part2 (#7)
-  ┃ ┃ ┃ ┏━□ feat4-part2 (#8)
+  ┏━━□ feat1-part2 (#5)
+  ┃ ┏━━□ feat2-part2 (#6)
+  ┃ ┃ ┏━━□ feat3-part2 (#7)
+  ┃ ┃ ┃ ┏━━□ feat4-part2 (#8)
   ┃ ┃ ┣━┻□ feat4 (#4)
   ┃ ┣━┻□ feat3 (#3)
   ┣━┻□ feat2 (#2)
@@ -165,12 +165,12 @@ main ◀
 |/  
 * f6036b5 Initial commit
 -- golden/ll.final.txt --
-┏━□ feat1-part2 (#5) (needs restack)
-┃   3b90c1c feat1.part2 (now)
-┣━□ feat2-part2 (#6) (needs restack)
-┃   a252f85 feat2.part2 (now)
-┣━□ feat3-part2 (#7) (needs restack)
-┃   9a90907 feat3.part2 (now)
-┣━□ feat4-part2 (#8) (needs restack)
-┃   d568d96 feat4.part2 (now)
+┏━━□ feat1-part2 (#5) (needs restack)
+┃    3b90c1c feat1.part2 (now)
+┣━━□ feat2-part2 (#6) (needs restack)
+┃    a252f85 feat2.part2 (now)
+┣━━□ feat3-part2 (#7) (needs restack)
+┃    9a90907 feat3.part2 (now)
+┣━━□ feat4-part2 (#8) (needs restack)
+┃    d568d96 feat4.part2 (now)
 main ◀

--- a/testdata/script/issue701_stack_edit_with_unstaged_changes.txt
+++ b/testdata/script/issue701_stack_edit_with_unstaged_changes.txt
@@ -63,7 +63,7 @@ Feature 3
 -- other/feat2-new.txt --
 Feature 2 (modified)
 -- golden/ls-before.txt --
-  ┏━■ feat1 ◀
+  ┏━━■ feat1 ◀
 ┏━┻□ feat2
 main
 -- edit/give.txt --
@@ -88,8 +88,8 @@ ERR Resolve the conflict and run 'git stash drop' to remove the stash entry.
 ERR Or change to a branch where the stash can apply, and run 'git stash pop'.
 FTL gs: edit downstack: branch feat1 onto main: rebase: feat1: dirty changes could not be re-applied
 -- golden/ls-after-fail.txt --
-  ┏━■ feat1 (needs restack) ◀
-  ┃   94ce439 Add feature 1 (now)
+  ┏━━■ feat1 (needs restack) ◀
+  ┃    94ce439 Add feature 1 (now)
 ┏━┻□ feat2
 ┃    d9e6a97 Add feature 2 (now)
 main
@@ -99,8 +99,8 @@ main
 |/  
 * 632b702 (main) Initial commit
 -- golden/ls-after.txt --
-  ┏━■ feat2 ◀
-  ┃   c709a8d Add feature 2 (now)
+  ┏━━■ feat2 ◀
+  ┃    c709a8d Add feature 2 (now)
 ┏━┻□ feat1
 ┃    94ce439 Add feature 1 (now)
 main

--- a/testdata/script/issue731_rebase_update_refs_warnings.txt
+++ b/testdata/script/issue731_rebase_update_refs_warnings.txt
@@ -54,8 +54,8 @@ change A
 additional change in A
 
 -- golden/ll-before.txt --
-      ┏━■ featD ◀
-      ┃   dab4857 commit D (now)
+      ┏━━■ featD ◀
+      ┃    dab4857 commit D (now)
     ┏━┻□ featC
     ┃    f56fce0 commit C (now)
   ┏━┻□ featB
@@ -64,8 +64,8 @@ additional change in A
 ┃    eb56755 commit A (now)
 main
 -- golden/ll-after.txt --
-      ┏━■ featD ◀
-      ┃   285a1b7 commit D (now)
+      ┏━━■ featD ◀
+      ┃    285a1b7 commit D (now)
     ┏━┻□ featC
     ┃    f21feba commit C (now)
   ┏━┻□ featB

--- a/testdata/script/issue897_repo_sync_with_worktree_branch.txt
+++ b/testdata/script/issue897_repo_sync_with_worktree_branch.txt
@@ -77,8 +77,8 @@ feat-1
 feat-2
 
 -- golden/ll-after-sync-unix.txt --
-┏━□ feat-2 (#2) [wt: ~/feat-2] (needs restack)
-┃   7e23316 Add feat-2 (now)
+┏━━□ feat-2 (#2) [wt: ~/feat-2] (needs restack)
+┃    7e23316 Add feat-2 (now)
 main ◀
 -- golden/ll-after-sync-windows.txt --
 ┏━□ feat-2 (#2) [wt: ~\feat-2] (needs restack)
@@ -94,8 +94,8 @@ main ◀
 |/  
 * c5c110d Initial commit
 -- golden/ll-after-restack-unix.txt --
-┏━□ feat-2 (#2) [wt: ~/feat-2] (needs push)
-┃   19505d8 Add feat-2 (now)
+┏━━□ feat-2 (#2) [wt: ~/feat-2] (needs push)
+┃    19505d8 Add feat-2 (now)
 main ◀
 -- golden/ll-after-restack-windows.txt --
 ┏━□ feat-2 (#2) [wt: ~\feat-2] (needs push)

--- a/testdata/script/issue934_bc_am_with_no_commit_default.txt
+++ b/testdata/script/issue934_bc_am_with_no_commit_default.txt
@@ -33,7 +33,7 @@ git status --porcelain
 -- repo/feature.txt --
 This is a new feature file.
 -- golden/ls.txt --
-┏━■ add-feature ◀
+┏━━■ add-feature ◀
 main
 -- golden/commit-message.txt --
 Add feature

--- a/testdata/script/issue936_stack_submit_interactive_draft_prompt.txt
+++ b/testdata/script/issue936_stack_submit_interactive_draft_prompt.txt
@@ -80,7 +80,7 @@ false
 false
 
 -- golden/ls.txt --
-    ┏━■ feat3 (#3) ◀
+    ┏━━■ feat3 (#3) ◀
   ┏━┻□ feat2 (#2)
 ┏━┻□ feat1 (#1)
 main

--- a/testdata/script/issue944_special_chars_in_branch_names.txt
+++ b/testdata/script/issue944_special_chars_in_branch_names.txt
@@ -70,7 +70,7 @@ Café feature content
 -- repo/feat5.txt --
 Japanese feature content
 -- golden/ls-after-create.txt --
-        ┏━■ feature/日本語 ◀
+        ┏━━■ feature/日本語 ◀
       ┏━┻□ feature/café
     ┏━┻□ feature/👨‍💻-developer
   ┏━┻□ feature/✅-checkmark
@@ -196,7 +196,7 @@ main
 ]
 
 -- golden/ls-after-restack.txt --
-      ┏━■ feature/日本語 (#5) (needs push) ◀
+      ┏━━■ feature/日本語 (#5) (needs push) ◀
     ┏━┻□ feature/café (#4) (needs push)
   ┏━┻□ feature/👨‍💻-developer (#3) (needs push)
 ┏━┻□ feature/θ-theta (#1)

--- a/testdata/script/log_comments.txt
+++ b/testdata/script/log_comments.txt
@@ -68,26 +68,26 @@ feat2
 feat3
 
 -- golden/ls-without-comments.txt --
-    ┏━■ feat3 (#3) ◀
+    ┏━━■ feat3 (#3) ◀
   ┏━┻□ feat2 (#2)
 ┏━┻□ feat1 (#1)
 main
 -- golden/ll-without-comments.txt --
-    ┏━■ feat3 (#3) ◀
-    ┃   7112afb feat3 (now)
+    ┏━━■ feat3 (#3) ◀
+    ┃    7112afb feat3 (now)
   ┏━┻□ feat2 (#2)
   ┃    87abb98 feat2 (now)
 ┏━┻□ feat1 (#1)
 ┃    92fc5a4 feat1 (now)
 main
 -- golden/ls-with-comments.txt --
-    ┏━■ feat3 (#3) ◀
+    ┏━━■ feat3 (#3) ◀
   ┏━┻□ feat2 (#2) [☑️1/1💬]
 ┏━┻□ feat1 (#1) [☑️1/2💬]
 main
 -- golden/ll-with-comments.txt --
-    ┏━■ feat3 (#3) ◀
-    ┃   7112afb feat3 (now)
+    ┏━━■ feat3 (#3) ◀
+    ┃    7112afb feat3 (now)
   ┏━┻□ feat2 (#2) [☑️1/1💬]
   ┃    87abb98 feat2 (now)
 ┏━┻□ feat1 (#1) [☑️1/2💬]

--- a/testdata/script/log_cr_status.txt
+++ b/testdata/script/log_cr_status.txt
@@ -72,26 +72,26 @@ feat3
 feat4
 
 -- golden/ls-without-status.txt --
-    ┏━■ feat3 (#3) ◀
+    ┏━━■ feat3 (#3) ◀
   ┏━┻□ feat2 (#2)
 ┏━┻□ feat1 (#1)
 main
 -- golden/ll-without-status.txt --
-    ┏━■ feat3 (#3) ◀
-    ┃   67480b6 feat3 (now)
+    ┏━━■ feat3 (#3) ◀
+    ┃    67480b6 feat3 (now)
   ┏━┻□ feat2 (#2)
   ┃    769cbf5 feat2 (now)
 ┏━┻□ feat1 (#1)
 ┃    ed5e364 feat1 (now)
 main
 -- golden/ls-with-status.txt --
-    ┏━■ feat3 (#3 closed) ◀
+    ┏━━■ feat3 (#3 closed) ◀
   ┏━┻□ feat2 (#2 open)
 ┏━┻□ feat1 (#1 merged)
 main
 -- golden/ll-with-status.txt --
-    ┏━■ feat3 (#3 closed) ◀
-    ┃   67480b6 feat3 (now)
+    ┏━━■ feat3 (#3 closed) ◀
+    ┃    67480b6 feat3 (now)
   ┏━┻□ feat2 (#2 open)
   ┃    769cbf5 feat2 (now)
 ┏━┻□ feat1 (#1 merged)

--- a/testdata/script/log_from_untracked_and_detached.txt
+++ b/testdata/script/log_from_untracked_and_detached.txt
@@ -52,9 +52,9 @@ cmp stdout $WORK/golden/log_long.json
 untracked content
 
 -- golden/log_short.txt --
-    ┏━□ feat3
+    ┏━━□ feat3
   ┏━┻□ feat2
-  ┃ ┏━□ feat5
+  ┃ ┏━━□ feat5
   ┣━┻□ feat4
 ┏━┻□ feat1
 main
@@ -73,12 +73,12 @@ main
 {"name":"feat5","down":{"name":"feat4"},"commits":[{"sha":"5b70527eb6680668e05a29111c083ae23292c6e4","subject":"Add feature 5"}]}
 {"name":"main","ups":[{"name":"feat1"}]}
 -- golden/log_long.txt --
-    ┏━□ feat3
-    ┃   9276838 Add feature 3 (now)
+    ┏━━□ feat3
+    ┃    9276838 Add feature 3 (now)
   ┏━┻□ feat2
   ┃    588a367 Add feature 2 (now)
-  ┃ ┏━□ feat5
-  ┃ ┃   5b70527 Add feature 5 (now)
+  ┃ ┏━━□ feat5
+  ┃ ┃    5b70527 Add feature 5 (now)
   ┣━┻□ feat4
   ┃    9037034 Add feature 4 (now)
 ┏━┻□ feat1

--- a/testdata/script/log_long.txt
+++ b/testdata/script/log_long.txt
@@ -72,8 +72,8 @@ stuff
 more
 
 -- golden/linear.txt --
-        ┏━■ feature5 ◀
-        ┃   32bf40a Add feature5 (now)
+        ┏━━■ feature5 ◀
+        ┃    32bf40a Add feature5 (now)
       ┏━┻□ feature4
       ┃    16fd303 Add feature4 (16 minutes ago)
     ┏━┻□ feature3
@@ -84,8 +84,8 @@ more
 ┃    b649e21 Add feature1 (1 hour ago)
 main
 -- golden/linear_next_day.txt --
-        ┏━□ feature5
-        ┃   165476c Add feature5 (1 day ago)
+        ┏━━□ feature5
+        ┃    165476c Add feature5 (1 day ago)
       ┏━┻□ feature4
       ┃    97739c2 Add feature4 (1 day ago)
     ┏━┻■ feature3 ◀
@@ -97,8 +97,8 @@ main
 ┃    b649e21 Add feature1 (1 day ago)
 main
 -- golden/linear_next_month.txt --
-        ┏━□ feature5
-        ┃   02d2ceb Add feature5 (1 month ago)
+        ┏━━□ feature5
+        ┃    02d2ceb Add feature5 (1 month ago)
       ┏━┻□ feature4
       ┃    88bfff0 Add feature4 (1 month ago)
     ┏━┻□ feature3
@@ -139,8 +139,8 @@ main
 {"name":"feature5","down":{"name":"feature4"},"commits":[{"sha":"02d2cebb53f1cf3226c9a080e3866d442e20fb3c","subject":"Add feature5"}]}
 {"name":"main","ups":[{"name":"feature1"}]}
 -- golden/merge_commit.txt --
-        ┏━□ feature5
-        ┃   02d2ceb Add feature5 (1 month ago)
+        ┏━━□ feature5
+        ┃    02d2ceb Add feature5 (1 month ago)
       ┏━┻□ feature4
       ┃    88bfff0 Add feature4 (1 month ago)
     ┏━┻□ feature3

--- a/testdata/script/log_short_branch_deleted_out_of_band.txt
+++ b/testdata/script/log_short_branch_deleted_out_of_band.txt
@@ -25,12 +25,12 @@ gs ls
 cmp stderr $WORK/golden/ls-after.txt
 
 -- golden/ls-before.txt --
-    ┏━□ feat3
+    ┏━━□ feat3
   ┏━┻□ feat2
 ┏━┻□ feat1
 main ◀
 -- golden/ls-after.txt --
 INF tracked branch feat3 was deleted out of band: removing...
-  ┏━□ feat2
+  ┏━━□ feat2
 ┏━┻□ feat1
 main ◀

--- a/testdata/script/log_short_reconciles_recovered_boundary.txt
+++ b/testdata/script/log_short_reconciles_recovered_boundary.txt
@@ -40,18 +40,18 @@ cmp stderr $WORK/golden/second-fork-point-list.txt
 -- golden/first-merge-base-list.txt --
 DBG Recorded base hash is out of date. Using merge base as ownership boundary.  base=main branch=feature mergeBase=a1d1c71
 DBG Updating recorded base hash  branch=feature base=main
-┏━□ feature (needs restack)
+┏━━□ feature (needs restack)
 main ◀
 -- golden/second-merge-base-list.txt --
-┏━□ feature (needs restack)
+┏━━□ feature (needs restack)
 main ◀
 -- golden/first-fork-point-list.txt --
 DBG Recorded base hash is out of date. Using fork point as ownership boundary.  base=main branch=feature-fork forkPoint=a1d1c71
 DBG Updating recorded base hash  branch=feature-fork base=main
-┏━□ feature (needs restack)
-┣━□ feature-fork (needs restack)
+┏━━□ feature (needs restack)
+┣━━□ feature-fork (needs restack)
 main ◀
 -- golden/second-fork-point-list.txt --
-┏━□ feature (needs restack)
-┣━□ feature-fork (needs restack)
+┏━━□ feature (needs restack)
+┣━━□ feature-fork (needs restack)
 main ◀

--- a/testdata/script/repo_sync_closed_cr_ignore.txt
+++ b/testdata/script/repo_sync_closed_cr_ignore.txt
@@ -61,15 +61,15 @@ Contents of feature2
 Contents of feature3
 
 -- golden/open.txt --
-  ┏━■ feature2 (#2) ◀
+  ┏━━■ feature2 (#2) ◀
 ┏━┻□ feature1 (#1)
 main
 -- golden/ls-first-submit.txt --
-  ┏━■ feature2 (#2) ◀
+  ┏━━■ feature2 (#2) ◀
 ┏━┻□ feature1 (#1)
 main
 -- golden/ls-second-submit.txt --
-    ┏━■ feature3 (#3) ◀
+    ┏━━■ feature3 (#3) ◀
   ┏━┻□ feature2 (#2)
 ┏━┻□ feature1 (#1)
 main

--- a/testdata/script/repo_sync_closed_pr_prompt.txt
+++ b/testdata/script/repo_sync_closed_pr_prompt.txt
@@ -44,7 +44,7 @@ Contents of feature1
 Contents of feature2
 
 -- golden/open.txt --
-  ┏━■ feature2 (#2) ◀
+  ┏━━■ feature2 (#2) ◀
 ┏━┻□ feature1 (#1)
 main
 -- golden/prompt.txt --
@@ -53,5 +53,5 @@ main
 > #1 was closed but not merged.
 true
 -- golden/closed.txt --
-┏━■ feature2 (#2) (needs restack) ◀
+┏━━■ feature2 (#2) (needs restack) ◀
 main

--- a/testdata/script/repo_sync_conflict.txt
+++ b/testdata/script/repo_sync_conflict.txt
@@ -78,16 +78,16 @@ feat 2 different
 -- extra/feat2-resolved.txt --
 feat 2 slightly different
 -- golden/ll-before.txt --
-    ┏━■ feat3 (#3) ◀
-    ┃   5844149 Add feat3 (now)
+    ┏━━■ feat3 (#3) ◀
+    ┃    5844149 Add feat3 (now)
   ┏━┻□ feat2 (#2)
   ┃    5ccaa46 Add feat2 (now)
 ┏━┻□ feat1 (#1)
 ┃    5016e56 Add feat1 (now)
 main
 -- golden/ll-after.txt --
-  ┏━■ feat3 (#3) (needs push) ◀
-  ┃   fe1a376 Add feat3 (now)
+  ┏━━■ feat3 (#3) (needs push) ◀
+  ┃    fe1a376 Add feat3 (now)
 ┏━┻□ feat2 (#2) (needs push)
 ┃    89ca0a7 Add feat2 (now)
 main

--- a/testdata/script/repo_sync_restack.txt
+++ b/testdata/script/repo_sync_restack.txt
@@ -54,7 +54,7 @@ Contents of feature2
 Contents of feature3
 
 -- golden/restacked.txt --
-  ┏━□ feature3
+  ┏━━□ feature3
 ┏━┻□ feature2
 main ◀
 -- golden/graph.txt --

--- a/testdata/script/repo_sync_restack_aboves.txt
+++ b/testdata/script/repo_sync_restack_aboves.txt
@@ -48,8 +48,8 @@ b
 -- repo/c.txt --
 c
 -- golden/ll-after-sync.txt --
-  ┏━■ c (#3) (needs restack) ◀
-  ┃   b62d5a6 Add c (now)
+  ┏━━■ c (#3) (needs restack) ◀
+  ┃    b62d5a6 Add c (now)
 ┏━┻□ b (#2) (needs push)
 ┃    a0b8ffd Add b (now)
 main

--- a/testdata/script/repo_sync_restack_config.txt
+++ b/testdata/script/repo_sync_restack_config.txt
@@ -60,12 +60,12 @@ c
 -- repo/d.txt --
 d
 -- golden/config-branch-ll.txt --
-┏━■ b (#2) (needs push) ◀
-┃   b57bc06 Add b (now)
+┏━━■ b (#2) (needs push) ◀
+┃    b57bc06 Add b (now)
 main
 -- golden/override-none-ll.txt --
-┏━□ b (#2) (needs restack) (needs push)
-┃   b57bc06 Add b (now)
-┣━■ d (#4) (needs restack) ◀
-┃   c40282a Add d (now)
+┏━━□ b (#2) (needs restack) (needs push)
+┃    b57bc06 Add b (now)
+┣━━■ d (#4) (needs restack) ◀
+┃    c40282a Add d (now)
 main

--- a/testdata/script/repo_sync_retarget_skipped_local_delete.txt
+++ b/testdata/script/repo_sync_retarget_skipped_local_delete.txt
@@ -56,7 +56,7 @@ This is feature 1
 -- repo/feature2.txt --
 This is feature 2
 -- golden/ls-before.txt --
-  ┏━■ feature2 (#2) ◀
+  ┏━━■ feature2 (#2) ◀
 ┏━┻□ feature1 (#1)
 main
 -- golden/change-2.json --

--- a/testdata/script/repo_sync_squash_merged.txt
+++ b/testdata/script/repo_sync_squash_merged.txt
@@ -93,10 +93,10 @@ false
 }
 
 -- golden/ll-before.txt --
-┏━■ add-feature-1 (#1) ◀
-┃   a9548da Add feature 3 (now)
-┃   bcb3a72 Add feature 2 (now)
-┃   4be7a61 Add feature 1 (now)
+┏━━■ add-feature-1 (#1) ◀
+┃    a9548da Add feature 3 (now)
+┃    bcb3a72 Add feature 2 (now)
+┃    4be7a61 Add feature 1 (now)
 main
 -- golden/ll-after.txt --
 main ◀

--- a/testdata/script/repo_sync_unsubmitted_upstack_history.txt
+++ b/testdata/script/repo_sync_unsubmitted_upstack_history.txt
@@ -49,7 +49,7 @@ feat 1
 -- repo/feat2.txt --
 feat 2
 -- golden/ls-after.txt --
-┏━■ feat2 (#2) ◀
+┏━━■ feat2 (#2) ◀
 main
 -- golden/final-comments.txt --
 - change: 1

--- a/testdata/script/stack_edit.txt
+++ b/testdata/script/stack_edit.txt
@@ -60,12 +60,12 @@ feature1
 # Save and quit the editor to apply the changes.
 # Delete all lines in the editor to abort the operation.
 -- golden/ls-before.txt --
-    ┏━■ feature3 ◀
+    ┏━━■ feature3 ◀
   ┏━┻□ feature2
 ┏━┻□ feature1
 main
 -- golden/ls-after.txt --
-    ┏━□ feature1
+    ┏━━□ feature1
   ┏━┻□ feature2
 ┏━┻□ feature3
 main ◀

--- a/testdata/script/stack_edit_inserted_at_bottom_with_downstack_history.txt
+++ b/testdata/script/stack_edit_inserted_at_bottom_with_downstack_history.txt
@@ -92,13 +92,13 @@ feature2
 # Save and quit the editor to apply the changes.
 # Delete all lines in the editor to abort the operation.
 -- golden/ls-before.txt --
-      ┏━■ feature4 ◀
+      ┏━━■ feature4 ◀
     ┏━┻□ feature3
   ┏━┻□ feature2
 ┏━┻□ feature1
 main
 -- golden/ls-after.txt --
-    ┏━□ feature2 (#2)
+    ┏━━□ feature2 (#2)
   ┏━┻□ feature3 (#3)
 ┏━┻□ feature4 (#4)
 main ◀

--- a/testdata/script/stack_submit.txt
+++ b/testdata/script/stack_submit.txt
@@ -274,7 +274,7 @@ This is feature 3
     <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
     <!-- gs:navigation comment -->
 -- golden/ls.txt --
-    ┏━□ feature3 (#3)
+    ┏━━□ feature3 (#3)
   ┏━┻□ feature2 (#2)
 ┏━┻■ feature1 (#1) ◀
 main

--- a/testdata/script/stack_submit_default_update_only.txt
+++ b/testdata/script/stack_submit_default_update_only.txt
@@ -50,6 +50,6 @@ feature2
 feature update
 
 -- golden/ls.txt --
-  ┏━□ feature2
+  ┏━━□ feature2
 ┏━┻■ feature (#1) ◀
 main

--- a/testdata/script/stack_submit_multiple_merged_history.txt
+++ b/testdata/script/stack_submit_multiple_merged_history.txt
@@ -119,7 +119,7 @@ This is feature 3
     <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
     <!-- gs:navigation comment -->
 -- golden/ls.txt --
-    ┏━□ feature3 (#3)
+    ┏━━□ feature3 (#3)
   ┏━┻□ feature2 (#2)
 ┏━┻■ feature1 (#1) ◀
 main

--- a/testdata/script/submit_update_only.txt
+++ b/testdata/script/submit_update_only.txt
@@ -62,9 +62,9 @@ feature 1 new
 -- extra/feat2-new.txt --
 feature 2 new
 -- golden/ll-after.txt --
-  ┏━■ feat2 ◀
-  ┃   ec789dc update feat2 (now)
-  ┃   f76d5f5 feat2 (now)
+  ┏━━■ feat2 ◀
+  ┃    ec789dc update feat2 (now)
+  ┃    f76d5f5 feat2 (now)
 ┏━┻□ feat1 (#1)
 ┃    f879555 update feat1 (now)
 ┃    4ea4a27 feat1 (now)

--- a/testdata/script/top_multiple_prompt.txt
+++ b/testdata/script/top_multiple_prompt.txt
@@ -81,17 +81,17 @@ feature 1 sub feature 2 sub feature
 -- robot.golden --
 ===
 > Pick a branch: 
-> ┏━■ f2 ◀
-> ┣━□ f1-s1
-> ┣━□ f1-s2-s
+> ┏━━■ f2 ◀
+> ┣━━□ f1-s1
+> ┣━━□ f1-s2-s
 > main
 >
 > There are multiple top-level branches reachable from the current branch.
 "f2"
 ===
 > Pick a branch: 
-> ┏━■ f1-s1 ◀
-> ┣━□ f1-s2-s
+> ┏━━■ f1-s1 ◀
+> ┣━━□ f1-s2-s
 > f1
 >
 > There are multiple top-level branches reachable from the current branch.

--- a/testdata/script/up_down_top_bottom.txt
+++ b/testdata/script/up_down_top_bottom.txt
@@ -150,15 +150,15 @@ cmp stderr $WORK/golden/git_ll_a.output
 * feature5
   main
 -- golden/git_ls_a.output --
-        ┏━□ feature5
+        ┏━━□ feature5
       ┏━┻□ feature4
     ┏━┻□ feature3
   ┏━┻□ feature2
 ┏━┻□ feature1
 main ◀
 -- golden/git_ll_a.output --
-        ┏━□ feature5
-        ┃   a9357f7 Add feature5 (now)
+        ┏━━□ feature5
+        ┃    a9357f7 Add feature5 (now)
       ┏━┻□ feature4
       ┃    93a1ae5 Add feature4 (now)
     ┏━┻□ feature3

--- a/testdata/script/up_down_top_bottom_prompt.txt
+++ b/testdata/script/up_down_top_bottom_prompt.txt
@@ -69,17 +69,17 @@ gs up -n 2
 cmp $WORK/robot.up-2.actual $WORK/robot.up-2.golden
 
 -- golden/ls.txt --
-    ┏━□ feature3
+    ┏━━□ feature3
   ┏━┻□ feature2
-  ┃ ┏━□ feature5
+  ┃ ┏━━□ feature5
   ┣━┻□ feature4
 ┏━┻□ feature1
 main ◀
 -- robot.up.golden --
 ===
 > Pick a branch: 
-> ┏━■ feature2 ◀
-> ┣━□ feature4
+> ┏━━■ feature2 ◀
+> ┣━━□ feature4
 > feature1
 >
 > There are multiple branches above the current branch.
@@ -88,8 +88,8 @@ main ◀
 -- robot.top.golden --
 ===
 > Pick a branch: 
-> ┏━■ feature3 ◀
-> ┣━□ feature5
+> ┏━━■ feature3 ◀
+> ┣━━□ feature5
 > feature1
 >
 > There are multiple top-level branches reachable from the current branch.
@@ -98,8 +98,8 @@ main ◀
 -- robot.up-2.golden --
 ===
 > Pick a branch: 
-> ┏━■ feature2 ◀
-> ┣━□ feature4
+> ┏━━■ feature2 ◀
+> ┣━━□ feature4
 > feature1
 >
 > There are multiple branches above the current branch.

--- a/testdata/script/up_multiple_prompt.txt
+++ b/testdata/script/up_multiple_prompt.txt
@@ -35,9 +35,9 @@ cmp stdout $WORK/golden/git-branch.txt
 -- robot.golden --
 ===
 > Pick a branch: 
-> ┏━■ head1 ◀
-> ┣━□ head2
-> ┣━□ head3
+> ┏━━■ head1 ◀
+> ┣━━□ head2
+> ┣━━□ head3
 > main
 >
 > There are multiple branches above the current branch.

--- a/testdata/script/upstack_delete.txt
+++ b/testdata/script/upstack_delete.txt
@@ -75,10 +75,10 @@ Feature 5
 Unmerged change
 
 -- golden/ls-after-interactive.txt --
-┏━■ feature1 ◀
+┏━━■ feature1 ◀
 main
 -- golden/ls-final.txt --
-  ┏━■ feature3 ◀
+  ┏━━■ feature3 ◀
 ┏━┻□ feature1
 main
 -- robot.golden --

--- a/testdata/script/upstack_onto_diverged_from_base.txt
+++ b/testdata/script/upstack_onto_diverged_from_base.txt
@@ -45,15 +45,15 @@ feature 2
 feature 3
 
 -- golden/ls-before.txt --
-    ┏━■ feat3 ◀
-    ┃   e6984b4 Add feature 3 (now)
+    ┏━━■ feat3 ◀
+    ┃    e6984b4 Add feature 3 (now)
   ┏━┻□ feat2
   ┃    e3b0e7d Add feature 2 (now)
 ┏━┻□ feat1
 main
 -- golden/ls-after.txt --
-    ┏━□ feat3
-    ┃   d4de41e Add feature 3 (now)
+    ┏━━□ feat3
+    ┃    d4de41e Add feature 3 (now)
   ┏━┻■ feat2 ◀
   ┃    9995287 Add feature 2 (now)
 ┏━┻□ feat1

--- a/testdata/script/upstack_onto_prompt_sort_order.txt
+++ b/testdata/script/upstack_onto_prompt_sort_order.txt
@@ -48,9 +48,9 @@ Feature 3
 -- robot.golden --
 ===
 > Select a branch to move onto: 
-> ┏━□ bbb
-> ┣━□ ccc
-> ┣━□ aaa
+> ┏━━□ bbb
+> ┣━━□ ccc
+> ┣━━□ aaa
 > main ◀
 >
 > Moving the upstack of bbb onto another branch

--- a/testdata/script/upstack_submit_main.txt
+++ b/testdata/script/upstack_submit_main.txt
@@ -75,13 +75,13 @@ INF Created #2: $SHAMHUB_URL/alice/example/change/2
 INF Created #3: $SHAMHUB_URL/alice/example/change/3
 INF Created #4: $SHAMHUB_URL/alice/example/change/4
 -- golden/ls-before.txt --
-    ┏━■ feature4 ◀
+    ┏━━■ feature4 ◀
   ┏━┻□ feature3
 ┏━┻□ feature1
 main
 -- golden/ls-after.txt --
-  ┏━□ feature2 (#2)
-  ┃ ┏━□ feature4 (#4)
+  ┏━━□ feature2 (#2)
+  ┃ ┏━━□ feature4 (#4)
   ┣━┻□ feature3 (#3)
 ┏━┻□ feature1 (#1)
 main ◀


### PR DESCRIPTION
Fix https://github.com/abhinav/git-spice/issues/1383

When two branches share the same parent but one has children and the other doesn't, their labels don't line up in gs ls and related commands. The branch with children gets a ┻ junction glyph, which shifts its node marker and label one column to the right compared to the leaf sibling.

Before:
```
┃     ┏━┻□ branch-a
┃     ┣━□ branch-b
```
After:
```
┃     ┏━┻□ branch-a
┃     ┣━━□ branch-b
```

The fix adds a horizontal segment to leaf node connectors so they match the width of the junction glyph. This keeps same-level branches reading at the same indent.

Added a regression test covering the leaf/parent sibling case
Updated all affected fixtures (unit tests, widget scripts, and integration scripts)
Added changelog entry