### PR TITLE
forge: Add linear merge range capability

### DIFF
--- a/internal/forge/forgetest/integration.go
+++ b/internal/forge/forgetest/integration.go
@@ -157,6 +157,13 @@ type IntegrationConfig struct {
 	// The scenario creates, extends, and reuses a native stack, so the selected
 	// fixture and remote repository must support those provider operations.
 	TestStacks bool // optional
+
+	// TestMergeRange enables the shared linear merge range integration scenario.
+	// OpenRepository must return a repository that implements
+	// [forge.StackRepository].
+	// The scenario verifies branch alignment, creates a native stack, starts an
+	// asynchronous merge, and waits for all changes to reach merged state.
+	TestMergeRange bool // optional
 }
 
 // RunIntegration runs integration tests with the given configuration.
@@ -335,6 +342,17 @@ func RunIntegration(t *testing.T, config IntegrationConfig) {
 			stackRepository, ok := repo.(forge.StackRepository)
 			require.True(t, ok, "%T does not implement forge.StackRepository", repo)
 			suite.TestStacks(t, stackRepository)
+		})
+	}
+
+	if config.TestMergeRange {
+		t.Run("MergeRange", func(t *testing.T) {
+			t.Parallel()
+
+			repo := suite.OpenRepository(t)
+			stackRepository, ok := repo.(forge.StackRepository)
+			require.True(t, ok, "%T does not implement forge.StackRepository", repo)
+			suite.TestMergeRange(t, stackRepository)
 		})
 	}
 }

--- a/internal/forge/forgetest/repo_builder.go
+++ b/internal/forge/forgetest/repo_builder.go
@@ -193,5 +193,3 @@ func (r *RepositoryBuilder) Repository() *git.Repository {
 func (r *RepositoryBuilder) Worktree() *git.Worktree {
 	return r.work
 }
-
-// randomString generates a random alphanumeric string of length n.

--- a/internal/forge/forgetest/scenario_merge_range.go
+++ b/internal/forge/forgetest/scenario_merge_range.go
@@ -1,0 +1,125 @@
+package forgetest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/fixturetest"
+	"go.abhg.dev/gs/internal/forge"
+)
+
+// TestMergeRange exercises validation, asynchronous acceptance, and final
+// merged state for a linear range of provider changes.
+func (s *integrationSuite) TestMergeRange(
+	t *testing.T,
+	repo forge.StackRepository,
+) {
+	bottomBranch := fixturetest.New(s.Fixtures, "mergeRangeBottomBranch", func() string {
+		return "merge-range-bottom-" + randomString(8)
+	}).Get(t)
+	topBranch := fixturetest.New(s.Fixtures, "mergeRangeTopBranch", func() string {
+		return "merge-range-top-" + randomString(8)
+	}).Get(t)
+
+	if Update() {
+		testRepo := NewRepositoryBuilder(t, s.RemoteURL)
+		testRepo.CheckoutBranch("main")
+		testRepo.CreateBranch(bottomBranch)
+		testRepo.CheckoutBranch(bottomBranch)
+		testRepo.WriteFile(bottomBranch+".txt", randomString(32))
+		testRepo.AddAllAndCommit("commit for merge range bottom")
+		testRepo.Push(bottomBranch)
+
+		// The top branch starts at the bottom branch's head so the remote PR
+		// relationships describe one fully restacked linear path.
+		testRepo.CreateBranch(topBranch)
+		testRepo.CheckoutBranch(topBranch)
+		testRepo.WriteFile(topBranch+".txt", randomString(32))
+		testRepo.AddAllAndCommit("commit for merge range top")
+		testRepo.Push(topBranch)
+
+		t.Cleanup(func() {
+			testRepo.DeleteRemoteBranch(topBranch)
+			testRepo.DeleteRemoteBranch(bottomBranch)
+		})
+	}
+
+	bottom, err := repo.SubmitChange(t.Context(), forge.SubmitChangeRequest{
+		Subject: "Merge range bottom " + bottomBranch,
+		Body:    "Merge range integration test",
+		Base:    "main",
+		Head:    bottomBranch,
+	})
+	require.NoError(t, err, "create merge range bottom change")
+	top, err := repo.SubmitChange(t.Context(), forge.SubmitChangeRequest{
+		Subject: "Merge range top " + topBranch,
+		Body:    "Merge range integration test",
+		Base:    bottomBranch,
+		Head:    topBranch,
+	})
+	require.NoError(t, err, "create merge range top change")
+
+	stackChanges := []forge.StackChange{
+		{Change: bottom.ID, BaseBranch: "main"},
+		{Change: top.ID, BaseChange: bottom.ID, BaseBranch: bottomBranch},
+	}
+	stackPlan, err := repo.PlanStackUpdate(t.Context(), stackChanges)
+	require.NoError(t, err, "plan merge range native stack")
+	require.NoError(t, stackPlan.Execute(t.Context()), "create merge range native stack")
+
+	plans, err := repo.PlanMergeRanges(t.Context(), stackChanges)
+	require.NoError(t, err, "plan merge range")
+	require.Len(t, plans, 1, "planned merge range count")
+	assert.Equal(t, []forge.ChangeID{bottom.ID, top.ID}, plans[0].Changes())
+
+	changeIDs := []forge.ChangeID{bottom.ID, top.ID}
+	statuses, err := repo.ChangeStatuses(t.Context(), changeIDs)
+	require.NoError(t, err, "read merge range head hashes")
+	require.Len(t, statuses, len(changeIDs), "merge range status count")
+
+	operation, err := plans[0].Merge(t.Context(), forge.MergeRangeRequest{
+		Changes: []forge.MergeRangeChange{
+			{
+				Change:   bottom.ID,
+				Base:     "main",
+				Head:     bottomBranch,
+				HeadHash: statuses[0].HeadHash,
+			},
+			{
+				Change:   top.ID,
+				Base:     bottomBranch,
+				Head:     topBranch,
+				HeadHash: statuses[1].HeadHash,
+			},
+		},
+	})
+	require.NoError(t, err, "start merge range")
+
+	status, err := operation.Status(t.Context())
+	require.NoError(t, err, "probe merge range operation")
+	assert.Equal(t, forge.MergeOperationPending, status, "merge range operation status")
+
+	// This should be plenty of time--probably.
+	// Bump it up if this test is flaky during recording.
+	if Update() {
+		select {
+		case <-time.After(5 * time.Second):
+
+		case <-t.Context().Done():
+			require.FailNow(t, "merge range test context canceled")
+		}
+	}
+
+	status, err = operation.Status(t.Context())
+	require.NoError(t, err, "probe merge range operation")
+	assert.Equal(t, forge.MergeOperationAccepted, status, "merge range operation status")
+
+	statuses, err = repo.ChangeStatuses(t.Context(), changeIDs)
+	require.NoError(t, err, "read merge range change states")
+	require.Len(t, statuses, len(changeIDs), "merge range status count")
+	for _, status := range statuses {
+		assert.Equal(t, forge.ChangeMerged, status.State, "change %d state", status)
+	}
+}

