### PR TITLE
forge: Add native stack updates

### DIFF
--- a/internal/forge/forgetest/integration.go
+++ b/internal/forge/forgetest/integration.go
@@ -138,7 +138,6 @@ type IntegrationConfig struct {
 	// SkipCommentCounts skips the CommentCountsByChange test.
 	// Set to true for forges that don't support comment resolution tracking.
 	SkipCommentCounts bool // optional
-
 	// ReviewThreads enables the shared review-thread scenario.
 	// Enable it only when OpenRepository returns a forge.ReviewRepository.
 	ReviewThreads bool // optional
@@ -151,6 +150,13 @@ type IntegrationConfig struct {
 	// ReviewThreadCommitHash indicates that review threads expose the change
 	// head against which the root comment was created.
 	ReviewThreadCommitHash bool // optional
+
+	// TestStacks enables the shared native stack integration scenario.
+	// OpenRepository must return a repository that implements
+	// [forge.StackRepository].
+	// The scenario creates, extends, and reuses a native stack, so the selected
+	// fixture and remote repository must support those provider operations.
+	TestStacks bool // optional
 }
 
 // RunIntegration runs integration tests with the given configuration.
@@ -313,12 +319,22 @@ func RunIntegration(t *testing.T, config IntegrationConfig) {
 			suite.TestCommentCountsByChange(t)
 		})
 	}
-
 	if config.ReviewThreads {
 		t.Run("ReviewThreads", func(t *testing.T) {
 			t.Parallel()
 
 			suite.TestReviewThreads(t)
+		})
+	}
+
+	if config.TestStacks {
+		t.Run("Stacks", func(t *testing.T) {
+			t.Parallel()
+
+			repo := suite.OpenRepository(t)
+			stackRepository, ok := repo.(forge.StackRepository)
+			require.True(t, ok, "%T does not implement forge.StackRepository", repo)
+			suite.TestStacks(t, stackRepository)
 		})
 	}
 }

--- a/internal/forge/forgetest/repo_builder.go
+++ b/internal/forge/forgetest/repo_builder.go
@@ -8,22 +8,32 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.abhg.dev/gs/internal/git"
 	"go.abhg.dev/gs/internal/silog/silogtest"
 	"go.abhg.dev/gs/internal/xec"
 )
 