--- a/internal/forge/forgetest/scenario_repository.go
+++ b/internal/forge/forgetest/scenario_repository.go
@@ -155,7 +155,8 @@ func (s *integrationSuite) TestListChangeTemplates(t *testing.T) {
 
 				testRepo.WriteFile(
 					filepath.Join(templateDir, nonEmptyTemplateName),
-					"This is a test template")
+					"This is a test template",
+				)
 				t.Logf("Created non-empty template at: %s",
 					filepath.Join(templateDir, nonEmptyTemplateName))
 			} else {

--- a/internal/forge/github/integration_test.go
+++ b/internal/forge/github/integration_test.go
@@ -103,11 +103,12 @@ func TestIntegration(t *testing.T) {
 	}
 
 	forgetest.RunIntegration(t, forgetest.IntegrationConfig{
-		RemoteURL:     remoteURL,
-		PushRemoteURL: pushRemoteURL,
-		Forge:         &githubForge,
-		TestStacks:    true,
-		Sanitizers:    sanitizers,
+		RemoteURL:      remoteURL,
+		PushRemoteURL:  pushRemoteURL,
+		Forge:          &githubForge,
+		TestStacks:     true,
+		TestMergeRange: true,
+		Sanitizers:     sanitizers,
 		OpenRepository: func(t *testing.T, httpClient *http.Client) forge.Repository {
 			token := forgetest.Token(t, remoteURL, "GITHUB_TOKEN")
 			httpClient.Transport = &oauth2.Transport{
@@ -440,6 +441,209 @@ func TestIntegration_stackReplacementWithMergedMember(t *testing.T) {
 		{Number: bottom.ID.(*github.PR).Number, State: githubgateway.PullRequestStateMerged},
 		{Number: top.ID.(*github.PR).Number, State: githubgateway.PullRequestStateOpen},
 	}, pullRequests[2].Stack.Members)
+}
+
+func TestIntegration_DivergentStackMerge(t *testing.T) {
+	cfg, sanitizers := testConfig(t)
+	remoteURL := "https://github.com/" + cfg.Owner + "/" + cfg.Repo
+
+	aBranch := fixturetest.New(_fixtures, "aBranch", func() string {
+		return "divergent-stack-a-" + randomString(8)
+	}).Get(t)
+	bBranch := fixturetest.New(_fixtures, "bBranch", func() string {
+		return "divergent-stack-b-" + randomString(8)
+	}).Get(t)
+	cBranch := fixturetest.New(_fixtures, "cBranch", func() string {
+		return "divergent-stack-c-" + randomString(8)
+	}).Get(t)
+	dBranch := fixturetest.New(_fixtures, "dBranch", func() string {
+		return "divergent-stack-d-" + randomString(8)
+	}).Get(t)
+
+	// Recording provisions a disposable remote branch graph and captures its
+	// API traffic. Replay begins below with the recorded branch names and HTTP
+	// fixture, without touching GitHub.
+	if forgetest.Update() {
+		testRepo := forgetest.NewRepositoryBuilder(t, remoteURL)
+		t.Cleanup(func() {
+			for _, branch := range []string{dBranch, cBranch, bBranch, aBranch} {
+				testRepo.DeleteRemoteBranch(branch)
+			}
+		})
+
+		// Build a divergent branch graph.
+		// A-B-C becomes the native stack;
+		// D remains an unstacked pull request based on B.
+		//
+		//     main
+		//       |
+		//       A
+		//       |
+		//       B
+		//      / \
+		//     C   D
+		testRepo.CheckoutBranch("main")
+		for _, branch := range []string{aBranch, bBranch, cBranch} {
+			testRepo.CreateBranch(branch)
+			testRepo.CheckoutBranch(branch)
+			testRepo.WriteFile(branch+".txt", "commit for "+branch)
+			testRepo.AddAllAndCommit("commit for " + branch)
+			testRepo.Push(branch)
+		}
+
+		testRepo.CheckoutBranch(bBranch)
+		testRepo.CreateBranch(dBranch)
+		testRepo.CheckoutBranch(dBranch)
+		testRepo.WriteFile(dBranch+".txt", "commit for "+dBranch)
+		testRepo.AddAllAndCommit("commit for " + dBranch)
+		testRepo.Push(dBranch)
+	}
+
+	rec := newRecorder(t, t.Name(), sanitizers)
+	httpClient := rec.GetDefaultClient()
+	token := forgetest.Token(t, remoteURL, "GITHUB_TOKEN")
+	httpClient.Transport = &oauth2.Transport{
+		Base:   httpClient.Transport,
+		Source: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token}),
+	}
+
+	gatewayClient := newGateway(t, httpClient)
+	repo, err := github.NewRepository(
+		t.Context(), new(github.Forge), cfg.Owner, cfg.Repo,
+		silogtest.New(t), gatewayClient, "",
+	)
+	require.NoError(t, err)
+	a, err := repo.SubmitChange(t.Context(), forge.SubmitChangeRequest{
+		Subject: "Divergent native stack A " + aBranch,
+		Body:    "Divergent native stack integration test",
+		Base:    "main",
+		Head:    aBranch,
+	})
+	require.NoError(t, err, "create change A")
+	b, err := repo.SubmitChange(t.Context(), forge.SubmitChangeRequest{
+		Subject: "Divergent native stack B " + bBranch,
+		Body:    "Divergent native stack integration test",
+		Base:    aBranch,
+		Head:    bBranch,
+	})
+	require.NoError(t, err, "create change B")
+	c, err := repo.SubmitChange(t.Context(), forge.SubmitChangeRequest{
+		Subject: "Divergent native stack C " + cBranch,
+		Body:    "Divergent native stack integration test",
+		Base:    bBranch,
+		Head:    cBranch,
+	})
+	require.NoError(t, err, "create change C")
+	d, err := repo.SubmitChange(t.Context(), forge.SubmitChangeRequest{
+		Subject: "Divergent native stack D " + dBranch,
+		Body:    "Divergent native stack integration test",
+		Base:    bBranch,
+		Head:    dBranch,
+	})
+	require.NoError(t, err, "create change D")
+
+	stackChanges := []forge.StackChange{
+		{Change: a.ID, BaseBranch: "main"},
+		{Change: b.ID, BaseChange: a.ID, BaseBranch: aBranch},
+		{Change: c.ID, BaseChange: b.ID, BaseBranch: bBranch},
+		{Change: d.ID, BaseChange: b.ID, BaseBranch: bBranch},
+	}
+	stackPlan, err := repo.PlanStackUpdate(t.Context(), stackChanges[:3])
+	require.NoError(t, err, "plan A-B-C native stack")
+	require.NoError(t, stackPlan.Execute(t.Context()), "register A-B-C as a native stack")
+
+	plans, err := repo.PlanMergeRanges(t.Context(), stackChanges)
+	require.NoError(t, err, "plan divergent native stack merge")
+	require.Len(t, plans, 2, "planned merge range count")
+	assert.Equal(t, []forge.ChangeID{a.ID, b.ID, c.ID}, plans[0].Changes())
+	assert.Equal(t, []forge.ChangeID{d.ID}, plans[1].Changes())
+
+	changeIDs := []forge.ChangeID{a.ID, b.ID, c.ID, d.ID}
+	beforeMerge, err := repo.ChangeStatuses(t.Context(), changeIDs)
+	require.NoError(t, err, "read change head hashes before merge")
+	require.Len(t, beforeMerge, len(changeIDs), "pre-merge status count")
+	dHeadHash := beforeMerge[3].HeadHash
+
+	operation, err := plans[0].Merge(t.Context(), forge.MergeRangeRequest{
+		Method: forge.MergeMethodSquash,
+		Changes: []forge.MergeRangeChange{
+			{
+				Change:   a.ID,
+				Base:     "main",
+				Head:     aBranch,
+				HeadHash: beforeMerge[0].HeadHash,
+			},
+			{
+				Change:   b.ID,
+				Base:     aBranch,
+				Head:     bBranch,
+				HeadHash: beforeMerge[1].HeadHash,
+			},
+			{
+				Change:   c.ID,
+				Base:     bBranch,
+				Head:     cBranch,
+				HeadHash: beforeMerge[2].HeadHash,
+			},
+		},
+	})
+	require.NoError(t, err, "start A-B-C squash merge")
+
+	status, err := operation.Status(t.Context())
+	require.NoError(t, err, "probe A-B-C merge operation")
+	assert.Equal(t, forge.MergeOperationPending, status,
+		"A-B-C merge operation status")
+
+	// This should be plenty of time--probably.
+	// Bump it up if this test is flaky during recording.
+	if forgetest.Update() {
+		select {
+		case <-time.After(5 * time.Second):
+
+		case <-t.Context().Done():
+			require.FailNow(t, "divergent stack test context canceled")
+		}
+	}
+
+	status, err = operation.Status(t.Context())
+	require.NoError(t, err, "probe A-B-C merge operation")
+	assert.Equal(t, forge.MergeOperationAccepted, status,
+		"A-B-C merge operation status")
+
+	mergedStatuses, err := repo.ChangeStatuses(t.Context(), changeIDs[:3])
+	require.NoError(t, err, "read A-B-C states after merge")
+	require.Len(t, mergedStatuses, 3, "A-B-C status count")
+	for _, status := range mergedStatuses {
+		assert.Equal(t, forge.ChangeMerged, status.State,
+			"change %d state", status)
+	}
+
+	dStatuses, err := repo.ChangeStatuses(t.Context(), []forge.ChangeID{d.ID})
+	require.NoError(t, err, "read change D state after A-B-C merge")
+	require.Len(t, dStatuses, 1, "change D status count")
+	assert.Equal(t, forge.ChangeOpen, dStatuses[0].State)
+	assert.Equal(t, dHeadHash, dStatuses[0].HeadHash)
+
+	dPullRequests, err := gatewayClient.PullRequestsForMergeRange(
+		t.Context(),
+		cfg.Owner,
+		cfg.Repo,
+		[]int{d.ID.(*github.PR).Number},
+	)
+	require.NoError(t, err, "read change D after A-B-C merge")
+	require.Len(t, dPullRequests, 1, "change D pull request count")
+	dPullRequest := dPullRequests[0]
+	require.NotNil(t, dPullRequest, "change D pull request")
+	assert.Equal(t, githubgateway.PullRequestStateOpen, dPullRequest.State)
+	assert.Equal(t, bBranch, dPullRequest.BaseRefName)
+	assert.Equal(t, dBranch, dPullRequest.HeadRefName)
+	assert.Equal(t, dHeadHash.String(), dPullRequest.HeadRefOID)
+	assert.Nil(t, dPullRequest.Stack)
+
+	mergeability, err := repo.ChangeMergeability(t.Context(), d.ID)
+	require.NoError(t, err, "read change D mergeability")
+	assert.Equal(t, forge.ChangeMergeabilityReady, mergeability.State,
+		"change D mergeability: %v", mergeability.Reason)
 }
 
 func TestIntegration_Repository_LabelCreateDelete(t *testing.T) {

--- a/internal/forge/github/merge_range.go
+++ b/internal/forge/github/merge_range.go
@@ -1,0 +1,482 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/gateway/github"
+)
+
+// PlanMergeRanges identifies atomic merge ranges from GitHub's current native
+// stack membership.
+// Unstacked pull requests and selected lowest stack members produce
+// single-change plans so standalone merges also use GitHub's asynchronous API.
+func (r *Repository) PlanMergeRanges(
+	ctx context.Context,
+	changes []forge.StackChange,
+) ([]forge.MergeRangePlan, error) {
+	type requestedChange struct {
+		change forge.ChangeID
+		base   int
+	}
+
+	requestedByNumber := make(map[int]requestedChange, len(changes))
+	numbers := make([]int, len(changes))
+	for i, change := range changes {
+		number := mustPR(change.Change).Number
+		if _, exists := requestedByNumber[number]; exists {
+			return nil, fmt.Errorf("duplicate GitHub pull request #%d", number)
+		}
+		numbers[i] = number
+		requestedByNumber[number] = requestedChange{change: change.Change}
+	}
+	for _, change := range changes {
+		if change.BaseChange == nil {
+			continue
+		}
+		number := mustPR(change.Change).Number
+		base := mustPR(change.BaseChange).Number
+		if _, included := requestedByNumber[base]; included {
+			requested := requestedByNumber[number]
+			requested.base = base
+			requestedByNumber[number] = requested
+		}
+	}
+
+	pullRequests, err := r.gateway.PullRequestsForMergeRange(
+		ctx,
+		r.owner,
+		r.repo,
+		numbers,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("inspect GitHub pull requests for merge planning: %w", err)
+	}
+	if len(pullRequests) != len(numbers) {
+		return nil, fmt.Errorf(
+			"inspect GitHub pull requests for merge planning: got %d results for %d changes",
+			len(pullRequests),
+			len(numbers),
+		)
+	}
+
+	var plans []*githubMergeRangePlan
+	stacksByNumber := make(map[int]*github.PullRequestStack)
+	for i, pullRequest := range pullRequests {
+		number := numbers[i]
+		if pullRequest == nil {
+			return nil, fmt.Errorf(
+				"inspect GitHub pull request #%d: %w", number, forge.ErrNotFound,
+			)
+		}
+		if pullRequest.Stack == nil {
+			plans = append(plans, &githubMergeRangePlan{
+				repository: r,
+				changes:    []forge.ChangeID{requestedByNumber[number].change},
+			})
+			continue
+		}
+		stacksByNumber[pullRequest.Stack.Number] = pullRequest.Stack
+	}
+
+	// GitHub merges only a lowest open prefix of a native stack. Follow each
+	// remote stack from its bottom while the selected forest contains the same
+	// immediate relationships. A missing lower member or a local divergence
+	// stops the range; remaining selected changes stay available to the
+	// handler's ordinary merge path.
+	for _, stack := range stacksByNumber {
+		var planned []forge.ChangeID
+		previous := 0
+		for _, member := range stack.Members {
+			if member.State != github.PullRequestStateOpen {
+				continue
+			}
+			number := member.Number
+			requested, selected := requestedByNumber[number]
+			if !selected || previous != 0 && requested.base != previous {
+				break
+			}
+			planned = append(planned, requested.change)
+			previous = number
+		}
+		if len(planned) > 0 {
+			plans = append(plans, &githubMergeRangePlan{
+				repository: r,
+				changes:    planned,
+			})
+		}
+	}
+
+	slices.SortFunc(plans, func(left, right *githubMergeRangePlan) int {
+		return mustPR(left.changes[0]).Number - mustPR(right.changes[0]).Number
+	})
+	result := make([]forge.MergeRangePlan, len(plans))
+	for i, plan := range plans {
+		result[i] = plan
+	}
+	return result, nil
+}
+
+// githubMergeRangePlan binds GitHub's observed stack membership to the
+// operation that can safely consume it.
+// Merge reloads provider state because queue preparation may restack and
+// republish branches after planning.
+type githubMergeRangePlan struct {
+	repository *Repository
+	changes    []forge.ChangeID
+}
+
+func (p *githubMergeRangePlan) Changes() []forge.ChangeID {
+	return p.changes
+}
+
+func (p *githubMergeRangePlan) Merge(
+	ctx context.Context,
+	request forge.MergeRangeRequest,
+) (forge.MergeOperation, error) {
+	if len(request.Changes) != len(p.changes) {
+		return nil, fmt.Errorf(
+			"merge range request has %d changes, planned %d",
+			len(request.Changes),
+			len(p.changes),
+		)
+	}
+	for i, change := range request.Changes {
+		if change.Change.String() != p.changes[i].String() {
+			return nil, fmt.Errorf(
+				"merge range request change %d is %v, planned %v",
+				i,
+				change.Change,
+				p.changes[i],
+			)
+		}
+	}
+
+	mergeRange, err := newGitHubMergeRange(p.repository, request)
+	if err != nil {
+		return nil, err
+	}
+	if err := mergeRange.loadPullRequests(ctx); err != nil {
+		return nil, err
+	}
+	if err := mergeRange.validatePullRequests(); err != nil {
+		return nil, err
+	}
+	return mergeRange.start(ctx)
+}
+
+// githubMergeRange owns one conversion from a requested forge path to a GitHub
+// stack-prefix merge request.
+//
+// Construction establishes the bottom-to-top linear path. loadPullRequests
+// then attaches GitHub's two-read remote view to the corresponding change
+// records, and validatePullRequests checks that view against the requested path
+// and native-stack constraints. start is the only phase that may create a
+// remote merge operation; GitHub rechecks the requested top head there.
+type githubMergeRange struct {
+	repository *Repository
+	method     forge.MergeMethod
+	changes    []githubMergeRangeChange
+}
+
+// githubMergeRangeChange keeps one expected relationship, repository-local
+// pull request number, and attached remote view together across all phases.
+type githubMergeRangeChange struct {
+	expected    forge.MergeRangeChange
+	number      int
+	pullRequest *github.MergeRangePullRequest
+}
+
+func newGitHubMergeRange(
+	repository *Repository,
+	request forge.MergeRangeRequest,
+) (*githubMergeRange, error) {
+	if len(request.Changes) == 0 {
+		return nil, errors.New("merge range must not be empty")
+	}
+
+	changes := make([]githubMergeRangeChange, len(request.Changes))
+	for i, change := range request.Changes {
+		if i > 0 && request.Changes[i-1].Head != change.Base {
+			return nil, fmt.Errorf(
+				"merge range change #%d base branch %q does not match previous head branch %q",
+				mustPR(change.Change).Number,
+				change.Base,
+				request.Changes[i-1].Head,
+			)
+		}
+		if change.Base == "" {
+			return nil, fmt.Errorf("merge range change %d has no base branch", i)
+		}
+		if change.Head == "" {
+			return nil, fmt.Errorf("merge range change %d has no head branch", i)
+		}
+		if change.HeadHash.IsZero() {
+			return nil, fmt.Errorf("merge range change %d has no head commit", i)
+		}
+		changes[i] = githubMergeRangeChange{
+			expected: change,
+			number:   mustPR(change.Change).Number,
+		}
+	}
+
+	return &githubMergeRange{
+		repository: repository,
+		method:     request.Method,
+		changes:    changes,
+	}, nil
+}
+
+// loadPullRequests attaches GitHub's compact merge-range view to each requested
+// change. The gateway preserves input order, so the positional relationship is
+// consumed once here rather than propagated through later phases.
+func (m *githubMergeRange) loadPullRequests(ctx context.Context) error {
+	numbers := make([]int, len(m.changes))
+	for i, change := range m.changes {
+		numbers[i] = change.number
+	}
+	pullRequests, err := m.repository.gateway.PullRequestsForMergeRange(
+		ctx,
+		m.repository.owner,
+		m.repository.repo,
+		numbers,
+	)
+	if err != nil {
+		return fmt.Errorf("inspect GitHub pull requests for merge range: %w", err)
+	}
+	for i, pullRequest := range pullRequests {
+		m.changes[i].pullRequest = pullRequest
+	}
+	return nil
+}
+
+// validatePullRequests checks the remote view against the requested open path.
+// This is the last phase before a remote merge may start, so any error from
+// this method guarantees that no merge was submitted.
+func (m *githubMergeRange) validatePullRequests() error {
+	for i := range m.changes {
+		if err := m.validatePullRequest(&m.changes[i]); err != nil {
+			return err
+		}
+	}
+	return m.validateNativeStack()
+}
+
+func (m *githubMergeRange) validatePullRequest(
+	change *githubMergeRangeChange,
+) error {
+	number := change.number
+	pullRequest := change.pullRequest
+	expected := change.expected
+	if pullRequest == nil {
+		return fmt.Errorf(
+			"inspect GitHub pull request #%d: %w", number, forge.ErrNotFound,
+		)
+	}
+	if pullRequest.State != github.PullRequestStateOpen {
+		return fmt.Errorf("GitHub pull request #%d is not open", number)
+	}
+	if pullRequest.IsDraft {
+		return fmt.Errorf("GitHub pull request #%d is a draft", number)
+	}
+	if pullRequest.BaseRefName != expected.Base {
+		return fmt.Errorf(
+			"GitHub pull request #%d base branch is %q, expected %q",
+			number,
+			pullRequest.BaseRefName,
+			expected.Base,
+		)
+	}
+	if pullRequest.HeadRefName != expected.Head {
+		return fmt.Errorf(
+			"GitHub pull request #%d head branch is %q, expected %q",
+			number,
+			pullRequest.HeadRefName,
+			expected.Head,
+		)
+	}
+	if pullRequest.HeadRefOID != expected.HeadHash.String() {
+		return fmt.Errorf(
+			"GitHub pull request #%d head commit is %q, expected %q",
+			number,
+			pullRequest.HeadRefOID,
+			expected.HeadHash,
+		)
+	}
+	if len(m.changes) > 1 &&
+		(!strings.EqualFold(pullRequest.HeadRepositoryOwner, m.repository.owner) ||
+			!strings.EqualFold(pullRequest.HeadRepositoryName, m.repository.repo)) {
+		return fmt.Errorf(
+			"GitHub pull request #%d must use a head branch in %s for a stack merge",
+			number,
+			m.repository.owner+"/"+m.repository.repo,
+		)
+	}
+	return nil
+}
+
+// validateNativeStack checks that the observed multi-change view is the lowest
+// open prefix of one native stack. GitHub's asynchronous merge of the top pull
+// request would otherwise merge a different set than the caller requested.
+func (m *githubMergeRange) validateNativeStack() error {
+	var stack *github.PullRequestStack
+	for _, change := range m.changes {
+		pullRequest := change.pullRequest
+		if pullRequest.Stack == nil {
+			if len(m.changes) > 1 {
+				return fmt.Errorf(
+					"merge range pull request #%d is not in a GitHub native stack",
+					change.number,
+				)
+			}
+			continue
+		}
+		if stack != nil && stack.Number != pullRequest.Stack.Number {
+			return errors.New("merge range belongs to different GitHub native stacks")
+		}
+		if stack == nil {
+			stack = pullRequest.Stack
+		}
+	}
+	if stack == nil {
+		return nil
+	}
+	numbers := make([]int, len(m.changes))
+	for i, change := range m.changes {
+		numbers[i] = change.number
+	}
+	openPullRequests := openStackMemberNumbers(stack.Members)
+	if len(openPullRequests) < len(numbers) || !slices.Equal(
+		openPullRequests[:len(numbers)],
+		numbers,
+	) {
+		return fmt.Errorf(
+			"merge range %s must begin with the lowest open member of GitHub native stack #%d (%s)",
+			formatPullRequestNumbers(numbers),
+			stack.Number,
+			formatPullRequestNumbers(openPullRequests),
+		)
+	}
+	return nil
+}
+
+func (m *githubMergeRange) start(ctx context.Context) (forge.MergeOperation, error) {
+	method, err := githubMergeMethod(m.method)
+	if err != nil {
+		return nil, err
+	}
+	top := m.changes[len(m.changes)-1]
+	result, err := m.repository.gateway.MergePullRequestAsync(ctx, &github.MergePullRequestAsyncInput{
+		Owner:             m.repository.owner,
+		Repo:              m.repository.repo,
+		PullRequestNumber: top.number,
+		ExpectedHeadSHA:   top.expected.HeadHash.String(),
+		Method:            method,
+	})
+	if errors.Is(err, github.ErrNotFound) {
+		return nil, fmt.Errorf(
+			"submit GitHub asynchronous merge: %w",
+			errors.Join(forge.ErrUnsupported, err),
+		)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("submit GitHub asynchronous merge: %w", err)
+	}
+	status, err := githubMergeOperationStatus(result)
+	if err != nil {
+		return nil, err
+	}
+	if status == forge.MergeOperationPending {
+		return &githubMergeOperation{
+			repository:  m.repository,
+			pullRequest: top.number,
+			operationID: result.OperationID,
+		}, nil
+	}
+	return nil, nil
+}
+
+func githubMergeMethod(method forge.MergeMethod) (github.MergeMethod, error) {
+	switch method {
+	case forge.MergeMethodDefault:
+		return github.MergeMethodUnknown, nil
+	case forge.MergeMethodMerge:
+		return github.MergeMethodMerge, nil
+	case forge.MergeMethodSquash:
+		return github.MergeMethodSquash, nil
+	case forge.MergeMethodRebase:
+		return github.MergeMethodRebase, nil
+	default:
+		return github.MergeMethodUnknown, fmt.Errorf(
+			"unsupported GitHub merge method %v", method,
+		)
+	}
+}
+
+type githubMergeOperation struct {
+	repository  *Repository
+	pullRequest int
+	operationID string
+}
+
+var _ forge.MergeOperation = (*githubMergeOperation)(nil)
+
+// Status performs one GitHub asynchronous merge status probe.
+func (o *githubMergeOperation) Status(
+	ctx context.Context,
+) (forge.MergeOperationStatus, error) {
+	result, err := o.repository.gateway.AsyncMergeResult(
+		ctx,
+		o.repository.owner,
+		o.repository.repo,
+		o.pullRequest,
+		o.operationID,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("poll GitHub asynchronous merge: %w", err)
+	}
+	return githubMergeOperationStatus(result)
+}
+
+// githubMergeOperationStatus is the forge-facing interpretation shared by
+// initial submission and later status probes. Both a completed merge and a
+// merge-queue admission release the caller to observe pull request state;
+// neither requires another asynchronous-operation probe.
+func githubMergeOperationStatus(
+	result *github.AsyncMergeResult,
+) (forge.MergeOperationStatus, error) {
+	if result == nil {
+		return 0, errors.New("GitHub asynchronous merge returned no result")
+	}
+	switch result.Status {
+	case github.AsyncMergeStatusPending:
+		return forge.MergeOperationPending, nil
+	case github.AsyncMergeStatusMerged, github.AsyncMergeStatusEnqueued:
+		return forge.MergeOperationAccepted, nil
+	case github.AsyncMergeStatusFailed:
+		return 0, asyncMergeFailure(result.Message)
+	default:
+		return 0, fmt.Errorf(
+			"GitHub asynchronous merge returned unknown status %v", result.Status,
+		)
+	}
+}
+
+func asyncMergeFailure(message string) error {
+	if strings.TrimSpace(message) == "" {
+		message = "GitHub did not provide a failure reason"
+	}
+	return fmt.Errorf("GitHub asynchronous merge failed: %s", message)
+}
+
+func formatPullRequestNumbers(numbers []int) string {
+	formatted := make([]string, len(numbers))
+	for i, number := range numbers {
+		formatted[i] = fmt.Sprintf("#%d", number)
+	}
+	return strings.Join(formatted, ", ")
+}

--- a/internal/forge/github/merge_range_test.go
+++ b/internal/forge/github/merge_range_test.go
@@ -1,0 +1,277 @@
+package github
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/gateway/github"
+	"go.uber.org/mock/gomock"
+)
+
+func TestRepository_PlanMergeRanges(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	stack := newPullRequestStack(42, 1, 2, 4)
+	gateway.EXPECT().PullRequestsForMergeRange(
+		gomock.Any(), "acme", "repo", []int{1, 2, 3, 4},
+	).Return([]*github.MergeRangePullRequest{
+		newMergeRangePullRequest("main", "a", "hash-1", stack),
+		newMergeRangePullRequest("a", "b", "hash-2", stack),
+		newMergeRangePullRequest("b", "c", "hash-3", nil),
+		newMergeRangePullRequest("b", "d", "hash-4", stack),
+	}, nil)
+
+	pr1, pr2 := &PR{Number: 1}, &PR{Number: 2}
+	pr3, pr4 := &PR{Number: 3}, &PR{Number: 4}
+	plans, err := newStackRepository(t, gateway).PlanMergeRanges(
+		t.Context(),
+		[]forge.StackChange{
+			{Change: pr1, BaseBranch: "base"},
+			{Change: pr2, BaseChange: pr1, BaseBranch: "base"},
+			{Change: pr3, BaseChange: pr2, BaseBranch: "base"},
+			{Change: pr4, BaseChange: pr2, BaseBranch: "base"},
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, plans, 2)
+	assert.Equal(t, []int{1, 2, 4}, mergeRangePlanNumbers(plans[0]))
+	assert.Equal(t, []int{3}, mergeRangePlanNumbers(plans[1]))
+}
+
+func TestRepository_PlanMergeRanges_ignoresMergedStackMembers(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	stack := &github.PullRequestStack{
+		Number: 42,
+		Members: []github.PullRequestStackMember{
+			{Number: 9, State: github.PullRequestStateMerged},
+			{Number: 1, State: github.PullRequestStateOpen},
+			{Number: 2, State: github.PullRequestStateOpen},
+		},
+	}
+	gateway.EXPECT().PullRequestsForMergeRange(
+		gomock.Any(), "acme", "repo", []int{1, 2},
+	).Return([]*github.MergeRangePullRequest{
+		newMergeRangePullRequest("main", "a", "hash-1", stack),
+		newMergeRangePullRequest("a", "b", "hash-2", stack),
+	}, nil)
+
+	pr1, pr2 := &PR{Number: 1}, &PR{Number: 2}
+	plans, err := newStackRepository(t, gateway).PlanMergeRanges(
+		t.Context(),
+		[]forge.StackChange{
+			{Change: pr1, BaseBranch: "main"},
+			{Change: pr2, BaseChange: pr1, BaseBranch: "a"},
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, plans, 1)
+	assert.Equal(t, []int{1, 2}, mergeRangePlanNumbers(plans[0]))
+}
+
+func TestRepository_PlanMergeRanges_requiresLowestStackMember(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	stack := newPullRequestStack(42, 1, 2, 3)
+	gateway.EXPECT().PullRequestsForMergeRange(
+		gomock.Any(), "acme", "repo", []int{2, 3},
+	).Return([]*github.MergeRangePullRequest{
+		newMergeRangePullRequest("a", "b", "hash-2", stack),
+		newMergeRangePullRequest("b", "c", "hash-3", stack),
+	}, nil)
+
+	pr2, pr3 := &PR{Number: 2}, &PR{Number: 3}
+	plans, err := newStackRepository(t, gateway).PlanMergeRanges(
+		t.Context(),
+		[]forge.StackChange{
+			{Change: pr2, BaseBranch: "base"},
+			{Change: pr3, BaseChange: pr2, BaseBranch: "base"},
+		},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, plans)
+}
+
+func TestRepository_MergeRangeImmediate(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	stack := newPullRequestStack(42, 1, 2, 3)
+	gateway.EXPECT().PullRequestsForMergeRange(
+		gomock.Any(), "acme", "repo", []int{1, 2},
+	).Return([]*github.MergeRangePullRequest{
+		newMergeRangePullRequest("main", "bottom", "hash-1", stack),
+		newMergeRangePullRequest("bottom", "top", "hash-2", stack),
+	}, nil)
+	gateway.EXPECT().MergePullRequestAsync(gomock.Any(), &github.MergePullRequestAsyncInput{
+		Owner:             "acme",
+		Repo:              "repo",
+		PullRequestNumber: 2,
+		ExpectedHeadSHA:   "hash-2",
+		Method:            github.MergeMethodSquash,
+	}).Return(&github.AsyncMergeResult{
+		Status: github.AsyncMergeStatusMerged,
+	}, nil)
+
+	operation, err := newMergeRangePlan(t, gateway, 1, 2).Merge(
+		t.Context(),
+		forge.MergeRangeRequest{
+			Method: forge.MergeMethodSquash,
+			Changes: []forge.MergeRangeChange{
+				{Change: &PR{Number: 1}, Base: "main", Head: "bottom", HeadHash: "hash-1"},
+				{Change: &PR{Number: 2}, Base: "bottom", Head: "top", HeadHash: "hash-2"},
+			},
+		},
+	)
+	require.NoError(t, err)
+	assert.Nil(t, operation)
+}
+
+func TestRepository_MergeRangePendingOperation(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	gateway.EXPECT().PullRequestsForMergeRange(
+		gomock.Any(), "acme", "repo", []int{1},
+	).Return([]*github.MergeRangePullRequest{
+		newMergeRangePullRequest("main", "feature", "hash-1", nil),
+	}, nil)
+	gateway.EXPECT().MergePullRequestAsync(gomock.Any(), gomock.Any()).Return(
+		&github.AsyncMergeResult{
+			Status:      github.AsyncMergeStatusPending,
+			OperationID: "operation-1",
+		},
+		nil,
+	)
+	gateway.EXPECT().AsyncMergeResult(
+		gomock.Any(), "acme", "repo", 1, "operation-1",
+	).Return(&github.AsyncMergeResult{
+		Status: github.AsyncMergeStatusEnqueued,
+	}, nil)
+
+	operation, err := newMergeRangePlan(t, gateway, 1).Merge(
+		t.Context(),
+		forge.MergeRangeRequest{Changes: []forge.MergeRangeChange{
+			{Change: &PR{Number: 1}, Base: "main", Head: "feature", HeadHash: "hash-1"},
+		}},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, operation)
+
+	status, err := operation.Status(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, forge.MergeOperationAccepted, status)
+}
+
+func TestRepository_MergeRangeRejectsUnalignedPath(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	operation, err := newMergeRangePlan(t, gateway, 1, 2).Merge(
+		t.Context(),
+		forge.MergeRangeRequest{Changes: []forge.MergeRangeChange{
+			{Change: &PR{Number: 1}, Base: "main", Head: "bottom", HeadHash: "hash-1"},
+			{Change: &PR{Number: 2}, Base: "other", Head: "top", HeadHash: "hash-2"},
+		}},
+	)
+	assert.Nil(t, operation)
+	assert.ErrorContains(t, err, "does not match previous head branch")
+}
+
+func TestRepository_MergeRangeRejectsRemoteHeadChange(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	gateway.EXPECT().PullRequestsForMergeRange(
+		gomock.Any(), "acme", "repo", []int{1},
+	).Return([]*github.MergeRangePullRequest{
+		newMergeRangePullRequest("main", "feature", "remote-hash", nil),
+	}, nil)
+
+	operation, err := newMergeRangePlan(t, gateway, 1).Merge(
+		t.Context(),
+		forge.MergeRangeRequest{Changes: []forge.MergeRangeChange{
+			{Change: &PR{Number: 1}, Base: "main", Head: "feature", HeadHash: "expected-hash"},
+		}},
+	)
+	assert.Nil(t, operation)
+	assert.ErrorContains(t, err, "head commit")
+}
+
+func TestRepository_MergeRangeRequiresNativeStack(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	gateway.EXPECT().PullRequestsForMergeRange(
+		gomock.Any(), "acme", "repo", []int{1, 2},
+	).Return([]*github.MergeRangePullRequest{
+		newMergeRangePullRequest("main", "bottom", "hash-1", nil),
+		newMergeRangePullRequest("bottom", "top", "hash-2", nil),
+	}, nil)
+
+	operation, err := newMergeRangePlan(t, gateway, 1, 2).Merge(
+		t.Context(),
+		forge.MergeRangeRequest{Changes: []forge.MergeRangeChange{
+			{Change: &PR{Number: 1}, Base: "main", Head: "bottom", HeadHash: "hash-1"},
+			{Change: &PR{Number: 2}, Base: "bottom", Head: "top", HeadHash: "hash-2"},
+		}},
+	)
+	assert.Nil(t, operation)
+	assert.ErrorContains(t, err, "not in a GitHub native stack")
+}
+
+func TestRepository_MergeRangeUnsupported(t *testing.T) {
+	gateway := NewMockGithubGateway(gomock.NewController(t))
+	gateway.EXPECT().PullRequestsForMergeRange(
+		gomock.Any(), "acme", "repo", []int{1},
+	).Return([]*github.MergeRangePullRequest{
+		newMergeRangePullRequest("main", "feature", "hash-1", nil),
+	}, nil)
+	gateway.EXPECT().MergePullRequestAsync(gomock.Any(), gomock.Any()).Return(
+		nil,
+		github.ErrNotFound,
+	)
+
+	operation, err := newMergeRangePlan(t, gateway, 1).Merge(
+		t.Context(),
+		forge.MergeRangeRequest{Changes: []forge.MergeRangeChange{
+			{Change: &PR{Number: 1}, Base: "main", Head: "feature", HeadHash: "hash-1"},
+		}},
+	)
+	assert.Nil(t, operation)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, forge.ErrUnsupported)
+	assert.ErrorIs(t, err, github.ErrNotFound)
+}
+
+func newMergeRangePlan(
+	t *testing.T,
+	gateway *MockGithubGateway,
+	numbers ...int,
+) *githubMergeRangePlan {
+	changes := make([]forge.ChangeID, len(numbers))
+	for i, number := range numbers {
+		changes[i] = &PR{Number: number}
+	}
+	return &githubMergeRangePlan{
+		repository: newStackRepository(t, gateway),
+		changes:    changes,
+	}
+}
+
+func mergeRangePlanNumbers(plan forge.MergeRangePlan) []int {
+	return slices.Collect(func(yield func(int) bool) {
+		for _, change := range plan.Changes() {
+			if !yield(mustPR(change).Number) {
+				return
+			}
+		}
+	})
+}
+
+func newMergeRangePullRequest(
+	base string,
+	head string,
+	headHash string,
+	stack *github.PullRequestStack,
+) *github.MergeRangePullRequest {
+	return &github.MergeRangePullRequest{
+		State:               github.PullRequestStateOpen,
+		BaseRefName:         base,
+		HeadRefName:         head,
+		HeadRefOID:          headHash,
+		HeadRepositoryOwner: "acme",
+		HeadRepositoryName:  "repo",
+		Stack:               stack,
+	}
+}

--- a/internal/forge/github/mocks_test.go
+++ b/internal/forge/github/mocks_test.go
@@ -273,6 +273,45 @@ func (c *MockGithubGatewayAddPullRequestsToStackCall) DoAndReturn(f func(context
 	return c
 }
 
+// AsyncMergeResult mocks base method.
+func (m *MockGithubGateway) AsyncMergeResult(arg0 context.Context, arg1, arg2 string, arg3 int, arg4 string) (*github.AsyncMergeResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AsyncMergeResult", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(*github.AsyncMergeResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AsyncMergeResult indicates an expected call of AsyncMergeResult.
+func (mr *MockGithubGatewayMockRecorder) AsyncMergeResult(arg0, arg1, arg2, arg3, arg4 any) *MockGithubGatewayAsyncMergeResultCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AsyncMergeResult", reflect.TypeOf((*MockGithubGateway)(nil).AsyncMergeResult), arg0, arg1, arg2, arg3, arg4)
+	return &MockGithubGatewayAsyncMergeResultCall{Call: call}
+}
+
+// MockGithubGatewayAsyncMergeResultCall wrap *gomock.Call
+type MockGithubGatewayAsyncMergeResultCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockGithubGatewayAsyncMergeResultCall) Return(arg0 *github.AsyncMergeResult, arg1 error) *MockGithubGatewayAsyncMergeResultCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockGithubGatewayAsyncMergeResultCall) Do(f func(context.Context, string, string, int, string) (*github.AsyncMergeResult, error)) *MockGithubGatewayAsyncMergeResultCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockGithubGatewayAsyncMergeResultCall) DoAndReturn(f func(context.Context, string, string, int, string) (*github.AsyncMergeResult, error)) *MockGithubGatewayAsyncMergeResultCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ChangeStatuses mocks base method.
 func (m *MockGithubGateway) ChangeStatuses(arg0 context.Context, arg1 []github.ID) ([]*github.ChangeStatus, error) {
 	m.ctrl.T.Helper()
@@ -890,6 +929,45 @@ func (c *MockGithubGatewayMergePullRequestCall) DoAndReturn(f func(context.Conte
 	return c
 }
 
+// MergePullRequestAsync mocks base method.
+func (m *MockGithubGateway) MergePullRequestAsync(arg0 context.Context, arg1 *github.MergePullRequestAsyncInput) (*github.AsyncMergeResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MergePullRequestAsync", arg0, arg1)
+	ret0, _ := ret[0].(*github.AsyncMergeResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MergePullRequestAsync indicates an expected call of MergePullRequestAsync.
+func (mr *MockGithubGatewayMockRecorder) MergePullRequestAsync(arg0, arg1 any) *MockGithubGatewayMergePullRequestAsyncCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MergePullRequestAsync", reflect.TypeOf((*MockGithubGateway)(nil).MergePullRequestAsync), arg0, arg1)
+	return &MockGithubGatewayMergePullRequestAsyncCall{Call: call}
+}
+
+// MockGithubGatewayMergePullRequestAsyncCall wrap *gomock.Call
+type MockGithubGatewayMergePullRequestAsyncCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockGithubGatewayMergePullRequestAsyncCall) Return(arg0 *github.AsyncMergeResult, arg1 error) *MockGithubGatewayMergePullRequestAsyncCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockGithubGatewayMergePullRequestAsyncCall) Do(f func(context.Context, *github.MergePullRequestAsyncInput) (*github.AsyncMergeResult, error)) *MockGithubGatewayMergePullRequestAsyncCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockGithubGatewayMergePullRequestAsyncCall) DoAndReturn(f func(context.Context, *github.MergePullRequestAsyncInput) (*github.AsyncMergeResult, error)) *MockGithubGatewayMergePullRequestAsyncCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // PullRequest mocks base method.
 func (m *MockGithubGateway) PullRequest(arg0 context.Context, arg1, arg2 string, arg3 int) (*github.PullRequest, error) {
 	m.ctrl.T.Helper()
@@ -1156,6 +1234,45 @@ func (c *MockGithubGatewayPullRequestReviewThreadsCall) Do(f func(context.Contex
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockGithubGatewayPullRequestReviewThreadsCall) DoAndReturn(f func(context.Context, github.ID, *github.PaginationOptions) iter.Seq2[*github.PullRequestReviewThread, error]) *MockGithubGatewayPullRequestReviewThreadsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// PullRequestsForMergeRange mocks base method.
+func (m *MockGithubGateway) PullRequestsForMergeRange(arg0 context.Context, arg1, arg2 string, arg3 []int) ([]*github.MergeRangePullRequest, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PullRequestsForMergeRange", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].([]*github.MergeRangePullRequest)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PullRequestsForMergeRange indicates an expected call of PullRequestsForMergeRange.
+func (mr *MockGithubGatewayMockRecorder) PullRequestsForMergeRange(arg0, arg1, arg2, arg3 any) *MockGithubGatewayPullRequestsForMergeRangeCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullRequestsForMergeRange", reflect.TypeOf((*MockGithubGateway)(nil).PullRequestsForMergeRange), arg0, arg1, arg2, arg3)
+	return &MockGithubGatewayPullRequestsForMergeRangeCall{Call: call}
+}
+
+// MockGithubGatewayPullRequestsForMergeRangeCall wrap *gomock.Call
+type MockGithubGatewayPullRequestsForMergeRangeCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockGithubGatewayPullRequestsForMergeRangeCall) Return(arg0 []*github.MergeRangePullRequest, arg1 error) *MockGithubGatewayPullRequestsForMergeRangeCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockGithubGatewayPullRequestsForMergeRangeCall) Do(f func(context.Context, string, string, []int) ([]*github.MergeRangePullRequest, error)) *MockGithubGatewayPullRequestsForMergeRangeCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockGithubGatewayPullRequestsForMergeRangeCall) DoAndReturn(f func(context.Context, string, string, []int) ([]*github.MergeRangePullRequest, error)) *MockGithubGatewayPullRequestsForMergeRangeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/forge/github/repository.go
+++ b/internal/forge/github/repository.go
@@ -22,6 +22,7 @@ type githubGateway interface {
 	AddPullRequestReviewThreadReply(context.Context, *github.AddPullRequestReviewThreadReplyInput) (*github.AddedPullRequestReviewComment, error)
 	AddPullRequestsToStack(context.Context, *github.AddPullRequestsToStackInput) error
 	AddPullRequestMetadata(context.Context, *github.PullRequestMetadataInput) error
+	AsyncMergeResult(context.Context, string, string, int, string) (*github.AsyncMergeResult, error)
 	ChangeStatuses(context.Context, []github.ID) ([]*github.ChangeStatus, error)
 	ChangeTemplates(context.Context, string, string) ([]*github.ChangeTemplate, error)
 	CheckPullRequestStacks(context.Context, string, string) error
@@ -38,7 +39,9 @@ type githubGateway interface {
 	LabelIDs(context.Context, string, string, []string) ([]github.ID, error)
 	MarkPullRequestReadyForReview(context.Context, github.ID) error
 	MergePullRequest(context.Context, *github.MergePullRequestInput) error
+	MergePullRequestAsync(context.Context, *github.MergePullRequestAsyncInput) (*github.AsyncMergeResult, error)
 	PullRequest(context.Context, string, string, int) (*github.PullRequest, error)
+	PullRequestsForMergeRange(context.Context, string, string, []int) ([]*github.MergeRangePullRequest, error)
 	PullRequestsForStackUpdate(context.Context, string, string, []int) ([]*github.StackUpdatePullRequest, error)
 	PullRequestComments(context.Context, github.ID, *github.PaginationOptions) iter.Seq2[*github.Comment, error]
 	PullRequestID(context.Context, string, string, int) (github.ID, error)

--- a/internal/forge/github/testdata/TestIntegration/MergeRange/mergeRangeBottomBranch
+++ b/internal/forge/github/testdata/TestIntegration/MergeRange/mergeRangeBottomBranch
@@ -1,0 +1,1 @@
+"merge-range-bottom-bZiK8Eda"

--- a/internal/forge/github/testdata/TestIntegration/MergeRange/mergeRangeTopBranch
+++ b/internal/forge/github/testdata/TestIntegration/MergeRange/mergeRangeTopBranch
@@ -1,0 +1,1 @@
+"merge-range-top-hIOTMX1T"

--- a/internal/forge/github/testdata/TestIntegration_DivergentStackMerge/aBranch
+++ b/internal/forge/github/testdata/TestIntegration_DivergentStackMerge/aBranch
@@ -1,0 +1,1 @@
+"divergent-stack-a-pO7wJfwF"

--- a/internal/forge/github/testdata/TestIntegration_DivergentStackMerge/bBranch
+++ b/internal/forge/github/testdata/TestIntegration_DivergentStackMerge/bBranch
@@ -1,0 +1,1 @@
+"divergent-stack-b-9iT5TOLK"

--- a/internal/forge/github/testdata/TestIntegration_DivergentStackMerge/cBranch
+++ b/internal/forge/github/testdata/TestIntegration_DivergentStackMerge/cBranch
@@ -1,0 +1,1 @@
+"divergent-stack-c-iXygp4Wc"

--- a/internal/forge/github/testdata/TestIntegration_DivergentStackMerge/dBranch
+++ b/internal/forge/github/testdata/TestIntegration_DivergentStackMerge/dBranch
@@ -1,0 +1,1 @@
+"divergent-stack-d-HtiSetd4"

--- a/internal/forge/github/testdata/fixtures/TestIntegration/MergeRange.yaml
+++ b/internal/forge/github/testdata/fixtures/TestIntegration/MergeRange.yaml
@@ -1,0 +1,315 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 142
+        host: api.github.com
+        body: |
+            {"query":"query($owner:String!$repo:String!){repository(owner: $owner, name: $repo){id}}","variables":{"owner":"test-owner","repo":"test-repo"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"repository":{"id":"R_kgDOMVd0xg"}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 261.712291ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 329
+        host: api.github.com
+        body: |
+            {"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"main","headRefName":"merge-range-bottom-bZiK8Eda","title":"Merge range bottom merge-range-bottom-bZiK8Eda","body":"Merge range integration test"}}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs793H6g","number":158,"url":"https://github.com/test-owner/test-repo/pull/158"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1.667342s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 343
+        host: api.github.com
+        body: |
+            {"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"merge-range-bottom-bZiK8Eda","headRefName":"merge-range-top-hIOTMX1T","title":"Merge range top merge-range-top-hIOTMX1T","body":"Merge range integration test"}}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs793H8d","number":159,"url":"https://github.com/test-owner/test-repo/pull/159"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1.578511875s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 342
+        host: api.github.com
+        body: |
+            {"query":"query($owner:String!,$repo:String!,$pr0:Int!,$pr1:Int!){repository(owner: $owner, name: $repo){pr0:pullRequest(number: $pr0){state,headRepository{owner{login},name},stack{id}},pr1:pullRequest(number: $pr1){state,headRepository{owner{login},name},stack{id}}}}","variables":{"owner":"test-owner","pr0":158,"pr1":159,"repo":"test-repo"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"repository":{"pr0":{"state":"OPEN","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":null},"pr1":{"state":"OPEN","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":null}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 358.217542ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 28
+        host: api.github.com
+        body: |
+            {"pull_requests":[158,159]}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/repos/test-owner/test-repo/stacks
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 3367
+        body: '{"id":302729,"number":160,"node_id":"PRS_kwDOMVd0xs4ABJ6J","url":"https://api.github.com/repos/test-owner/test-repo/stacks/160","base":{"ref":"main"},"open":true,"created_at":"2026-08-12T04:18:42Z","pull_requests":[{"url":"https://api.github.com/repos/test-owner/test-repo/pulls/158","id":4259085984,"number":158,"head":{"ref":"merge-range-bottom-bZiK8Eda","sha":"24777ef044c0a4bc712d1345bf9c0ed8b791197b","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"base":{"ref":"main","sha":"7d4bdbcf64b4302bdb1af0923056b479a32a5eb5","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"node_id":"PR_kwDOMVd0xs793H6g","title":"Merge range bottom merge-range-bottom-bZiK8Eda","state":"open","merged_at":null,"draft":false,"html_url":"https://github.com/test-owner/test-repo/pull/158","user":{"login":"test-owner","id":41730,"node_id":"MDQ6VXNlcjQxNzMw","avatar_url":"https://avatars.githubusercontent.com/u/41730?v=4","gravatar_id":"","url":"https://api.github.com/users/test-owner","html_url":"https://github.com/test-owner","followers_url":"https://api.github.com/users/test-owner/followers","following_url":"https://api.github.com/users/test-owner/following{/other_user}","gists_url":"https://api.github.com/users/test-owner/gists{/gist_id}","starred_url":"https://api.github.com/users/test-owner/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/test-owner/subscriptions","organizations_url":"https://api.github.com/users/test-owner/orgs","repos_url":"https://api.github.com/users/test-owner/repos","events_url":"https://api.github.com/users/test-owner/events{/privacy}","received_events_url":"https://api.github.com/users/test-owner/received_events","type":"User","user_view_type":"public","site_admin":false}},{"url":"https://api.github.com/repos/test-owner/test-repo/pulls/159","id":4259086109,"number":159,"head":{"ref":"merge-range-top-hIOTMX1T","sha":"bb58f1370879a404c18b51898dcf2e08ea740727","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"base":{"ref":"merge-range-bottom-bZiK8Eda","sha":"24777ef044c0a4bc712d1345bf9c0ed8b791197b","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"node_id":"PR_kwDOMVd0xs793H8d","title":"Merge range top merge-range-top-hIOTMX1T","state":"open","merged_at":null,"draft":false,"html_url":"https://github.com/test-owner/test-repo/pull/159","user":{"login":"test-owner","id":41730,"node_id":"MDQ6VXNlcjQxNzMw","avatar_url":"https://avatars.githubusercontent.com/u/41730?v=4","gravatar_id":"","url":"https://api.github.com/users/test-owner","html_url":"https://github.com/test-owner","followers_url":"https://api.github.com/users/test-owner/followers","following_url":"https://api.github.com/users/test-owner/following{/other_user}","gists_url":"https://api.github.com/users/test-owner/gists{/gist_id}","starred_url":"https://api.github.com/users/test-owner/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/test-owner/subscriptions","organizations_url":"https://api.github.com/users/test-owner/orgs","repos_url":"https://api.github.com/users/test-owner/repos","events_url":"https://api.github.com/users/test-owner/events{/privacy}","received_events_url":"https://api.github.com/users/test-owner/received_events","type":"User","user_view_type":"public","site_admin":false}}]}'
+        headers:
+            Content-Length:
+                - "3367"
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 354.559208ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 153
+        host: api.github.com
+        body: |
+            {"query":"query($ids:[ID!]!){nodes(ids: $ids){... on PullRequest{state,headRefOid}}}","variables":{"ids":["PR_kwDOMVd0xs793H6g","PR_kwDOMVd0xs793H8d"]}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"nodes":[{"state":"OPEN","headRefOid":"24777ef044c0a4bc712d1345bf9c0ed8b791197b"},{"state":"OPEN","headRefOid":"bb58f1370879a404c18b51898dcf2e08ea740727"}]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 388.325459ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 428
+        host: api.github.com
+        body: |
+            {"query":"query($owner:String!,$repo:String!,$pr0:Int!,$pr1:Int!){repository(owner: $owner, name: $repo){pr0:pullRequest(number: $pr0){state,isDraft,baseRefName,headRefName,headRefOid,headRepository{owner{login},name},stack{id}},pr1:pullRequest(number: $pr1){state,isDraft,baseRefName,headRefName,headRefOid,headRepository{owner{login},name},stack{id}}}}","variables":{"owner":"test-owner","pr0":158,"pr1":159,"repo":"test-repo"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"repository":{"pr0":{"state":"OPEN","isDraft":false,"baseRefName":"main","headRefName":"merge-range-bottom-bZiK8Eda","headRefOid":"24777ef044c0a4bc712d1345bf9c0ed8b791197b","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":{"id":"PRS_kwDOMVd0xs4ABJ6J"}},"pr1":{"state":"OPEN","isDraft":false,"baseRefName":"merge-range-bottom-bZiK8Eda","headRefName":"merge-range-top-hIOTMX1T","headRefOid":"bb58f1370879a404c18b51898dcf2e08ea740727","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":{"id":"PRS_kwDOMVd0xs4ABJ6J"}}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 272.209958ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 184
+        host: api.github.com
+        body: |
+            {"query":"query($ids:[ID!]!){nodes(ids: $ids){... on PullRequestStack{id,number,entries(first: 100){nodes{pullRequest{number,state}}}}}}","variables":{"ids":["PRS_kwDOMVd0xs4ABJ6J"]}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"nodes":[{"id":"PRS_kwDOMVd0xs4ABJ6J","number":160,"entries":{"nodes":[{"pullRequest":{"number":158,"state":"OPEN"}},{"pullRequest":{"number":159,"state":"OPEN"}}]}}]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 656.415ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 76
+        host: api.github.com
+        body: |
+            {"sha":"bb58f1370879a404c18b51898dcf2e08ea740727","merge_action":"default"}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/repos/test-owner/test-repo/pulls/159/merge-async
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 227
+        body: '{"status":"pending","details":{"message":"Merge request enqueued.","uuid":"2f776f09-a980-40c7-a01d-882c7d6596b1","merge_method":"default","merge_action":"default","expected_head_sha":"bb58f1370879a404c18b51898dcf2e08ea740727"}}'
+        headers:
+            Content-Length:
+                - "227"
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 211.988042ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.github.com
+        url: https://api.github.com/repos/test-owner/test-repo/pulls/159/merge-async/2f776f09-a980-40c7-a01d-882c7d6596b1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"status":"pending","details":{"message":"Merge request is in progress.","uuid":"2f776f09-a980-40c7-a01d-882c7d6596b1","merge_method":"default","merge_action":"default","expected_head_sha":"bb58f1370879a404c18b51898dcf2e08ea740727"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 181.046583ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.github.com
+        url: https://api.github.com/repos/test-owner/test-repo/pulls/159/merge-async/2f776f09-a980-40c7-a01d-882c7d6596b1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"status":"merged","details":{"message":"Pull request was merged.","sha":"da312ddc707bee1d1ea938427b95ce9e580a4c16"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 168.156208ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 153
+        host: api.github.com
+        body: |
+            {"query":"query($ids:[ID!]!){nodes(ids: $ids){... on PullRequest{state,headRefOid}}}","variables":{"ids":["PR_kwDOMVd0xs793H6g","PR_kwDOMVd0xs793H8d"]}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"nodes":[{"state":"MERGED","headRefOid":"24777ef044c0a4bc712d1345bf9c0ed8b791197b"},{"state":"MERGED","headRefOid":"bb58f1370879a404c18b51898dcf2e08ea740727"}]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 496.802291ms

--- a/internal/forge/github/testdata/fixtures/TestIntegration_DivergentStackMerge.yaml
+++ b/internal/forge/github/testdata/fixtures/TestIntegration_DivergentStackMerge.yaml
@@ -1,0 +1,451 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 142
+        host: api.github.com
+        body: |
+            {"query":"query($owner:String!$repo:String!){repository(owner: $owner, name: $repo){id}}","variables":{"owner":"test-owner","repo":"test-repo"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"repository":{"id":"R_kgDOMVd0xg"}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 321.368667ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 344
+        host: api.github.com
+        body: |
+            {"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"main","headRefName":"divergent-stack-a-pO7wJfwF","title":"Divergent native stack A divergent-stack-a-pO7wJfwF","body":"Divergent native stack integration test"}}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs7-FQFU","number":170,"url":"https://github.com/test-owner/test-repo/pull/170"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1.330168625s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 366
+        host: api.github.com
+        body: |
+            {"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"divergent-stack-a-pO7wJfwF","headRefName":"divergent-stack-b-9iT5TOLK","title":"Divergent native stack B divergent-stack-b-9iT5TOLK","body":"Divergent native stack integration test"}}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs7-FQHm","number":171,"url":"https://github.com/test-owner/test-repo/pull/171"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 935.200041ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 366
+        host: api.github.com
+        body: |
+            {"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"divergent-stack-b-9iT5TOLK","headRefName":"divergent-stack-c-iXygp4Wc","title":"Divergent native stack C divergent-stack-c-iXygp4Wc","body":"Divergent native stack integration test"}}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs7-FQJT","number":172,"url":"https://github.com/test-owner/test-repo/pull/172"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1.0237815s
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 366
+        host: api.github.com
+        body: |
+            {"query":"mutation($input:CreatePullRequestInput!){createPullRequest(input: $input){pullRequest{id,number,url}}}","variables":{"input":{"repositoryId":"R_kgDOMVd0xg","baseRefName":"divergent-stack-b-9iT5TOLK","headRefName":"divergent-stack-d-HtiSetd4","title":"Divergent native stack D divergent-stack-d-HtiSetd4","body":"Divergent native stack integration test"}}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"createPullRequest":{"pullRequest":{"id":"PR_kwDOMVd0xs7-FQMA","number":173,"url":"https://github.com/test-owner/test-repo/pull/173"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1.515385583s
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 443
+        host: api.github.com
+        body: |
+            {"query":"query($owner:String!,$repo:String!,$pr0:Int!,$pr1:Int!,$pr2:Int!){repository(owner: $owner, name: $repo){pr0:pullRequest(number: $pr0){state,headRepository{owner{login},name},stack{id}},pr1:pullRequest(number: $pr1){state,headRepository{owner{login},name},stack{id}},pr2:pullRequest(number: $pr2){state,headRepository{owner{login},name},stack{id}}}}","variables":{"owner":"test-owner","pr0":170,"pr1":171,"pr2":172,"repo":"test-repo"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"repository":{"pr0":{"state":"OPEN","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":null},"pr1":{"state":"OPEN","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":null},"pr2":{"state":"OPEN","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":null}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 428.405333ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 32
+        host: api.github.com
+        body: |
+            {"pull_requests":[170,171,172]}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/repos/test-owner/test-repo/stacks
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 4979
+        body: '{"id":313473,"number":174,"node_id":"PRS_kwDOMVd0xs4ABMiB","url":"https://api.github.com/repos/test-owner/test-repo/stacks/174","base":{"ref":"main"},"open":true,"created_at":"2026-08-12T13:40:09Z","pull_requests":[{"url":"https://api.github.com/repos/test-owner/test-repo/pulls/170","id":4262789460,"number":170,"head":{"ref":"divergent-stack-a-pO7wJfwF","sha":"cbba7e8dcfec641a88f530c0ccc7c8ce535aeeae","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"base":{"ref":"main","sha":"671f333e4fd471ee58f11ed382670d7f4ff92995","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"node_id":"PR_kwDOMVd0xs7-FQFU","title":"Divergent native stack A divergent-stack-a-pO7wJfwF","state":"open","merged_at":null,"draft":false,"html_url":"https://github.com/test-owner/test-repo/pull/170","user":{"login":"test-owner","id":41730,"node_id":"MDQ6VXNlcjQxNzMw","avatar_url":"https://avatars.githubusercontent.com/u/41730?v=4","gravatar_id":"","url":"https://api.github.com/users/test-owner","html_url":"https://github.com/test-owner","followers_url":"https://api.github.com/users/test-owner/followers","following_url":"https://api.github.com/users/test-owner/following{/other_user}","gists_url":"https://api.github.com/users/test-owner/gists{/gist_id}","starred_url":"https://api.github.com/users/test-owner/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/test-owner/subscriptions","organizations_url":"https://api.github.com/users/test-owner/orgs","repos_url":"https://api.github.com/users/test-owner/repos","events_url":"https://api.github.com/users/test-owner/events{/privacy}","received_events_url":"https://api.github.com/users/test-owner/received_events","type":"User","user_view_type":"public","site_admin":false}},{"url":"https://api.github.com/repos/test-owner/test-repo/pulls/171","id":4262789606,"number":171,"head":{"ref":"divergent-stack-b-9iT5TOLK","sha":"04f50ba691258ef2c136849b1ad0a9e45a6d964a","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"base":{"ref":"divergent-stack-a-pO7wJfwF","sha":"cbba7e8dcfec641a88f530c0ccc7c8ce535aeeae","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"node_id":"PR_kwDOMVd0xs7-FQHm","title":"Divergent native stack B divergent-stack-b-9iT5TOLK","state":"open","merged_at":null,"draft":false,"html_url":"https://github.com/test-owner/test-repo/pull/171","user":{"login":"test-owner","id":41730,"node_id":"MDQ6VXNlcjQxNzMw","avatar_url":"https://avatars.githubusercontent.com/u/41730?v=4","gravatar_id":"","url":"https://api.github.com/users/test-owner","html_url":"https://github.com/test-owner","followers_url":"https://api.github.com/users/test-owner/followers","following_url":"https://api.github.com/users/test-owner/following{/other_user}","gists_url":"https://api.github.com/users/test-owner/gists{/gist_id}","starred_url":"https://api.github.com/users/test-owner/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/test-owner/subscriptions","organizations_url":"https://api.github.com/users/test-owner/orgs","repos_url":"https://api.github.com/users/test-owner/repos","events_url":"https://api.github.com/users/test-owner/events{/privacy}","received_events_url":"https://api.github.com/users/test-owner/received_events","type":"User","user_view_type":"public","site_admin":false}},{"url":"https://api.github.com/repos/test-owner/test-repo/pulls/172","id":4262789715,"number":172,"head":{"ref":"divergent-stack-c-iXygp4Wc","sha":"5e059d8b881a4c03271f7bd6eff43496fb7bfba2","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"base":{"ref":"divergent-stack-b-9iT5TOLK","sha":"04f50ba691258ef2c136849b1ad0a9e45a6d964a","repo":{"id":827815110,"url":"https://api.github.com/repos/test-owner/test-repo","name":"test-repo"}},"node_id":"PR_kwDOMVd0xs7-FQJT","title":"Divergent native stack C divergent-stack-c-iXygp4Wc","state":"open","merged_at":null,"draft":false,"html_url":"https://github.com/test-owner/test-repo/pull/172","user":{"login":"test-owner","id":41730,"node_id":"MDQ6VXNlcjQxNzMw","avatar_url":"https://avatars.githubusercontent.com/u/41730?v=4","gravatar_id":"","url":"https://api.github.com/users/test-owner","html_url":"https://github.com/test-owner","followers_url":"https://api.github.com/users/test-owner/followers","following_url":"https://api.github.com/users/test-owner/following{/other_user}","gists_url":"https://api.github.com/users/test-owner/gists{/gist_id}","starred_url":"https://api.github.com/users/test-owner/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/test-owner/subscriptions","organizations_url":"https://api.github.com/users/test-owner/orgs","repos_url":"https://api.github.com/users/test-owner/repos","events_url":"https://api.github.com/users/test-owner/events{/privacy}","received_events_url":"https://api.github.com/users/test-owner/received_events","type":"User","user_view_type":"public","site_admin":false}}]}'
+        headers:
+            Content-Length:
+                - "4979"
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 514.412625ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 197
+        host: api.github.com
+        body: |
+            {"query":"query($ids:[ID!]!){nodes(ids: $ids){... on PullRequest{state,headRefOid}}}","variables":{"ids":["PR_kwDOMVd0xs7-FQFU","PR_kwDOMVd0xs7-FQHm","PR_kwDOMVd0xs7-FQJT","PR_kwDOMVd0xs7-FQMA"]}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"nodes":[{"state":"OPEN","headRefOid":"cbba7e8dcfec641a88f530c0ccc7c8ce535aeeae"},{"state":"OPEN","headRefOid":"04f50ba691258ef2c136849b1ad0a9e45a6d964a"},{"state":"OPEN","headRefOid":"5e059d8b881a4c03271f7bd6eff43496fb7bfba2"},{"state":"OPEN","headRefOid":"e6ea6d4b4f57a71e97e5a2c3d9d4a8325a56bc77"}]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 289.063708ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 572
+        host: api.github.com
+        body: |
+            {"query":"query($owner:String!,$repo:String!,$pr0:Int!,$pr1:Int!,$pr2:Int!){repository(owner: $owner, name: $repo){pr0:pullRequest(number: $pr0){state,isDraft,baseRefName,headRefName,headRefOid,headRepository{owner{login},name},stack{id}},pr1:pullRequest(number: $pr1){state,isDraft,baseRefName,headRefName,headRefOid,headRepository{owner{login},name},stack{id}},pr2:pullRequest(number: $pr2){state,isDraft,baseRefName,headRefName,headRefOid,headRepository{owner{login},name},stack{id}}}}","variables":{"owner":"test-owner","pr0":170,"pr1":171,"pr2":172,"repo":"test-repo"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"repository":{"pr0":{"state":"OPEN","isDraft":false,"baseRefName":"main","headRefName":"divergent-stack-a-pO7wJfwF","headRefOid":"cbba7e8dcfec641a88f530c0ccc7c8ce535aeeae","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":{"id":"PRS_kwDOMVd0xs4ABMiB"}},"pr1":{"state":"OPEN","isDraft":false,"baseRefName":"divergent-stack-a-pO7wJfwF","headRefName":"divergent-stack-b-9iT5TOLK","headRefOid":"04f50ba691258ef2c136849b1ad0a9e45a6d964a","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":{"id":"PRS_kwDOMVd0xs4ABMiB"}},"pr2":{"state":"OPEN","isDraft":false,"baseRefName":"divergent-stack-b-9iT5TOLK","headRefName":"divergent-stack-c-iXygp4Wc","headRefOid":"5e059d8b881a4c03271f7bd6eff43496fb7bfba2","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":{"id":"PRS_kwDOMVd0xs4ABMiB"}}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 319.684375ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 184
+        host: api.github.com
+        body: |
+            {"query":"query($ids:[ID!]!){nodes(ids: $ids){... on PullRequestStack{id,number,entries(first: 100){nodes{pullRequest{number,state}}}}}}","variables":{"ids":["PRS_kwDOMVd0xs4ABMiB"]}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"nodes":[{"id":"PRS_kwDOMVd0xs4ABMiB","number":174,"entries":{"nodes":[{"pullRequest":{"number":170,"state":"OPEN"}},{"pullRequest":{"number":171,"state":"OPEN"}},{"pullRequest":{"number":172,"state":"OPEN"}}]}}]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 410.232083ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 100
+        host: api.github.com
+        body: |
+            {"sha":"5e059d8b881a4c03271f7bd6eff43496fb7bfba2","merge_method":"squash","merge_action":"default"}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/repos/test-owner/test-repo/pulls/172/merge-async
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 226
+        body: '{"status":"pending","details":{"message":"Merge request enqueued.","uuid":"c414aa90-f853-4746-ac39-13f27c62ac22","merge_method":"squash","merge_action":"default","expected_head_sha":"5e059d8b881a4c03271f7bd6eff43496fb7bfba2"}}'
+        headers:
+            Content-Length:
+                - "226"
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 285.034041ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.github.com
+        url: https://api.github.com/repos/test-owner/test-repo/pulls/172/merge-async/c414aa90-f853-4746-ac39-13f27c62ac22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"status":"pending","details":{"message":"Merge request is in progress.","uuid":"c414aa90-f853-4746-ac39-13f27c62ac22","merge_method":"squash","merge_action":"default","expected_head_sha":"5e059d8b881a4c03271f7bd6eff43496fb7bfba2"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 193.626208ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.github.com
+        url: https://api.github.com/repos/test-owner/test-repo/pulls/172/merge-async/c414aa90-f853-4746-ac39-13f27c62ac22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"status":"merged","details":{"message":"Pull request was merged.","sha":"64adfb2f4b54a69373ea283c80837cc220eb94ba"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 232.69575ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 175
+        host: api.github.com
+        body: |
+            {"query":"query($ids:[ID!]!){nodes(ids: $ids){... on PullRequest{state,headRefOid}}}","variables":{"ids":["PR_kwDOMVd0xs7-FQFU","PR_kwDOMVd0xs7-FQHm","PR_kwDOMVd0xs7-FQJT"]}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"nodes":[{"state":"MERGED","headRefOid":"cbba7e8dcfec641a88f530c0ccc7c8ce535aeeae"},{"state":"MERGED","headRefOid":"04f50ba691258ef2c136849b1ad0a9e45a6d964a"},{"state":"MERGED","headRefOid":"5e059d8b881a4c03271f7bd6eff43496fb7bfba2"}]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 341.735667ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 131
+        host: api.github.com
+        body: |
+            {"query":"query($ids:[ID!]!){nodes(ids: $ids){... on PullRequest{state,headRefOid}}}","variables":{"ids":["PR_kwDOMVd0xs7-FQMA"]}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"data":{"nodes":[{"state":"OPEN","headRefOid":"e6ea6d4b4f57a71e97e5a2c3d9d4a8325a56bc77"}]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 273.861042ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 284
+        host: api.github.com
+        body: |
+            {"query":"query($owner:String!,$repo:String!,$pr0:Int!){repository(owner: $owner, name: $repo){pr0:pullRequest(number: $pr0){state,isDraft,baseRefName,headRefName,headRefOid,headRepository{owner{login},name},stack{id}}}}","variables":{"owner":"test-owner","pr0":173,"repo":"test-repo"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"repository":{"pr0":{"state":"OPEN","isDraft":false,"baseRefName":"divergent-stack-b-9iT5TOLK","headRefName":"divergent-stack-d-HtiSetd4","headRefOid":"e6ea6d4b4f57a71e97e5a2c3d9d4a8325a56bc77","headRepository":{"owner":{"login":"test-owner"},"name":"test-repo"},"stack":null}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 314.393959ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 139
+        host: api.github.com
+        body: |
+            {"query":"query($id:ID!){node(id: $id){... on PullRequest{mergeable,mergeStateStatus,isDraft}}}","variables":{"id":"PR_kwDOMVd0xs7-FQMA"}}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.github.com/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"node":{"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","isDraft":false}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 776.866875ms

--- a/internal/forge/merge.go
+++ b/internal/forge/merge.go
@@ -1,6 +1,7 @@
 package forge
 
 import (
+	"context"
 	"encoding"
 	"fmt"
 	"strings"
@@ -22,6 +23,81 @@ type MergeChangeOptions struct {
 	// Not all forges support this; unsupported forges
 	// ignore the field.
 	HeadHash git.Hash
+}
+
+// MergeRangeRequest gives the expected provider-facing state of a non-empty
+// linear path from its lowest change upward.
+// Each change after the first must target the previous change's head branch.
+// Together with each exact head commit, that alignment lets the forge reject a
+// stale or partially restacked path before requesting an atomic merge.
+type MergeRangeRequest struct {
+	// Changes lists the changes from bottom to top.
+	Changes []MergeRangeChange // required
+
+	// Method selects one merge strategy for the complete path.
+	// If zero, the forge uses its repository default.
+	Method MergeMethod
+}
+
+// MergeRangeChange identifies one change and the exact remote relationship it
+// must still have before the forge starts merging the path.
+type MergeRangeChange struct {
+	// Change identifies the change to merge.
+	Change ChangeID // required
+
+	// Base is the expected provider-facing base branch name for Change.
+	Base string // required
+
+	// Head is the expected provider-facing head branch name for Change.
+	Head string // required
+
+	// HeadHash is the exact expected head commit of Change.
+	HeadHash git.Hash // required
+}
+
+// MergeOperation reports asynchronous acceptance of a merge range.
+type MergeOperation interface {
+	// Status performs one provider status probe.
+	// Pending means the provider has not accepted the request yet.
+	// Accepted means the request was accepted for direct execution or queueing;
+	// callers must continue observing change states for final completion.
+	Status(context.Context) (MergeOperationStatus, error)
+}
+
+// MergeOperationStatus describes asynchronous merge request acceptance.
+// The zero value is invalid.
+type MergeOperationStatus int
+
+const (
+	// MergeOperationPending means the provider is still processing the request.
+	MergeOperationPending MergeOperationStatus = iota + 1
+
+	// MergeOperationAccepted means the provider accepted the request.
+	MergeOperationAccepted
+)
+
+// String returns the text form of the merge operation status.
+func (s MergeOperationStatus) String() string {
+	switch s {
+	case MergeOperationPending:
+		return "pending"
+	case MergeOperationAccepted:
+		return "accepted"
+	default:
+		return fmt.Sprintf("MergeOperationStatus(%d)", int(s))
+	}
+}
+
+// GoString returns a Go-syntax representation of the merge operation status.
+func (s MergeOperationStatus) GoString() string {
+	switch s {
+	case MergeOperationPending:
+		return "MergeOperationPending"
+	case MergeOperationAccepted:
+		return "MergeOperationAccepted"
+	default:
+		return fmt.Sprintf("MergeOperationStatus(%d)", int(s))
+	}
 }
 
 // MergeMethod names a forge-level strategy for merging a change request.

--- a/internal/forge/merge_test.go
+++ b/internal/forge/merge_test.go
@@ -1,0 +1,16 @@
+package forge_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.abhg.dev/gs/internal/forge"
+)
+
+func TestMergeOperationStatus(t *testing.T) {
+	assert.Equal(t, "pending", forge.MergeOperationPending.String())
+	assert.Equal(t, "accepted", forge.MergeOperationAccepted.String())
+	assert.Equal(t, "MergeOperationPending", forge.MergeOperationPending.GoString())
+	assert.Equal(t, "MergeOperationAccepted", forge.MergeOperationAccepted.GoString())
+	assert.Equal(t, "MergeOperationStatus(42)", forge.MergeOperationStatus(42).String())
+}

--- a/internal/forge/stacks.go
+++ b/internal/forge/stacks.go
@@ -3,7 +3,7 @@ package forge
 import "context"
 
 // StackRepository is an optional repository capability
-// for repositories that support forge-native stacks.
+// for reconciling and merging forge-native stacks.
 type StackRepository interface {
 	Repository
 
@@ -21,6 +21,17 @@ type StackRepository interface {
 	// unsupported. Implementations may warn and omit those trees from the
 	// returned plan.
 	PlanStackUpdate(context.Context, []StackChange) (StackUpdatePlan, error)
+
+	// PlanMergeRanges identifies the supplied changes that the provider can
+	// merge atomically using its current native-stack representation.
+	// Returned plans are non-empty, disjoint subsets of changes.
+	// Each plan follows the supplied relationships from bottom to top;
+	// changes omitted from every plan remain eligible for ordinary per-change
+	// merging.
+	//
+	// [ErrUnsupported] means that no plans were created and the caller may merge
+	// every supplied change individually.
+	PlanMergeRanges(context.Context, []StackChange) ([]MergeRangePlan, error)
 }
 
 // StackUpdatePlan owns one prepared provider stack transition.
@@ -31,6 +42,22 @@ type StackUpdatePlan interface {
 	// returns [ErrUnsupported]; callers must prepare a new plan before retrying
 	// after any result.
 	Execute(context.Context) error
+}
+
+// MergeRangePlan identifies one provider-selected atomic merge range and owns
+// the operation that can merge it.
+type MergeRangePlan interface {
+	// Changes identifies this range from bottom to top.
+	// The caller must not modify the returned slice.
+	Changes() []ChangeID
+
+	// Merge atomically merges this planned range.
+	// The request must contain exactly the changes returned by Changes in the
+	// same order, with their provider-facing state after preparation.
+	//
+	// [ErrUnsupported] means that no atomic merge was started and the caller may
+	// merge the planned changes individually.
+	Merge(context.Context, MergeRangeRequest) (MergeOperation, error)
 }
 
 // StackChange identifies one member and its desired immediate base.


### PR DESCRIPTION
Forge repositories need an optional operation that can atomically merge
a fully restacked linear change range while rejecting stale remote
state. Add `WithMergeRange` with the expected branch names and head
commits needed for providers to enforce that boundary.

GitHub keeps its full pull request projection local to range validation,
checks branches, commits, and native-stack membership, then delegates to
the asynchronous merge gateway. The shared integration scenario creates
the required native stack before starting the range merge and waits for
operation acceptance and final merged states.

The GitHub integration cassette remains deliberately unrecorded for a
human operator to capture.

Refs #1388