-type testRepository struct {
+// RepositoryBuilder provisions commits and branches in a disposable clone of
+// a forge integration-test repository.
+//
+// RepositoryBuilder is available only while recording fixtures.
+// The test owns any remote state it creates:
+// callers must register cleanup for every branch they push.
+// Local state lives in the test's temporary directory and is removed by the
+// testing package.
+type RepositoryBuilder struct {
 	repo *git.Repository
 	work *git.Worktree
 	root string
 	t    *testing.T
 }
 
-func newTestRepository(t *testing.T, remoteURL string) *testRepository {
-	require.True(t, Update(), "testRepository only available in update mode")
+// NewRepositoryBuilder clones remoteURL and disables commit signing in the
+// clone so tests can commit without relying on user configuration.
+// It fails the test if fixture recording is disabled or setup fails.
+func NewRepositoryBuilder(t *testing.T, remoteURL string) *RepositoryBuilder {
+	require.True(t, Update(), "RepositoryBuilder only available in update mode")
 
 	repoDir := t.TempDir()
 	output := t.Output()
@@ -48,7 +58,7 @@ func newTestRepository(t *testing.T, remoteURL string) *testRepository {
 	})
 	require.NoError(t, err, "failed to open git worktree")
 
-	return &testRepository{
+	return &RepositoryBuilder{
 		repo: work.Repository(),
 		work: work,
 		root: repoDir,
@@ -56,7 +66,7 @@ func newTestRepository(t *testing.T, remoteURL string) *testRepository {
 	}
 }
 
-func (r *testRepository) ctx() context.Context {
+func (r *RepositoryBuilder) ctx() context.Context {
 	ctx := r.t.Context()
 	// If the context was canceled, ignore its cancellation.
 	if errors.Is(ctx.Err(), context.Canceled) {
@@ -65,8 +75,9 @@ func (r *testRepository) ctx() context.Context {
 	return ctx
 }
 
-// WriteFile writes a file to the repository with the given lines.
-func (r *testRepository) WriteFile(path string, lines ...string) {
+// WriteFile replaces the repository-relative path with the given lines.
+// It creates parent directories and terminates non-empty content with a newline.
+func (r *RepositoryBuilder) WriteFile(path string, lines ...string) {
 	content := strings.Join(lines, "\n")
 	if len(lines) > 0 {
 		content += "\n"
@@ -82,8 +93,10 @@ func (r *testRepository) WriteFile(path string, lines ...string) {
 	), "could not write file: %s", path)
 }
 
-// AddAllAndCommit stages all changes and creates a commit.
-func (r *testRepository) AddAllAndCommit(message string) git.Hash {
+// AddAllAndCommit stages the entire worktree and commits it with the shared
+// integration-test identity.
+// It returns the new commit's hash.
+func (r *RepositoryBuilder) AddAllAndCommit(message string) git.Hash {
 	output := r.t.Output()
 	cmd := xec.Command(r.t.Context(), silogtest.New(r.t), "git", "add", ".").
 		WithDir(r.root).
@@ -107,28 +120,28 @@ func (r *testRepository) AddAllAndCommit(message string) git.Hash {
 	return hash
 }
 
-// CreateBranch creates a new branch.
-func (r *testRepository) CreateBranch(name string) {
+// CreateBranch creates name at the current HEAD without checking it out.
+func (r *RepositoryBuilder) CreateBranch(name string) {
 	ctx := r.ctx()
 	require.NoError(r.t, r.repo.CreateBranch(ctx, git.CreateBranchRequest{
 		Name: name,
 	}), "could not create branch: %s", name)
 }
 
-// CheckoutBranch checks out an existing branch.
-func (r *testRepository) CheckoutBranch(name string) {
+// CheckoutBranch checks out an existing local branch.
+func (r *RepositoryBuilder) CheckoutBranch(name string) {
 	ctx := r.ctx()
 	require.NoError(r.t, r.work.CheckoutBranch(ctx, name),
 		"could not checkout branch: %s", name)
 }
 
-// Push pushes the given refspec to origin.
-func (r *testRepository) Push(refspec string) {
+// Push sends refspec to the clone's origin remote.
+func (r *RepositoryBuilder) Push(refspec string) {
 	r.PushTo("origin", refspec)
 }
 
-// AddRemote adds a remote to the test repository.
-func (r *testRepository) AddRemote(name, remoteURL string) {
+// AddRemote adds name with remoteURL to the clone.
+func (r *RepositoryBuilder) AddRemote(name, remoteURL string) {
 	output := r.t.Output()
 	cmd := xec.Command(
 		r.ctx(),
@@ -141,8 +154,8 @@ func (r *testRepository) AddRemote(name, remoteURL string) {
 	require.NoError(r.t, cmd.Run(), "could not add remote: %s", name)
 }
 
-// PushTo pushes the given refspec to a remote.
-func (r *testRepository) PushTo(remote, refspec string) {
+// PushTo sends refspec to the named remote.
+func (r *RepositoryBuilder) PushTo(remote, refspec string) {
 	ctx := r.ctx()
 	require.NoError(r.t, r.work.Push(ctx, git.PushOptions{
 		Remote:  remote,
@@ -150,28 +163,34 @@ func (r *testRepository) PushTo(remote, refspec string) {
 	}), "error pushing refspec %s to %s", refspec, remote)
 }
 
-// DeleteRemoteBranch deletes a remote branch.
-func (r *testRepository) DeleteRemoteBranch(name string) {
+// DeleteRemoteBranch attempts to delete name from the origin remote.
+// Cleanup failures are logged instead of failing the test.
+func (r *RepositoryBuilder) DeleteRemoteBranch(name string) {
 	r.DeleteRemoteBranchFrom("origin", name)
 }
 
-// DeleteRemoteBranchFrom deletes a branch from a remote.
-func (r *testRepository) DeleteRemoteBranchFrom(remote, name string) {
+// DeleteRemoteBranchFrom attempts to delete name from the named remote.
+// Cleanup failures are logged instead of failing the test.
+func (r *RepositoryBuilder) DeleteRemoteBranchFrom(remote, name string) {
 	ctx := r.ctx()
 	r.t.Logf("Deleting remote branch: %s/%s", remote, name)
-	assert.NoError(r.t, r.work.Push(ctx, git.PushOptions{
+	if err := r.work.Push(ctx, git.PushOptions{
 		Remote:  remote,
 		Refspec: git.Refspec(":" + name),
-	}), "error deleting branch")
+	}); err != nil {
+		r.t.Logf("Warning: failed to delete remote branch %s/%s: %v", remote, name, err)
+	}
 }
 
-// Repository returns the underlying git.Repository.
-func (r *testRepository) Repository() *git.Repository {
+// Repository returns the repository for the builder's temporary clone.
+// The value remains valid until the test completes.
+func (r *RepositoryBuilder) Repository() *git.Repository {
 	return r.repo
 }
 
-// Worktree returns the underlying git.Worktree.
-func (r *testRepository) Worktree() *git.Worktree {
+// Worktree returns the worktree for the builder's temporary clone.
+// The value remains valid until the test completes.
+func (r *RepositoryBuilder) Worktree() *git.Worktree {
 	return r.work
 }
 

--- a/internal/forge/forgetest/scenario_repository.go
+++ b/internal/forge/forgetest/scenario_repository.go
@@ -25,7 +25,7 @@ func (s *integrationSuite) TestSubmitChangeFromPushRepository(t *testing.T) {
 	branchName := branchFixture.Get(t)
 	t.Logf("Creating fork branch: %s", branchName)
 	if Update() {
-		testRepo := newTestRepository(t, s.RemoteURL)
+		testRepo := NewRepositoryBuilder(t, s.RemoteURL)
 
 		testRepo.CreateBranch(branchName)
 		testRepo.CheckoutBranch(branchName)
@@ -93,7 +93,7 @@ func (s *integrationSuite) TestListChangeTemplates(t *testing.T) {
 
 	t.Run("NoTemplates", func(t *testing.T) {
 		if Update() {
-			testRepo := newTestRepository(t, s.RemoteURL)
+			testRepo := NewRepositoryBuilder(t, s.RemoteURL)
 
 			t.Logf("Removing all templates from main")
 			var deleted bool
@@ -146,7 +146,7 @@ func (s *integrationSuite) TestListChangeTemplates(t *testing.T) {
 		}
 
 		if Update() {
-			testRepo := newTestRepository(t, s.RemoteURL)
+			testRepo := NewRepositoryBuilder(t, s.RemoteURL)
 
 			if templateDir != "" {
 				testRepo.WriteFile(filepath.Join(templateDir, emptyTemplateName))
@@ -234,7 +234,7 @@ func (s *integrationSuite) TestSubmitEditLabels(t *testing.T) {
 	t.Logf("Creating branch: %s", branchName)
 
 	if Update() {
-		testRepo := newTestRepository(t, s.RemoteURL)
+		testRepo := NewRepositoryBuilder(t, s.RemoteURL)
 
 		testRepo.CreateBranch(branchName)
 		testRepo.CheckoutBranch(branchName)
@@ -304,7 +304,7 @@ func (s *integrationSuite) TestSubmitBaseDoesNotExist(t *testing.T) {
 	t.Logf("Creating branch %s with base branch %s", branchName, baseBranchName)
 
 	if Update() {
-		testRepo := newTestRepository(t, s.RemoteURL)
+		testRepo := NewRepositoryBuilder(t, s.RemoteURL)
 
 		testRepo.CreateBranch(branchName)
 		testRepo.CheckoutBranch(branchName)

--- a/internal/forge/forgetest/scenario_review.go
+++ b/internal/forge/forgetest/scenario_review.go
@@ -21,7 +21,7 @@ func (s *integrationSuite) TestSubmitCombinedMetadata(t *testing.T) {
 	t.Logf("Creating branch: %s", branchName)
 
 	if Update() {
-		testRepo := newTestRepository(t, s.RemoteURL)
+		testRepo := NewRepositoryBuilder(t, s.RemoteURL)
 
 		testRepo.CreateBranch(branchName)
 		testRepo.CheckoutBranch(branchName)
@@ -65,7 +65,7 @@ func (s *integrationSuite) TestSubmitEditReviewers(t *testing.T) {
 		t.Logf("Creating branch: %s", branchName)
 
 		if Update() {
-			testRepo := newTestRepository(t, s.RemoteURL)
+			testRepo := NewRepositoryBuilder(t, s.RemoteURL)
 
 			testRepo.CreateBranch(branchName)
 			testRepo.CheckoutBranch(branchName)
@@ -107,7 +107,7 @@ func (s *integrationSuite) TestSubmitEditReviewers(t *testing.T) {
 		t.Logf("Creating branch: %s", branchName)
 
 		if Update() {
-			testRepo := newTestRepository(t, s.RemoteURL)
+			testRepo := NewRepositoryBuilder(t, s.RemoteURL)
 
 			testRepo.CreateBranch(branchName)
 			testRepo.CheckoutBranch(branchName)
@@ -161,7 +161,7 @@ func (s *integrationSuite) TestSubmitEditReviewers(t *testing.T) {
 			t.Logf("Creating branch: %s", branchName)
 
 			if Update() {
-				testRepo := newTestRepository(t, s.RemoteURL)
+				testRepo := NewRepositoryBuilder(t, s.RemoteURL)
 
 				testRepo.CreateBranch(branchName)
 				testRepo.CheckoutBranch(branchName)
@@ -220,7 +220,7 @@ func (s *integrationSuite) TestSubmitEditAssignees(t *testing.T) {
 		t.Logf("Creating branch: %s", branchName)
 
 		if Update() {
-			testRepo := newTestRepository(t, s.RemoteURL)
+			testRepo := NewRepositoryBuilder(t, s.RemoteURL)
 
 			testRepo.CreateBranch(branchName)
 			testRepo.CheckoutBranch(branchName)
@@ -270,7 +270,7 @@ func (s *integrationSuite) TestSubmitEditAssignees(t *testing.T) {
 		t.Logf("Creating branch: %s", branchName)
 
 		if Update() {
-			testRepo := newTestRepository(t, s.RemoteURL)
+			testRepo := NewRepositoryBuilder(t, s.RemoteURL)
 
 			testRepo.CreateBranch(branchName)
 			testRepo.CheckoutBranch(branchName)
@@ -325,7 +325,7 @@ func (s *integrationSuite) TestSubmitEditAssignees(t *testing.T) {
 			t.Logf("Creating branch: %s", branchName)
 
 			if Update() {
-				testRepo := newTestRepository(t, s.RemoteURL)
+				testRepo := NewRepositoryBuilder(t, s.RemoteURL)
 
 				testRepo.CreateBranch(branchName)
 				testRepo.CheckoutBranch(branchName)
@@ -375,7 +375,7 @@ func (s *integrationSuite) TestChangeComments(t *testing.T) {
 	t.Logf("Creating branch: %s", branchName)
 
 	if Update() {
-		testRepo := newTestRepository(t, s.RemoteURL)
+		testRepo := NewRepositoryBuilder(t, s.RemoteURL)
 
 		testRepo.CreateBranch(branchName)
 		testRepo.CheckoutBranch(branchName)
@@ -498,7 +498,7 @@ func (s *integrationSuite) TestCommentCountsByChange(t *testing.T) {
 	t.Logf("Creating branch: %s", branchName)
 
 	if Update() {
-		testRepo := newTestRepository(t, s.RemoteURL)
+		testRepo := NewRepositoryBuilder(t, s.RemoteURL)
 
 		testRepo.CreateBranch(branchName)
 		testRepo.CheckoutBranch(branchName)
@@ -536,6 +536,3 @@ func (s *integrationSuite) TestCommentCountsByChange(t *testing.T) {
 	assert.Equal(t, result.Total, result.Resolved+result.Unresolved,
 		"total should equal resolved + unresolved")
 }
-
-// testRepository manages a local Git repository clone for testing.
-// Only available in update mode.

--- a/internal/forge/forgetest/scenario_review_thread.go
+++ b/internal/forge/forgetest/scenario_review_thread.go
@@ -34,7 +34,7 @@ func (s *integrationSuite) TestReviewThreadsSingleAndReply(t *testing.T) {
 	// Update mode creates the Git state consumed by the live forge.
 	// Replay mode reuses the recorded branch name and HTTP interactions.
 	if Update() {
-		testRepo := newTestRepository(t, s.RemoteURL)
+		testRepo := NewRepositoryBuilder(t, s.RemoteURL)
 		testRepo.CreateBranch(branchName)
 		testRepo.CheckoutBranch(branchName)
 		testRepo.WriteFile(
@@ -117,7 +117,7 @@ func (s *integrationSuite) TestReviewThreadsSingleAndReply(t *testing.T) {
 	}
 
 	if s.reviewThreadCommitHash && Update() {
-		testRepo := newTestRepository(t, s.RemoteURL)
+		testRepo := NewRepositoryBuilder(t, s.RemoteURL)
 		testRepo.CheckoutBranch(branchName)
 		testRepo.WriteFile("reply.go", "package review")
 		replyHash := testRepo.AddAllAndCommit("advance change before reply")
@@ -258,7 +258,7 @@ func (s *integrationSuite) TestReviewThreadsBatch(t *testing.T) {
 	// Update mode creates the Git state consumed by the live forge.
 	// Replay mode reuses the recorded branch name and HTTP interactions.
 	if Update() {
-		testRepo := newTestRepository(t, s.RemoteURL)
+		testRepo := NewRepositoryBuilder(t, s.RemoteURL)
 		testRepo.CreateBranch(branchName)
 		testRepo.CheckoutBranch(branchName)
 		testRepo.WriteFile(
@@ -357,7 +357,7 @@ func (s *integrationSuite) TestReviewThreadsFile(t *testing.T) {
 	// Update mode creates the Git state consumed by the live forge.
 	// Replay mode reuses the recorded branch name and HTTP interactions.
 	if Update() {
-		testRepo := newTestRepository(t, s.RemoteURL)
+		testRepo := NewRepositoryBuilder(t, s.RemoteURL)
 		testRepo.CreateBranch(branchName)
 		testRepo.CheckoutBranch(branchName)
 		testRepo.WriteFile(
@@ -448,7 +448,7 @@ func (s *integrationSuite) TestReviewThreadsReviewerStates(t *testing.T) {
 	// Update mode creates the Git state consumed by the live forge.
 	// Replay mode reuses the recorded branch name and HTTP interactions.
 	if Update() {
-		testRepo := newTestRepository(t, s.RemoteURL)
+		testRepo := NewRepositoryBuilder(t, s.RemoteURL)
 		testRepo.CreateBranch(branchName)
 		testRepo.CheckoutBranch(branchName)
 		testRepo.WriteFile(

--- a/internal/forge/forgetest/scenario_stacks.go
+++ b/internal/forge/forgetest/scenario_stacks.go
@@ -1,0 +1,84 @@
+package forgetest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/fixturetest"
+	"go.abhg.dev/gs/internal/forge"
+)
+
+// TestStacks exercises creation, extension, and idempotent updates of a
+// provider-native stack.
+func (s *integrationSuite) TestStacks(t *testing.T, repo forge.StackRepository) {
+	bottomBranch := fixturetest.New(s.Fixtures, "bottomBranch", func() string {
+		return "stack-bottom-" + randomString(8)
+	}).Get(t)
+	middleBranch := fixturetest.New(s.Fixtures, "middleBranch", func() string {
+		return "stack-middle-" + randomString(8)
+	}).Get(t)
+	topBranch := fixturetest.New(s.Fixtures, "topBranch", func() string {
+		return "stack-top-" + randomString(8)
+	}).Get(t)
+
+	if Update() {
+		testRepo := NewRepositoryBuilder(t, s.RemoteURL)
+		testRepo.CheckoutBranch("main")
+		for _, branch := range []string{bottomBranch, middleBranch, topBranch} {
+			testRepo.CreateBranch(branch)
+			testRepo.CheckoutBranch(branch)
+			testRepo.WriteFile(branch+".txt", randomString(32))
+			testRepo.AddAllAndCommit("commit for " + branch)
+			testRepo.Push(branch)
+		}
+
+		t.Cleanup(func() {
+			for _, branch := range []string{topBranch, middleBranch, bottomBranch} {
+				testRepo.DeleteRemoteBranch(branch)
+			}
+		})
+	}
+
+	bottom, err := repo.SubmitChange(t.Context(), forge.SubmitChangeRequest{
+		Subject: "Native stack bottom " + bottomBranch,
+		Body:    "Native stack integration test",
+		Base:    "main",
+		Head:    bottomBranch,
+	})
+	require.NoError(t, err, "create bottom change")
+	middle, err := repo.SubmitChange(t.Context(), forge.SubmitChangeRequest{
+		Subject: "Native stack middle " + middleBranch,
+		Body:    "Native stack integration test",
+		Base:    bottomBranch,
+		Head:    middleBranch,
+	})
+	require.NoError(t, err, "create middle change")
+
+	firstUpdate := []forge.StackChange{
+		{Change: bottom.ID, BaseBranch: "main"},
+		{Change: middle.ID, BaseChange: bottom.ID, BaseBranch: bottomBranch},
+	}
+	plan, err := repo.PlanStackUpdate(t.Context(), firstUpdate)
+	require.NoError(t, err, "plan native stack creation")
+	require.NoError(t, plan.Execute(t.Context()), "create native stack")
+
+	top, err := repo.SubmitChange(t.Context(), forge.SubmitChangeRequest{
+		Subject: "Native stack top " + topBranch,
+		Body:    "Native stack integration test",
+		Base:    middleBranch,
+		Head:    topBranch,
+	})
+	require.NoError(t, err, "create top change")
+
+	completeStack := []forge.StackChange{
+		{Change: bottom.ID, BaseBranch: "main"},
+		{Change: middle.ID, BaseChange: bottom.ID, BaseBranch: bottomBranch},
+		{Change: top.ID, BaseChange: middle.ID, BaseBranch: middleBranch},
+	}
+	plan, err = repo.PlanStackUpdate(t.Context(), completeStack)
+	require.NoError(t, err, "plan native stack extension")
+	require.NoError(t, plan.Execute(t.Context()), "extend native stack")
+	plan, err = repo.PlanStackUpdate(t.Context(), completeStack)
+	require.NoError(t, err, "plan repeated native stack update")
+	require.NoError(t, plan.Execute(t.Context()), "repeat native stack update")
+}

--- a/internal/forge/forgetest/scenario_state.go
+++ b/internal/forge/forgetest/scenario_state.go
@@ -31,7 +31,7 @@ func (s *integrationSuite) TestChangeStates(t *testing.T) {
 		openBranch, mergedBranch, closedBranch)
 
 	if Update() {
-		testRepo := newTestRepository(t, s.RemoteURL)
+		testRepo := NewRepositoryBuilder(t, s.RemoteURL)
 
 		// Create and push all three branches.
 		for _, branch := range []string{openBranch, mergedBranch, closedBranch} {
@@ -193,7 +193,7 @@ func (s *integrationSuite) TestChangeChecks(t *testing.T) {
 
 			branch := branchFixture.Get(t)
 			if Update() {
-				testRepo := newTestRepository(t, s.RemoteURL)
+				testRepo := NewRepositoryBuilder(t, s.RemoteURL)
 				testRepo.CheckoutBranch("main")
 				testRepo.CreateBranch(branch)
 				testRepo.CheckoutBranch(branch)
@@ -271,7 +271,7 @@ func (s *integrationSuite) testChangeMergeabilityReady(t *testing.T) {
 	}).Get(t)
 
 	if Update() {
-		testRepo := newTestRepository(t, s.RemoteURL)
+		testRepo := NewRepositoryBuilder(t, s.RemoteURL)
 		testRepo.CheckoutBranch("main")
 		testRepo.Push("main:" + baseName)
 		t.Cleanup(func() {
@@ -326,7 +326,7 @@ func (s *integrationSuite) testChangeMergeabilityConflicts(t *testing.T) {
 	}).Get(t)
 
 	if Update() {
-		testRepo := newTestRepository(t, s.RemoteURL)
+		testRepo := NewRepositoryBuilder(t, s.RemoteURL)
 		testRepo.CheckoutBranch("main")
 		testRepo.Push("main:" + baseName)
 		t.Cleanup(func() {
@@ -387,7 +387,7 @@ func (s *integrationSuite) testChangeMergeabilityDraft(t *testing.T) {
 	}).Get(t)
 
 	if Update() {
-		testRepo := newTestRepository(t, s.RemoteURL)
+		testRepo := NewRepositoryBuilder(t, s.RemoteURL)
 		testRepo.CheckoutBranch("main")
 		testRepo.Push("main:" + baseName)
 		t.Cleanup(func() {

--- a/internal/forge/forgetest/scenario_submit.go
+++ b/internal/forge/forgetest/scenario_submit.go
@@ -20,7 +20,7 @@ func (s *integrationSuite) TestSubmitEditChange(t *testing.T) {
 	branchName := branchFixture.Get(t)
 	t.Logf("Creating branch: %s", branchName)
 	if Update() {
-		testRepo := newTestRepository(t, s.RemoteURL)
+		testRepo := NewRepositoryBuilder(t, s.RemoteURL)
 
 		// Create branch with random content
 		testRepo.CreateBranch(branchName)
@@ -120,7 +120,7 @@ func (s *integrationSuite) TestSubmitChangeBase(t *testing.T) {
 	t.Logf("Creating branch: %s with base: %s", branchName, baseName)
 
 	if Update() {
-		testRepo := newTestRepository(t, s.RemoteURL)
+		testRepo := NewRepositoryBuilder(t, s.RemoteURL)
 
 		// Push the base branch at current main position
 		testRepo.Push("main:" + baseName)
@@ -178,7 +178,7 @@ func (s *integrationSuite) TestSubmitChangeDraft(t *testing.T) {
 	t.Logf("Creating branch: %s", branchName)
 
 	if Update() {
-		testRepo := newTestRepository(t, s.RemoteURL)
+		testRepo := NewRepositoryBuilder(t, s.RemoteURL)
 
 		testRepo.CreateBranch(branchName)
 		testRepo.CheckoutBranch(branchName)

--- a/internal/forge/github/integration_test.go
+++ b/internal/forge/github/integration_test.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -104,6 +106,7 @@ func TestIntegration(t *testing.T) {
 		RemoteURL:     remoteURL,
 		PushRemoteURL: pushRemoteURL,
 		Forge:         &githubForge,
+		TestStacks:    true,
 		Sanitizers:    sanitizers,
 		OpenRepository: func(t *testing.T, httpClient *http.Client) forge.Repository {
 			token := forgetest.Token(t, remoteURL, "GITHUB_TOKEN")
@@ -150,6 +153,293 @@ func TestIntegration(t *testing.T) {
 		Reviewers:              []string{cfg.Reviewer},
 		Assignees:              []string{cfg.Assignee},
 	})
+}
+
+func TestIntegration_stackReplacement(t *testing.T) {
+	cfg, sanitizers := testConfig(t)
+	remoteURL := "https://github.com/" + cfg.Owner + "/" + cfg.Repo
+	bottomBranch := fixturetest.New(_fixtures, "bottomBranch", func() string {
+		return "stack-replace-bottom-" + randomString(8)
+	}).Get(t)
+	insertedBranch := fixturetest.New(_fixtures, "insertedBranch", func() string {
+		return "stack-replace-inserted-" + randomString(8)
+	}).Get(t)
+	topBranch := fixturetest.New(_fixtures, "topBranch", func() string {
+		return "stack-replace-top-" + randomString(8)
+	}).Get(t)
+
+	if forgetest.Update() {
+		builder := forgetest.NewRepositoryBuilder(t, remoteURL)
+		t.Cleanup(func() {
+			for _, branch := range []string{topBranch, insertedBranch, bottomBranch} {
+				builder.DeleteRemoteBranch(branch)
+			}
+		})
+
+		// Build the ancestry needed by the desired stack while initially leaving
+		// the middle branch without a pull request:
+		//
+		//     main
+		//       |
+		//     bottom
+		//       |
+		//    inserted
+		//       |
+		//      top
+		builder.CheckoutBranch("main")
+		for _, branch := range []string{bottomBranch, insertedBranch, topBranch} {
+			builder.CreateBranch(branch)
+			builder.CheckoutBranch(branch)
+			builder.WriteFile(branch+".txt", "commit for "+branch)
+			builder.AddAllAndCommit("commit for " + branch)
+			builder.Push(branch)
+		}
+	}
+
+	rec := newRecorder(t, t.Name(), sanitizers)
+	httpClient := rec.GetDefaultClient()
+	token := forgetest.Token(t, remoteURL, "GITHUB_TOKEN")
+	httpClient.Transport = &oauth2.Transport{
+		Base:   httpClient.Transport,
+		Source: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token}),
+	}
+	gatewayClient := newGateway(t, httpClient)
+	repo, err := github.NewRepository(
+		t.Context(), new(github.Forge), cfg.Owner, cfg.Repo,
+		silogtest.New(t), gatewayClient, "",
+	)
+	require.NoError(t, err)
+
+	var openChanges []forge.ChangeID
+	t.Cleanup(func() {
+		ctx := context.WithoutCancel(t.Context())
+		for _, openChange := range slices.Backward(openChanges) {
+			assert.NoError(t, github.CloseChange(
+				ctx,
+				repo,
+				openChange.(*github.PR),
+			))
+		}
+	})
+
+	bottom, err := repo.SubmitChange(t.Context(), forge.SubmitChangeRequest{
+		Subject: "Native stack replacement bottom " + bottomBranch,
+		Body:    "Native stack replacement integration test",
+		Base:    "main",
+		Head:    bottomBranch,
+	})
+	require.NoError(t, err, "create bottom change")
+	openChanges = append(openChanges, bottom.ID)
+	top, err := repo.SubmitChange(t.Context(), forge.SubmitChangeRequest{
+		Subject: "Native stack replacement top " + topBranch,
+		Body:    "Native stack replacement integration test",
+		Base:    bottomBranch,
+		Head:    topBranch,
+	})
+	require.NoError(t, err, "create top change")
+	openChanges = append(openChanges, top.ID)
+
+	plan, err := repo.PlanStackUpdate(t.Context(), []forge.StackChange{
+		{Change: bottom.ID, BaseBranch: "main"},
+		{Change: top.ID, BaseChange: bottom.ID, BaseBranch: bottomBranch},
+	})
+	require.NoError(t, err, "plan initial native stack")
+	require.NoError(t, plan.Execute(t.Context()), "create initial native stack")
+
+	inserted, err := repo.SubmitChange(t.Context(), forge.SubmitChangeRequest{
+		Subject: "Native stack replacement middle " + insertedBranch,
+		Body:    "Native stack replacement integration test",
+		Base:    bottomBranch,
+		Head:    insertedBranch,
+	})
+	require.NoError(t, err, "create inserted change")
+	openChanges = append(openChanges, inserted.ID)
+
+	desired := []forge.StackChange{
+		{Change: bottom.ID, BaseBranch: "main"},
+		{Change: inserted.ID, BaseChange: bottom.ID, BaseBranch: bottomBranch},
+		{Change: top.ID, BaseChange: inserted.ID, BaseBranch: insertedBranch},
+	}
+	plan, err = repo.PlanStackUpdate(t.Context(), desired)
+	require.NoError(t, err, "plan native stack replacement")
+	require.NoError(t, plan.Execute(t.Context()), "replace native stack")
+
+	pullRequests, err := gatewayClient.PullRequestsForStackUpdate(
+		t.Context(),
+		cfg.Owner,
+		cfg.Repo,
+		[]int{
+			bottom.ID.(*github.PR).Number,
+			inserted.ID.(*github.PR).Number,
+			top.ID.(*github.PR).Number,
+		},
+	)
+	require.NoError(t, err, "read replaced native stack")
+	require.Len(t, pullRequests, 3)
+	for _, pullRequest := range pullRequests {
+		require.NotNil(t, pullRequest)
+		require.NotNil(t, pullRequest.Stack)
+		assert.Equal(t, []githubgateway.PullRequestStackMember{
+			{Number: bottom.ID.(*github.PR).Number, State: githubgateway.PullRequestStateOpen},
+			{Number: inserted.ID.(*github.PR).Number, State: githubgateway.PullRequestStateOpen},
+			{Number: top.ID.(*github.PR).Number, State: githubgateway.PullRequestStateOpen},
+		}, pullRequest.Stack.Members)
+	}
+	assert.Equal(t, insertedBranch, pullRequests[2].BaseRefName)
+}
+
+func TestIntegration_stackReplacementWithMergedMember(t *testing.T) {
+	cfg, sanitizers := testConfig(t)
+	remoteURL := "https://github.com/" + cfg.Owner + "/" + cfg.Repo
+	bottomBranch := fixturetest.New(_fixtures, "bottomBranch", func() string {
+		return "stack-merged-bottom-" + randomString(8)
+	}).Get(t)
+	insertedBranch := fixturetest.New(_fixtures, "insertedBranch", func() string {
+		return "stack-merged-inserted-" + randomString(8)
+	}).Get(t)
+	topBranch := fixturetest.New(_fixtures, "topBranch", func() string {
+		return "stack-merged-top-" + randomString(8)
+	}).Get(t)
+
+	if forgetest.Update() {
+		builder := forgetest.NewRepositoryBuilder(t, remoteURL)
+		t.Cleanup(func() {
+			for _, branch := range []string{topBranch, insertedBranch, bottomBranch} {
+				builder.DeleteRemoteBranch(branch)
+			}
+		})
+
+		// Create one linear ancestry. The initial native stack omits inserted;
+		// after bottom merges, adding inserted would require replacing a stack
+		// whose historical bottom member cannot be removed.
+		//
+		//     main
+		//       |
+		//     bottom (merged before replacement)
+		//       |
+		//    inserted
+		//       |
+		//      top
+		builder.CheckoutBranch("main")
+		for _, branch := range []string{bottomBranch, insertedBranch, topBranch} {
+			builder.CreateBranch(branch)
+			builder.CheckoutBranch(branch)
+			builder.WriteFile(branch+".txt", "commit for "+branch)
+			builder.AddAllAndCommit("commit for " + branch)
+			builder.Push(branch)
+		}
+	}
+
+	rec := newRecorder(t, t.Name(), sanitizers)
+	httpClient := rec.GetDefaultClient()
+	token := forgetest.Token(t, remoteURL, "GITHUB_TOKEN")
+	httpClient.Transport = &oauth2.Transport{
+		Base:   httpClient.Transport,
+		Source: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token}),
+	}
+	gatewayClient := newGateway(t, httpClient)
+	repo, err := github.NewRepository(
+		t.Context(), new(github.Forge), cfg.Owner, cfg.Repo,
+		silogtest.New(t), gatewayClient, "",
+	)
+	require.NoError(t, err)
+
+	var openChanges []forge.ChangeID
+	t.Cleanup(func() {
+		ctx := context.WithoutCancel(t.Context())
+		for _, openChange := range slices.Backward(openChanges) {
+			assert.NoError(t, github.CloseChange(
+				ctx,
+				repo,
+				openChange.(*github.PR),
+			))
+		}
+	})
+
+	bottom, err := repo.SubmitChange(t.Context(), forge.SubmitChangeRequest{
+		Subject: "Native stack merged-member bottom " + bottomBranch,
+		Body:    "Native stack merged-member integration test",
+		Base:    "main",
+		Head:    bottomBranch,
+	})
+	require.NoError(t, err, "create bottom change")
+	openChanges = append(openChanges, bottom.ID)
+	inserted, err := repo.SubmitChange(t.Context(), forge.SubmitChangeRequest{
+		Subject: "Native stack merged-member middle " + insertedBranch,
+		Body:    "Native stack merged-member integration test",
+		Base:    bottomBranch,
+		Head:    insertedBranch,
+	})
+	require.NoError(t, err, "create inserted change")
+	openChanges = append(openChanges, inserted.ID)
+	top, err := repo.SubmitChange(t.Context(), forge.SubmitChangeRequest{
+		Subject: "Native stack merged-member top " + topBranch,
+		Body:    "Native stack merged-member integration test",
+		Base:    bottomBranch,
+		Head:    topBranch,
+	})
+	require.NoError(t, err, "create top change")
+	openChanges = append(openChanges, top.ID)
+
+	plan, err := repo.PlanStackUpdate(t.Context(), []forge.StackChange{
+		{Change: bottom.ID, BaseBranch: "main"},
+		{Change: top.ID, BaseChange: bottom.ID, BaseBranch: bottomBranch},
+	})
+	require.NoError(t, err, "plan initial native stack")
+	require.NoError(t, plan.Execute(t.Context()), "create initial native stack")
+	_, err = gatewayClient.MergePullRequestAsync(
+		t.Context(),
+		&githubgateway.MergePullRequestAsyncInput{
+			Owner:             cfg.Owner,
+			Repo:              cfg.Repo,
+			PullRequestNumber: bottom.ID.(*github.PR).Number,
+			Method:            githubgateway.MergeMethodSquash,
+		},
+	)
+	require.NoError(t, err, "start native stack bottom merge")
+
+	if forgetest.Update() {
+		select {
+		case <-time.After(10 * time.Second):
+		case <-t.Context().Done():
+			require.FailNow(t, "merged-member test context canceled")
+		}
+	}
+	bottomState, err := repo.FindChangeByID(t.Context(), bottom.ID)
+	require.NoError(t, err, "read merged bottom change")
+	require.Equal(t, forge.ChangeMerged, bottomState.State)
+	openChanges = openChanges[1:]
+
+	desired := []forge.StackChange{
+		{Change: bottom.ID, BaseBranch: "main"},
+		{Change: inserted.ID, BaseChange: bottom.ID, BaseBranch: bottomBranch},
+		{Change: top.ID, BaseChange: inserted.ID, BaseBranch: insertedBranch},
+	}
+	plan, err = repo.PlanStackUpdate(t.Context(), desired)
+	require.NoError(t, err, "plan replacement around merged member")
+	require.NoError(t, plan.Execute(t.Context()), "leave merged-member stack unchanged")
+
+	pullRequests, err := gatewayClient.PullRequestsForStackUpdate(
+		t.Context(),
+		cfg.Owner,
+		cfg.Repo,
+		[]int{
+			bottom.ID.(*github.PR).Number,
+			inserted.ID.(*github.PR).Number,
+			top.ID.(*github.PR).Number,
+		},
+	)
+	require.NoError(t, err, "read native stack after omitted replacement")
+	require.Len(t, pullRequests, 3)
+	require.NotNil(t, pullRequests[1])
+	assert.Nil(t, pullRequests[1].Stack)
+	require.NotNil(t, pullRequests[2])
+	require.NotNil(t, pullRequests[2].Stack)
+	assert.NotEqual(t, insertedBranch, pullRequests[2].BaseRefName)
+	assert.Equal(t, []githubgateway.PullRequestStackMember{
+		{Number: bottom.ID.(*github.PR).Number, State: githubgateway.PullRequestStateMerged},
+		{Number: top.ID.(*github.PR).Number, State: githubgateway.PullRequestStateOpen},
+	}, pullRequests[2].Stack.Members)
 }
 
 func TestIntegration_Repository_LabelCreateDelete(t *testing.T) {

--- a/internal/forge/github/mocks_test.go
+++ b/internal/forge/github/mocks_test.go
@@ -235,6 +235,44 @@ func (c *MockGithubGatewayAddPullRequestReviewThreadReplyCall) DoAndReturn(f fun
 	return c
 }
 
+// AddPullRequestsToStack mocks base method.
+func (m *MockGithubGateway) AddPullRequestsToStack(arg0 context.Context, arg1 *github.AddPullRequestsToStackInput) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddPullRequestsToStack", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddPullRequestsToStack indicates an expected call of AddPullRequestsToStack.
+func (mr *MockGithubGatewayMockRecorder) AddPullRequestsToStack(arg0, arg1 any) *MockGithubGatewayAddPullRequestsToStackCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPullRequestsToStack", reflect.TypeOf((*MockGithubGateway)(nil).AddPullRequestsToStack), arg0, arg1)
+	return &MockGithubGatewayAddPullRequestsToStackCall{Call: call}
+}
+
+// MockGithubGatewayAddPullRequestsToStackCall wrap *gomock.Call
+type MockGithubGatewayAddPullRequestsToStackCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockGithubGatewayAddPullRequestsToStackCall) Return(arg0 error) *MockGithubGatewayAddPullRequestsToStackCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockGithubGatewayAddPullRequestsToStackCall) Do(f func(context.Context, *github.AddPullRequestsToStackInput) error) *MockGithubGatewayAddPullRequestsToStackCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockGithubGatewayAddPullRequestsToStackCall) DoAndReturn(f func(context.Context, *github.AddPullRequestsToStackInput) error) *MockGithubGatewayAddPullRequestsToStackCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ChangeStatuses mocks base method.
 func (m *MockGithubGateway) ChangeStatuses(arg0 context.Context, arg1 []github.ID) ([]*github.ChangeStatus, error) {
 	m.ctrl.T.Helper()
@@ -309,6 +347,44 @@ func (c *MockGithubGatewayChangeTemplatesCall) Do(f func(context.Context, string
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockGithubGatewayChangeTemplatesCall) DoAndReturn(f func(context.Context, string, string) ([]*github.ChangeTemplate, error)) *MockGithubGatewayChangeTemplatesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// CheckPullRequestStacks mocks base method.
+func (m *MockGithubGateway) CheckPullRequestStacks(arg0 context.Context, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckPullRequestStacks", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CheckPullRequestStacks indicates an expected call of CheckPullRequestStacks.
+func (mr *MockGithubGatewayMockRecorder) CheckPullRequestStacks(arg0, arg1, arg2 any) *MockGithubGatewayCheckPullRequestStacksCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckPullRequestStacks", reflect.TypeOf((*MockGithubGateway)(nil).CheckPullRequestStacks), arg0, arg1, arg2)
+	return &MockGithubGatewayCheckPullRequestStacksCall{Call: call}
+}
+
+// MockGithubGatewayCheckPullRequestStacksCall wrap *gomock.Call
+type MockGithubGatewayCheckPullRequestStacksCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockGithubGatewayCheckPullRequestStacksCall) Return(arg0 error) *MockGithubGatewayCheckPullRequestStacksCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockGithubGatewayCheckPullRequestStacksCall) Do(f func(context.Context, string, string) error) *MockGithubGatewayCheckPullRequestStacksCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockGithubGatewayCheckPullRequestStacksCall) DoAndReturn(f func(context.Context, string, string) error) *MockGithubGatewayCheckPullRequestStacksCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -463,6 +539,44 @@ func (c *MockGithubGatewayCreatePullRequestCall) Do(f func(context.Context, *git
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockGithubGatewayCreatePullRequestCall) DoAndReturn(f func(context.Context, *github.CreatePullRequestInput) (*github.CreatedPullRequest, error)) *MockGithubGatewayCreatePullRequestCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// CreatePullRequestStack mocks base method.
+func (m *MockGithubGateway) CreatePullRequestStack(arg0 context.Context, arg1 *github.CreatePullRequestStackInput) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreatePullRequestStack", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreatePullRequestStack indicates an expected call of CreatePullRequestStack.
+func (mr *MockGithubGatewayMockRecorder) CreatePullRequestStack(arg0, arg1 any) *MockGithubGatewayCreatePullRequestStackCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePullRequestStack", reflect.TypeOf((*MockGithubGateway)(nil).CreatePullRequestStack), arg0, arg1)
+	return &MockGithubGatewayCreatePullRequestStackCall{Call: call}
+}
+
+// MockGithubGatewayCreatePullRequestStackCall wrap *gomock.Call
+type MockGithubGatewayCreatePullRequestStackCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockGithubGatewayCreatePullRequestStackCall) Return(arg0 error) *MockGithubGatewayCreatePullRequestStackCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockGithubGatewayCreatePullRequestStackCall) Do(f func(context.Context, *github.CreatePullRequestStackInput) error) *MockGithubGatewayCreatePullRequestStackCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockGithubGatewayCreatePullRequestStackCall) DoAndReturn(f func(context.Context, *github.CreatePullRequestStackInput) error) *MockGithubGatewayCreatePullRequestStackCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1046,6 +1160,45 @@ func (c *MockGithubGatewayPullRequestReviewThreadsCall) DoAndReturn(f func(conte
 	return c
 }
 
+// PullRequestsForStackUpdate mocks base method.
+func (m *MockGithubGateway) PullRequestsForStackUpdate(arg0 context.Context, arg1, arg2 string, arg3 []int) ([]*github.StackUpdatePullRequest, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PullRequestsForStackUpdate", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].([]*github.StackUpdatePullRequest)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PullRequestsForStackUpdate indicates an expected call of PullRequestsForStackUpdate.
+func (mr *MockGithubGatewayMockRecorder) PullRequestsForStackUpdate(arg0, arg1, arg2, arg3 any) *MockGithubGatewayPullRequestsForStackUpdateCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullRequestsForStackUpdate", reflect.TypeOf((*MockGithubGateway)(nil).PullRequestsForStackUpdate), arg0, arg1, arg2, arg3)
+	return &MockGithubGatewayPullRequestsForStackUpdateCall{Call: call}
+}
+
+// MockGithubGatewayPullRequestsForStackUpdateCall wrap *gomock.Call
+type MockGithubGatewayPullRequestsForStackUpdateCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockGithubGatewayPullRequestsForStackUpdateCall) Return(arg0 []*github.StackUpdatePullRequest, arg1 error) *MockGithubGatewayPullRequestsForStackUpdateCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockGithubGatewayPullRequestsForStackUpdateCall) Do(f func(context.Context, string, string, []int) ([]*github.StackUpdatePullRequest, error)) *MockGithubGatewayPullRequestsForStackUpdateCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockGithubGatewayPullRequestsForStackUpdateCall) DoAndReturn(f func(context.Context, string, string, []int) ([]*github.StackUpdatePullRequest, error)) *MockGithubGatewayPullRequestsForStackUpdateCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // RefExists mocks base method.
 func (m *MockGithubGateway) RefExists(arg0 context.Context, arg1, arg2, arg3 string) (bool, error) {
 	m.ctrl.T.Helper()
@@ -1272,6 +1425,45 @@ func (c *MockGithubGatewayUnresolveReviewThreadCall) Do(f func(context.Context, 
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockGithubGatewayUnresolveReviewThreadCall) DoAndReturn(f func(context.Context, github.ID) error) *MockGithubGatewayUnresolveReviewThreadCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// UnstackPullRequestStack mocks base method.
+func (m *MockGithubGateway) UnstackPullRequestStack(arg0 context.Context, arg1 *github.UnstackPullRequestStackInput) (*github.UnstackPullRequestStackResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UnstackPullRequestStack", arg0, arg1)
+	ret0, _ := ret[0].(*github.UnstackPullRequestStackResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UnstackPullRequestStack indicates an expected call of UnstackPullRequestStack.
+func (mr *MockGithubGatewayMockRecorder) UnstackPullRequestStack(arg0, arg1 any) *MockGithubGatewayUnstackPullRequestStackCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnstackPullRequestStack", reflect.TypeOf((*MockGithubGateway)(nil).UnstackPullRequestStack), arg0, arg1)
+	return &MockGithubGatewayUnstackPullRequestStackCall{Call: call}
+}
+
+// MockGithubGatewayUnstackPullRequestStackCall wrap *gomock.Call
+type MockGithubGatewayUnstackPullRequestStackCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockGithubGatewayUnstackPullRequestStackCall) Return(arg0 *github.UnstackPullRequestStackResult, arg1 error) *MockGithubGatewayUnstackPullRequestStackCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockGithubGatewayUnstackPullRequestStackCall) Do(f func(context.Context, *github.UnstackPullRequestStackInput) (*github.UnstackPullRequestStackResult, error)) *MockGithubGatewayUnstackPullRequestStackCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockGithubGatewayUnstackPullRequestStackCall) DoAndReturn(f func(context.Context, *github.UnstackPullRequestStackInput) (*github.UnstackPullRequestStackResult, error)) *MockGithubGatewayUnstackPullRequestStackCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/forge/github/repository.go
+++ b/internal/forge/github/repository.go
@@ -20,11 +20,14 @@ type githubGateway interface {
 	AddPullRequestReview(context.Context, *github.AddPullRequestReviewInput) (*github.AddedPullRequestReview, error)
 	AddPullRequestReviewThread(context.Context, *github.AddPullRequestReviewThreadInput) (*github.AddedPullRequestReviewThread, error)
 	AddPullRequestReviewThreadReply(context.Context, *github.AddPullRequestReviewThreadReplyInput) (*github.AddedPullRequestReviewComment, error)
+	AddPullRequestsToStack(context.Context, *github.AddPullRequestsToStackInput) error
 	AddPullRequestMetadata(context.Context, *github.PullRequestMetadataInput) error
 	ChangeStatuses(context.Context, []github.ID) ([]*github.ChangeStatus, error)
 	ChangeTemplates(context.Context, string, string) ([]*github.ChangeTemplate, error)
+	CheckPullRequestStacks(context.Context, string, string) error
 	ClosePullRequest(context.Context, github.ID) error
 	ConvertPullRequestToDraft(context.Context, github.ID) error
+	CreatePullRequestStack(context.Context, *github.CreatePullRequestStackInput) error
 	CreateLabel(context.Context, github.ID, string, string) (github.ID, error)
 	CreatePullRequest(context.Context, *github.CreatePullRequestInput) (*github.CreatedPullRequest, error)
 	DeleteIssueComment(context.Context, github.ID) error
@@ -36,6 +39,7 @@ type githubGateway interface {
 	MarkPullRequestReadyForReview(context.Context, github.ID) error
 	MergePullRequest(context.Context, *github.MergePullRequestInput) error
 	PullRequest(context.Context, string, string, int) (*github.PullRequest, error)
+	PullRequestsForStackUpdate(context.Context, string, string, []int) ([]*github.StackUpdatePullRequest, error)
 	PullRequestComments(context.Context, github.ID, *github.PaginationOptions) iter.Seq2[*github.Comment, error]
 	PullRequestID(context.Context, string, string, int) (github.ID, error)
 	PullRequestMergeability(context.Context, github.ID) (*github.Mergeability, error)
@@ -51,6 +55,7 @@ type githubGateway interface {
 	UpdateIssueComment(context.Context, github.ID, string) error
 	UpdatePullRequest(context.Context, *github.UpdatePullRequestInput) error
 	UpdatePullRequestReviewComment(context.Context, github.ID, string) error
+	UnstackPullRequestStack(context.Context, *github.UnstackPullRequestStackInput) (*github.UnstackPullRequestStackResult, error)
 }
 
 var _ githubGateway = (*github.Gateway)(nil)

--- a/internal/forge/github/stack_reconciliation.go
+++ b/internal/forge/github/stack_reconciliation.go
@@ -1,0 +1,519 @@
+package github
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+	"strings"
+
+	"go.abhg.dev/container/ring"
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/gateway/github"
+	"go.abhg.dev/gs/internal/graph"
+)
+
+// githubStackReconciliation is the deterministic result of reconciling one
+// desired forest with its observed GitHub state.
+type githubStackReconciliation struct {
+	transitions []githubStackTransition
+	warnings    []string
+	errs        []error
+}
+
+// reconcileGitHubStacks is the pure policy boundary for native-stack updates.
+// It projects GitHub-ineligible pull requests, preserves compatible existing
+// membership, selects GitHub's linear representation, and returns only the
+// ordered mutations required to reach that representation.
+func reconcileGitHubStacks(
+	snapshot githubStackSnapshot,
+) githubStackReconciliation {
+	// Copy the immutable snapshot into a pointer-linked working forest.
+	// Later phases annotate these nodes as GitHub eligibility and selected bases
+	// become known without mutating caller-owned input.
+	reconciler := githubStackReconciler{
+		changesByNumber: make(map[int]*githubStackChange, len(snapshot)),
+		orderedChanges:  make([]*githubStackChange, len(snapshot)),
+	}
+	for i, observed := range snapshot {
+		change := &githubStackChange{
+			number:      observed.desired.number,
+			baseBranch:  observed.desired.baseBranch,
+			pullRequest: observed.pullRequest,
+		}
+		reconciler.changesByNumber[change.number] = change
+		reconciler.orderedChanges[i] = change
+	}
+	for i, observed := range snapshot {
+		reconciler.orderedChanges[i].requestedBase = reconciler.changesByNumber[observed.desired.baseNumber]
+	}
+
+	// Projection removes relationships GitHub cannot represent.
+	// Selection then chooses one linear path per projected tree.
+	// Coalescing makes one remote stack the unit of replacement before the
+	// selected paths are converted into provider writes.
+	errs := reconciler.projectChangeTrees()
+	candidates := reconciler.planChangeTrees()
+	transitions := reconciler.coalesceReplacements(candidates)
+	return githubStackReconciliation{
+		transitions: transitions,
+		warnings:    reconciler.warnings,
+		errs:        errs,
+	}
+}
+
+// githubStackReconciler owns the mutable working representation used by the
+// pure reconciliation operation. Its state is allocated for one invocation
+// and never escapes in the result.
+type githubStackReconciler struct {
+	changesByNumber map[int]*githubStackChange
+	orderedChanges  []*githubStackChange
+
+	// aboves and bottoms describe the projected forest after closed and merged
+	// pull requests have been removed.
+	aboves  map[*githubStackChange][]*githubStackChange
+	bottoms []*githubStackChange
+
+	warnings []string
+}
+
+// githubStackChange carries one requested relationship through GitHub lookup,
+// projection, and linear-path selection.
+type githubStackChange struct {
+	// number is the repository-local pull request number.
+	number int
+
+	// requestedBase is the immediate base supplied in the forge request.
+	requestedBase *githubStackChange
+
+	// baseBranch is the desired provider-facing base branch.
+	baseBranch string
+
+	// pullRequest is nil when GitHub did not find the requested change.
+	pullRequest *githubStackPullRequestState
+
+	// projection records how this change participates in GitHub's
+	// representation.
+	projection githubStackProjection
+
+	// nearestIncluded is this change when it is included. Transparent changes
+	// inherit their requested base's value so their upstack reconnects to the
+	// nearest included change below them.
+	nearestIncluded *githubStackChange
+
+	// projectedBase is the nearest included change below this change. It is set
+	// only for included changes.
+	projectedBase *githubStackChange
+}
+
+// githubStackProjection records how a requested change participates in GitHub's
+// open, same-repository stack representation. The zero value means projection
+// has not inspected the change yet.
+type githubStackProjection uint8
+
+const (
+	// githubStackProjectionExcluded means GitHub cannot represent the change
+	// or its requested upstack.
+	githubStackProjectionExcluded githubStackProjection = iota + 1
+
+	// githubStackProjectionTransparent means the pull request is closed or
+	// merged. GitHub omits it and joins its upstack to the nearest included
+	// change below.
+	githubStackProjectionTransparent
+
+	// githubStackProjectionIncluded means the pull request is open and eligible
+	// for a GitHub native stack.
+	githubStackProjectionIncluded
+)
+
+// projectChangeTrees converts requested forge relationships into the forest
+// from which GitHub native stacks may be selected.
+//
+// A closed or merged pull request is transparent because its upstack remains
+// valid and can reconnect to the nearest included change below it. A missing
+// or cross-repository pull request instead excludes its complete requested
+// upstack: GitHub cannot form a same-repository native stack through that
+// boundary. Missing pull requests are genuine lookup failures as well as
+// projection boundaries, so they are returned after projection completes.
+func (r *githubStackReconciler) projectChangeTrees() []error {
+	var errs []error
+	// Project changes in base-first order. That makes each requested base's
+	// exclusion and nearest included change final before its upstack is visited.
+	for _, change := range r.orderedChanges {
+		if change.requestedBase != nil &&
+			change.requestedBase.projection == githubStackProjectionExcluded {
+			change.projection = githubStackProjectionExcluded
+			continue
+		}
+
+		// Closed and merged pull requests disappear from GitHub's native stack,
+		// so carry the nearest included change through them. Eligible open pull
+		// requests use that change as their projected base.
+		var below *githubStackChange
+		if change.requestedBase != nil {
+			below = change.requestedBase.nearestIncluded
+		}
+		pullRequest := change.pullRequest
+		if pullRequest == nil {
+			change.projection = githubStackProjectionExcluded
+			errs = append(errs, fmt.Errorf(
+				"inspect GitHub pull request #%d: %w",
+				change.number,
+				forge.ErrNotFound,
+			))
+			r.warnOmittedUpstack(change.number, "the pull request was not found")
+			continue
+		}
+		if pullRequest.state != github.PullRequestStateOpen {
+			change.projection = githubStackProjectionTransparent
+			change.nearestIncluded = below
+			continue
+		}
+		if !pullRequest.headInRepository {
+			change.projection = githubStackProjectionExcluded
+			r.warnOmittedUpstack(
+				change.number,
+				"the head branch is not in the receiving repository",
+			)
+			continue
+		}
+
+		change.projection = githubStackProjectionIncluded
+		change.nearestIncluded = change
+		change.projectedBase = below
+	}
+
+	// Materialize the projected forest only after every change has been
+	// classified. Excluded changes never become traversal roots or edges.
+	r.aboves = make(map[*githubStackChange][]*githubStackChange, len(r.changesByNumber))
+	for _, change := range r.orderedChanges {
+		if change.projection != githubStackProjectionIncluded {
+			continue
+		}
+		if change.projectedBase == nil {
+			r.bottoms = append(r.bottoms, change)
+			continue
+		}
+		r.aboves[change.projectedBase] = append(r.aboves[change.projectedBase], change)
+	}
+
+	// PR-number ordering makes independent-tree processing, equal-length path
+	// selection, and divergent-upstack warnings deterministic.
+	slices.SortFunc(r.bottoms, func(a, b *githubStackChange) int {
+		return cmp.Compare(a.number, b.number)
+	})
+	for _, changes := range r.aboves {
+		slices.SortFunc(changes, func(a, b *githubStackChange) int {
+			return cmp.Compare(a.number, b.number)
+		})
+	}
+	return errs
+}
+
+// planChangeTrees independently selects a desired linear path for each
+// projected tree and records the transition from the observed GitHub stack.
+// Selection limitations warn and omit their tree before any write is possible.
+func (r *githubStackReconciler) planChangeTrees() []githubStackTransitionCandidate {
+	var candidates []githubStackTransitionCandidate
+	// Each bottom owns one complete projected change tree.
+	// Selection inspects every reachable change
+	// so existing native membership can constrain the path
+	// before longest-path selection.
+	// The selected path is the complete desired linear stack,
+	// including any existing prefix.
+	// The transition records whether execution can append the missing suffix
+	// or must dissolve and recreate a changed linear composition.
+	for _, bottom := range r.bottoms {
+		selected, remoteStack, ok := r.selectLinearPath(bottom)
+		if !ok {
+			continue
+		}
+
+		// For each selected branch in the stack, if it has siblings,
+		// those siblings are omitted from the native stack.
+		for idx, change := range selected {
+			var selectedAbove *githubStackChange
+			if idx+1 < len(selected) {
+				selectedAbove = selected[idx+1]
+			}
+			for _, above := range r.aboves[change] {
+				if above != selectedAbove {
+					r.warnOmittedUpstack(
+						above.number,
+						"the change tree diverges from the selected linear path",
+					)
+				}
+			}
+		}
+
+		candidate := newGitHubStackTransitionCandidate(selected, remoteStack)
+		if candidate.kind != githubStackTransitionCurrent {
+			candidates = append(candidates, candidate)
+		}
+	}
+	return candidates
+}
+
+// selectLinearPath applies GitHub's non-divergence constraint before choosing
+// among the projected tree's remaining paths.
+//
+// If a divergent tree intersects an existing native stack,
+// that stack's complete open membership must be a compatible selected prefix.
+// This preserves GitHub's one-path representation
+// rather than silently replacing it with a sibling path.
+// A linear desired tree may replace incompatible membership during execution.
+// Multiple existing native stacks remain ambiguous and leave the tree unchanged.
+// Only the upstack above a compatible prefix participates in longest-path
+// selection; equal lengths prefer the lower pull request number.
+//
+// On success, selectLinearPath returns the selected base-up path, the remote
+// stack to extend or restructure,
+// or nil when GitHub must create one,
+// and true.
+// When divergent existing membership cannot be preserved,
+// it warns, returns false,
+// and the caller leaves the complete projected tree unchanged.
+func (r *githubStackReconciler) selectLinearPath(
+	bottom *githubStackChange,
+) ([]*githubStackChange, *github.PullRequestStack, bool) {
+	tree, ok := r.inspectExistingStack(bottom)
+	if !ok {
+		return nil, nil, false
+	}
+
+	extensionBase := bottom
+	if tree.stack != nil {
+		prefixTop, compatible := r.existingStackPrefix(bottom, tree.stack)
+		if !compatible && tree.divergent {
+			openPullRequests := openStackMemberNumbers(tree.stack.Members)
+			formatted := make([]string, len(openPullRequests))
+			for i, number := range openPullRequests {
+				formatted[i] = fmt.Sprintf("#%d", number)
+			}
+			r.warnings = append(r.warnings, fmt.Sprintf(
+				"#%d: Leaving pull request and its upstack in existing GitHub native stack #%d: open pull requests %s have incompatible membership",
+				bottom.number,
+				tree.stack.Number,
+				strings.Join(formatted, ", "),
+			))
+			return nil, nil, false
+		}
+		if compatible {
+			extensionBase = prefixTop
+		}
+	}
+
+	// Select only above the fixed remote prefix. FurthestChildren establishes
+	// maximum path length; PR number supplies GitHub's deterministic tie-break.
+	tops := graph.FurthestChildren(
+		extensionBase,
+		func(change *githubStackChange) []*githubStackChange {
+			return r.aboves[change]
+		},
+	)
+	top := slices.MinFunc(tops, func(a, b *githubStackChange) int {
+		return cmp.Compare(a.number, b.number)
+	})
+	var selected []*githubStackChange
+	for change := top; change != nil; change = change.projectedBase {
+		selected = append(selected, change)
+	}
+	slices.Reverse(selected)
+	return selected, tree.stack, true
+}
+
+// githubStackTreeInspection records the existing GitHub state that constrains
+// linear-path selection for one projected tree.
+type githubStackTreeInspection struct {
+	stack     *github.PullRequestStack
+	divergent bool
+}
+
+// inspectExistingStack finds the one native stack that constrains path
+// selection and records whether the projected tree diverges. A tree spanning
+// multiple native stacks is ambiguous and is left unchanged.
+func (r *githubStackReconciler) inspectExistingStack(
+	bottom *githubStackChange,
+) (githubStackTreeInspection, bool) {
+	var result githubStackTreeInspection
+	var remaining ring.Q[*githubStackChange]
+	remaining.Push(bottom)
+	for !remaining.Empty() {
+		change := remaining.Pop()
+		if len(r.aboves[change]) > 1 {
+			result.divergent = true
+		}
+		for _, above := range r.aboves[change] {
+			remaining.Push(above)
+		}
+
+		currentStack := change.pullRequest.stack
+		if currentStack == nil {
+			continue
+		}
+		if result.stack == nil {
+			result.stack = currentStack
+			continue
+		}
+		if result.stack.Number != currentStack.Number {
+			r.warnings = append(r.warnings, fmt.Sprintf(
+				"#%d: Leaving pull request and its upstack in existing GitHub native stacks: pull requests belong to different native stacks",
+				bottom.number,
+			))
+			return githubStackTreeInspection{}, false
+		}
+	}
+	return result, true
+}
+
+// existingStackPrefix proves that every open member of stack forms one
+// base-up path from bottom through the projected tree. The returned change is
+// the top of that fixed prefix.
+func (r *githubStackReconciler) existingStackPrefix(
+	bottom *githubStackChange,
+	stack *github.PullRequestStack,
+) (*githubStackChange, bool) {
+	openMembers := openStackMemberNumbers(stack.Members)
+	if len(openMembers) == 0 {
+		return nil, false
+	}
+
+	var below *githubStackChange
+	for i, number := range openMembers {
+		change := r.changesByNumber[number]
+		if change == nil || change.projection != githubStackProjectionIncluded ||
+			(i == 0 && change != bottom) ||
+			(i > 0 && change.projectedBase != below) {
+			return nil, false
+		}
+		below = change
+	}
+	return below, true
+}
+
+type githubStackTransitionKind uint8
+
+const (
+	githubStackTransitionCurrent githubStackTransitionKind = iota
+	githubStackTransitionCreate
+	githubStackTransitionAppend
+	githubStackTransitionReplace
+)
+
+// githubStackTransitionCandidate retains the selected paths and observed stack
+// until every desired component has been considered. Candidates that touch the
+// same remote stack must be coalesced before their mutations are materialized.
+type githubStackTransitionCandidate struct {
+	kind        githubStackTransitionKind
+	remoteStack *github.PullRequestStack
+	paths       [][]*githubStackChange
+}
+
+func newGitHubStackTransitionCandidate(
+	path []*githubStackChange,
+	remoteStack *github.PullRequestStack,
+) githubStackTransitionCandidate {
+	candidate := githubStackTransitionCandidate{
+		remoteStack: remoteStack,
+		paths:       [][]*githubStackChange{path},
+	}
+	if remoteStack == nil {
+		candidate.kind = githubStackTransitionCreate
+		return candidate
+	}
+
+	numbers := stackChangeNumbers(path)
+	currentBases := func(changes []*githubStackChange) bool {
+		for _, change := range changes {
+			if change.baseBranch != "" && change.pullRequest.baseBranch != change.baseBranch {
+				return false
+			}
+		}
+		return true
+	}
+	remoteNumbers := openStackMemberNumbers(remoteStack.Members)
+	remoteLength := len(remoteNumbers)
+	remoteIsPrefix := remoteLength <= len(numbers) &&
+		slices.Equal(remoteNumbers, numbers[:remoteLength])
+	switch {
+	case remoteLength == len(numbers) && remoteIsPrefix && currentBases(path):
+		candidate.kind = githubStackTransitionCurrent
+	case remoteLength < len(numbers) && remoteIsPrefix && currentBases(path[:remoteLength]):
+		candidate.kind = githubStackTransitionAppend
+	default:
+		candidate.kind = githubStackTransitionReplace
+	}
+	return candidate
+}
+
+// coalesceReplacements makes one remote stack the unit of mutation. A split
+// therefore un-stacks once and recreates every desired component, rather than
+// letting component-local transitions race over the same provider object.
+func (r *githubStackReconciler) coalesceReplacements(
+	candidates []githubStackTransitionCandidate,
+) []githubStackTransition {
+	byStack := make(map[int]int)
+	kept := make([]githubStackTransitionCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.remoteStack == nil {
+			kept = append(kept, candidate)
+			continue
+		}
+		priorIndex, exists := byStack[candidate.remoteStack.Number]
+		if !exists {
+			byStack[candidate.remoteStack.Number] = len(kept)
+			kept = append(kept, candidate)
+			continue
+		}
+		prior := &kept[priorIndex]
+		prior.kind = githubStackTransitionReplace
+		prior.paths = append(prior.paths, candidate.paths...)
+	}
+
+	var result []githubStackTransition
+	for _, candidate := range kept {
+		// Replacement is safe only when unstacking can dissolve the provider
+		// object completely. Otherwise execution would discover the retained
+		// members only after it had already changed remote state.
+		replacementBlocked := candidate.kind == githubStackTransitionReplace &&
+			slices.ContainsFunc(
+				candidate.remoteStack.Members,
+				func(member github.PullRequestStackMember) bool {
+					return member.Locked ||
+						member.State == github.PullRequestStateMerged
+				},
+			)
+		if !replacementBlocked {
+			materialized := newGitHubStackTransition(candidate)
+			if materialized.unstackNumber != 0 || len(materialized.paths) > 0 {
+				result = append(result, materialized)
+			}
+			continue
+		}
+		r.warnings = append(r.warnings, fmt.Sprintf(
+			"#%d: Leaving pull request and its upstack in existing GitHub native stack #%d: merged, queued, or auto-merge pull requests prevent restructuring",
+			candidate.paths[0][0].number,
+			candidate.remoteStack.Number,
+		))
+	}
+	return result
+}
+
+// openStackMemberNumbers projects GitHub's historical stack entries onto the
+// active membership used for prefix selection and append operations.
+func openStackMemberNumbers(members []github.PullRequestStackMember) []int {
+	var numbers []int
+	for _, member := range members {
+		if member.State == github.PullRequestStateOpen {
+			numbers = append(numbers, member.Number)
+		}
+	}
+	return numbers
+}
+
+func (r *githubStackReconciler) warnOmittedUpstack(number int, reason string) {
+	r.warnings = append(r.warnings, fmt.Sprintf(
+		"#%d: Leaving pull request and its upstack out of the GitHub native stack: %s",
+		number,
+		reason,
+	))
+}

--- a/internal/forge/github/stack_reconciliation_test.go
+++ b/internal/forge/github/stack_reconciliation_test.go
@@ -1,0 +1,367 @@
+package github
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.abhg.dev/gs/internal/gateway/github"
+)
+
+func TestReconcileGitHubStacks(t *testing.T) {
+	openChange := func(
+		number int,
+		baseNumber int,
+		desiredBase string,
+		currentBase string,
+		stack *github.PullRequestStack,
+	) githubStackSnapshotChange {
+		return githubStackSnapshotChange{
+			desired: githubStackDesiredChange{
+				number:     number,
+				baseNumber: baseNumber,
+				baseBranch: desiredBase,
+			},
+			pullRequest: &githubStackPullRequestState{
+				id:               github.ID(fmt.Sprintf("PR_%d", number)),
+				state:            github.PullRequestStateOpen,
+				baseBranch:       currentBase,
+				headInRepository: true,
+				stack:            stack,
+			},
+		}
+	}
+	mergedChange := func(
+		number int,
+		baseNumber int,
+		desiredBase string,
+		currentBase string,
+	) githubStackSnapshotChange {
+		change := openChange(number, baseNumber, desiredBase, currentBase, nil)
+		change.pullRequest.state = github.PullRequestStateMerged
+		return change
+	}
+	nativeStack := func(number int, members ...int) *github.PullRequestStack {
+		stack := &github.PullRequestStack{Number: number}
+		for _, member := range members {
+			stack.Members = append(stack.Members, github.PullRequestStackMember{
+				Number: member,
+				State:  github.PullRequestStateOpen,
+			})
+		}
+		return stack
+	}
+
+	tests := []struct {
+		name string
+		give githubStackSnapshot
+		want []githubStackTransition
+	}{
+		{
+			name: "Current",
+			give: githubStackSnapshot{
+				openChange(1, 0, "main", "main", nativeStack(42, 1, 2)),
+				openChange(2, 1, "a", "a", nativeStack(42, 1, 2)),
+			},
+		},
+		{
+			name: "SinglePullRequestNeedsNoNativeStack",
+			give: githubStackSnapshot{
+				openChange(1, 0, "main", "main", nil),
+			},
+		},
+		{
+			name: "Create",
+			give: githubStackSnapshot{
+				openChange(1, 0, "main", "main", nil),
+				openChange(2, 1, "a", "a", nil),
+			},
+			want: []githubStackTransition{{
+				paths: []githubStackPathTransition{{
+					stackUpdate: &githubStackMembershipUpdate{
+						pullRequests: []int{1, 2},
+					},
+				}},
+			}},
+		},
+		{
+			name: "Append",
+			give: githubStackSnapshot{
+				openChange(1, 0, "main", "main", nativeStack(42, 1, 2)),
+				openChange(2, 1, "a", "a", nativeStack(42, 1, 2)),
+				openChange(3, 2, "b", "a", nil),
+			},
+			want: []githubStackTransition{{
+				paths: []githubStackPathTransition{{
+					baseUpdates: []githubPullRequestBaseUpdate{{
+						pullRequestNumber: 3,
+						pullRequestID:     "PR_3",
+						baseBranch:        "b",
+					}},
+					stackUpdate: &githubStackMembershipUpdate{
+						stackNumber:  42,
+						pullRequests: []int{3},
+					},
+				}},
+			}},
+		},
+		{
+			// Desired: 1 -> 3 -> 2. Current native stack: 1 -> 2.
+			name: "Insert",
+			give: githubStackSnapshot{
+				openChange(1, 0, "main", "main", nativeStack(42, 1, 2)),
+				openChange(3, 1, "a", "a", nil),
+				openChange(2, 3, "c", "a", nativeStack(42, 1, 2)),
+			},
+			want: []githubStackTransition{{
+				unstackNumber: 42,
+				paths: []githubStackPathTransition{{
+					baseUpdates: []githubPullRequestBaseUpdate{{
+						pullRequestNumber: 2,
+						pullRequestID:     "PR_2",
+						baseBranch:        "c",
+					}},
+					stackUpdate: &githubStackMembershipUpdate{
+						pullRequests: []int{1, 3, 2},
+					},
+				}},
+			}},
+		},
+		{
+			// Desired: 1 -> 3. Current native stack: 1 -> 2 -> 3.
+			name: "Remove",
+			give: githubStackSnapshot{
+				openChange(1, 0, "main", "main", nativeStack(42, 1, 2, 3)),
+				openChange(3, 1, "a", "b", nativeStack(42, 1, 2, 3)),
+			},
+			want: []githubStackTransition{{
+				unstackNumber: 42,
+				paths: []githubStackPathTransition{{
+					baseUpdates: []githubPullRequestBaseUpdate{{
+						pullRequestNumber: 3,
+						pullRequestID:     "PR_3",
+						baseBranch:        "a",
+					}},
+					stackUpdate: &githubStackMembershipUpdate{
+						pullRequests: []int{1, 3},
+					},
+				}},
+			}},
+		},
+		{
+			// Desired: 1 and 2 are separate roots. Current native stack: 1 -> 2.
+			name: "Split",
+			give: githubStackSnapshot{
+				openChange(1, 0, "main", "main", nativeStack(42, 1, 2)),
+				openChange(2, 0, "main", "a", nativeStack(42, 1, 2)),
+			},
+			want: []githubStackTransition{{
+				unstackNumber: 42,
+				paths: []githubStackPathTransition{{
+					baseUpdates: []githubPullRequestBaseUpdate{{
+						pullRequestNumber: 2,
+						pullRequestID:     "PR_2",
+						baseBranch:        "main",
+					}},
+				}},
+			}},
+		},
+		{
+			name: "ReconnectAboveMergedChange",
+			give: githubStackSnapshot{
+				mergedChange(1, 0, "main", "main"),
+				openChange(2, 1, "a", "a", nil),
+				openChange(3, 2, "b", "b", nil),
+			},
+			want: []githubStackTransition{{
+				paths: []githubStackPathTransition{{
+					stackUpdate: &githubStackMembershipUpdate{
+						pullRequests: []int{2, 3},
+					},
+				}},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := reconcileGitHubStacks(tt.give)
+
+			assert.Equal(t, tt.want, got.transitions)
+			assert.Empty(t, got.warnings)
+			assert.Empty(t, got.errs)
+		})
+	}
+}
+
+func TestReconcileGitHubStacks_errors(t *testing.T) {
+	openChange := func(
+		number int,
+		baseNumber int,
+		desiredBase string,
+		currentBase string,
+		stack *github.PullRequestStack,
+	) githubStackSnapshotChange {
+		return githubStackSnapshotChange{
+			desired: githubStackDesiredChange{
+				number:     number,
+				baseNumber: baseNumber,
+				baseBranch: desiredBase,
+			},
+			pullRequest: &githubStackPullRequestState{
+				id:               github.ID(fmt.Sprintf("PR_%d", number)),
+				state:            github.PullRequestStateOpen,
+				baseBranch:       currentBase,
+				headInRepository: true,
+				stack:            stack,
+			},
+		}
+	}
+	missingChange := func(
+		number int,
+		baseNumber int,
+		desiredBase string,
+	) githubStackSnapshotChange {
+		return githubStackSnapshotChange{
+			desired: githubStackDesiredChange{
+				number:     number,
+				baseNumber: baseNumber,
+				baseBranch: desiredBase,
+			},
+		}
+	}
+	nativeStack := func(number int, members ...int) *github.PullRequestStack {
+		stack := &github.PullRequestStack{Number: number}
+		for _, member := range members {
+			stack.Members = append(stack.Members, github.PullRequestStackMember{
+				Number: member,
+				State:  github.PullRequestStateOpen,
+			})
+		}
+		return stack
+	}
+	lockedStack := func(number int, members ...int) *github.PullRequestStack {
+		stack := nativeStack(number, members...)
+		stack.Members[len(stack.Members)-1].Locked = true
+		return stack
+	}
+	errorMessages := func(errs []error) []string {
+		var messages []string
+		for _, err := range errs {
+			messages = append(messages, err.Error())
+		}
+		return messages
+	}
+
+	tests := []struct {
+		name string
+		give githubStackSnapshot
+
+		wantTransitions []githubStackTransition
+		wantWarnings    []string
+		wantErrors      []string
+	}{
+		{
+			// 1 -+-> 2 -> 5
+			//    `-> 3 -> 4
+			name: "DivergentLongestPath",
+			give: githubStackSnapshot{
+				openChange(1, 0, "base", "base", nil),
+				openChange(2, 1, "base", "base", nil),
+				openChange(3, 1, "base", "base", nil),
+				openChange(4, 3, "base", "base", nil),
+				openChange(5, 2, "base", "base", nil),
+			},
+			wantTransitions: []githubStackTransition{{
+				paths: []githubStackPathTransition{{
+					stackUpdate: &githubStackMembershipUpdate{
+						pullRequests: []int{1, 3, 4},
+					},
+				}},
+			}},
+			wantWarnings: []string{
+				"#2: Leaving pull request and its upstack out of the GitHub native stack: the change tree diverges from the selected linear path",
+			},
+		},
+		{
+			// 1 -> 2 -+-> 3 -> 5
+			//         `-> 4 (existing native stack)
+			name: "PreferExistingStack",
+			give: githubStackSnapshot{
+				openChange(1, 0, "base", "base", nativeStack(42, 1, 2, 4)),
+				openChange(2, 1, "base", "base", nativeStack(42, 1, 2, 4)),
+				openChange(3, 2, "base", "base", nil),
+				openChange(4, 2, "base", "base", nativeStack(42, 1, 2, 4)),
+				openChange(5, 3, "base", "base", nil),
+			},
+			wantWarnings: []string{
+				"#3: Leaving pull request and its upstack out of the GitHub native stack: the change tree diverges from the selected linear path",
+			},
+		},
+		{
+			// Desired: 1 -> {2, 3}. Current native stack references absent #4.
+			name: "LeaveIncompatibleDivergentStack",
+			give: githubStackSnapshot{
+				openChange(1, 0, "base", "base", nativeStack(42, 1, 4)),
+				openChange(2, 1, "base", "base", nil),
+				openChange(3, 1, "base", "base", nil),
+			},
+			wantWarnings: []string{
+				"#1: Leaving pull request and its upstack in existing GitHub native stack #42: open pull requests #1, #4 have incompatible membership",
+			},
+		},
+		{
+			name: "LeaveLockedReplacement",
+			give: githubStackSnapshot{
+				openChange(1, 0, "main", "main", lockedStack(42, 1, 2)),
+				openChange(3, 1, "a", "a", nil),
+				openChange(2, 3, "c", "a", lockedStack(42, 1, 2)),
+			},
+			wantWarnings: []string{
+				"#1: Leaving pull request and its upstack in existing GitHub native stack #42: merged, queued, or auto-merge pull requests prevent restructuring",
+			},
+		},
+		{
+			name: "LeaveReplacementWithMergedMember",
+			give: func() githubStackSnapshot {
+				stack := &github.PullRequestStack{
+					Number: 42,
+					Members: []github.PullRequestStackMember{
+						{Number: 1, State: github.PullRequestStateMerged},
+						{Number: 2, State: github.PullRequestStateOpen},
+					},
+				}
+				merged := openChange(1, 0, "main", "main", stack)
+				merged.pullRequest.state = github.PullRequestStateMerged
+				return githubStackSnapshot{
+					merged,
+					openChange(3, 1, "a", "a", nil),
+					openChange(2, 3, "c", "a", stack),
+				}
+			}(),
+			wantWarnings: []string{
+				"#3: Leaving pull request and its upstack in existing GitHub native stack #42: merged, queued, or auto-merge pull requests prevent restructuring",
+			},
+		},
+		{
+			name: "MissingPullRequest",
+			give: githubStackSnapshot{
+				missingChange(1, 0, "main"),
+			},
+			wantWarnings: []string{
+				"#1: Leaving pull request and its upstack out of the GitHub native stack: the pull request was not found",
+			},
+			wantErrors: []string{"inspect GitHub pull request #1: not found"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := reconcileGitHubStacks(tt.give)
+
+			assert.Equal(t, tt.wantTransitions, got.transitions)
+			assert.Equal(t, tt.wantWarnings, got.warnings)
+			assert.Equal(t, tt.wantErrors, errorMessages(got.errs))
+		})
+	}
+}

--- a/internal/forge/github/stack_transition.go
+++ b/internal/forge/github/stack_transition.go
@@ -1,0 +1,178 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+
+	"go.abhg.dev/gs/internal/gateway/github"
+)
+
+// githubStackTransition describes one independent remote stack update.
+// The unstack number, when non-zero, must succeed before any path begins.
+// Paths remain independent after that shared prerequisite.
+type githubStackTransition struct {
+	unstackNumber int
+	paths         []githubStackPathTransition
+}
+
+// githubStackPathTransition aligns one path's bases before publishing its
+// native stack membership. A nil stack update leaves the path unstacked.
+type githubStackPathTransition struct {
+	baseUpdates []githubPullRequestBaseUpdate
+	stackUpdate *githubStackMembershipUpdate
+}
+
+type githubPullRequestBaseUpdate struct {
+	pullRequestNumber int
+	pullRequestID     github.ID
+	baseBranch        string
+}
+
+// githubStackMembershipUpdate creates a native stack when stackNumber is zero
+// and appends to that existing stack otherwise.
+type githubStackMembershipUpdate struct {
+	stackNumber  int
+	pullRequests []int
+}
+
+func newGitHubStackTransition(
+	candidate githubStackTransitionCandidate,
+) githubStackTransition {
+	var transition githubStackTransition
+	if candidate.kind == githubStackTransitionReplace {
+		transition.unstackNumber = candidate.remoteStack.Number
+	}
+
+	for _, selected := range candidate.paths {
+		start := 0
+		if candidate.kind == githubStackTransitionAppend {
+			start = len(openStackMemberNumbers(candidate.remoteStack.Members))
+		}
+
+		// Retarget bottom-to-top before publishing membership. Once a write in
+		// this path fails, later writes would rely on a base relationship that was
+		// never established.
+		var path githubStackPathTransition
+		for _, change := range selected[start:] {
+			if change.baseBranch == "" || change.pullRequest.baseBranch == change.baseBranch {
+				continue
+			}
+			path.baseUpdates = append(path.baseUpdates, githubPullRequestBaseUpdate{
+				pullRequestNumber: change.number,
+				pullRequestID:     change.pullRequest.id,
+				baseBranch:        change.baseBranch,
+			})
+		}
+
+		numbers := stackChangeNumbers(selected)
+		switch {
+		case len(numbers) < 2:
+		case candidate.kind == githubStackTransitionAppend:
+			path.stackUpdate = &githubStackMembershipUpdate{
+				stackNumber:  candidate.remoteStack.Number,
+				pullRequests: slices.Clone(numbers[start:]),
+			}
+		default:
+			path.stackUpdate = &githubStackMembershipUpdate{
+				pullRequests: slices.Clone(numbers),
+			}
+		}
+		if len(path.baseUpdates) > 0 || path.stackUpdate != nil {
+			transition.paths = append(transition.paths, path)
+		}
+	}
+	return transition
+}
+
+func (t githubStackTransition) execute(
+	ctx context.Context,
+	repository *Repository,
+) error {
+	// A replacement must dissolve the old provider object completely before
+	// any base or membership write may use the desired topology.
+	if t.unstackNumber != 0 {
+		result, err := repository.gateway.UnstackPullRequestStack(
+			ctx,
+			&github.UnstackPullRequestStackInput{
+				Owner:       repository.owner,
+				Repo:        repository.repo,
+				StackNumber: t.unstackNumber,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("unstack GitHub native stack #%d: %w", t.unstackNumber, err)
+		}
+		if len(result.RemainingPullRequests) > 0 {
+			return fmt.Errorf(
+				"unstack GitHub native stack #%d: GitHub retained pull requests %v",
+				t.unstackNumber,
+				result.RemainingPullRequests,
+			)
+		}
+	}
+
+	var errs []error
+	for _, path := range t.paths {
+		pathFailed := false
+		for _, update := range path.baseUpdates {
+			base := update.baseBranch
+			if err := repository.gateway.UpdatePullRequest(ctx, &github.UpdatePullRequestInput{
+				PullRequestID: update.pullRequestID,
+				BaseRefName:   &base,
+			}); err != nil {
+				errs = append(errs, fmt.Errorf(
+					"update GitHub pull request #%d base: %w",
+					update.pullRequestNumber,
+					err,
+				))
+				pathFailed = true
+				break
+			}
+		}
+		if pathFailed || path.stackUpdate == nil {
+			continue
+		}
+
+		stackUpdate := path.stackUpdate
+		if stackUpdate.stackNumber == 0 {
+			if err := repository.gateway.CreatePullRequestStack(
+				ctx,
+				&github.CreatePullRequestStackInput{
+					Owner:        repository.owner,
+					Repo:         repository.repo,
+					PullRequests: slices.Clone(stackUpdate.pullRequests),
+				},
+			); err != nil {
+				errs = append(errs, fmt.Errorf("create GitHub native stack: %w", err))
+			}
+			continue
+		}
+
+		if err := repository.gateway.AddPullRequestsToStack(
+			ctx,
+			&github.AddPullRequestsToStackInput{
+				Owner:        repository.owner,
+				Repo:         repository.repo,
+				StackNumber:  stackUpdate.stackNumber,
+				PullRequests: slices.Clone(stackUpdate.pullRequests),
+			},
+		); err != nil {
+			errs = append(errs, fmt.Errorf(
+				"extend GitHub native stack #%d: %w",
+				stackUpdate.stackNumber,
+				err,
+			))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func stackChangeNumbers(changes []*githubStackChange) []int {
+	numbers := make([]int, len(changes))
+	for i, change := range changes {
+		numbers[i] = change.number
+	}
+	return numbers
+}

--- a/internal/forge/github/stack_transition_test.go
+++ b/internal/forge/github/stack_transition_test.go
@@ -1,0 +1,80 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/gateway/github"
+	"go.abhg.dev/gs/internal/silog/silogtest"
+	"go.uber.org/mock/gomock"
+)
+
+func TestGitHubStackTransition_Execute_stopsAfterPrerequisiteFailure(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	gateway.EXPECT().UnstackPullRequestStack(
+		gomock.Any(),
+		&github.UnstackPullRequestStackInput{
+			Owner:       "acme",
+			Repo:        "repo",
+			StackNumber: 42,
+		},
+	).Return(nil, github.ErrForbidden)
+	transition := githubStackTransition{
+		unstackNumber: 42,
+		paths: []githubStackPathTransition{{
+			stackUpdate: &githubStackMembershipUpdate{
+				pullRequests: []int{1, 2},
+			},
+		}},
+	}
+	repository := &Repository{
+		owner:   "acme",
+		repo:    "repo",
+		gateway: gateway,
+		log:     silogtest.New(t),
+	}
+
+	err := transition.execute(t.Context(), repository)
+	require.ErrorIs(t, err, github.ErrForbidden)
+}
+
+func TestGitHubStackTransition_Execute_continuesIndependentPath(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	gateway.EXPECT().UpdatePullRequest(gomock.Any(), &github.UpdatePullRequestInput{
+		PullRequestID: "PR_2",
+		BaseRefName:   new("a"),
+	}).Return(github.ErrForbidden)
+	gateway.EXPECT().CreatePullRequestStack(gomock.Any(), &github.CreatePullRequestStackInput{
+		Owner:        "acme",
+		Repo:         "repo",
+		PullRequests: []int{10, 11},
+	}).Return(nil)
+	transition := githubStackTransition{
+		paths: []githubStackPathTransition{
+			{
+				baseUpdates: []githubPullRequestBaseUpdate{{
+					pullRequestNumber: 2,
+					pullRequestID:     "PR_2",
+					baseBranch:        "a",
+				}},
+				stackUpdate: &githubStackMembershipUpdate{
+					pullRequests: []int{1, 2},
+				},
+			},
+			{
+				stackUpdate: &githubStackMembershipUpdate{
+					pullRequests: []int{10, 11},
+				},
+			},
+		},
+	}
+	repository := &Repository{
+		owner:   "acme",
+		repo:    "repo",
+		gateway: gateway,
+		log:     silogtest.New(t),
+	}
+
+	err := transition.execute(t.Context(), repository)
+	require.ErrorIs(t, err, github.ErrForbidden)
+}

--- a/internal/forge/github/stacks.go
+++ b/internal/forge/github/stacks.go
@@ -1,0 +1,214 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/gateway/github"
+	"go.abhg.dev/gs/internal/graph"
+)
+
+var _ forge.StackRepository = (*Repository)(nil)
+
+// PlanStackUpdate inspects the supplied change relationships and prepares the
+// GitHub mutations needed to reconcile its native stack representation.
+//
+// GitHub accepts only linear stacks of open pull requests
+// whose head branches belong to the receiving repository.
+// PlanStackUpdate projects each unrestricted change tree
+// onto that representation,
+// preserves compatible existing native stack membership,
+// and selects one longest remaining path.
+// When divergence leaves a branch and its upstack out of the native stack,
+// PlanStackUpdate warns once for the omitted branch tree
+// instead of returning an error.
+//
+// Planning is read-only. Execute applies independent prepared transitions on a
+// best-effort basis and joins genuine failures. Divergence only warns.
+func (r *Repository) PlanStackUpdate(
+	ctx context.Context,
+	changes []forge.StackChange,
+) (forge.StackUpdatePlan, error) {
+	if err := r.gateway.CheckPullRequestStacks(ctx, r.owner, r.repo); err != nil {
+		if errors.Is(err, github.ErrNotFound) {
+			return nil, errors.Join(forge.ErrUnsupported, err)
+		}
+		return nil, fmt.Errorf("check GitHub native stack support: %w", err)
+	}
+
+	desired, err := newGitHubStackDesiredState(changes)
+	if err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	pullRequests, err := r.gateway.PullRequestsForStackUpdate(
+		ctx,
+		r.owner,
+		r.repo,
+		desired.pullRequestNumbers(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("inspect GitHub pull requests for stack update: %w", err)
+	}
+
+	reconciliation := reconcileGitHubStacks(
+		desired.snapshot(r.owner, r.repo, pullRequests),
+	)
+	for _, warning := range reconciliation.warnings {
+		r.log.Warnf("%s", warning)
+	}
+	plan := &githubStackUpdatePlan{
+		repository:  r,
+		transitions: reconciliation.transitions,
+		errs:        reconciliation.errs,
+	}
+	return plan, nil
+}
+
+// githubStackUpdatePlan owns the transitions selected from one immutable
+// snapshot. Plans are single-use because any attempted transition may make
+// that snapshot stale.
+type githubStackUpdatePlan struct {
+	repository  *Repository
+	transitions []githubStackTransition
+	errs        []error
+	executed    bool
+}
+
+// Execute applies every independent planned transition and joins failures so
+// one repository tree cannot prevent another from being reconciled.
+func (p *githubStackUpdatePlan) Execute(ctx context.Context) error {
+	if p.executed {
+		return errors.New("GitHub stack update plan was already executed")
+	}
+	p.executed = true
+
+	errs := slices.Clone(p.errs)
+	for _, transition := range p.transitions {
+		if err := transition.execute(ctx, p.repository); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// githubStackDesiredState lists the desired pull request relationships and
+// provider-facing bases in base-first order.
+type githubStackDesiredState []githubStackDesiredChange
+
+type githubStackDesiredChange struct {
+	number     int
+	baseNumber int
+	baseBranch string
+}
+
+// githubStackSnapshot joins each desired change with the current GitHub state
+// returned for it. A nil pull request means GitHub did not find that change.
+type githubStackSnapshot []githubStackSnapshotChange
+
+type githubStackSnapshotChange struct {
+	desired     githubStackDesiredChange
+	pullRequest *githubStackPullRequestState
+}
+
+type githubStackPullRequestState struct {
+	id               github.ID
+	state            github.PullRequestState
+	baseBranch       string
+	headInRepository bool
+	stack            *github.PullRequestStack
+}
+
+func newGitHubStackDesiredState(
+	changes []forge.StackChange,
+) (githubStackDesiredState, error) {
+	changesByNumber := make(map[int]githubStackDesiredChange, len(changes))
+	for _, change := range changes {
+		number := mustPR(change.Change).Number
+		if _, exists := changesByNumber[number]; exists {
+			return nil, fmt.Errorf(
+				"duplicate GitHub pull request #%d",
+				number,
+			)
+		}
+		changesByNumber[number] = githubStackDesiredChange{
+			number:     number,
+			baseBranch: change.BaseBranch,
+		}
+	}
+	for _, change := range changes {
+		if change.BaseChange == nil {
+			continue
+		}
+		number := mustPR(change.Change).Number
+		baseNumber := mustPR(change.BaseChange).Number
+		if _, exists := changesByNumber[baseNumber]; !exists {
+			continue
+		}
+		desired := changesByNumber[number]
+		desired.baseNumber = baseNumber
+		changesByNumber[number] = desired
+	}
+
+	orderedNumbers, err := graph.Toposort(
+		slices.Sorted(maps.Keys(changesByNumber)),
+		func(number int) (int, bool) {
+			baseNumber := changesByNumber[number].baseNumber
+			return baseNumber, baseNumber != 0
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"order GitHub stack changes: %w",
+			err,
+		)
+	}
+
+	desired := make(githubStackDesiredState, len(orderedNumbers))
+	for i, number := range orderedNumbers {
+		desired[i] = changesByNumber[number]
+	}
+	return desired, nil
+}
+
+func (s githubStackDesiredState) pullRequestNumbers() []int {
+	numbers := make([]int, len(s))
+	for i, change := range s {
+		numbers[i] = change.number
+	}
+	return numbers
+}
+
+// snapshot joins the current pull requests by position.
+// PullRequestsForStackUpdate returns one entry for each requested number
+// in the same order.
+func (s githubStackDesiredState) snapshot(
+	owner string,
+	repo string,
+	pullRequests []*github.StackUpdatePullRequest,
+) githubStackSnapshot {
+	observed := make(githubStackSnapshot, len(s))
+	for i, desired := range s {
+		pullRequest := pullRequests[i]
+		observed[i].desired = desired
+		if pullRequest == nil {
+			continue
+		}
+		observed[i].pullRequest = &githubStackPullRequestState{
+			id:         pullRequest.ID,
+			state:      pullRequest.State,
+			baseBranch: pullRequest.BaseRefName,
+			headInRepository: strings.EqualFold(pullRequest.HeadRepositoryOwner, owner) &&
+				strings.EqualFold(pullRequest.HeadRepositoryName, repo),
+			stack: pullRequest.Stack,
+		}
+	}
+	return observed
+}

--- a/internal/forge/github/stacks_test.go
+++ b/internal/forge/github/stacks_test.go
@@ -1,0 +1,566 @@
+package github
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/gateway/github"
+	"go.abhg.dev/gs/internal/silog"
+	"go.abhg.dev/gs/internal/silog/silogtest"
+	"go.uber.org/mock/gomock"
+)
+
+func TestRepository_UpdateStackCreate(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	expectPullRequests(t, gateway, map[int]*github.StackUpdatePullRequest{
+		1: newStackPullRequest(nil),
+		2: newStackPullRequest(nil),
+	})
+	gateway.EXPECT().CreatePullRequestStack(gomock.Any(), &github.CreatePullRequestStackInput{
+		Owner:        "acme",
+		Repo:         "repo",
+		PullRequests: []int{1, 2},
+	}).Return(nil)
+
+	err := executeStackUpdate(t.Context(), newStackRepository(t, gateway), []forge.StackChange{
+		{Change: &PR{Number: 2}, BaseChange: &PR{Number: 1}, BaseBranch: "base"},
+		{Change: &PR{Number: 1}, BaseBranch: "base"},
+	})
+	require.NoError(t, err)
+}
+
+func TestRepository_UpdateStackCurrent(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	stack := newPullRequestStack(42, 1, 2)
+	expectPullRequests(t, gateway, map[int]*github.StackUpdatePullRequest{
+		1: newStackPullRequest(stack),
+		2: newStackPullRequest(stack),
+	})
+
+	err := executeStackUpdate(t.Context(), newStackRepository(t, gateway), []forge.StackChange{
+		{Change: &PR{Number: 1}, BaseBranch: "base"},
+		{Change: &PR{Number: 2}, BaseChange: &PR{Number: 1}, BaseBranch: "base"},
+	})
+	require.NoError(t, err)
+}
+
+func TestRepository_UpdateStackExtend(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	stack := newPullRequestStack(42, 1, 2)
+	expectPullRequests(t, gateway, map[int]*github.StackUpdatePullRequest{
+		1: newStackPullRequest(stack),
+		2: newStackPullRequest(stack),
+		3: newStackPullRequest(nil),
+	})
+	gateway.EXPECT().AddPullRequestsToStack(gomock.Any(), &github.AddPullRequestsToStackInput{
+		Owner:        "acme",
+		Repo:         "repo",
+		StackNumber:  42,
+		PullRequests: []int{3},
+	}).Return(nil)
+
+	err := executeStackUpdate(t.Context(), newStackRepository(t, gateway), []forge.StackChange{
+		{Change: &PR{Number: 1}, BaseBranch: "base"},
+		{Change: &PR{Number: 2}, BaseChange: &PR{Number: 1}, BaseBranch: "base"},
+		{Change: &PR{Number: 3}, BaseChange: &PR{Number: 2}, BaseBranch: "base"},
+	})
+	require.NoError(t, err)
+}
+
+func TestRepository_UpdateStackInsertsIntoLinearStack(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	stack := newPullRequestStack(42, 1, 2)
+	expectPullRequests(t, gateway, map[int]*github.StackUpdatePullRequest{
+		1: stackPullRequest("PR_1", "main", stack),
+		2: stackPullRequest("PR_2", "a", stack),
+		3: stackPullRequest("PR_3", "a", nil),
+	})
+	gateway.EXPECT().UnstackPullRequestStack(gomock.Any(), &github.UnstackPullRequestStackInput{
+		Owner:       "acme",
+		Repo:        "repo",
+		StackNumber: 42,
+	}).Return(&github.UnstackPullRequestStackResult{}, nil)
+	gateway.EXPECT().UpdatePullRequest(gomock.Any(), &github.UpdatePullRequestInput{
+		PullRequestID: "PR_2",
+		BaseRefName:   new("c"),
+	}).Return(nil)
+	gateway.EXPECT().CreatePullRequestStack(gomock.Any(), &github.CreatePullRequestStackInput{
+		Owner:        "acme",
+		Repo:         "repo",
+		PullRequests: []int{1, 3, 2},
+	}).Return(nil)
+
+	err := executeStackUpdate(t.Context(), newStackRepository(t, gateway), []forge.StackChange{
+		{Change: &PR{Number: 1}, BaseBranch: "main"},
+		{Change: &PR{Number: 3}, BaseChange: &PR{Number: 1}, BaseBranch: "a"},
+		{Change: &PR{Number: 2}, BaseChange: &PR{Number: 3}, BaseBranch: "c"},
+	})
+	require.NoError(t, err)
+}
+
+func TestRepository_UpdateStackRemovesMember(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	stack := newPullRequestStack(42, 1, 2, 3)
+	expectPullRequests(t, gateway, map[int]*github.StackUpdatePullRequest{
+		1: stackPullRequest("PR_1", "main", stack),
+		3: stackPullRequest("PR_3", "b", stack),
+	})
+	gateway.EXPECT().UnstackPullRequestStack(gomock.Any(), gomock.Any()).
+		Return(&github.UnstackPullRequestStackResult{}, nil)
+	gateway.EXPECT().UpdatePullRequest(gomock.Any(), &github.UpdatePullRequestInput{
+		PullRequestID: "PR_3",
+		BaseRefName:   new("a"),
+	}).Return(nil)
+	gateway.EXPECT().CreatePullRequestStack(gomock.Any(), &github.CreatePullRequestStackInput{
+		Owner:        "acme",
+		Repo:         "repo",
+		PullRequests: []int{1, 3},
+	}).Return(nil)
+
+	err := executeStackUpdate(t.Context(), newStackRepository(t, gateway), []forge.StackChange{
+		{Change: &PR{Number: 1}, BaseBranch: "main"},
+		{Change: &PR{Number: 3}, BaseChange: &PR{Number: 1}, BaseBranch: "a"},
+	})
+	require.NoError(t, err)
+}
+
+func TestRepository_UpdateStackSplitsExistingStack(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	stack := newPullRequestStack(42, 1, 2)
+	expectPullRequests(t, gateway, map[int]*github.StackUpdatePullRequest{
+		1: stackPullRequest("PR_1", "main", stack),
+		2: stackPullRequest("PR_2", "a", stack),
+	})
+	gateway.EXPECT().UnstackPullRequestStack(gomock.Any(), gomock.Any()).
+		Return(&github.UnstackPullRequestStackResult{}, nil)
+	gateway.EXPECT().UpdatePullRequest(gomock.Any(), &github.UpdatePullRequestInput{
+		PullRequestID: "PR_2",
+		BaseRefName:   new("main"),
+	}).Return(nil)
+
+	err := executeStackUpdate(t.Context(), newStackRepository(t, gateway), []forge.StackChange{
+		{Change: &PR{Number: 1}, BaseBranch: "main"},
+		{Change: &PR{Number: 2}, BaseBranch: "main"},
+	})
+	require.NoError(t, err)
+}
+
+func TestRepository_UpdateStackLeavesLockedStackUnchanged(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	stack := &github.PullRequestStack{
+		Number: 42,
+		Members: []github.PullRequestStackMember{
+			{Number: 1, State: github.PullRequestStateOpen},
+			{Number: 2, State: github.PullRequestStateOpen, Locked: true},
+		},
+	}
+	expectPullRequests(t, gateway, map[int]*github.StackUpdatePullRequest{
+		1: stackPullRequest("PR_1", "main", stack),
+		2: stackPullRequest("PR_2", "a", stack),
+		3: stackPullRequest("PR_3", "a", nil),
+	})
+
+	var logs strings.Builder
+	repo := newStackRepository(t, gateway)
+	repo.log = silog.New(&logs, &silog.Options{Level: silog.LevelDebug})
+	err := executeStackUpdate(t.Context(), repo, []forge.StackChange{
+		{Change: &PR{Number: 1}, BaseBranch: "main"},
+		{Change: &PR{Number: 3}, BaseChange: &PR{Number: 1}, BaseBranch: "a"},
+		{Change: &PR{Number: 2}, BaseChange: &PR{Number: 3}, BaseBranch: "c"},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, logs.String(),
+		"#1: Leaving pull request and its upstack in existing GitHub native stack #42: merged, queued, or auto-merge pull requests prevent restructuring")
+}
+
+func TestRepository_UpdateStackLeavesMergedMemberStackUnchanged(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	stack := &github.PullRequestStack{
+		Number: 42,
+		Members: []github.PullRequestStackMember{
+			{Number: 1, State: github.PullRequestStateMerged},
+			{Number: 2, State: github.PullRequestStateOpen},
+		},
+	}
+	merged := newStackPullRequest(stack)
+	merged.State = github.PullRequestStateMerged
+	expectPullRequests(t, gateway, map[int]*github.StackUpdatePullRequest{
+		1: merged,
+		2: stackPullRequest("PR_2", "a", stack),
+		3: stackPullRequest("PR_3", "a", nil),
+	})
+
+	var logs strings.Builder
+	repo := newStackRepository(t, gateway)
+	repo.log = silog.New(&logs, &silog.Options{Level: silog.LevelDebug})
+	err := executeStackUpdate(t.Context(), repo, []forge.StackChange{
+		{Change: &PR{Number: 1}, BaseBranch: "main"},
+		{Change: &PR{Number: 3}, BaseChange: &PR{Number: 1}, BaseBranch: "a"},
+		{Change: &PR{Number: 2}, BaseChange: &PR{Number: 3}, BaseBranch: "c"},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, logs.String(),
+		"#3: Leaving pull request and its upstack in existing GitHub native stack #42: merged, queued, or auto-merge pull requests prevent restructuring")
+}
+
+func TestRepository_PlanStackUpdateDoesNotWrite(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	expectPullRequests(t, gateway, map[int]*github.StackUpdatePullRequest{
+		1: newStackPullRequest(nil),
+		2: newStackPullRequest(nil),
+	})
+	writes := 0
+	gateway.EXPECT().CreatePullRequestStack(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(context.Context, *github.CreatePullRequestStackInput) error {
+			writes++
+			return nil
+		})
+
+	plan, err := newStackRepository(t, gateway).PlanStackUpdate(
+		t.Context(),
+		[]forge.StackChange{
+			{Change: &PR{Number: 1}, BaseBranch: "base"},
+			{Change: &PR{Number: 2}, BaseChange: &PR{Number: 1}, BaseBranch: "base"},
+		},
+	)
+	require.NoError(t, err)
+	assert.Zero(t, writes)
+	require.NoError(t, plan.Execute(t.Context()))
+	assert.Equal(t, 1, writes)
+}
+
+func TestRepository_UpdateStackDivergent(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	expectPullRequests(t, gateway, map[int]*github.StackUpdatePullRequest{
+		1: newStackPullRequest(nil),
+		2: newStackPullRequest(nil),
+		3: newStackPullRequest(nil),
+		4: newStackPullRequest(nil),
+		5: newStackPullRequest(nil),
+	})
+	gateway.EXPECT().CreatePullRequestStack(gomock.Any(), &github.CreatePullRequestStackInput{
+		Owner:        "acme",
+		Repo:         "repo",
+		PullRequests: []int{1, 3, 4},
+	}).Return(nil)
+
+	var logs strings.Builder
+	repo := newStackRepository(t, gateway)
+	repo.log = silog.New(&logs, &silog.Options{Level: silog.LevelDebug})
+	err := executeStackUpdate(t.Context(), repo, []forge.StackChange{
+		{Change: &PR{Number: 3}, BaseChange: &PR{Number: 1}, BaseBranch: "base"},
+		{Change: &PR{Number: 4}, BaseChange: &PR{Number: 3}, BaseBranch: "base"},
+		{Change: &PR{Number: 1}, BaseBranch: "base"},
+		{Change: &PR{Number: 2}, BaseChange: &PR{Number: 1}, BaseBranch: "base"},
+		{Change: &PR{Number: 5}, BaseChange: &PR{Number: 2}, BaseBranch: "base"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, strings.Count(logs.String(),
+		"#2: Leaving pull request and its upstack out of the GitHub native stack: the change tree diverges from the selected linear path"))
+	assert.NotContains(t, logs.String(), "#5:")
+}
+
+func TestRepository_UpdateStackPrefersExistingStackOverLongerPath(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	stack := newPullRequestStack(42, 1, 2, 4)
+	expectPullRequests(t, gateway, map[int]*github.StackUpdatePullRequest{
+		1: newStackPullRequest(stack),
+		2: newStackPullRequest(stack),
+		3: newStackPullRequest(nil),
+		4: newStackPullRequest(stack),
+		5: newStackPullRequest(nil),
+	})
+
+	var logs strings.Builder
+	repo := newStackRepository(t, gateway)
+	repo.log = silog.New(&logs, &silog.Options{Level: silog.LevelDebug})
+	err := executeStackUpdate(t.Context(), repo, []forge.StackChange{
+		{Change: &PR{Number: 1}, BaseBranch: "base"},
+		{Change: &PR{Number: 2}, BaseChange: &PR{Number: 1}, BaseBranch: "base"},
+		{Change: &PR{Number: 3}, BaseChange: &PR{Number: 2}, BaseBranch: "base"},
+		{Change: &PR{Number: 4}, BaseChange: &PR{Number: 2}, BaseBranch: "base"},
+		{Change: &PR{Number: 5}, BaseChange: &PR{Number: 3}, BaseBranch: "base"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, strings.Count(logs.String(),
+		"#3: Leaving pull request and its upstack out of the GitHub native stack: the change tree diverges from the selected linear path"))
+	assert.NotContains(t, logs.String(), "#4:")
+	assert.NotContains(t, logs.String(), "incompatible membership")
+}
+
+func TestRepository_UpdateStackReplacesIncompatibleLinearStack(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	stack := newPullRequestStack(42, 1, 3)
+	expectPullRequests(t, gateway, map[int]*github.StackUpdatePullRequest{
+		1: newStackPullRequest(stack),
+		2: newStackPullRequest(stack),
+	})
+	gateway.EXPECT().UnstackPullRequestStack(gomock.Any(), &github.UnstackPullRequestStackInput{
+		Owner:       "acme",
+		Repo:        "repo",
+		StackNumber: 42,
+	}).Return(&github.UnstackPullRequestStackResult{}, nil)
+	gateway.EXPECT().CreatePullRequestStack(gomock.Any(), &github.CreatePullRequestStackInput{
+		Owner:        "acme",
+		Repo:         "repo",
+		PullRequests: []int{1, 2},
+	}).Return(nil)
+
+	repo := newStackRepository(t, gateway)
+	err := executeStackUpdate(t.Context(), repo, []forge.StackChange{
+		{Change: &PR{Number: 1}, BaseBranch: "base"},
+		{Change: &PR{Number: 2}, BaseChange: &PR{Number: 1}, BaseBranch: "base"},
+	})
+	require.NoError(t, err)
+}
+
+func TestRepository_UpdateStackMultipleExistingStacks(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	expectPullRequests(t, gateway, map[int]*github.StackUpdatePullRequest{
+		1: newStackPullRequest(newPullRequestStack(42, 1)),
+		2: newStackPullRequest(newPullRequestStack(43, 2)),
+	})
+
+	var logs strings.Builder
+	repo := newStackRepository(t, gateway)
+	repo.log = silog.New(&logs, &silog.Options{Level: silog.LevelDebug})
+	err := executeStackUpdate(t.Context(), repo, []forge.StackChange{
+		{Change: &PR{Number: 1}, BaseBranch: "base"},
+		{Change: &PR{Number: 2}, BaseChange: &PR{Number: 1}, BaseBranch: "base"},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, logs.String(),
+		"#1: Leaving pull request and its upstack in existing GitHub native stacks: pull requests belong to different native stacks")
+}
+
+func TestRepository_UpdateStackUnsupported(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	gateway.EXPECT().CheckPullRequestStacks(gomock.Any(), "acme", "repo").
+		Return(github.ErrNotFound)
+
+	err := executeStackUpdate(t.Context(), newStackRepository(t, gateway), []forge.StackChange{
+		{Change: &PR{Number: 1}, BaseBranch: "base"},
+		{Change: &PR{Number: 2}, BaseChange: &PR{Number: 1}, BaseBranch: "base"},
+	})
+	require.ErrorIs(t, err, forge.ErrUnsupported)
+	assert.ErrorIs(t, err, github.ErrNotFound)
+}
+
+func TestRepository_UpdateStackWriteNotFoundIsFailure(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	expectPullRequests(t, gateway, map[int]*github.StackUpdatePullRequest{
+		1: newStackPullRequest(nil),
+		2: newStackPullRequest(nil),
+	})
+	gateway.EXPECT().CreatePullRequestStack(gomock.Any(), gomock.Any()).
+		Return(github.ErrNotFound)
+
+	err := executeStackUpdate(t.Context(), newStackRepository(t, gateway), []forge.StackChange{
+		{Change: &PR{Number: 1}, BaseBranch: "base"},
+		{Change: &PR{Number: 2}, BaseChange: &PR{Number: 1}, BaseBranch: "base"},
+	})
+	require.ErrorIs(t, err, github.ErrNotFound)
+	assert.NotErrorIs(t, err, forge.ErrUnsupported)
+}
+
+func TestRepository_UpdateStackMissingChange(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	expectPullRequests(t, gateway, map[int]*github.StackUpdatePullRequest{1: nil})
+
+	err := executeStackUpdate(t.Context(), newStackRepository(t, gateway), []forge.StackChange{
+		{Change: &PR{Number: 1}, BaseBranch: "base"},
+	})
+	require.ErrorIs(t, err, forge.ErrNotFound)
+}
+
+func TestRepository_UpdateStackLookupFailure(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	gateway.EXPECT().CheckPullRequestStacks(gomock.Any(), "acme", "repo").Return(nil)
+	gateway.EXPECT().PullRequestsForStackUpdate(
+		gomock.Any(),
+		"acme",
+		"repo",
+		[]int{1},
+	).Return(nil, github.ErrForbidden)
+
+	err := executeStackUpdate(t.Context(), newStackRepository(t, gateway), []forge.StackChange{
+		{Change: &PR{Number: 1}, BaseBranch: "base"},
+	})
+	require.ErrorIs(t, err, github.ErrForbidden)
+}
+
+func TestRepository_UpdateStackCanceled(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	gateway.EXPECT().CheckPullRequestStacks(gomock.Any(), "acme", "repo").Return(nil)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := executeStackUpdate(ctx, newStackRepository(t, gateway), []forge.StackChange{
+		{Change: &PR{Number: 1}, BaseBranch: "base"},
+	})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestRepository_UpdateStackMultipleRoots(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	expectPullRequests(t, gateway, map[int]*github.StackUpdatePullRequest{
+		1:  newStackPullRequest(nil),
+		2:  newStackPullRequest(nil),
+		10: newStackPullRequest(nil),
+		11: newStackPullRequest(nil),
+	})
+	gateway.EXPECT().CreatePullRequestStack(gomock.Any(), &github.CreatePullRequestStackInput{
+		Owner:        "acme",
+		Repo:         "repo",
+		PullRequests: []int{1, 2},
+	}).Return(nil)
+	gateway.EXPECT().CreatePullRequestStack(gomock.Any(), &github.CreatePullRequestStackInput{
+		Owner:        "acme",
+		Repo:         "repo",
+		PullRequests: []int{10, 11},
+	}).Return(nil)
+
+	err := executeStackUpdate(t.Context(), newStackRepository(t, gateway), []forge.StackChange{
+		{Change: &PR{Number: 11}, BaseChange: &PR{Number: 10}, BaseBranch: "base"},
+		{Change: &PR{Number: 2}, BaseChange: &PR{Number: 1}, BaseBranch: "base"},
+		{Change: &PR{Number: 10}, BaseBranch: "base"},
+		{Change: &PR{Number: 1}, BaseBranch: "base"},
+	})
+	require.NoError(t, err)
+}
+
+func TestRepository_UpdateStackContinuesAfterFailure(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	expectPullRequests(t, gateway, map[int]*github.StackUpdatePullRequest{
+		1:  newStackPullRequest(nil),
+		2:  newStackPullRequest(nil),
+		10: newStackPullRequest(nil),
+		11: newStackPullRequest(nil),
+	})
+	gateway.EXPECT().CreatePullRequestStack(gomock.Any(), &github.CreatePullRequestStackInput{
+		Owner:        "acme",
+		Repo:         "repo",
+		PullRequests: []int{1, 2},
+	}).Return(github.ErrForbidden)
+	gateway.EXPECT().CreatePullRequestStack(gomock.Any(), &github.CreatePullRequestStackInput{
+		Owner:        "acme",
+		Repo:         "repo",
+		PullRequests: []int{10, 11},
+	}).Return(nil)
+
+	err := executeStackUpdate(t.Context(), newStackRepository(t, gateway), []forge.StackChange{
+		{Change: &PR{Number: 1}, BaseBranch: "base"},
+		{Change: &PR{Number: 2}, BaseChange: &PR{Number: 1}, BaseBranch: "base"},
+		{Change: &PR{Number: 10}, BaseBranch: "base"},
+		{Change: &PR{Number: 11}, BaseChange: &PR{Number: 10}, BaseBranch: "base"},
+	})
+	require.ErrorIs(t, err, github.ErrForbidden)
+}
+
+func TestRepository_UpdateStackReconnectsAboveMergedChange(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	merged := newStackPullRequest(nil)
+	merged.State = github.PullRequestStateMerged
+	expectPullRequests(t, gateway, map[int]*github.StackUpdatePullRequest{
+		1: merged,
+		2: newStackPullRequest(nil),
+		3: newStackPullRequest(nil),
+	})
+	gateway.EXPECT().CreatePullRequestStack(gomock.Any(), &github.CreatePullRequestStackInput{
+		Owner:        "acme",
+		Repo:         "repo",
+		PullRequests: []int{2, 3},
+	}).Return(nil)
+
+	err := executeStackUpdate(t.Context(), newStackRepository(t, gateway), []forge.StackChange{
+		{Change: &PR{Number: 1}, BaseBranch: "base"},
+		{Change: &PR{Number: 2}, BaseChange: &PR{Number: 1}, BaseBranch: "base"},
+		{Change: &PR{Number: 3}, BaseChange: &PR{Number: 2}, BaseBranch: "base"},
+	})
+	require.NoError(t, err)
+}
+
+func newStackRepository(t *testing.T, gateway githubGateway) *Repository {
+	return &Repository{
+		owner:   "acme",
+		repo:    "repo",
+		gateway: gateway,
+		log:     silogtest.New(t),
+	}
+}
+
+func newStackPullRequest(stack *github.PullRequestStack) *github.StackUpdatePullRequest {
+	return &github.StackUpdatePullRequest{
+		State:               github.PullRequestStateOpen,
+		BaseRefName:         "base",
+		Stack:               stack,
+		HeadRepositoryOwner: "acme",
+		HeadRepositoryName:  "repo",
+	}
+}
+
+func newPullRequestStack(number int, members ...int) *github.PullRequestStack {
+	stack := &github.PullRequestStack{Number: number}
+	for _, member := range members {
+		stack.Members = append(stack.Members, github.PullRequestStackMember{
+			Number: member,
+			State:  github.PullRequestStateOpen,
+		})
+	}
+	return stack
+}
+
+func stackPullRequest(
+	id github.ID,
+	base string,
+	stack *github.PullRequestStack,
+) *github.StackUpdatePullRequest {
+	pullRequest := newStackPullRequest(stack)
+	pullRequest.ID = id
+	pullRequest.BaseRefName = base
+	return pullRequest
+}
+
+func expectPullRequests(
+	t *testing.T,
+	gateway *MockGithubGateway,
+	pullRequests map[int]*github.StackUpdatePullRequest,
+) {
+	t.Helper()
+	gateway.EXPECT().CheckPullRequestStacks(gomock.Any(), "acme", "repo").Return(nil)
+	gateway.EXPECT().PullRequestsForStackUpdate(
+		gomock.Any(),
+		"acme",
+		"repo",
+		gomock.Any(),
+	).DoAndReturn(func(
+		_ context.Context,
+		_, _ string,
+		numbers []int,
+	) ([]*github.StackUpdatePullRequest, error) {
+		require.Len(t, numbers, len(pullRequests))
+		result := make([]*github.StackUpdatePullRequest, len(numbers))
+		for i, number := range numbers {
+			var ok bool
+			result[i], ok = pullRequests[number]
+			require.True(t, ok, "unexpected pull request #%d", number)
+		}
+		return result, nil
+	})
+}
+
+func executeStackUpdate(
+	ctx context.Context,
+	repository *Repository,
+	changes []forge.StackChange,
+) error {
+	plan, err := repository.PlanStackUpdate(ctx, changes)
+	if err != nil {
+		return err
+	}
+	return plan.Execute(ctx)
+}

--- a/internal/forge/github/testdata/TestIntegration/Stacks/bottomBranch
+++ b/internal/forge/github/testdata/TestIntegration/Stacks/bottomBranch
@@ -1,0 +1,1 @@
+"stack-bottom-geOs2I70"

--- a/internal/forge/github/testdata/TestIntegration/Stacks/middleBranch
+++ b/internal/forge/github/testdata/TestIntegration/Stacks/middleBranch
@@ -1,0 +1,1 @@
+"stack-middle-VEtQX9yQ"

--- a/internal/forge/github/testdata/TestIntegration/Stacks/topBranch
+++ b/internal/forge/github/testdata/TestIntegration/Stacks/topBranch
@@ -1,0 +1,1 @@
+"stack-top-ip5EzT1K"

--- a/internal/forge/github/testdata/TestIntegration_stackReplacement/bottomBranch
+++ b/internal/forge/github/testdata/TestIntegration_stackReplacement/bottomBranch
@@ -1,0 +1,1 @@
+"stack-replace-bottom-Hydxxy1R"

--- a/internal/forge/github/testdata/TestIntegration_stackReplacement/insertedBranch
+++ b/internal/forge/github/testdata/TestIntegration_stackReplacement/insertedBranch
@@ -1,0 +1,1 @@
+"stack-replace-inserted-WNuOA0uR"

--- a/internal/forge/github/testdata/TestIntegration_stackReplacement/topBranch
+++ b/internal/forge/github/testdata/TestIntegration_stackReplacement/topBranch
@@ -1,0 +1,1 @@
+"stack-replace-top-92YL4XjC"

--- a/internal/forge/github/testdata/TestIntegration_stackReplacementWithMergedMember/bottomBranch
+++ b/internal/forge/github/testdata/TestIntegration_stackReplacementWithMergedMember/bottomBranch
@@ -1,0 +1,1 @@
+"stack-merged-bottom-5nHARMp1"

--- a/internal/forge/github/testdata/TestIntegration_stackReplacementWithMergedMember/insertedBranch
+++ b/internal/forge/github/testdata/TestIntegration_stackReplacementWithMergedMember/insertedBranch
@@ -1,0 +1,1 @@
+"stack-merged-inserted-aX9bGOqd"

--- a/internal/forge/github/testdata/TestIntegration_stackReplacementWithMergedMember/topBranch
+++ b/internal/forge/github/testdata/TestIntegration_stackReplacementWithMergedMember/topBranch
@@ -1,0 +1,1 @@
+"stack-merged-top-Bubo7AXB"

--- a/internal/forge/github/testdata/fixtures/TestIntegration/Stacks.yaml
+++ b/internal/forge/github/testdata/fixtures/TestIntegration/Stacks.yaml
@@ -1,0 +1,357 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 141
+        host: api.github.com
+        body: '{"query":"query($owner:String!$repo:String!){repository(owner: $owner, name: $repo){id}}","variables":{"owner":"test-owner","repo":"test-repo"}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"repository":{"id":"R_kgDOMVd0xg"}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 245.813458ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 318
+        host: api.github.com
+        body: '{"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"main","headRefName":"stack-bottom-geOs2I70","title":"Native stack bottom stack-bottom-geOs2I70","body":"Native stack integration test"}}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs8AAAABAvngeg","number":189,"url":"https://github.com/test-owner/test-repo/pull/189"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 2.566483666s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 335
+        host: api.github.com
+        body: '{"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"stack-bottom-geOs2I70","headRefName":"stack-middle-VEtQX9yQ","title":"Native stack middle stack-middle-VEtQX9yQ","body":"Native stack integration test"}}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs8AAAABAvnhBw","number":190,"url":"https://github.com/test-owner/test-repo/pull/190"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 2.6603865s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.github.com
+        url: https://api.github.com/repos/test-owner/test-repo/stacks
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":313473,"number":174,"node_id":"PRS_kwDOMVd0xs4ABMiB","url":"https://api.github.com/repos/test-owner/test-repo/stacks/174","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T13:40:09Z","pull_requests":[{"number":170,"state":"closed","draft":false,"merged_at":"2026-08-12T13:40:15Z","head":{"ref":"divergent-stack-a-pO7wJfwF","sha":"cbba7e8dcfec641a88f530c0ccc7c8ce535aeeae"}},{"number":171,"state":"closed","draft":false,"merged_at":"2026-08-12T13:40:16Z","head":{"ref":"divergent-stack-b-9iT5TOLK","sha":"04f50ba691258ef2c136849b1ad0a9e45a6d964a"}},{"number":172,"state":"closed","draft":false,"merged_at":"2026-08-12T13:40:17Z","head":{"ref":"divergent-stack-c-iXygp4Wc","sha":"5e059d8b881a4c03271f7bd6eff43496fb7bfba2"}}]},{"id":313446,"number":169,"node_id":"PRS_kwDOMVd0xs4ABMhm","url":"https://api.github.com/repos/test-owner/test-repo/stacks/169","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T13:39:16Z","pull_requests":[{"number":165,"state":"closed","draft":false,"merged_at":"2026-08-12T13:39:22Z","head":{"ref":"divergent-stack-a-ZwG2QqxN","sha":"bad73a03fe75bb84a66c18758f6a33e964fa5623"}},{"number":166,"state":"closed","draft":false,"merged_at":"2026-08-12T13:39:23Z","head":{"ref":"divergent-stack-b-VxbXF3H4","sha":"1835fe77d5079914c4050ce7f480688f4de316b0"}},{"number":167,"state":"closed","draft":false,"merged_at":"2026-08-12T13:39:23Z","head":{"ref":"divergent-stack-c-MAlCUfYp","sha":"09d733256cafd094d360cb399794138c766a1fef"}}]},{"id":302729,"number":160,"node_id":"PRS_kwDOMVd0xs4ABJ6J","url":"https://api.github.com/repos/test-owner/test-repo/stacks/160","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T04:18:42Z","pull_requests":[{"number":158,"state":"closed","draft":false,"merged_at":"2026-08-12T04:18:46Z","head":{"ref":"merge-range-bottom-bZiK8Eda","sha":"24777ef044c0a4bc712d1345bf9c0ed8b791197b"}},{"number":159,"state":"closed","draft":false,"merged_at":"2026-08-12T04:18:47Z","head":{"ref":"merge-range-top-hIOTMX1T","sha":"bb58f1370879a404c18b51898dcf2e08ea740727"}}]},{"id":302716,"number":157,"node_id":"PRS_kwDOMVd0xs4ABJ58","url":"https://api.github.com/repos/test-owner/test-repo/stacks/157","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T04:17:41Z","pull_requests":[{"number":155,"state":"closed","draft":false,"merged_at":"2026-08-12T04:17:45Z","head":{"ref":"merge-range-bottom-0tvkFGY5","sha":"5c1b178950b3b777fb9ebbede6d383db05d22467"}},{"number":156,"state":"closed","draft":false,"merged_at":"2026-08-12T04:17:45Z","head":{"ref":"merge-range-top-J25jZjmP","sha":"12a7613a380b2b58338e3860d2f328f7cdff03b0"}}]},{"id":302692,"number":154,"node_id":"PRS_kwDOMVd0xs4ABJ5k","url":"https://api.github.com/repos/test-owner/test-repo/stacks/154","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T04:15:44Z","pull_requests":[{"number":152,"state":"closed","draft":false,"merged_at":"2026-08-12T04:15:48Z","head":{"ref":"merge-range-bottom-K06vsatq","sha":"da0f854fa38886c46c4e140f6ccbbf97a0617fda"}},{"number":153,"state":"closed","draft":false,"merged_at":"2026-08-12T04:15:48Z","head":{"ref":"merge-range-top-UQMItpa9","sha":"408a67f73119d0e8394e8f82eeca982994ed20be"}}]},{"id":302586,"number":151,"node_id":"PRS_kwDOMVd0xs4ABJ36","url":"https://api.github.com/repos/test-owner/test-repo/stacks/151","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T04:06:06Z","pull_requests":[{"number":149,"state":"closed","draft":false,"merged_at":"2026-08-12T04:06:10Z","head":{"ref":"merge-range-bottom-j0y6OqrT","sha":"11e275c782e6d64ef1453ca2a4e1509f8ef1d10a"}},{"number":150,"state":"closed","draft":false,"merged_at":"2026-08-12T04:06:10Z","head":{"ref":"merge-range-top-G8bqRe1G","sha":"4cb95e7edc28838635b54236918b825a9130fcb8"}}]},{"id":302031,"number":147,"node_id":"PRS_kwDOMVd0xs4ABJvP","url":"https://api.github.com/repos/test-owner/test-repo/stacks/147","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T03:16:01Z","pull_requests":[{"number":145,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-bottom-dW4RtWmC","sha":"b5bec1eaccc7a5fb6d5ac747c67832c156bf51bd"}},{"number":146,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-middle-g3WXJxSb","sha":"f740dffc87f2ddf00824f1a09d2c24b70811b247"}},{"number":148,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-top-gampXI6B","sha":"711662448930f8a00d161c842fb0ee8d401c994e"}}]},{"id":167872,"number":144,"node_id":"PRS_kwDOMVd0xs4AAo_A","url":"https://api.github.com/repos/test-owner/test-repo/stacks/144","base":{"ref":"main"},"open":false,"created_at":"2026-08-05T12:16:14Z","pull_requests":[{"number":140,"state":"closed","draft":false,"merged_at":"2026-08-05T12:18:48Z","head":{"ref":"probe-autodelete-20260805-9c4e-a","sha":"920069c11160c4fe98a1b7e346be68ca51d59b73"}},{"number":141,"state":"closed","draft":false,"merged_at":"2026-08-05T12:18:49Z","head":{"ref":"probe-autodelete-20260805-9c4e-b","sha":"1007602d9b285fe3c2825da02aaf020c4f0ecdd7"}},{"number":142,"state":"closed","draft":false,"merged_at":"2026-08-05T12:18:50Z","head":{"ref":"probe-autodelete-20260805-9c4e-c","sha":"d0753d932262f7b817599a792e317f5339a5849d"}}]},{"id":167438,"number":139,"node_id":"PRS_kwDOMVd0xs4AAo4O","url":"https://api.github.com/repos/test-owner/test-repo/stacks/139","base":{"ref":"main"},"open":false,"created_at":"2026-08-05T11:55:14Z","pull_requests":[{"number":135,"state":"closed","draft":false,"merged_at":"2026-08-05T11:55:56Z","head":{"ref":"probe-divergence-20260805-7f3c-a","sha":"b70346dd87e33f1b0182223edee11f43a3a9db66"}},{"number":136,"state":"closed","draft":false,"merged_at":"2026-08-05T11:55:57Z","head":{"ref":"probe-divergence-20260805-7f3c-b","sha":"f5367dbc180b397617065a700e42df50f7646329"}},{"number":137,"state":"closed","draft":false,"merged_at":"2026-08-05T11:55:58Z","head":{"ref":"probe-divergence-20260805-7f3c-c","sha":"f820a52d526b01daba6bd583066d97dd03d33fcd"}}]},{"id":101032,"number":134,"node_id":"PRS_kwDOMVd0xs4AAYqo","url":"https://api.github.com/repos/test-owner/test-repo/stacks/134","base":{"ref":"main"},"open":false,"created_at":"2026-08-02T06:04:41Z","pull_requests":[{"number":132,"state":"closed","draft":false,"merged_at":"2026-08-02T06:05:07Z","head":{"ref":"gs-native-stack-probe-019fbe36-base","sha":"640dd83224aabd95f66ff91912b26f08f33edbbd"}},{"number":133,"state":"closed","draft":false,"merged_at":"2026-08-02T06:05:08Z","head":{"ref":"gs-native-stack-probe-019fbe36-top","sha":"67d6b814fe522ff1e3d850fcf6b1cdc02ac11b43"}}]}]'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 244.73425ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 395
+        host: api.github.com
+        body: '{"query":"query($owner:String!,$repo:String!,$pr0:Int!,$pr1:Int!){repository(owner: $owner, name: $repo){pr0:pullRequest(number: $pr0){id,state,headRefName,baseRefName,headRepository{owner{login},name},stack{id}},pr1:pullRequest(number: $pr1){id,state,headRefName,baseRefName,headRepository{owner{login},name},stack{id}}}}","variables":{"owner":"test-owner","pr0":189,"pr1":190,"repo":"test-repo"}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"repository":{"pr0":{"id":"PR_kwDOMVd0xs8AAAABAvngeg","state":"OPEN","headRefName":"stack-bottom-geOs2I70","baseRefName":"main","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":null},"pr1":{"id":"PR_kwDOMVd0xs8AAAABAvnhBw","state":"OPEN","headRefName":"stack-middle-VEtQX9yQ","baseRefName":"stack-bottom-geOs2I70","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":null}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 255.773625ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 28
+        host: api.github.com
+        body: |
+            {"pull_requests":[189,190]}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/repos/test-owner/test-repo/stacks
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 3360
+        body: '{"id":560648,"number":191,"node_id":"PRS_kwDOMVd0xs4ACI4I","url":"https://api.github.com/repos/test-owner/test-repo/stacks/191","base":{"ref":"main"},"open":true,"created_at":"2026-08-24T02:35:35Z","pull_requests":[{"url":"https://api.github.com/repos/test-owner/test-repo/pulls/189","id":4344897658,"number":189,"head":{"ref":"stack-bottom-geOs2I70","sha":"d09aa9285a4200d6ec0a1454033a5302a8c15f94","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"base":{"ref":"main","sha":"64adfb2f4b54a69373ea283c80837cc220eb94ba","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"node_id":"PR_kwDOMVd0xs8AAAABAvngeg","title":"Native stack bottom stack-bottom-geOs2I70","state":"open","merged_at":null,"draft":false,"html_url":"https://github.com/test-owner/test-repo/pull/189","user":{"login":"test-owner","id":41730,"node_id":"MDQ6VXNlcjQxNzMw","avatar_url":"https://avatars.githubusercontent.com/u/41730?v=4","gravatar_id":"","url":"https://api.github.com/users/test-owner","html_url":"https://github.com/test-owner","followers_url":"https://api.github.com/users/test-owner/followers","following_url":"https://api.github.com/users/test-owner/following{/other_user}","gists_url":"https://api.github.com/users/test-owner/gists{/gist_id}","starred_url":"https://api.github.com/users/test-owner/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/test-owner/subscriptions","organizations_url":"https://api.github.com/users/test-owner/orgs","repos_url":"https://api.github.com/users/test-owner/repos","events_url":"https://api.github.com/users/test-owner/events{/privacy}","received_events_url":"https://api.github.com/users/test-owner/received_events","type":"User","user_view_type":"public","site_admin":false}},{"url":"https://api.github.com/repos/test-owner/test-repo/pulls/190","id":4344897799,"number":190,"head":{"ref":"stack-middle-VEtQX9yQ","sha":"7b6309fa47e62cd6b9984a4e9dc1c1081756fd76","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"base":{"ref":"stack-bottom-geOs2I70","sha":"d09aa9285a4200d6ec0a1454033a5302a8c15f94","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"node_id":"PR_kwDOMVd0xs8AAAABAvnhBw","title":"Native stack middle stack-middle-VEtQX9yQ","state":"open","merged_at":null,"draft":false,"html_url":"https://github.com/test-owner/test-repo/pull/190","user":{"login":"test-owner","id":41730,"node_id":"MDQ6VXNlcjQxNzMw","avatar_url":"https://avatars.githubusercontent.com/u/41730?v=4","gravatar_id":"","url":"https://api.github.com/users/test-owner","html_url":"https://github.com/test-owner","followers_url":"https://api.github.com/users/test-owner/followers","following_url":"https://api.github.com/users/test-owner/following{/other_user}","gists_url":"https://api.github.com/users/test-owner/gists{/gist_id}","starred_url":"https://api.github.com/users/test-owner/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/test-owner/subscriptions","organizations_url":"https://api.github.com/users/test-owner/orgs","repos_url":"https://api.github.com/users/test-owner/repos","events_url":"https://api.github.com/users/test-owner/events{/privacy}","received_events_url":"https://api.github.com/users/test-owner/received_events","type":"User","user_view_type":"public","site_admin":false}}]}'
+        headers:
+            Content-Length:
+                - "3360"
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 388.543542ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 326
+        host: api.github.com
+        body: '{"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"stack-middle-VEtQX9yQ","headRefName":"stack-top-ip5EzT1K","title":"Native stack top stack-top-ip5EzT1K","body":"Native stack integration test"}}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs8AAAABAvnicw","number":192,"url":"https://github.com/test-owner/test-repo/pull/192"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1.257556375s
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.github.com
+        url: https://api.github.com/repos/test-owner/test-repo/stacks
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":560648,"number":191,"node_id":"PRS_kwDOMVd0xs4ACI4I","url":"https://api.github.com/repos/test-owner/test-repo/stacks/191","base":{"ref":"main"},"open":true,"created_at":"2026-08-24T02:35:35Z","pull_requests":[{"number":189,"state":"open","draft":false,"merged_at":null,"head":{"ref":"stack-bottom-geOs2I70","sha":"d09aa9285a4200d6ec0a1454033a5302a8c15f94"}},{"number":190,"state":"open","draft":false,"merged_at":null,"head":{"ref":"stack-middle-VEtQX9yQ","sha":"7b6309fa47e62cd6b9984a4e9dc1c1081756fd76"}}]},{"id":313473,"number":174,"node_id":"PRS_kwDOMVd0xs4ABMiB","url":"https://api.github.com/repos/test-owner/test-repo/stacks/174","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T13:40:09Z","pull_requests":[{"number":170,"state":"closed","draft":false,"merged_at":"2026-08-12T13:40:15Z","head":{"ref":"divergent-stack-a-pO7wJfwF","sha":"cbba7e8dcfec641a88f530c0ccc7c8ce535aeeae"}},{"number":171,"state":"closed","draft":false,"merged_at":"2026-08-12T13:40:16Z","head":{"ref":"divergent-stack-b-9iT5TOLK","sha":"04f50ba691258ef2c136849b1ad0a9e45a6d964a"}},{"number":172,"state":"closed","draft":false,"merged_at":"2026-08-12T13:40:17Z","head":{"ref":"divergent-stack-c-iXygp4Wc","sha":"5e059d8b881a4c03271f7bd6eff43496fb7bfba2"}}]},{"id":313446,"number":169,"node_id":"PRS_kwDOMVd0xs4ABMhm","url":"https://api.github.com/repos/test-owner/test-repo/stacks/169","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T13:39:16Z","pull_requests":[{"number":165,"state":"closed","draft":false,"merged_at":"2026-08-12T13:39:22Z","head":{"ref":"divergent-stack-a-ZwG2QqxN","sha":"bad73a03fe75bb84a66c18758f6a33e964fa5623"}},{"number":166,"state":"closed","draft":false,"merged_at":"2026-08-12T13:39:23Z","head":{"ref":"divergent-stack-b-VxbXF3H4","sha":"1835fe77d5079914c4050ce7f480688f4de316b0"}},{"number":167,"state":"closed","draft":false,"merged_at":"2026-08-12T13:39:23Z","head":{"ref":"divergent-stack-c-MAlCUfYp","sha":"09d733256cafd094d360cb399794138c766a1fef"}}]},{"id":302729,"number":160,"node_id":"PRS_kwDOMVd0xs4ABJ6J","url":"https://api.github.com/repos/test-owner/test-repo/stacks/160","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T04:18:42Z","pull_requests":[{"number":158,"state":"closed","draft":false,"merged_at":"2026-08-12T04:18:46Z","head":{"ref":"merge-range-bottom-bZiK8Eda","sha":"24777ef044c0a4bc712d1345bf9c0ed8b791197b"}},{"number":159,"state":"closed","draft":false,"merged_at":"2026-08-12T04:18:47Z","head":{"ref":"merge-range-top-hIOTMX1T","sha":"bb58f1370879a404c18b51898dcf2e08ea740727"}}]},{"id":302716,"number":157,"node_id":"PRS_kwDOMVd0xs4ABJ58","url":"https://api.github.com/repos/test-owner/test-repo/stacks/157","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T04:17:41Z","pull_requests":[{"number":155,"state":"closed","draft":false,"merged_at":"2026-08-12T04:17:45Z","head":{"ref":"merge-range-bottom-0tvkFGY5","sha":"5c1b178950b3b777fb9ebbede6d383db05d22467"}},{"number":156,"state":"closed","draft":false,"merged_at":"2026-08-12T04:17:45Z","head":{"ref":"merge-range-top-J25jZjmP","sha":"12a7613a380b2b58338e3860d2f328f7cdff03b0"}}]},{"id":302692,"number":154,"node_id":"PRS_kwDOMVd0xs4ABJ5k","url":"https://api.github.com/repos/test-owner/test-repo/stacks/154","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T04:15:44Z","pull_requests":[{"number":152,"state":"closed","draft":false,"merged_at":"2026-08-12T04:15:48Z","head":{"ref":"merge-range-bottom-K06vsatq","sha":"da0f854fa38886c46c4e140f6ccbbf97a0617fda"}},{"number":153,"state":"closed","draft":false,"merged_at":"2026-08-12T04:15:48Z","head":{"ref":"merge-range-top-UQMItpa9","sha":"408a67f73119d0e8394e8f82eeca982994ed20be"}}]},{"id":302586,"number":151,"node_id":"PRS_kwDOMVd0xs4ABJ36","url":"https://api.github.com/repos/test-owner/test-repo/stacks/151","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T04:06:06Z","pull_requests":[{"number":149,"state":"closed","draft":false,"merged_at":"2026-08-12T04:06:10Z","head":{"ref":"merge-range-bottom-j0y6OqrT","sha":"11e275c782e6d64ef1453ca2a4e1509f8ef1d10a"}},{"number":150,"state":"closed","draft":false,"merged_at":"2026-08-12T04:06:10Z","head":{"ref":"merge-range-top-G8bqRe1G","sha":"4cb95e7edc28838635b54236918b825a9130fcb8"}}]},{"id":302031,"number":147,"node_id":"PRS_kwDOMVd0xs4ABJvP","url":"https://api.github.com/repos/test-owner/test-repo/stacks/147","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T03:16:01Z","pull_requests":[{"number":145,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-bottom-dW4RtWmC","sha":"b5bec1eaccc7a5fb6d5ac747c67832c156bf51bd"}},{"number":146,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-middle-g3WXJxSb","sha":"f740dffc87f2ddf00824f1a09d2c24b70811b247"}},{"number":148,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-top-gampXI6B","sha":"711662448930f8a00d161c842fb0ee8d401c994e"}}]},{"id":167872,"number":144,"node_id":"PRS_kwDOMVd0xs4AAo_A","url":"https://api.github.com/repos/test-owner/test-repo/stacks/144","base":{"ref":"main"},"open":false,"created_at":"2026-08-05T12:16:14Z","pull_requests":[{"number":140,"state":"closed","draft":false,"merged_at":"2026-08-05T12:18:48Z","head":{"ref":"probe-autodelete-20260805-9c4e-a","sha":"920069c11160c4fe98a1b7e346be68ca51d59b73"}},{"number":141,"state":"closed","draft":false,"merged_at":"2026-08-05T12:18:49Z","head":{"ref":"probe-autodelete-20260805-9c4e-b","sha":"1007602d9b285fe3c2825da02aaf020c4f0ecdd7"}},{"number":142,"state":"closed","draft":false,"merged_at":"2026-08-05T12:18:50Z","head":{"ref":"probe-autodelete-20260805-9c4e-c","sha":"d0753d932262f7b817599a792e317f5339a5849d"}}]},{"id":167438,"number":139,"node_id":"PRS_kwDOMVd0xs4AAo4O","url":"https://api.github.com/repos/test-owner/test-repo/stacks/139","base":{"ref":"main"},"open":false,"created_at":"2026-08-05T11:55:14Z","pull_requests":[{"number":135,"state":"closed","draft":false,"merged_at":"2026-08-05T11:55:56Z","head":{"ref":"probe-divergence-20260805-7f3c-a","sha":"b70346dd87e33f1b0182223edee11f43a3a9db66"}},{"number":136,"state":"closed","draft":false,"merged_at":"2026-08-05T11:55:57Z","head":{"ref":"probe-divergence-20260805-7f3c-b","sha":"f5367dbc180b397617065a700e42df50f7646329"}},{"number":137,"state":"closed","draft":false,"merged_at":"2026-08-05T11:55:58Z","head":{"ref":"probe-divergence-20260805-7f3c-c","sha":"f820a52d526b01daba6bd583066d97dd03d33fcd"}}]},{"id":101032,"number":134,"node_id":"PRS_kwDOMVd0xs4AAYqo","url":"https://api.github.com/repos/test-owner/test-repo/stacks/134","base":{"ref":"main"},"open":false,"created_at":"2026-08-02T06:04:41Z","pull_requests":[{"number":132,"state":"closed","draft":false,"merged_at":"2026-08-02T06:05:07Z","head":{"ref":"gs-native-stack-probe-019fbe36-base","sha":"640dd83224aabd95f66ff91912b26f08f33edbbd"}},{"number":133,"state":"closed","draft":false,"merged_at":"2026-08-02T06:05:08Z","head":{"ref":"gs-native-stack-probe-019fbe36-top","sha":"67d6b814fe522ff1e3d850fcf6b1cdc02ac11b43"}}]}]'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 233.355334ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 523
+        host: api.github.com
+        body: '{"query":"query($owner:String!,$repo:String!,$pr0:Int!,$pr1:Int!,$pr2:Int!){repository(owner: $owner, name: $repo){pr0:pullRequest(number: $pr0){id,state,headRefName,baseRefName,headRepository{owner{login},name},stack{id}},pr1:pullRequest(number: $pr1){id,state,headRefName,baseRefName,headRepository{owner{login},name},stack{id}},pr2:pullRequest(number: $pr2){id,state,headRefName,baseRefName,headRepository{owner{login},name},stack{id}}}}","variables":{"owner":"test-owner","pr0":189,"pr1":190,"pr2":192,"repo":"test-repo"}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"repository":{"pr0":{"id":"PR_kwDOMVd0xs8AAAABAvngeg","state":"OPEN","headRefName":"stack-bottom-geOs2I70","baseRefName":"main","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":{"id":"PRS_kwDOMVd0xs4ACI4I"}},"pr1":{"id":"PR_kwDOMVd0xs8AAAABAvnhBw","state":"OPEN","headRefName":"stack-middle-VEtQX9yQ","baseRefName":"stack-bottom-geOs2I70","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":{"id":"PRS_kwDOMVd0xs4ACI4I"}},"pr2":{"id":"PR_kwDOMVd0xs8AAAABAvnicw","state":"OPEN","headRefName":"stack-top-ip5EzT1K","baseRefName":"stack-middle-VEtQX9yQ","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":null}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 284.43175ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 263
+        host: api.github.com
+        body: '{"query":"query($ids:[ID!]!){nodes(ids: $ids){... on PullRequestStack{id,number,entries(first: 100){nodes{pullRequest{number,state,mergeQueueEntry{id},autoMergeRequest{enabledAt}}},pageInfo{endCursor,hasNextPage}}}}}","variables":{"ids":["PRS_kwDOMVd0xs4ACI4I"]}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"nodes":[{"id":"PRS_kwDOMVd0xs4ACI4I","number":191,"entries":{"nodes":[{"pullRequest":{"number":189,"state":"OPEN","mergeQueueEntry":null,"autoMergeRequest":null}},{"pullRequest":{"number":190,"state":"OPEN","mergeQueueEntry":null,"autoMergeRequest":null}}],"pageInfo":{"endCursor":"Mg","hasNextPage":false}}}]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 282.453ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 24
+        host: api.github.com
+        body: |
+            {"pull_requests":[192]}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/repos/test-owner/test-repo/stacks/191/add
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":560648,"number":191,"node_id":"PRS_kwDOMVd0xs4ACI4I","url":"https://api.github.com/repos/test-owner/test-repo/stacks/191","base":{"ref":"main"},"open":true,"created_at":"2026-08-24T02:35:35Z","pull_requests":[{"url":"https://api.github.com/repos/test-owner/test-repo/pulls/189","id":4344897658,"number":189,"head":{"ref":"stack-bottom-geOs2I70","sha":"d09aa9285a4200d6ec0a1454033a5302a8c15f94","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"base":{"ref":"main","sha":"64adfb2f4b54a69373ea283c80837cc220eb94ba","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"node_id":"PR_kwDOMVd0xs8AAAABAvngeg","title":"Native stack bottom stack-bottom-geOs2I70","state":"open","merged_at":null,"draft":false,"html_url":"https://github.com/test-owner/test-repo/pull/189","user":{"login":"test-owner","id":41730,"node_id":"MDQ6VXNlcjQxNzMw","avatar_url":"https://avatars.githubusercontent.com/u/41730?v=4","gravatar_id":"","url":"https://api.github.com/users/test-owner","html_url":"https://github.com/test-owner","followers_url":"https://api.github.com/users/test-owner/followers","following_url":"https://api.github.com/users/test-owner/following{/other_user}","gists_url":"https://api.github.com/users/test-owner/gists{/gist_id}","starred_url":"https://api.github.com/users/test-owner/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/test-owner/subscriptions","organizations_url":"https://api.github.com/users/test-owner/orgs","repos_url":"https://api.github.com/users/test-owner/repos","events_url":"https://api.github.com/users/test-owner/events{/privacy}","received_events_url":"https://api.github.com/users/test-owner/received_events","type":"User","user_view_type":"public","site_admin":false}},{"url":"https://api.github.com/repos/test-owner/test-repo/pulls/190","id":4344897799,"number":190,"head":{"ref":"stack-middle-VEtQX9yQ","sha":"7b6309fa47e62cd6b9984a4e9dc1c1081756fd76","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"base":{"ref":"stack-bottom-geOs2I70","sha":"d09aa9285a4200d6ec0a1454033a5302a8c15f94","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"node_id":"PR_kwDOMVd0xs8AAAABAvnhBw","title":"Native stack middle stack-middle-VEtQX9yQ","state":"open","merged_at":null,"draft":false,"html_url":"https://github.com/test-owner/test-repo/pull/190","user":{"login":"test-owner","id":41730,"node_id":"MDQ6VXNlcjQxNzMw","avatar_url":"https://avatars.githubusercontent.com/u/41730?v=4","gravatar_id":"","url":"https://api.github.com/users/test-owner","html_url":"https://github.com/test-owner","followers_url":"https://api.github.com/users/test-owner/followers","following_url":"https://api.github.com/users/test-owner/following{/other_user}","gists_url":"https://api.github.com/users/test-owner/gists{/gist_id}","starred_url":"https://api.github.com/users/test-owner/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/test-owner/subscriptions","organizations_url":"https://api.github.com/users/test-owner/orgs","repos_url":"https://api.github.com/users/test-owner/repos","events_url":"https://api.github.com/users/test-owner/events{/privacy}","received_events_url":"https://api.github.com/users/test-owner/received_events","type":"User","user_view_type":"public","site_admin":false}},{"url":"https://api.github.com/repos/test-owner/test-repo/pulls/192","id":4344898163,"number":192,"head":{"ref":"stack-top-ip5EzT1K","sha":"0e2fa2c652ecd15211e206798f0c6790c360ccdd","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"base":{"ref":"stack-middle-VEtQX9yQ","sha":"7b6309fa47e62cd6b9984a4e9dc1c1081756fd76","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"node_id":"PR_kwDOMVd0xs8AAAABAvnicw","title":"Native stack top stack-top-ip5EzT1K","state":"open","merged_at":null,"draft":false,"html_url":"https://github.com/test-owner/test-repo/pull/192","user":{"login":"test-owner","id":41730,"node_id":"MDQ6VXNlcjQxNzMw","avatar_url":"https://avatars.githubusercontent.com/u/41730?v=4","gravatar_id":"","url":"https://api.github.com/users/test-owner","html_url":"https://github.com/test-owner","followers_url":"https://api.github.com/users/test-owner/followers","following_url":"https://api.github.com/users/test-owner/following{/other_user}","gists_url":"https://api.github.com/users/test-owner/gists{/gist_id}","starred_url":"https://api.github.com/users/test-owner/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/test-owner/subscriptions","organizations_url":"https://api.github.com/users/test-owner/orgs","repos_url":"https://api.github.com/users/test-owner/repos","events_url":"https://api.github.com/users/test-owner/events{/privacy}","received_events_url":"https://api.github.com/users/test-owner/received_events","type":"User","user_view_type":"public","site_admin":false}}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 318.7545ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.github.com
+        url: https://api.github.com/repos/test-owner/test-repo/stacks
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":560648,"number":191,"node_id":"PRS_kwDOMVd0xs4ACI4I","url":"https://api.github.com/repos/test-owner/test-repo/stacks/191","base":{"ref":"main"},"open":true,"created_at":"2026-08-24T02:35:35Z","pull_requests":[{"number":189,"state":"open","draft":false,"merged_at":null,"head":{"ref":"stack-bottom-geOs2I70","sha":"d09aa9285a4200d6ec0a1454033a5302a8c15f94"}},{"number":190,"state":"open","draft":false,"merged_at":null,"head":{"ref":"stack-middle-VEtQX9yQ","sha":"7b6309fa47e62cd6b9984a4e9dc1c1081756fd76"}},{"number":192,"state":"open","draft":false,"merged_at":null,"head":{"ref":"stack-top-ip5EzT1K","sha":"0e2fa2c652ecd15211e206798f0c6790c360ccdd"}}]},{"id":313473,"number":174,"node_id":"PRS_kwDOMVd0xs4ABMiB","url":"https://api.github.com/repos/test-owner/test-repo/stacks/174","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T13:40:09Z","pull_requests":[{"number":170,"state":"closed","draft":false,"merged_at":"2026-08-12T13:40:15Z","head":{"ref":"divergent-stack-a-pO7wJfwF","sha":"cbba7e8dcfec641a88f530c0ccc7c8ce535aeeae"}},{"number":171,"state":"closed","draft":false,"merged_at":"2026-08-12T13:40:16Z","head":{"ref":"divergent-stack-b-9iT5TOLK","sha":"04f50ba691258ef2c136849b1ad0a9e45a6d964a"}},{"number":172,"state":"closed","draft":false,"merged_at":"2026-08-12T13:40:17Z","head":{"ref":"divergent-stack-c-iXygp4Wc","sha":"5e059d8b881a4c03271f7bd6eff43496fb7bfba2"}}]},{"id":313446,"number":169,"node_id":"PRS_kwDOMVd0xs4ABMhm","url":"https://api.github.com/repos/test-owner/test-repo/stacks/169","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T13:39:16Z","pull_requests":[{"number":165,"state":"closed","draft":false,"merged_at":"2026-08-12T13:39:22Z","head":{"ref":"divergent-stack-a-ZwG2QqxN","sha":"bad73a03fe75bb84a66c18758f6a33e964fa5623"}},{"number":166,"state":"closed","draft":false,"merged_at":"2026-08-12T13:39:23Z","head":{"ref":"divergent-stack-b-VxbXF3H4","sha":"1835fe77d5079914c4050ce7f480688f4de316b0"}},{"number":167,"state":"closed","draft":false,"merged_at":"2026-08-12T13:39:23Z","head":{"ref":"divergent-stack-c-MAlCUfYp","sha":"09d733256cafd094d360cb399794138c766a1fef"}}]},{"id":302729,"number":160,"node_id":"PRS_kwDOMVd0xs4ABJ6J","url":"https://api.github.com/repos/test-owner/test-repo/stacks/160","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T04:18:42Z","pull_requests":[{"number":158,"state":"closed","draft":false,"merged_at":"2026-08-12T04:18:46Z","head":{"ref":"merge-range-bottom-bZiK8Eda","sha":"24777ef044c0a4bc712d1345bf9c0ed8b791197b"}},{"number":159,"state":"closed","draft":false,"merged_at":"2026-08-12T04:18:47Z","head":{"ref":"merge-range-top-hIOTMX1T","sha":"bb58f1370879a404c18b51898dcf2e08ea740727"}}]},{"id":302716,"number":157,"node_id":"PRS_kwDOMVd0xs4ABJ58","url":"https://api.github.com/repos/test-owner/test-repo/stacks/157","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T04:17:41Z","pull_requests":[{"number":155,"state":"closed","draft":false,"merged_at":"2026-08-12T04:17:45Z","head":{"ref":"merge-range-bottom-0tvkFGY5","sha":"5c1b178950b3b777fb9ebbede6d383db05d22467"}},{"number":156,"state":"closed","draft":false,"merged_at":"2026-08-12T04:17:45Z","head":{"ref":"merge-range-top-J25jZjmP","sha":"12a7613a380b2b58338e3860d2f328f7cdff03b0"}}]},{"id":302692,"number":154,"node_id":"PRS_kwDOMVd0xs4ABJ5k","url":"https://api.github.com/repos/test-owner/test-repo/stacks/154","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T04:15:44Z","pull_requests":[{"number":152,"state":"closed","draft":false,"merged_at":"2026-08-12T04:15:48Z","head":{"ref":"merge-range-bottom-K06vsatq","sha":"da0f854fa38886c46c4e140f6ccbbf97a0617fda"}},{"number":153,"state":"closed","draft":false,"merged_at":"2026-08-12T04:15:48Z","head":{"ref":"merge-range-top-UQMItpa9","sha":"408a67f73119d0e8394e8f82eeca982994ed20be"}}]},{"id":302586,"number":151,"node_id":"PRS_kwDOMVd0xs4ABJ36","url":"https://api.github.com/repos/test-owner/test-repo/stacks/151","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T04:06:06Z","pull_requests":[{"number":149,"state":"closed","draft":false,"merged_at":"2026-08-12T04:06:10Z","head":{"ref":"merge-range-bottom-j0y6OqrT","sha":"11e275c782e6d64ef1453ca2a4e1509f8ef1d10a"}},{"number":150,"state":"closed","draft":false,"merged_at":"2026-08-12T04:06:10Z","head":{"ref":"merge-range-top-G8bqRe1G","sha":"4cb95e7edc28838635b54236918b825a9130fcb8"}}]},{"id":302031,"number":147,"node_id":"PRS_kwDOMVd0xs4ABJvP","url":"https://api.github.com/repos/test-owner/test-repo/stacks/147","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T03:16:01Z","pull_requests":[{"number":145,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-bottom-dW4RtWmC","sha":"b5bec1eaccc7a5fb6d5ac747c67832c156bf51bd"}},{"number":146,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-middle-g3WXJxSb","sha":"f740dffc87f2ddf00824f1a09d2c24b70811b247"}},{"number":148,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-top-gampXI6B","sha":"711662448930f8a00d161c842fb0ee8d401c994e"}}]},{"id":167872,"number":144,"node_id":"PRS_kwDOMVd0xs4AAo_A","url":"https://api.github.com/repos/test-owner/test-repo/stacks/144","base":{"ref":"main"},"open":false,"created_at":"2026-08-05T12:16:14Z","pull_requests":[{"number":140,"state":"closed","draft":false,"merged_at":"2026-08-05T12:18:48Z","head":{"ref":"probe-autodelete-20260805-9c4e-a","sha":"920069c11160c4fe98a1b7e346be68ca51d59b73"}},{"number":141,"state":"closed","draft":false,"merged_at":"2026-08-05T12:18:49Z","head":{"ref":"probe-autodelete-20260805-9c4e-b","sha":"1007602d9b285fe3c2825da02aaf020c4f0ecdd7"}},{"number":142,"state":"closed","draft":false,"merged_at":"2026-08-05T12:18:50Z","head":{"ref":"probe-autodelete-20260805-9c4e-c","sha":"d0753d932262f7b817599a792e317f5339a5849d"}}]},{"id":167438,"number":139,"node_id":"PRS_kwDOMVd0xs4AAo4O","url":"https://api.github.com/repos/test-owner/test-repo/stacks/139","base":{"ref":"main"},"open":false,"created_at":"2026-08-05T11:55:14Z","pull_requests":[{"number":135,"state":"closed","draft":false,"merged_at":"2026-08-05T11:55:56Z","head":{"ref":"probe-divergence-20260805-7f3c-a","sha":"b70346dd87e33f1b0182223edee11f43a3a9db66"}},{"number":136,"state":"closed","draft":false,"merged_at":"2026-08-05T11:55:57Z","head":{"ref":"probe-divergence-20260805-7f3c-b","sha":"f5367dbc180b397617065a700e42df50f7646329"}},{"number":137,"state":"closed","draft":false,"merged_at":"2026-08-05T11:55:58Z","head":{"ref":"probe-divergence-20260805-7f3c-c","sha":"f820a52d526b01daba6bd583066d97dd03d33fcd"}}]},{"id":101032,"number":134,"node_id":"PRS_kwDOMVd0xs4AAYqo","url":"https://api.github.com/repos/test-owner/test-repo/stacks/134","base":{"ref":"main"},"open":false,"created_at":"2026-08-02T06:04:41Z","pull_requests":[{"number":132,"state":"closed","draft":false,"merged_at":"2026-08-02T06:05:07Z","head":{"ref":"gs-native-stack-probe-019fbe36-base","sha":"640dd83224aabd95f66ff91912b26f08f33edbbd"}},{"number":133,"state":"closed","draft":false,"merged_at":"2026-08-02T06:05:08Z","head":{"ref":"gs-native-stack-probe-019fbe36-top","sha":"67d6b814fe522ff1e3d850fcf6b1cdc02ac11b43"}}]}]'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 179.437667ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 523
+        host: api.github.com
+        body: '{"query":"query($owner:String!,$repo:String!,$pr0:Int!,$pr1:Int!,$pr2:Int!){repository(owner: $owner, name: $repo){pr0:pullRequest(number: $pr0){id,state,headRefName,baseRefName,headRepository{owner{login},name},stack{id}},pr1:pullRequest(number: $pr1){id,state,headRefName,baseRefName,headRepository{owner{login},name},stack{id}},pr2:pullRequest(number: $pr2){id,state,headRefName,baseRefName,headRepository{owner{login},name},stack{id}}}}","variables":{"owner":"test-owner","pr0":189,"pr1":190,"pr2":192,"repo":"test-repo"}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"repository":{"pr0":{"id":"PR_kwDOMVd0xs8AAAABAvngeg","state":"OPEN","headRefName":"stack-bottom-geOs2I70","baseRefName":"main","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":{"id":"PRS_kwDOMVd0xs4ACI4I"}},"pr1":{"id":"PR_kwDOMVd0xs8AAAABAvnhBw","state":"OPEN","headRefName":"stack-middle-VEtQX9yQ","baseRefName":"stack-bottom-geOs2I70","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":{"id":"PRS_kwDOMVd0xs4ACI4I"}},"pr2":{"id":"PR_kwDOMVd0xs8AAAABAvnicw","state":"OPEN","headRefName":"stack-top-ip5EzT1K","baseRefName":"stack-middle-VEtQX9yQ","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":{"id":"PRS_kwDOMVd0xs4ACI4I"}}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 230.991167ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 263
+        host: api.github.com
+        body: '{"query":"query($ids:[ID!]!){nodes(ids: $ids){... on PullRequestStack{id,number,entries(first: 100){nodes{pullRequest{number,state,mergeQueueEntry{id},autoMergeRequest{enabledAt}}},pageInfo{endCursor,hasNextPage}}}}}","variables":{"ids":["PRS_kwDOMVd0xs4ACI4I"]}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"nodes":[{"id":"PRS_kwDOMVd0xs4ACI4I","number":191,"entries":{"nodes":[{"pullRequest":{"number":189,"state":"OPEN","mergeQueueEntry":null,"autoMergeRequest":null}},{"pullRequest":{"number":190,"state":"OPEN","mergeQueueEntry":null,"autoMergeRequest":null}},{"pullRequest":{"number":192,"state":"OPEN","mergeQueueEntry":null,"autoMergeRequest":null}}],"pageInfo":{"endCursor":"Mw","hasNextPage":false}}}]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 288.943458ms

--- a/internal/forge/github/testdata/fixtures/TestIntegration_stackReplacement.yaml
+++ b/internal/forge/github/testdata/fixtures/TestIntegration_stackReplacement.yaml
@@ -1,0 +1,452 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 141
+        host: api.github.com
+        body: '{"query":"query($owner:String!$repo:String!){repository(owner: $owner, name: $repo){id}}","variables":{"owner":"test-owner","repo":"test-repo"}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"repository":{"id":"R_kgDOMVd0xg"}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 262.671625ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 358
+        host: api.github.com
+        body: '{"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"main","headRefName":"stack-replace-bottom-Hydxxy1R","title":"Native stack replacement bottom stack-replace-bottom-Hydxxy1R","body":"Native stack replacement integration test"}}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs8AAAABAvnqVg","number":193,"url":"https://github.com/test-owner/test-repo/pull/193"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1.168417875s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 374
+        host: api.github.com
+        body: '{"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"stack-replace-bottom-Hydxxy1R","headRefName":"stack-replace-top-92YL4XjC","title":"Native stack replacement top stack-replace-top-92YL4XjC","body":"Native stack replacement integration test"}}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs8AAAABAvnqrA","number":194,"url":"https://github.com/test-owner/test-repo/pull/194"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 2.494164292s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.github.com
+        url: https://api.github.com/repos/test-owner/test-repo/stacks
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":560648,"number":191,"node_id":"PRS_kwDOMVd0xs4ACI4I","url":"https://api.github.com/repos/test-owner/test-repo/stacks/191","base":{"ref":"main"},"open":false,"created_at":"2026-08-24T02:35:35Z","pull_requests":[{"number":189,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-bottom-geOs2I70","sha":"d09aa9285a4200d6ec0a1454033a5302a8c15f94"}},{"number":190,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-middle-VEtQX9yQ","sha":"7b6309fa47e62cd6b9984a4e9dc1c1081756fd76"}},{"number":192,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-top-ip5EzT1K","sha":"0e2fa2c652ecd15211e206798f0c6790c360ccdd"}}]},{"id":313473,"number":174,"node_id":"PRS_kwDOMVd0xs4ABMiB","url":"https://api.github.com/repos/test-owner/test-repo/stacks/174","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T13:40:09Z","pull_requests":[{"number":170,"state":"closed","draft":false,"merged_at":"2026-08-12T13:40:15Z","head":{"ref":"divergent-stack-a-pO7wJfwF","sha":"cbba7e8dcfec641a88f530c0ccc7c8ce535aeeae"}},{"number":171,"state":"closed","draft":false,"merged_at":"2026-08-12T13:40:16Z","head":{"ref":"divergent-stack-b-9iT5TOLK","sha":"04f50ba691258ef2c136849b1ad0a9e45a6d964a"}},{"number":172,"state":"closed","draft":false,"merged_at":"2026-08-12T13:40:17Z","head":{"ref":"divergent-stack-c-iXygp4Wc","sha":"5e059d8b881a4c03271f7bd6eff43496fb7bfba2"}}]},{"id":313446,"number":169,"node_id":"PRS_kwDOMVd0xs4ABMhm","url":"https://api.github.com/repos/test-owner/test-repo/stacks/169","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T13:39:16Z","pull_requests":[{"number":165,"state":"closed","draft":false,"merged_at":"2026-08-12T13:39:22Z","head":{"ref":"divergent-stack-a-ZwG2QqxN","sha":"bad73a03fe75bb84a66c18758f6a33e964fa5623"}},{"number":166,"state":"closed","draft":false,"merged_at":"2026-08-12T13:39:23Z","head":{"ref":"divergent-stack-b-VxbXF3H4","sha":"1835fe77d5079914c4050ce7f480688f4de316b0"}},{"number":167,"state":"closed","draft":false,"merged_at":"2026-08-12T13:39:23Z","head":{"ref":"divergent-stack-c-MAlCUfYp","sha":"09d733256cafd094d360cb399794138c766a1fef"}}]},{"id":302729,"number":160,"node_id":"PRS_kwDOMVd0xs4ABJ6J","url":"https://api.github.com/repos/test-owner/test-repo/stacks/160","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T04:18:42Z","pull_requests":[{"number":158,"state":"closed","draft":false,"merged_at":"2026-08-12T04:18:46Z","head":{"ref":"merge-range-bottom-bZiK8Eda","sha":"24777ef044c0a4bc712d1345bf9c0ed8b791197b"}},{"number":159,"state":"closed","draft":false,"merged_at":"2026-08-12T04:18:47Z","head":{"ref":"merge-range-top-hIOTMX1T","sha":"bb58f1370879a404c18b51898dcf2e08ea740727"}}]},{"id":302716,"number":157,"node_id":"PRS_kwDOMVd0xs4ABJ58","url":"https://api.github.com/repos/test-owner/test-repo/stacks/157","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T04:17:41Z","pull_requests":[{"number":155,"state":"closed","draft":false,"merged_at":"2026-08-12T04:17:45Z","head":{"ref":"merge-range-bottom-0tvkFGY5","sha":"5c1b178950b3b777fb9ebbede6d383db05d22467"}},{"number":156,"state":"closed","draft":false,"merged_at":"2026-08-12T04:17:45Z","head":{"ref":"merge-range-top-J25jZjmP","sha":"12a7613a380b2b58338e3860d2f328f7cdff03b0"}}]},{"id":302692,"number":154,"node_id":"PRS_kwDOMVd0xs4ABJ5k","url":"https://api.github.com/repos/test-owner/test-repo/stacks/154","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T04:15:44Z","pull_requests":[{"number":152,"state":"closed","draft":false,"merged_at":"2026-08-12T04:15:48Z","head":{"ref":"merge-range-bottom-K06vsatq","sha":"da0f854fa38886c46c4e140f6ccbbf97a0617fda"}},{"number":153,"state":"closed","draft":false,"merged_at":"2026-08-12T04:15:48Z","head":{"ref":"merge-range-top-UQMItpa9","sha":"408a67f73119d0e8394e8f82eeca982994ed20be"}}]},{"id":302586,"number":151,"node_id":"PRS_kwDOMVd0xs4ABJ36","url":"https://api.github.com/repos/test-owner/test-repo/stacks/151","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T04:06:06Z","pull_requests":[{"number":149,"state":"closed","draft":false,"merged_at":"2026-08-12T04:06:10Z","head":{"ref":"merge-range-bottom-j0y6OqrT","sha":"11e275c782e6d64ef1453ca2a4e1509f8ef1d10a"}},{"number":150,"state":"closed","draft":false,"merged_at":"2026-08-12T04:06:10Z","head":{"ref":"merge-range-top-G8bqRe1G","sha":"4cb95e7edc28838635b54236918b825a9130fcb8"}}]},{"id":302031,"number":147,"node_id":"PRS_kwDOMVd0xs4ABJvP","url":"https://api.github.com/repos/test-owner/test-repo/stacks/147","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T03:16:01Z","pull_requests":[{"number":145,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-bottom-dW4RtWmC","sha":"b5bec1eaccc7a5fb6d5ac747c67832c156bf51bd"}},{"number":146,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-middle-g3WXJxSb","sha":"f740dffc87f2ddf00824f1a09d2c24b70811b247"}},{"number":148,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-top-gampXI6B","sha":"711662448930f8a00d161c842fb0ee8d401c994e"}}]},{"id":167872,"number":144,"node_id":"PRS_kwDOMVd0xs4AAo_A","url":"https://api.github.com/repos/test-owner/test-repo/stacks/144","base":{"ref":"main"},"open":false,"created_at":"2026-08-05T12:16:14Z","pull_requests":[{"number":140,"state":"closed","draft":false,"merged_at":"2026-08-05T12:18:48Z","head":{"ref":"probe-autodelete-20260805-9c4e-a","sha":"920069c11160c4fe98a1b7e346be68ca51d59b73"}},{"number":141,"state":"closed","draft":false,"merged_at":"2026-08-05T12:18:49Z","head":{"ref":"probe-autodelete-20260805-9c4e-b","sha":"1007602d9b285fe3c2825da02aaf020c4f0ecdd7"}},{"number":142,"state":"closed","draft":false,"merged_at":"2026-08-05T12:18:50Z","head":{"ref":"probe-autodelete-20260805-9c4e-c","sha":"d0753d932262f7b817599a792e317f5339a5849d"}}]},{"id":167438,"number":139,"node_id":"PRS_kwDOMVd0xs4AAo4O","url":"https://api.github.com/repos/test-owner/test-repo/stacks/139","base":{"ref":"main"},"open":false,"created_at":"2026-08-05T11:55:14Z","pull_requests":[{"number":135,"state":"closed","draft":false,"merged_at":"2026-08-05T11:55:56Z","head":{"ref":"probe-divergence-20260805-7f3c-a","sha":"b70346dd87e33f1b0182223edee11f43a3a9db66"}},{"number":136,"state":"closed","draft":false,"merged_at":"2026-08-05T11:55:57Z","head":{"ref":"probe-divergence-20260805-7f3c-b","sha":"f5367dbc180b397617065a700e42df50f7646329"}},{"number":137,"state":"closed","draft":false,"merged_at":"2026-08-05T11:55:58Z","head":{"ref":"probe-divergence-20260805-7f3c-c","sha":"f820a52d526b01daba6bd583066d97dd03d33fcd"}}]},{"id":101032,"number":134,"node_id":"PRS_kwDOMVd0xs4AAYqo","url":"https://api.github.com/repos/test-owner/test-repo/stacks/134","base":{"ref":"main"},"open":false,"created_at":"2026-08-02T06:04:41Z","pull_requests":[{"number":132,"state":"closed","draft":false,"merged_at":"2026-08-02T06:05:07Z","head":{"ref":"gs-native-stack-probe-019fbe36-base","sha":"640dd83224aabd95f66ff91912b26f08f33edbbd"}},{"number":133,"state":"closed","draft":false,"merged_at":"2026-08-02T06:05:08Z","head":{"ref":"gs-native-stack-probe-019fbe36-top","sha":"67d6b814fe522ff1e3d850fcf6b1cdc02ac11b43"}}]}]'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 173.492875ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 395
+        host: api.github.com
+        body: '{"query":"query($owner:String!,$repo:String!,$pr0:Int!,$pr1:Int!){repository(owner: $owner, name: $repo){pr0:pullRequest(number: $pr0){id,state,headRefName,baseRefName,headRepository{owner{login},name},stack{id}},pr1:pullRequest(number: $pr1){id,state,headRefName,baseRefName,headRepository{owner{login},name},stack{id}}}}","variables":{"owner":"test-owner","pr0":193,"pr1":194,"repo":"test-repo"}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"repository":{"pr0":{"id":"PR_kwDOMVd0xs8AAAABAvnqVg","state":"OPEN","headRefName":"stack-replace-bottom-Hydxxy1R","baseRefName":"main","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":null},"pr1":{"id":"PR_kwDOMVd0xs8AAAABAvnqrA","state":"OPEN","headRefName":"stack-replace-top-92YL4XjC","baseRefName":"stack-replace-bottom-Hydxxy1R","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":null}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 239.933333ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 28
+        host: api.github.com
+        body: |
+            {"pull_requests":[193,194]}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/repos/test-owner/test-repo/stacks
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 3415
+        body: '{"id":560654,"number":195,"node_id":"PRS_kwDOMVd0xs4ACI4O","url":"https://api.github.com/repos/test-owner/test-repo/stacks/195","base":{"ref":"main"},"open":true,"created_at":"2026-08-24T02:36:11Z","pull_requests":[{"url":"https://api.github.com/repos/test-owner/test-repo/pulls/193","id":4344900182,"number":193,"head":{"ref":"stack-replace-bottom-Hydxxy1R","sha":"2ceeaa5efc3791ef3c43e7463cfb74adda1b4de3","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"base":{"ref":"main","sha":"64adfb2f4b54a69373ea283c80837cc220eb94ba","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"node_id":"PR_kwDOMVd0xs8AAAABAvnqVg","title":"Native stack replacement bottom stack-replace-bottom-Hydxxy1R","state":"open","merged_at":null,"draft":false,"html_url":"https://github.com/test-owner/test-repo/pull/193","user":{"login":"test-owner","id":41730,"node_id":"MDQ6VXNlcjQxNzMw","avatar_url":"https://avatars.githubusercontent.com/u/41730?v=4","gravatar_id":"","url":"https://api.github.com/users/test-owner","html_url":"https://github.com/test-owner","followers_url":"https://api.github.com/users/test-owner/followers","following_url":"https://api.github.com/users/test-owner/following{/other_user}","gists_url":"https://api.github.com/users/test-owner/gists{/gist_id}","starred_url":"https://api.github.com/users/test-owner/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/test-owner/subscriptions","organizations_url":"https://api.github.com/users/test-owner/orgs","repos_url":"https://api.github.com/users/test-owner/repos","events_url":"https://api.github.com/users/test-owner/events{/privacy}","received_events_url":"https://api.github.com/users/test-owner/received_events","type":"User","user_view_type":"public","site_admin":false}},{"url":"https://api.github.com/repos/test-owner/test-repo/pulls/194","id":4344900268,"number":194,"head":{"ref":"stack-replace-top-92YL4XjC","sha":"8590f670baa89e5b535210911353c9cbdfa2d0fc","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"base":{"ref":"stack-replace-bottom-Hydxxy1R","sha":"2ceeaa5efc3791ef3c43e7463cfb74adda1b4de3","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"node_id":"PR_kwDOMVd0xs8AAAABAvnqrA","title":"Native stack replacement top stack-replace-top-92YL4XjC","state":"open","merged_at":null,"draft":false,"html_url":"https://github.com/test-owner/test-repo/pull/194","user":{"login":"test-owner","id":41730,"node_id":"MDQ6VXNlcjQxNzMw","avatar_url":"https://avatars.githubusercontent.com/u/41730?v=4","gravatar_id":"","url":"https://api.github.com/users/test-owner","html_url":"https://github.com/test-owner","followers_url":"https://api.github.com/users/test-owner/followers","following_url":"https://api.github.com/users/test-owner/following{/other_user}","gists_url":"https://api.github.com/users/test-owner/gists{/gist_id}","starred_url":"https://api.github.com/users/test-owner/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/test-owner/subscriptions","organizations_url":"https://api.github.com/users/test-owner/orgs","repos_url":"https://api.github.com/users/test-owner/repos","events_url":"https://api.github.com/users/test-owner/events{/privacy}","received_events_url":"https://api.github.com/users/test-owner/received_events","type":"User","user_view_type":"public","site_admin":false}}]}'
+        headers:
+            Content-Length:
+                - "3415"
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 529.489959ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 387
+        host: api.github.com
+        body: '{"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"stack-replace-bottom-Hydxxy1R","headRefName":"stack-replace-inserted-WNuOA0uR","title":"Native stack replacement middle stack-replace-inserted-WNuOA0uR","body":"Native stack replacement integration test"}}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs8AAAABAvnrgw","number":196,"url":"https://github.com/test-owner/test-repo/pull/196"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1.124752292s
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.github.com
+        url: https://api.github.com/repos/test-owner/test-repo/stacks
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":560654,"number":195,"node_id":"PRS_kwDOMVd0xs4ACI4O","url":"https://api.github.com/repos/test-owner/test-repo/stacks/195","base":{"ref":"main"},"open":true,"created_at":"2026-08-24T02:36:11Z","pull_requests":[{"number":193,"state":"open","draft":false,"merged_at":null,"head":{"ref":"stack-replace-bottom-Hydxxy1R","sha":"2ceeaa5efc3791ef3c43e7463cfb74adda1b4de3"}},{"number":194,"state":"open","draft":false,"merged_at":null,"head":{"ref":"stack-replace-top-92YL4XjC","sha":"8590f670baa89e5b535210911353c9cbdfa2d0fc"}}]},{"id":560648,"number":191,"node_id":"PRS_kwDOMVd0xs4ACI4I","url":"https://api.github.com/repos/test-owner/test-repo/stacks/191","base":{"ref":"main"},"open":false,"created_at":"2026-08-24T02:35:35Z","pull_requests":[{"number":189,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-bottom-geOs2I70","sha":"d09aa9285a4200d6ec0a1454033a5302a8c15f94"}},{"number":190,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-middle-VEtQX9yQ","sha":"7b6309fa47e62cd6b9984a4e9dc1c1081756fd76"}},{"number":192,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-top-ip5EzT1K","sha":"0e2fa2c652ecd15211e206798f0c6790c360ccdd"}}]},{"id":313473,"number":174,"node_id":"PRS_kwDOMVd0xs4ABMiB","url":"https://api.github.com/repos/test-owner/test-repo/stacks/174","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T13:40:09Z","pull_requests":[{"number":170,"state":"closed","draft":false,"merged_at":"2026-08-12T13:40:15Z","head":{"ref":"divergent-stack-a-pO7wJfwF","sha":"cbba7e8dcfec641a88f530c0ccc7c8ce535aeeae"}},{"number":171,"state":"closed","draft":false,"merged_at":"2026-08-12T13:40:16Z","head":{"ref":"divergent-stack-b-9iT5TOLK","sha":"04f50ba691258ef2c136849b1ad0a9e45a6d964a"}},{"number":172,"state":"closed","draft":false,"merged_at":"2026-08-12T13:40:17Z","head":{"ref":"divergent-stack-c-iXygp4Wc","sha":"5e059d8b881a4c03271f7bd6eff43496fb7bfba2"}}]},{"id":313446,"number":169,"node_id":"PRS_kwDOMVd0xs4ABMhm","url":"https://api.github.com/repos/test-owner/test-repo/stacks/169","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T13:39:16Z","pull_requests":[{"number":165,"state":"closed","draft":false,"merged_at":"2026-08-12T13:39:22Z","head":{"ref":"divergent-stack-a-ZwG2QqxN","sha":"bad73a03fe75bb84a66c18758f6a33e964fa5623"}},{"number":166,"state":"closed","draft":false,"merged_at":"2026-08-12T13:39:23Z","head":{"ref":"divergent-stack-b-VxbXF3H4","sha":"1835fe77d5079914c4050ce7f480688f4de316b0"}},{"number":167,"state":"closed","draft":false,"merged_at":"2026-08-12T13:39:23Z","head":{"ref":"divergent-stack-c-MAlCUfYp","sha":"09d733256cafd094d360cb399794138c766a1fef"}}]},{"id":302729,"number":160,"node_id":"PRS_kwDOMVd0xs4ABJ6J","url":"https://api.github.com/repos/test-owner/test-repo/stacks/160","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T04:18:42Z","pull_requests":[{"number":158,"state":"closed","draft":false,"merged_at":"2026-08-12T04:18:46Z","head":{"ref":"merge-range-bottom-bZiK8Eda","sha":"24777ef044c0a4bc712d1345bf9c0ed8b791197b"}},{"number":159,"state":"closed","draft":false,"merged_at":"2026-08-12T04:18:47Z","head":{"ref":"merge-range-top-hIOTMX1T","sha":"bb58f1370879a404c18b51898dcf2e08ea740727"}}]},{"id":302716,"number":157,"node_id":"PRS_kwDOMVd0xs4ABJ58","url":"https://api.github.com/repos/test-owner/test-repo/stacks/157","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T04:17:41Z","pull_requests":[{"number":155,"state":"closed","draft":false,"merged_at":"2026-08-12T04:17:45Z","head":{"ref":"merge-range-bottom-0tvkFGY5","sha":"5c1b178950b3b777fb9ebbede6d383db05d22467"}},{"number":156,"state":"closed","draft":false,"merged_at":"2026-08-12T04:17:45Z","head":{"ref":"merge-range-top-J25jZjmP","sha":"12a7613a380b2b58338e3860d2f328f7cdff03b0"}}]},{"id":302692,"number":154,"node_id":"PRS_kwDOMVd0xs4ABJ5k","url":"https://api.github.com/repos/test-owner/test-repo/stacks/154","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T04:15:44Z","pull_requests":[{"number":152,"state":"closed","draft":false,"merged_at":"2026-08-12T04:15:48Z","head":{"ref":"merge-range-bottom-K06vsatq","sha":"da0f854fa38886c46c4e140f6ccbbf97a0617fda"}},{"number":153,"state":"closed","draft":false,"merged_at":"2026-08-12T04:15:48Z","head":{"ref":"merge-range-top-UQMItpa9","sha":"408a67f73119d0e8394e8f82eeca982994ed20be"}}]},{"id":302586,"number":151,"node_id":"PRS_kwDOMVd0xs4ABJ36","url":"https://api.github.com/repos/test-owner/test-repo/stacks/151","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T04:06:06Z","pull_requests":[{"number":149,"state":"closed","draft":false,"merged_at":"2026-08-12T04:06:10Z","head":{"ref":"merge-range-bottom-j0y6OqrT","sha":"11e275c782e6d64ef1453ca2a4e1509f8ef1d10a"}},{"number":150,"state":"closed","draft":false,"merged_at":"2026-08-12T04:06:10Z","head":{"ref":"merge-range-top-G8bqRe1G","sha":"4cb95e7edc28838635b54236918b825a9130fcb8"}}]},{"id":302031,"number":147,"node_id":"PRS_kwDOMVd0xs4ABJvP","url":"https://api.github.com/repos/test-owner/test-repo/stacks/147","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T03:16:01Z","pull_requests":[{"number":145,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-bottom-dW4RtWmC","sha":"b5bec1eaccc7a5fb6d5ac747c67832c156bf51bd"}},{"number":146,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-middle-g3WXJxSb","sha":"f740dffc87f2ddf00824f1a09d2c24b70811b247"}},{"number":148,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-top-gampXI6B","sha":"711662448930f8a00d161c842fb0ee8d401c994e"}}]},{"id":167872,"number":144,"node_id":"PRS_kwDOMVd0xs4AAo_A","url":"https://api.github.com/repos/test-owner/test-repo/stacks/144","base":{"ref":"main"},"open":false,"created_at":"2026-08-05T12:16:14Z","pull_requests":[{"number":140,"state":"closed","draft":false,"merged_at":"2026-08-05T12:18:48Z","head":{"ref":"probe-autodelete-20260805-9c4e-a","sha":"920069c11160c4fe98a1b7e346be68ca51d59b73"}},{"number":141,"state":"closed","draft":false,"merged_at":"2026-08-05T12:18:49Z","head":{"ref":"probe-autodelete-20260805-9c4e-b","sha":"1007602d9b285fe3c2825da02aaf020c4f0ecdd7"}},{"number":142,"state":"closed","draft":false,"merged_at":"2026-08-05T12:18:50Z","head":{"ref":"probe-autodelete-20260805-9c4e-c","sha":"d0753d932262f7b817599a792e317f5339a5849d"}}]},{"id":167438,"number":139,"node_id":"PRS_kwDOMVd0xs4AAo4O","url":"https://api.github.com/repos/test-owner/test-repo/stacks/139","base":{"ref":"main"},"open":false,"created_at":"2026-08-05T11:55:14Z","pull_requests":[{"number":135,"state":"closed","draft":false,"merged_at":"2026-08-05T11:55:56Z","head":{"ref":"probe-divergence-20260805-7f3c-a","sha":"b70346dd87e33f1b0182223edee11f43a3a9db66"}},{"number":136,"state":"closed","draft":false,"merged_at":"2026-08-05T11:55:57Z","head":{"ref":"probe-divergence-20260805-7f3c-b","sha":"f5367dbc180b397617065a700e42df50f7646329"}},{"number":137,"state":"closed","draft":false,"merged_at":"2026-08-05T11:55:58Z","head":{"ref":"probe-divergence-20260805-7f3c-c","sha":"f820a52d526b01daba6bd583066d97dd03d33fcd"}}]},{"id":101032,"number":134,"node_id":"PRS_kwDOMVd0xs4AAYqo","url":"https://api.github.com/repos/test-owner/test-repo/stacks/134","base":{"ref":"main"},"open":false,"created_at":"2026-08-02T06:04:41Z","pull_requests":[{"number":132,"state":"closed","draft":false,"merged_at":"2026-08-02T06:05:07Z","head":{"ref":"gs-native-stack-probe-019fbe36-base","sha":"640dd83224aabd95f66ff91912b26f08f33edbbd"}},{"number":133,"state":"closed","draft":false,"merged_at":"2026-08-02T06:05:08Z","head":{"ref":"gs-native-stack-probe-019fbe36-top","sha":"67d6b814fe522ff1e3d850fcf6b1cdc02ac11b43"}}]}]'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 175.255375ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 523
+        host: api.github.com
+        body: '{"query":"query($owner:String!,$repo:String!,$pr0:Int!,$pr1:Int!,$pr2:Int!){repository(owner: $owner, name: $repo){pr0:pullRequest(number: $pr0){id,state,headRefName,baseRefName,headRepository{owner{login},name},stack{id}},pr1:pullRequest(number: $pr1){id,state,headRefName,baseRefName,headRepository{owner{login},name},stack{id}},pr2:pullRequest(number: $pr2){id,state,headRefName,baseRefName,headRepository{owner{login},name},stack{id}}}}","variables":{"owner":"test-owner","pr0":193,"pr1":196,"pr2":194,"repo":"test-repo"}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"repository":{"pr0":{"id":"PR_kwDOMVd0xs8AAAABAvnqVg","state":"OPEN","headRefName":"stack-replace-bottom-Hydxxy1R","baseRefName":"main","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":{"id":"PRS_kwDOMVd0xs4ACI4O"}},"pr1":{"id":"PR_kwDOMVd0xs8AAAABAvnrgw","state":"OPEN","headRefName":"stack-replace-inserted-WNuOA0uR","baseRefName":"stack-replace-bottom-Hydxxy1R","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":null},"pr2":{"id":"PR_kwDOMVd0xs8AAAABAvnqrA","state":"OPEN","headRefName":"stack-replace-top-92YL4XjC","baseRefName":"stack-replace-bottom-Hydxxy1R","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":{"id":"PRS_kwDOMVd0xs4ACI4O"}}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 322.487292ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 263
+        host: api.github.com
+        body: '{"query":"query($ids:[ID!]!){nodes(ids: $ids){... on PullRequestStack{id,number,entries(first: 100){nodes{pullRequest{number,state,mergeQueueEntry{id},autoMergeRequest{enabledAt}}},pageInfo{endCursor,hasNextPage}}}}}","variables":{"ids":["PRS_kwDOMVd0xs4ACI4O"]}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"nodes":[{"id":"PRS_kwDOMVd0xs4ACI4O","number":195,"entries":{"nodes":[{"pullRequest":{"number":193,"state":"OPEN","mergeQueueEntry":null,"autoMergeRequest":null}},{"pullRequest":{"number":194,"state":"OPEN","mergeQueueEntry":null,"autoMergeRequest":null}}],"pageInfo":{"endCursor":"Mg","hasNextPage":false}}}]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 244.402291ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.github.com
+        url: https://api.github.com/repos/test-owner/test-repo/stacks/195/unstack
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers: {}
+        status: 204 No Content
+        code: 204
+        duration: 263.216166ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 220
+        host: api.github.com
+        body: '{"query":"mutation($input:UpdatePullRequestInput!){updatePullRequest(input: $input){clientMutationId}}","variables":{"input":{"pullRequestId":"PR_kwDOMVd0xs8AAAABAvnqrA","baseRefName":"stack-replace-inserted-WNuOA0uR"}}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"updatePullRequest":{"clientMutationId":null}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1.542655166s
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 32
+        host: api.github.com
+        body: |
+            {"pull_requests":[193,196,194]}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/repos/test-owner/test-repo/stacks
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 5039
+        body: '{"id":560655,"number":197,"node_id":"PRS_kwDOMVd0xs4ACI4P","url":"https://api.github.com/repos/test-owner/test-repo/stacks/197","base":{"ref":"main"},"open":true,"created_at":"2026-08-24T02:36:15Z","pull_requests":[{"url":"https://api.github.com/repos/test-owner/test-repo/pulls/193","id":4344900182,"number":193,"head":{"ref":"stack-replace-bottom-Hydxxy1R","sha":"2ceeaa5efc3791ef3c43e7463cfb74adda1b4de3","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"base":{"ref":"main","sha":"64adfb2f4b54a69373ea283c80837cc220eb94ba","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"node_id":"PR_kwDOMVd0xs8AAAABAvnqVg","title":"Native stack replacement bottom stack-replace-bottom-Hydxxy1R","state":"open","merged_at":null,"draft":false,"html_url":"https://github.com/test-owner/test-repo/pull/193","user":{"login":"test-owner","id":41730,"node_id":"MDQ6VXNlcjQxNzMw","avatar_url":"https://avatars.githubusercontent.com/u/41730?v=4","gravatar_id":"","url":"https://api.github.com/users/test-owner","html_url":"https://github.com/test-owner","followers_url":"https://api.github.com/users/test-owner/followers","following_url":"https://api.github.com/users/test-owner/following{/other_user}","gists_url":"https://api.github.com/users/test-owner/gists{/gist_id}","starred_url":"https://api.github.com/users/test-owner/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/test-owner/subscriptions","organizations_url":"https://api.github.com/users/test-owner/orgs","repos_url":"https://api.github.com/users/test-owner/repos","events_url":"https://api.github.com/users/test-owner/events{/privacy}","received_events_url":"https://api.github.com/users/test-owner/received_events","type":"User","user_view_type":"public","site_admin":false}},{"url":"https://api.github.com/repos/test-owner/test-repo/pulls/196","id":4344900483,"number":196,"head":{"ref":"stack-replace-inserted-WNuOA0uR","sha":"1b604a1deff0517ee22c665f662db6d42cec2921","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"base":{"ref":"stack-replace-bottom-Hydxxy1R","sha":"2ceeaa5efc3791ef3c43e7463cfb74adda1b4de3","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"node_id":"PR_kwDOMVd0xs8AAAABAvnrgw","title":"Native stack replacement middle stack-replace-inserted-WNuOA0uR","state":"open","merged_at":null,"draft":false,"html_url":"https://github.com/test-owner/test-repo/pull/196","user":{"login":"test-owner","id":41730,"node_id":"MDQ6VXNlcjQxNzMw","avatar_url":"https://avatars.githubusercontent.com/u/41730?v=4","gravatar_id":"","url":"https://api.github.com/users/test-owner","html_url":"https://github.com/test-owner","followers_url":"https://api.github.com/users/test-owner/followers","following_url":"https://api.github.com/users/test-owner/following{/other_user}","gists_url":"https://api.github.com/users/test-owner/gists{/gist_id}","starred_url":"https://api.github.com/users/test-owner/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/test-owner/subscriptions","organizations_url":"https://api.github.com/users/test-owner/orgs","repos_url":"https://api.github.com/users/test-owner/repos","events_url":"https://api.github.com/users/test-owner/events{/privacy}","received_events_url":"https://api.github.com/users/test-owner/received_events","type":"User","user_view_type":"public","site_admin":false}},{"url":"https://api.github.com/repos/test-owner/test-repo/pulls/194","id":4344900268,"number":194,"head":{"ref":"stack-replace-top-92YL4XjC","sha":"8590f670baa89e5b535210911353c9cbdfa2d0fc","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"base":{"ref":"stack-replace-inserted-WNuOA0uR","sha":"1b604a1deff0517ee22c665f662db6d42cec2921","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"node_id":"PR_kwDOMVd0xs8AAAABAvnqrA","title":"Native stack replacement top stack-replace-top-92YL4XjC","state":"open","merged_at":null,"draft":false,"html_url":"https://github.com/test-owner/test-repo/pull/194","user":{"login":"test-owner","id":41730,"node_id":"MDQ6VXNlcjQxNzMw","avatar_url":"https://avatars.githubusercontent.com/u/41730?v=4","gravatar_id":"","url":"https://api.github.com/users/test-owner","html_url":"https://github.com/test-owner","followers_url":"https://api.github.com/users/test-owner/followers","following_url":"https://api.github.com/users/test-owner/following{/other_user}","gists_url":"https://api.github.com/users/test-owner/gists{/gist_id}","starred_url":"https://api.github.com/users/test-owner/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/test-owner/subscriptions","organizations_url":"https://api.github.com/users/test-owner/orgs","repos_url":"https://api.github.com/users/test-owner/repos","events_url":"https://api.github.com/users/test-owner/events{/privacy}","received_events_url":"https://api.github.com/users/test-owner/received_events","type":"User","user_view_type":"public","site_admin":false}}]}'
+        headers:
+            Content-Length:
+                - "5039"
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 504.355417ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 523
+        host: api.github.com
+        body: '{"query":"query($owner:String!,$repo:String!,$pr0:Int!,$pr1:Int!,$pr2:Int!){repository(owner: $owner, name: $repo){pr0:pullRequest(number: $pr0){id,state,headRefName,baseRefName,headRepository{owner{login},name},stack{id}},pr1:pullRequest(number: $pr1){id,state,headRefName,baseRefName,headRepository{owner{login},name},stack{id}},pr2:pullRequest(number: $pr2){id,state,headRefName,baseRefName,headRepository{owner{login},name},stack{id}}}}","variables":{"owner":"test-owner","pr0":193,"pr1":196,"pr2":194,"repo":"test-repo"}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"repository":{"pr0":{"id":"PR_kwDOMVd0xs8AAAABAvnqVg","state":"OPEN","headRefName":"stack-replace-bottom-Hydxxy1R","baseRefName":"main","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":{"id":"PRS_kwDOMVd0xs4ACI4P"}},"pr1":{"id":"PR_kwDOMVd0xs8AAAABAvnrgw","state":"OPEN","headRefName":"stack-replace-inserted-WNuOA0uR","baseRefName":"stack-replace-bottom-Hydxxy1R","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":{"id":"PRS_kwDOMVd0xs4ACI4P"}},"pr2":{"id":"PR_kwDOMVd0xs8AAAABAvnqrA","state":"OPEN","headRefName":"stack-replace-top-92YL4XjC","baseRefName":"stack-replace-inserted-WNuOA0uR","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":{"id":"PRS_kwDOMVd0xs4ACI4P"}}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 319.762583ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 263
+        host: api.github.com
+        body: '{"query":"query($ids:[ID!]!){nodes(ids: $ids){... on PullRequestStack{id,number,entries(first: 100){nodes{pullRequest{number,state,mergeQueueEntry{id},autoMergeRequest{enabledAt}}},pageInfo{endCursor,hasNextPage}}}}}","variables":{"ids":["PRS_kwDOMVd0xs4ACI4P"]}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"nodes":[{"id":"PRS_kwDOMVd0xs4ACI4P","number":197,"entries":{"nodes":[{"pullRequest":{"number":193,"state":"OPEN","mergeQueueEntry":null,"autoMergeRequest":null}},{"pullRequest":{"number":196,"state":"OPEN","mergeQueueEntry":null,"autoMergeRequest":null}},{"pullRequest":{"number":194,"state":"OPEN","mergeQueueEntry":null,"autoMergeRequest":null}}],"pageInfo":{"endCursor":"Mw","hasNextPage":false}}}]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 301.025125ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 188
+        host: api.github.com
+        body: '{"query":"mutation($input:UpdatePullRequestInput!){updatePullRequest(input: $input){pullRequest{id}}}","variables":{"input":{"pullRequestId":"PR_kwDOMVd0xs8AAAABAvnrgw","state":"CLOSED"}}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"updatePullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs8AAAABAvnrgw"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 711.382ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 188
+        host: api.github.com
+        body: '{"query":"mutation($input:UpdatePullRequestInput!){updatePullRequest(input: $input){pullRequest{id}}}","variables":{"input":{"pullRequestId":"PR_kwDOMVd0xs8AAAABAvnqrA","state":"CLOSED"}}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"updatePullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs8AAAABAvnqrA"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 666.183791ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 188
+        host: api.github.com
+        body: '{"query":"mutation($input:UpdatePullRequestInput!){updatePullRequest(input: $input){pullRequest{id}}}","variables":{"input":{"pullRequestId":"PR_kwDOMVd0xs8AAAABAvnqVg","state":"CLOSED"}}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"updatePullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs8AAAABAvnqVg"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 752.883125ms

--- a/internal/forge/github/testdata/fixtures/TestIntegration_stackReplacementWithMergedMember.yaml
+++ b/internal/forge/github/testdata/fixtures/TestIntegration_stackReplacementWithMergedMember.yaml
@@ -1,0 +1,408 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 141
+        host: api.github.com
+        body: '{"query":"query($owner:String!$repo:String!){repository(owner: $owner, name: $repo){id}}","variables":{"owner":"test-owner","repo":"test-repo"}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"repository":{"id":"R_kgDOMVd0xg"}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 263.586958ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 360
+        host: api.github.com
+        body: '{"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"main","headRefName":"stack-merged-bottom-5nHARMp1","title":"Native stack merged-member bottom stack-merged-bottom-5nHARMp1","body":"Native stack merged-member integration test"}}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs8AAAABAvuKFw","number":202,"url":"https://github.com/test-owner/test-repo/pull/202"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1.117561709s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 388
+        host: api.github.com
+        body: '{"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"stack-merged-bottom-5nHARMp1","headRefName":"stack-merged-inserted-aX9bGOqd","title":"Native stack merged-member middle stack-merged-inserted-aX9bGOqd","body":"Native stack merged-member integration test"}}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs8AAAABAvuKWg","number":203,"url":"https://github.com/test-owner/test-repo/pull/203"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1.009610792s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 375
+        host: api.github.com
+        body: '{"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"stack-merged-bottom-5nHARMp1","headRefName":"stack-merged-top-Bubo7AXB","title":"Native stack merged-member top stack-merged-top-Bubo7AXB","body":"Native stack merged-member integration test"}}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs8AAAABAvuKow","number":204,"url":"https://github.com/test-owner/test-repo/pull/204"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1.0364035s
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.github.com
+        url: https://api.github.com/repos/test-owner/test-repo/stacks
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":560657,"number":201,"node_id":"PRS_kwDOMVd0xs4ACI4R","url":"https://api.github.com/repos/test-owner/test-repo/stacks/201","base":{"ref":"main"},"open":false,"created_at":"2026-08-24T02:36:33Z","pull_requests":[{"number":198,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-merged-bottom-dLKjmtVW","sha":"07b6e8cb44f5e5d13cd8a029a83bea789909d247"}},{"number":200,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-merged-top-fqg9w5za","sha":"3ef6501dce36b8774c06c95b0fbc46418ede856c"}}]},{"id":560655,"number":197,"node_id":"PRS_kwDOMVd0xs4ACI4P","url":"https://api.github.com/repos/test-owner/test-repo/stacks/197","base":{"ref":"main"},"open":false,"created_at":"2026-08-24T02:36:15Z","pull_requests":[{"number":193,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-replace-bottom-Hydxxy1R","sha":"2ceeaa5efc3791ef3c43e7463cfb74adda1b4de3"}},{"number":196,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-replace-inserted-WNuOA0uR","sha":"1b604a1deff0517ee22c665f662db6d42cec2921"}},{"number":194,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-replace-top-92YL4XjC","sha":"8590f670baa89e5b535210911353c9cbdfa2d0fc"}}]},{"id":560648,"number":191,"node_id":"PRS_kwDOMVd0xs4ACI4I","url":"https://api.github.com/repos/test-owner/test-repo/stacks/191","base":{"ref":"main"},"open":false,"created_at":"2026-08-24T02:35:35Z","pull_requests":[{"number":189,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-bottom-geOs2I70","sha":"d09aa9285a4200d6ec0a1454033a5302a8c15f94"}},{"number":190,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-middle-VEtQX9yQ","sha":"7b6309fa47e62cd6b9984a4e9dc1c1081756fd76"}},{"number":192,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-top-ip5EzT1K","sha":"0e2fa2c652ecd15211e206798f0c6790c360ccdd"}}]},{"id":313473,"number":174,"node_id":"PRS_kwDOMVd0xs4ABMiB","url":"https://api.github.com/repos/test-owner/test-repo/stacks/174","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T13:40:09Z","pull_requests":[{"number":170,"state":"closed","draft":false,"merged_at":"2026-08-12T13:40:15Z","head":{"ref":"divergent-stack-a-pO7wJfwF","sha":"cbba7e8dcfec641a88f530c0ccc7c8ce535aeeae"}},{"number":171,"state":"closed","draft":false,"merged_at":"2026-08-12T13:40:16Z","head":{"ref":"divergent-stack-b-9iT5TOLK","sha":"04f50ba691258ef2c136849b1ad0a9e45a6d964a"}},{"number":172,"state":"closed","draft":false,"merged_at":"2026-08-12T13:40:17Z","head":{"ref":"divergent-stack-c-iXygp4Wc","sha":"5e059d8b881a4c03271f7bd6eff43496fb7bfba2"}}]},{"id":313446,"number":169,"node_id":"PRS_kwDOMVd0xs4ABMhm","url":"https://api.github.com/repos/test-owner/test-repo/stacks/169","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T13:39:16Z","pull_requests":[{"number":165,"state":"closed","draft":false,"merged_at":"2026-08-12T13:39:22Z","head":{"ref":"divergent-stack-a-ZwG2QqxN","sha":"bad73a03fe75bb84a66c18758f6a33e964fa5623"}},{"number":166,"state":"closed","draft":false,"merged_at":"2026-08-12T13:39:23Z","head":{"ref":"divergent-stack-b-VxbXF3H4","sha":"1835fe77d5079914c4050ce7f480688f4de316b0"}},{"number":167,"state":"closed","draft":false,"merged_at":"2026-08-12T13:39:23Z","head":{"ref":"divergent-stack-c-MAlCUfYp","sha":"09d733256cafd094d360cb399794138c766a1fef"}}]},{"id":302729,"number":160,"node_id":"PRS_kwDOMVd0xs4ABJ6J","url":"https://api.github.com/repos/test-owner/test-repo/stacks/160","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T04:18:42Z","pull_requests":[{"number":158,"state":"closed","draft":false,"merged_at":"2026-08-12T04:18:46Z","head":{"ref":"merge-range-bottom-bZiK8Eda","sha":"24777ef044c0a4bc712d1345bf9c0ed8b791197b"}},{"number":159,"state":"closed","draft":false,"merged_at":"2026-08-12T04:18:47Z","head":{"ref":"merge-range-top-hIOTMX1T","sha":"bb58f1370879a404c18b51898dcf2e08ea740727"}}]},{"id":302716,"number":157,"node_id":"PRS_kwDOMVd0xs4ABJ58","url":"https://api.github.com/repos/test-owner/test-repo/stacks/157","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T04:17:41Z","pull_requests":[{"number":155,"state":"closed","draft":false,"merged_at":"2026-08-12T04:17:45Z","head":{"ref":"merge-range-bottom-0tvkFGY5","sha":"5c1b178950b3b777fb9ebbede6d383db05d22467"}},{"number":156,"state":"closed","draft":false,"merged_at":"2026-08-12T04:17:45Z","head":{"ref":"merge-range-top-J25jZjmP","sha":"12a7613a380b2b58338e3860d2f328f7cdff03b0"}}]},{"id":302692,"number":154,"node_id":"PRS_kwDOMVd0xs4ABJ5k","url":"https://api.github.com/repos/test-owner/test-repo/stacks/154","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T04:15:44Z","pull_requests":[{"number":152,"state":"closed","draft":false,"merged_at":"2026-08-12T04:15:48Z","head":{"ref":"merge-range-bottom-K06vsatq","sha":"da0f854fa38886c46c4e140f6ccbbf97a0617fda"}},{"number":153,"state":"closed","draft":false,"merged_at":"2026-08-12T04:15:48Z","head":{"ref":"merge-range-top-UQMItpa9","sha":"408a67f73119d0e8394e8f82eeca982994ed20be"}}]},{"id":302586,"number":151,"node_id":"PRS_kwDOMVd0xs4ABJ36","url":"https://api.github.com/repos/test-owner/test-repo/stacks/151","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T04:06:06Z","pull_requests":[{"number":149,"state":"closed","draft":false,"merged_at":"2026-08-12T04:06:10Z","head":{"ref":"merge-range-bottom-j0y6OqrT","sha":"11e275c782e6d64ef1453ca2a4e1509f8ef1d10a"}},{"number":150,"state":"closed","draft":false,"merged_at":"2026-08-12T04:06:10Z","head":{"ref":"merge-range-top-G8bqRe1G","sha":"4cb95e7edc28838635b54236918b825a9130fcb8"}}]},{"id":302031,"number":147,"node_id":"PRS_kwDOMVd0xs4ABJvP","url":"https://api.github.com/repos/test-owner/test-repo/stacks/147","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T03:16:01Z","pull_requests":[{"number":145,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-bottom-dW4RtWmC","sha":"b5bec1eaccc7a5fb6d5ac747c67832c156bf51bd"}},{"number":146,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-middle-g3WXJxSb","sha":"f740dffc87f2ddf00824f1a09d2c24b70811b247"}},{"number":148,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-top-gampXI6B","sha":"711662448930f8a00d161c842fb0ee8d401c994e"}}]},{"id":167872,"number":144,"node_id":"PRS_kwDOMVd0xs4AAo_A","url":"https://api.github.com/repos/test-owner/test-repo/stacks/144","base":{"ref":"main"},"open":false,"created_at":"2026-08-05T12:16:14Z","pull_requests":[{"number":140,"state":"closed","draft":false,"merged_at":"2026-08-05T12:18:48Z","head":{"ref":"probe-autodelete-20260805-9c4e-a","sha":"920069c11160c4fe98a1b7e346be68ca51d59b73"}},{"number":141,"state":"closed","draft":false,"merged_at":"2026-08-05T12:18:49Z","head":{"ref":"probe-autodelete-20260805-9c4e-b","sha":"1007602d9b285fe3c2825da02aaf020c4f0ecdd7"}},{"number":142,"state":"closed","draft":false,"merged_at":"2026-08-05T12:18:50Z","head":{"ref":"probe-autodelete-20260805-9c4e-c","sha":"d0753d932262f7b817599a792e317f5339a5849d"}}]},{"id":167438,"number":139,"node_id":"PRS_kwDOMVd0xs4AAo4O","url":"https://api.github.com/repos/test-owner/test-repo/stacks/139","base":{"ref":"main"},"open":false,"created_at":"2026-08-05T11:55:14Z","pull_requests":[{"number":135,"state":"closed","draft":false,"merged_at":"2026-08-05T11:55:56Z","head":{"ref":"probe-divergence-20260805-7f3c-a","sha":"b70346dd87e33f1b0182223edee11f43a3a9db66"}},{"number":136,"state":"closed","draft":false,"merged_at":"2026-08-05T11:55:57Z","head":{"ref":"probe-divergence-20260805-7f3c-b","sha":"f5367dbc180b397617065a700e42df50f7646329"}},{"number":137,"state":"closed","draft":false,"merged_at":"2026-08-05T11:55:58Z","head":{"ref":"probe-divergence-20260805-7f3c-c","sha":"f820a52d526b01daba6bd583066d97dd03d33fcd"}}]},{"id":101032,"number":134,"node_id":"PRS_kwDOMVd0xs4AAYqo","url":"https://api.github.com/repos/test-owner/test-repo/stacks/134","base":{"ref":"main"},"open":false,"created_at":"2026-08-02T06:04:41Z","pull_requests":[{"number":132,"state":"closed","draft":false,"merged_at":"2026-08-02T06:05:07Z","head":{"ref":"gs-native-stack-probe-019fbe36-base","sha":"640dd83224aabd95f66ff91912b26f08f33edbbd"}},{"number":133,"state":"closed","draft":false,"merged_at":"2026-08-02T06:05:08Z","head":{"ref":"gs-native-stack-probe-019fbe36-top","sha":"67d6b814fe522ff1e3d850fcf6b1cdc02ac11b43"}}]}]'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 169.542083ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 395
+        host: api.github.com
+        body: '{"query":"query($owner:String!,$repo:String!,$pr0:Int!,$pr1:Int!){repository(owner: $owner, name: $repo){pr0:pullRequest(number: $pr0){id,state,headRefName,baseRefName,headRepository{owner{login},name},stack{id}},pr1:pullRequest(number: $pr1){id,state,headRefName,baseRefName,headRepository{owner{login},name},stack{id}}}}","variables":{"owner":"test-owner","pr0":202,"pr1":204,"repo":"test-repo"}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"repository":{"pr0":{"id":"PR_kwDOMVd0xs8AAAABAvuKFw","state":"OPEN","headRefName":"stack-merged-bottom-5nHARMp1","baseRefName":"main","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":null},"pr1":{"id":"PR_kwDOMVd0xs8AAAABAvuKow","state":"OPEN","headRefName":"stack-merged-top-Bubo7AXB","baseRefName":"stack-merged-bottom-5nHARMp1","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":null}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 271.415292ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 28
+        host: api.github.com
+        body: |
+            {"pull_requests":[202,204]}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/repos/test-owner/test-repo/stacks
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 3414
+        body: '{"id":560920,"number":205,"node_id":"PRS_kwDOMVd0xs4ACI8Y","url":"https://api.github.com/repos/test-owner/test-repo/stacks/205","base":{"ref":"main"},"open":true,"created_at":"2026-08-24T03:01:58Z","pull_requests":[{"url":"https://api.github.com/repos/test-owner/test-repo/pulls/202","id":4345006615,"number":202,"head":{"ref":"stack-merged-bottom-5nHARMp1","sha":"fc61323edd0740e8026c2745083f77a644ab668e","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"base":{"ref":"main","sha":"64adfb2f4b54a69373ea283c80837cc220eb94ba","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"node_id":"PR_kwDOMVd0xs8AAAABAvuKFw","title":"Native stack merged-member bottom stack-merged-bottom-5nHARMp1","state":"open","merged_at":null,"draft":false,"html_url":"https://github.com/test-owner/test-repo/pull/202","user":{"login":"test-owner","id":41730,"node_id":"MDQ6VXNlcjQxNzMw","avatar_url":"https://avatars.githubusercontent.com/u/41730?v=4","gravatar_id":"","url":"https://api.github.com/users/test-owner","html_url":"https://github.com/test-owner","followers_url":"https://api.github.com/users/test-owner/followers","following_url":"https://api.github.com/users/test-owner/following{/other_user}","gists_url":"https://api.github.com/users/test-owner/gists{/gist_id}","starred_url":"https://api.github.com/users/test-owner/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/test-owner/subscriptions","organizations_url":"https://api.github.com/users/test-owner/orgs","repos_url":"https://api.github.com/users/test-owner/repos","events_url":"https://api.github.com/users/test-owner/events{/privacy}","received_events_url":"https://api.github.com/users/test-owner/received_events","type":"User","user_view_type":"public","site_admin":false}},{"url":"https://api.github.com/repos/test-owner/test-repo/pulls/204","id":4345006755,"number":204,"head":{"ref":"stack-merged-top-Bubo7AXB","sha":"e5d10f885f53524b4714f90981d9f74209c40100","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"base":{"ref":"stack-merged-bottom-5nHARMp1","sha":"fc61323edd0740e8026c2745083f77a644ab668e","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"node_id":"PR_kwDOMVd0xs8AAAABAvuKow","title":"Native stack merged-member top stack-merged-top-Bubo7AXB","state":"open","merged_at":null,"draft":false,"html_url":"https://github.com/test-owner/test-repo/pull/204","user":{"login":"test-owner","id":41730,"node_id":"MDQ6VXNlcjQxNzMw","avatar_url":"https://avatars.githubusercontent.com/u/41730?v=4","gravatar_id":"","url":"https://api.github.com/users/test-owner","html_url":"https://github.com/test-owner","followers_url":"https://api.github.com/users/test-owner/followers","following_url":"https://api.github.com/users/test-owner/following{/other_user}","gists_url":"https://api.github.com/users/test-owner/gists{/gist_id}","starred_url":"https://api.github.com/users/test-owner/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/test-owner/subscriptions","organizations_url":"https://api.github.com/users/test-owner/orgs","repos_url":"https://api.github.com/users/test-owner/repos","events_url":"https://api.github.com/users/test-owner/events{/privacy}","received_events_url":"https://api.github.com/users/test-owner/received_events","type":"User","user_view_type":"public","site_admin":false}}]}'
+        headers:
+            Content-Length:
+                - "3414"
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 373.003292ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 51
+        host: api.github.com
+        body: |
+            {"merge_method":"squash","merge_action":"default"}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/repos/test-owner/test-repo/pulls/202/merge-async
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 226
+        body: '{"status":"pending","details":{"message":"Merge request enqueued.","uuid":"be3ffd73-5436-4c0f-b6c3-5413ddac44df","merge_method":"squash","merge_action":"default","expected_head_sha":"fc61323edd0740e8026c2745083f77a644ab668e"}}'
+        headers:
+            Content-Length:
+                - "226"
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 228.392083ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 426
+        host: api.github.com
+        body: '{"query":"query($number:Int!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){pullRequest(number: $number){id,number,url,title,state,headRefOid,baseRefName,isDraft,headRepository{owner{login},name},labels(first: 100){nodes{name}},reviewRequests(first: 100){nodes{requestedReviewer{... on Actor{login}}}},assignees(first: 100){nodes{login}}}}}","variables":{"number":202,"owner":"test-owner","repo":"test-repo"}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"repository":{"pullRequest":{"id":"PR_kwDOMVd0xs8AAAABAvuKFw","number":202,"url":"https://github.com/test-owner/test-repo/pull/202","title":"Native stack merged-member bottom stack-merged-bottom-5nHARMp1","state":"MERGED","headRefOid":"fc61323edd0740e8026c2745083f77a644ab668e","baseRefName":"main","isDraft":false,"headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"labels":{"nodes":[]},"reviewRequests":{"nodes":[]},"assignees":{"nodes":[]}}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 267.005375ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.github.com
+        url: https://api.github.com/repos/test-owner/test-repo/stacks
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":560920,"number":205,"node_id":"PRS_kwDOMVd0xs4ACI8Y","url":"https://api.github.com/repos/test-owner/test-repo/stacks/205","base":{"ref":"main"},"open":true,"created_at":"2026-08-24T03:01:58Z","pull_requests":[{"number":202,"state":"closed","draft":false,"merged_at":"2026-08-24T03:02:00Z","head":{"ref":"stack-merged-bottom-5nHARMp1","sha":"fc61323edd0740e8026c2745083f77a644ab668e"}},{"number":204,"state":"open","draft":false,"merged_at":null,"head":{"ref":"stack-merged-top-Bubo7AXB","sha":"381be2239426e81ac49c336904cf1a7c55baf08e"}}]},{"id":560657,"number":201,"node_id":"PRS_kwDOMVd0xs4ACI4R","url":"https://api.github.com/repos/test-owner/test-repo/stacks/201","base":{"ref":"main"},"open":false,"created_at":"2026-08-24T02:36:33Z","pull_requests":[{"number":198,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-merged-bottom-dLKjmtVW","sha":"07b6e8cb44f5e5d13cd8a029a83bea789909d247"}},{"number":200,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-merged-top-fqg9w5za","sha":"3ef6501dce36b8774c06c95b0fbc46418ede856c"}}]},{"id":560655,"number":197,"node_id":"PRS_kwDOMVd0xs4ACI4P","url":"https://api.github.com/repos/test-owner/test-repo/stacks/197","base":{"ref":"main"},"open":false,"created_at":"2026-08-24T02:36:15Z","pull_requests":[{"number":193,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-replace-bottom-Hydxxy1R","sha":"2ceeaa5efc3791ef3c43e7463cfb74adda1b4de3"}},{"number":196,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-replace-inserted-WNuOA0uR","sha":"1b604a1deff0517ee22c665f662db6d42cec2921"}},{"number":194,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-replace-top-92YL4XjC","sha":"8590f670baa89e5b535210911353c9cbdfa2d0fc"}}]},{"id":560648,"number":191,"node_id":"PRS_kwDOMVd0xs4ACI4I","url":"https://api.github.com/repos/test-owner/test-repo/stacks/191","base":{"ref":"main"},"open":false,"created_at":"2026-08-24T02:35:35Z","pull_requests":[{"number":189,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-bottom-geOs2I70","sha":"d09aa9285a4200d6ec0a1454033a5302a8c15f94"}},{"number":190,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-middle-VEtQX9yQ","sha":"7b6309fa47e62cd6b9984a4e9dc1c1081756fd76"}},{"number":192,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-top-ip5EzT1K","sha":"0e2fa2c652ecd15211e206798f0c6790c360ccdd"}}]},{"id":313473,"number":174,"node_id":"PRS_kwDOMVd0xs4ABMiB","url":"https://api.github.com/repos/test-owner/test-repo/stacks/174","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T13:40:09Z","pull_requests":[{"number":170,"state":"closed","draft":false,"merged_at":"2026-08-12T13:40:15Z","head":{"ref":"divergent-stack-a-pO7wJfwF","sha":"cbba7e8dcfec641a88f530c0ccc7c8ce535aeeae"}},{"number":171,"state":"closed","draft":false,"merged_at":"2026-08-12T13:40:16Z","head":{"ref":"divergent-stack-b-9iT5TOLK","sha":"04f50ba691258ef2c136849b1ad0a9e45a6d964a"}},{"number":172,"state":"closed","draft":false,"merged_at":"2026-08-12T13:40:17Z","head":{"ref":"divergent-stack-c-iXygp4Wc","sha":"5e059d8b881a4c03271f7bd6eff43496fb7bfba2"}}]},{"id":313446,"number":169,"node_id":"PRS_kwDOMVd0xs4ABMhm","url":"https://api.github.com/repos/test-owner/test-repo/stacks/169","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T13:39:16Z","pull_requests":[{"number":165,"state":"closed","draft":false,"merged_at":"2026-08-12T13:39:22Z","head":{"ref":"divergent-stack-a-ZwG2QqxN","sha":"bad73a03fe75bb84a66c18758f6a33e964fa5623"}},{"number":166,"state":"closed","draft":false,"merged_at":"2026-08-12T13:39:23Z","head":{"ref":"divergent-stack-b-VxbXF3H4","sha":"1835fe77d5079914c4050ce7f480688f4de316b0"}},{"number":167,"state":"closed","draft":false,"merged_at":"2026-08-12T13:39:23Z","head":{"ref":"divergent-stack-c-MAlCUfYp","sha":"09d733256cafd094d360cb399794138c766a1fef"}}]},{"id":302729,"number":160,"node_id":"PRS_kwDOMVd0xs4ABJ6J","url":"https://api.github.com/repos/test-owner/test-repo/stacks/160","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T04:18:42Z","pull_requests":[{"number":158,"state":"closed","draft":false,"merged_at":"2026-08-12T04:18:46Z","head":{"ref":"merge-range-bottom-bZiK8Eda","sha":"24777ef044c0a4bc712d1345bf9c0ed8b791197b"}},{"number":159,"state":"closed","draft":false,"merged_at":"2026-08-12T04:18:47Z","head":{"ref":"merge-range-top-hIOTMX1T","sha":"bb58f1370879a404c18b51898dcf2e08ea740727"}}]},{"id":302716,"number":157,"node_id":"PRS_kwDOMVd0xs4ABJ58","url":"https://api.github.com/repos/test-owner/test-repo/stacks/157","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T04:17:41Z","pull_requests":[{"number":155,"state":"closed","draft":false,"merged_at":"2026-08-12T04:17:45Z","head":{"ref":"merge-range-bottom-0tvkFGY5","sha":"5c1b178950b3b777fb9ebbede6d383db05d22467"}},{"number":156,"state":"closed","draft":false,"merged_at":"2026-08-12T04:17:45Z","head":{"ref":"merge-range-top-J25jZjmP","sha":"12a7613a380b2b58338e3860d2f328f7cdff03b0"}}]},{"id":302692,"number":154,"node_id":"PRS_kwDOMVd0xs4ABJ5k","url":"https://api.github.com/repos/test-owner/test-repo/stacks/154","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T04:15:44Z","pull_requests":[{"number":152,"state":"closed","draft":false,"merged_at":"2026-08-12T04:15:48Z","head":{"ref":"merge-range-bottom-K06vsatq","sha":"da0f854fa38886c46c4e140f6ccbbf97a0617fda"}},{"number":153,"state":"closed","draft":false,"merged_at":"2026-08-12T04:15:48Z","head":{"ref":"merge-range-top-UQMItpa9","sha":"408a67f73119d0e8394e8f82eeca982994ed20be"}}]},{"id":302586,"number":151,"node_id":"PRS_kwDOMVd0xs4ABJ36","url":"https://api.github.com/repos/test-owner/test-repo/stacks/151","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T04:06:06Z","pull_requests":[{"number":149,"state":"closed","draft":false,"merged_at":"2026-08-12T04:06:10Z","head":{"ref":"merge-range-bottom-j0y6OqrT","sha":"11e275c782e6d64ef1453ca2a4e1509f8ef1d10a"}},{"number":150,"state":"closed","draft":false,"merged_at":"2026-08-12T04:06:10Z","head":{"ref":"merge-range-top-G8bqRe1G","sha":"4cb95e7edc28838635b54236918b825a9130fcb8"}}]},{"id":302031,"number":147,"node_id":"PRS_kwDOMVd0xs4ABJvP","url":"https://api.github.com/repos/test-owner/test-repo/stacks/147","base":{"ref":"main"},"open":false,"created_at":"2026-08-12T03:16:01Z","pull_requests":[{"number":145,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-bottom-dW4RtWmC","sha":"b5bec1eaccc7a5fb6d5ac747c67832c156bf51bd"}},{"number":146,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-middle-g3WXJxSb","sha":"f740dffc87f2ddf00824f1a09d2c24b70811b247"}},{"number":148,"state":"closed","draft":false,"merged_at":null,"head":{"ref":"stack-top-gampXI6B","sha":"711662448930f8a00d161c842fb0ee8d401c994e"}}]},{"id":167872,"number":144,"node_id":"PRS_kwDOMVd0xs4AAo_A","url":"https://api.github.com/repos/test-owner/test-repo/stacks/144","base":{"ref":"main"},"open":false,"created_at":"2026-08-05T12:16:14Z","pull_requests":[{"number":140,"state":"closed","draft":false,"merged_at":"2026-08-05T12:18:48Z","head":{"ref":"probe-autodelete-20260805-9c4e-a","sha":"920069c11160c4fe98a1b7e346be68ca51d59b73"}},{"number":141,"state":"closed","draft":false,"merged_at":"2026-08-05T12:18:49Z","head":{"ref":"probe-autodelete-20260805-9c4e-b","sha":"1007602d9b285fe3c2825da02aaf020c4f0ecdd7"}},{"number":142,"state":"closed","draft":false,"merged_at":"2026-08-05T12:18:50Z","head":{"ref":"probe-autodelete-20260805-9c4e-c","sha":"d0753d932262f7b817599a792e317f5339a5849d"}}]},{"id":167438,"number":139,"node_id":"PRS_kwDOMVd0xs4AAo4O","url":"https://api.github.com/repos/test-owner/test-repo/stacks/139","base":{"ref":"main"},"open":false,"created_at":"2026-08-05T11:55:14Z","pull_requests":[{"number":135,"state":"closed","draft":false,"merged_at":"2026-08-05T11:55:56Z","head":{"ref":"probe-divergence-20260805-7f3c-a","sha":"b70346dd87e33f1b0182223edee11f43a3a9db66"}},{"number":136,"state":"closed","draft":false,"merged_at":"2026-08-05T11:55:57Z","head":{"ref":"probe-divergence-20260805-7f3c-b","sha":"f5367dbc180b397617065a700e42df50f7646329"}},{"number":137,"state":"closed","draft":false,"merged_at":"2026-08-05T11:55:58Z","head":{"ref":"probe-divergence-20260805-7f3c-c","sha":"f820a52d526b01daba6bd583066d97dd03d33fcd"}}]},{"id":101032,"number":134,"node_id":"PRS_kwDOMVd0xs4AAYqo","url":"https://api.github.com/repos/test-owner/test-repo/stacks/134","base":{"ref":"main"},"open":false,"created_at":"2026-08-02T06:04:41Z","pull_requests":[{"number":132,"state":"closed","draft":false,"merged_at":"2026-08-02T06:05:07Z","head":{"ref":"gs-native-stack-probe-019fbe36-base","sha":"640dd83224aabd95f66ff91912b26f08f33edbbd"}},{"number":133,"state":"closed","draft":false,"merged_at":"2026-08-02T06:05:08Z","head":{"ref":"gs-native-stack-probe-019fbe36-top","sha":"67d6b814fe522ff1e3d850fcf6b1cdc02ac11b43"}}]}]'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 218.222125ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 523
+        host: api.github.com
+        body: '{"query":"query($owner:String!,$repo:String!,$pr0:Int!,$pr1:Int!,$pr2:Int!){repository(owner: $owner, name: $repo){pr0:pullRequest(number: $pr0){id,state,headRefName,baseRefName,headRepository{owner{login},name},stack{id}},pr1:pullRequest(number: $pr1){id,state,headRefName,baseRefName,headRepository{owner{login},name},stack{id}},pr2:pullRequest(number: $pr2){id,state,headRefName,baseRefName,headRepository{owner{login},name},stack{id}}}}","variables":{"owner":"test-owner","pr0":202,"pr1":203,"pr2":204,"repo":"test-repo"}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"repository":{"pr0":{"id":"PR_kwDOMVd0xs8AAAABAvuKFw","state":"MERGED","headRefName":"stack-merged-bottom-5nHARMp1","baseRefName":"main","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":{"id":"PRS_kwDOMVd0xs4ACI8Y"}},"pr1":{"id":"PR_kwDOMVd0xs8AAAABAvuKWg","state":"OPEN","headRefName":"stack-merged-inserted-aX9bGOqd","baseRefName":"main","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":null},"pr2":{"id":"PR_kwDOMVd0xs8AAAABAvuKow","state":"OPEN","headRefName":"stack-merged-top-Bubo7AXB","baseRefName":"main","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":{"id":"PRS_kwDOMVd0xs4ACI8Y"}}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 283.38425ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 263
+        host: api.github.com
+        body: '{"query":"query($ids:[ID!]!){nodes(ids: $ids){... on PullRequestStack{id,number,entries(first: 100){nodes{pullRequest{number,state,mergeQueueEntry{id},autoMergeRequest{enabledAt}}},pageInfo{endCursor,hasNextPage}}}}}","variables":{"ids":["PRS_kwDOMVd0xs4ACI8Y"]}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"nodes":[{"id":"PRS_kwDOMVd0xs4ACI8Y","number":205,"entries":{"nodes":[{"pullRequest":{"number":202,"state":"MERGED","mergeQueueEntry":null,"autoMergeRequest":null}},{"pullRequest":{"number":204,"state":"OPEN","mergeQueueEntry":null,"autoMergeRequest":null}}],"pageInfo":{"endCursor":"Mg","hasNextPage":false}}}]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 303.385916ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 523
+        host: api.github.com
+        body: '{"query":"query($owner:String!,$repo:String!,$pr0:Int!,$pr1:Int!,$pr2:Int!){repository(owner: $owner, name: $repo){pr0:pullRequest(number: $pr0){id,state,headRefName,baseRefName,headRepository{owner{login},name},stack{id}},pr1:pullRequest(number: $pr1){id,state,headRefName,baseRefName,headRepository{owner{login},name},stack{id}},pr2:pullRequest(number: $pr2){id,state,headRefName,baseRefName,headRepository{owner{login},name},stack{id}}}}","variables":{"owner":"test-owner","pr0":202,"pr1":203,"pr2":204,"repo":"test-repo"}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"repository":{"pr0":{"id":"PR_kwDOMVd0xs8AAAABAvuKFw","state":"MERGED","headRefName":"stack-merged-bottom-5nHARMp1","baseRefName":"main","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":{"id":"PRS_kwDOMVd0xs4ACI8Y"}},"pr1":{"id":"PR_kwDOMVd0xs8AAAABAvuKWg","state":"OPEN","headRefName":"stack-merged-inserted-aX9bGOqd","baseRefName":"main","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":null},"pr2":{"id":"PR_kwDOMVd0xs8AAAABAvuKow","state":"OPEN","headRefName":"stack-merged-top-Bubo7AXB","baseRefName":"main","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":{"id":"PRS_kwDOMVd0xs4ACI8Y"}}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 262.820042ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 263
+        host: api.github.com
+        body: '{"query":"query($ids:[ID!]!){nodes(ids: $ids){... on PullRequestStack{id,number,entries(first: 100){nodes{pullRequest{number,state,mergeQueueEntry{id},autoMergeRequest{enabledAt}}},pageInfo{endCursor,hasNextPage}}}}}","variables":{"ids":["PRS_kwDOMVd0xs4ACI8Y"]}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"nodes":[{"id":"PRS_kwDOMVd0xs4ACI8Y","number":205,"entries":{"nodes":[{"pullRequest":{"number":202,"state":"MERGED","mergeQueueEntry":null,"autoMergeRequest":null}},{"pullRequest":{"number":204,"state":"OPEN","mergeQueueEntry":null,"autoMergeRequest":null}}],"pageInfo":{"endCursor":"Mg","hasNextPage":false}}}]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 236.136625ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 188
+        host: api.github.com
+        body: '{"query":"mutation($input:UpdatePullRequestInput!){updatePullRequest(input: $input){pullRequest{id}}}","variables":{"input":{"pullRequestId":"PR_kwDOMVd0xs8AAAABAvuKow","state":"CLOSED"}}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"updatePullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs8AAAABAvuKow"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1.123948458s
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 188
+        host: api.github.com
+        body: '{"query":"mutation($input:UpdatePullRequestInput!){updatePullRequest(input: $input){pullRequest{id}}}","variables":{"input":{"pullRequestId":"PR_kwDOMVd0xs8AAAABAvuKWg","state":"CLOSED"}}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"updatePullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs8AAAABAvuKWg"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 968.710708ms

--- a/internal/forge/stacks.go
+++ b/internal/forge/stacks.go
@@ -1,0 +1,47 @@
+package forge
+
+import "context"
+
+// StackRepository is an optional repository capability
+// for repositories that support forge-native stacks.
+type StackRepository interface {
+	Repository
+
+	// PlanStackUpdate prepares an update that will make provider state represent
+	// the supplied change relationships.
+	// Each entry identifies a change and, when present, its immediate base from
+	// the same request. BaseBranch identifies the provider-facing branch even
+	// when BaseChange is absent from the request.
+	//
+	// Planning is read-only. [ErrUnsupported] means that no provider state was
+	// changed and the caller may apply its ordinary per-change base updates.
+	// Other planning failures also leave provider state unchanged.
+	//
+	// Provider-specific limits on individual trees do not make the capability
+	// unsupported. Implementations may warn and omit those trees from the
+	// returned plan.
+	PlanStackUpdate(context.Context, []StackChange) (StackUpdatePlan, error)
+}
+
+// StackUpdatePlan owns one prepared provider stack transition.
+type StackUpdatePlan interface {
+	// Execute applies the transition prepared by PlanStackUpdate.
+	//
+	// Execute may update independent trees before returning an error. It never
+	// returns [ErrUnsupported]; callers must prepare a new plan before retrying
+	// after any result.
+	Execute(context.Context) error
+}
+
+// StackChange identifies one member and its desired immediate base.
+type StackChange struct {
+	// Change identifies the stack member.
+	Change ChangeID // required
+
+	// BaseChange identifies the immediate base change when that change is also
+	// included in the request. It may be nil for a tree root.
+	BaseChange ChangeID
+
+	// BaseBranch is the desired provider-facing base branch.
+	BaseBranch string // required
+}

--- a/internal/gateway/github/pull_request_merge_range.go
+++ b/internal/gateway/github/pull_request_merge_range.go
@@ -41,7 +41,7 @@ type MergeRangePullRequest struct {
 // membership in input order.
 // A nil result entry means that GitHub did not find the corresponding pull
 // request.
-// When Stack is non-nil, it includes all open members in base-up order.
+// When Stack is non-nil, it includes all members in base-up order.
 //
 // The result combines two API reads because GitHub exposes stack identity on
 // the pull request and ordered membership on a separate stack node.
@@ -174,7 +174,7 @@ func (c *Gateway) PullRequestsForMergeRange(
 		return pullRequests, nil
 	}
 
-	// Resolve the ordered open members for every unique stack ID in one query.
+	// Resolve the ordered members for every unique stack ID in one query.
 	// A node may disappear after the pull request query; in that case, leaving
 	// Stack nil preserves the best remote view this non-atomic operation obtained.
 	resolvedStacksByID, err := c.pullRequestStacksByID(ctx, stackIDsToResolve)

--- a/internal/gateway/github/pull_request_merge_range_test.go
+++ b/internal/gateway/github/pull_request_merge_range_test.go
@@ -102,8 +102,9 @@ func TestGateway_PullRequestsForMergeRange(t *testing.T) {
 	require.NotNil(t, got[0].Stack)
 	assert.Equal(t, 42, got[0].Stack.Number)
 	assert.Equal(t, []PullRequestStackMember{
-		{Number: 1},
-		{Number: 2},
+		{Number: 1, State: PullRequestStateOpen},
+		{Number: 2, State: PullRequestStateOpen},
+		{Number: 4, State: PullRequestStateMerged},
 	}, got[0].Stack.Members)
 	assert.True(t, got[1].IsDraft)
 	assert.Equal(t, "fork", got[1].HeadRepositoryOwner)

--- a/internal/gateway/github/pull_request_stack_lookup_test.go
+++ b/internal/gateway/github/pull_request_stack_lookup_test.go
@@ -113,8 +113,9 @@ func TestGateway_PullRequestsForStackUpdate(t *testing.T) {
 	require.NotNil(t, got[0].Stack)
 	assert.Equal(t, 42, got[0].Stack.Number)
 	assert.Equal(t, []PullRequestStackMember{
-		{Number: 1},
-		{Number: 2, Locked: true},
+		{Number: 1, State: PullRequestStateOpen},
+		{Number: 2, State: PullRequestStateOpen, Locked: true},
+		{Number: 5, State: PullRequestStateMerged},
 	}, got[0].Stack.Members)
 	require.NotNil(t, got[1].Stack)
 	assert.Equal(t, 42, got[1].Stack.Number)
@@ -198,8 +199,9 @@ func TestGateway_PullRequestsForStackUpdate_paginatesStackEntries(t *testing.T) 
 	require.Len(t, got, 1)
 	require.NotNil(t, got[0].Stack)
 	assert.Equal(t, []PullRequestStackMember{
-		{Number: 1},
-		{Number: 3, Locked: true},
+		{Number: 1, State: PullRequestStateOpen},
+		{Number: 2, State: PullRequestStateMerged},
+		{Number: 3, State: PullRequestStateOpen, Locked: true},
 	}, got[0].Stack.Members)
 	assert.Equal(t, 3, requestNumber)
 }

--- a/internal/gateway/github/rest.go
+++ b/internal/gateway/github/rest.go
@@ -67,17 +67,6 @@ func (c *Gateway) postREST(
 	return c.doREST(ctx, http.MethodPost, path, req, res)
 }
 
-// deleteREST performs an authenticated DELETE request and, when res is
-// non-nil, decodes its JSON response into res.
-func (c *Gateway) deleteREST(
-	ctx context.Context,
-	path []string,
-	req any,
-	res any,
-) error {
-	return c.doREST(ctx, http.MethodDelete, path, req, res)
-}
-
 // putREST performs an authenticated PUT request with req as its JSON body and,
 // when res is non-nil, decodes the JSON response into res.
 // acceptedStatuses identifies non-2xx responses whose bodies still use res's

--- a/internal/gateway/github/stack.go
+++ b/internal/gateway/github/stack.go
@@ -12,14 +12,19 @@ type PullRequestStack struct {
 	// pull request numbers or entry positions.
 	Number int
 
-	// Members lists the open stack members from the base upward.
+	// Members lists every stack member from the base upward.
+	// Merged members remain present because GitHub cannot remove them when a
+	// stack is dissolved.
 	Members []PullRequestStackMember
 }
 
-// PullRequestStackMember describes one open member of a native stack.
+// PullRequestStackMember describes one member of a native stack.
 type PullRequestStackMember struct {
 	// Number is the repository-local pull request number.
 	Number int
+
+	// State is the pull request lifecycle state.
+	State PullRequestState
 
 	// Locked reports whether GitHub must preserve this member because it is in
 	// a merge queue or has auto-merge enabled.

--- a/internal/gateway/github/stack_lookup.go
+++ b/internal/gateway/github/stack_lookup.go
@@ -37,7 +37,7 @@ type StackUpdatePullRequest struct {
 // membership in input order.
 // A nil result entry means that GitHub did not find the corresponding pull
 // request.
-// When Stack is non-nil, it includes all open members in base-up order.
+// When Stack is non-nil, it includes all members in base-up order.
 //
 // The result combines two API snapshots because GitHub exposes stack identity
 // on the pull request and ordered membership on a separate stack node.
@@ -158,7 +158,7 @@ func (c *Gateway) PullRequestsForStackUpdate(
 		return pullRequests, nil
 	}
 
-	// Resolve the ordered open members for every unique stack ID in one query.
+	// Resolve the ordered members for every unique stack ID in one query.
 	// A node may disappear after the pull request query; in that case, leaving
 	// Stack nil preserves the best snapshot this non-atomic operation obtained.
 	resolvedStacksByID, err := c.pullRequestStacksByID(ctx, stackIDsToResolve)
@@ -177,7 +177,7 @@ func (c *Gateway) PullRequestsForStackUpdate(
 	return pullRequests, nil
 }
 
-// pullRequestStacksByID loads every ordered open member of each native stack.
+// pullRequestStacksByID loads every ordered member of each native stack.
 // The first page for all stacks is batched; stacks larger than one GraphQL page
 // are completed with per-stack continuation queries.
 func (c *Gateway) pullRequestStacksByID(
@@ -240,11 +240,12 @@ func (c *Gateway) pullRequestStacksByID(
 		for pageNum := 1; ; pageNum++ {
 			for _, entry := range entries.Nodes {
 				pullRequest := entry.PullRequest
-				if pullRequest == nil || pullRequest.State != PullRequestStateOpen {
+				if pullRequest == nil {
 					continue
 				}
 				stack.Members = append(stack.Members, PullRequestStackMember{
 					Number: pullRequest.Number,
+					State:  pullRequest.State,
 					Locked: pullRequest.MergeQueueEntry != nil ||
 						pullRequest.AutoMergeRequest != nil,
 				})

--- a/internal/gateway/github/stack_mutation.go
+++ b/internal/gateway/github/stack_mutation.go
@@ -27,8 +27,9 @@ type UnstackPullRequestStackResult struct {
 }
 
 // UnstackPullRequestStack dissolves a native pull request stack. GitHub may
-// preserve queued or auto-merge members and return them in a smaller stack.
-// See https://docs.github.com/en/rest/pulls/stacks#unstack-a-pull-request-stack.
+// preserve merged, queued, or auto-merge members and return them in a smaller
+// stack.
+// See https://docs.github.com/en/rest/pulls/stacks#remove-pull-requests-from-a-pull-request-stack.
 func (c *Gateway) UnstackPullRequestStack(
 	ctx context.Context,
 	input *UnstackPullRequestStackInput,
@@ -38,11 +39,12 @@ func (c *Gateway) UnstackPullRequestStack(
 			Number int `json:"number"`
 		} `json:"pull_requests"`
 	}
-	if err := c.deleteREST(
+	if err := c.postREST(
 		ctx,
 		[]string{
 			"repos", input.Owner, input.Repo, "stacks",
 			strconv.Itoa(input.StackNumber),
+			"unstack",
 		},
 		nil,
 		&res,

--- a/internal/gateway/github/stack_test.go
+++ b/internal/gateway/github/stack_test.go
@@ -131,8 +131,8 @@ func TestGateway_AddPullRequestsToStackCount(t *testing.T) {
 
 func TestGateway_UnstackPullRequestStack(t *testing.T) {
 	gateway := newTestGateway(t, roundTripFunc(func(r *http.Request) (*http.Response, error) {
-		assert.Equal(t, http.MethodDelete, r.Method)
-		assert.Equal(t, "/repos/octo/hello/stacks/42", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/repos/octo/hello/stacks/42/unstack", r.URL.Path)
 		return restJSONResponse(http.StatusOK, `{
 			"pull_requests":[{"number":102},{"number":103}]
 		}`), nil

--- a/internal/graph/furthest_children.go
+++ b/internal/graph/furthest_children.go
@@ -1,0 +1,24 @@
+package graph
+
+// FurthestChildren returns every node at the greatest depth reachable from
+// root.
+// It returns root when root has no children.
+//
+// The children callback must report direct children in deterministic traversal
+// order.
+// FurthestChildren preserves that order among results.
+// The caller must provide an acyclic tree;
+// cycles are not detected.
+func FurthestChildren[N any](root N, children func(N) []N) []N {
+	furthest := []N{root}
+	for {
+		var next []N
+		for _, node := range furthest {
+			next = append(next, children(node)...)
+		}
+		if len(next) == 0 {
+			return furthest
+		}
+		furthest = next
+	}
+}

--- a/internal/graph/furthest_children_test.go
+++ b/internal/graph/furthest_children_test.go
@@ -1,0 +1,60 @@
+package graph_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.abhg.dev/gs/internal/graph"
+)
+
+func TestFurthestChildren(t *testing.T) {
+	tests := []struct {
+		name     string
+		root     string
+		children map[string][]string
+		want     []string
+	}{
+		{
+			name: "Leaf",
+			root: "a",
+			want: []string{"a"},
+		},
+		{
+			name: "Linear",
+			root: "a",
+			children: map[string][]string{
+				"a": {"b"},
+				"b": {"c"},
+			},
+			want: []string{"c"},
+		},
+		{
+			name: "Longest",
+			root: "a",
+			children: map[string][]string{
+				"a": {"b", "c"},
+				"c": {"d"},
+			},
+			want: []string{"d"},
+		},
+		{
+			name: "StableTie",
+			root: "a",
+			children: map[string][]string{
+				"a": {"c", "b"},
+				"b": {"d"},
+				"c": {"e"},
+			},
+			want: []string{"e", "d"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := graph.FurthestChildren(tt.root, func(node string) []string {
+				return tt.children[node]
+			})
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Forge repositories can expose native stacking through the optional
`WithStacks` upgrade. GitHub projects the complete open change graph
onto a deterministic linear same-repository path, then creates or
extends the native stack on a best-effort basis.

GitHub cannot replace an existing native stack with a divergent path.
Constrain path selection with compatible native membership before
scanning its upstack, so a longer unstacked branch cannot displace a
manually chosen native path. Leave multiple or incompatible native
stacks unchanged and warn once for the affected tree.

Use the compact gateway projection for reconciliation. The shared forge
integration suite covers stack creation, extension, and idempotence.

Refs #1388