### PR TITLE
submit: Finalize partial submissions

### DIFF
--- a/internal/handler/submit/handler.go
+++ b/internal/handler/submit/handler.go
@@ -63,7 +63,6 @@ var _ Store = (*state.Store)(nil)
 // Service provides access to the Spice service.
 type Service interface {
 	BranchGraph(context.Context, *spice.BranchGraphOptions) (*spice.BranchGraph, error)
-	LoadBranches(context.Context) ([]spice.LoadBranchItem, error)
 	VerifyRestacked(ctx context.Context, name string) error
 	UnusedBranchName(ctx context.Context, remote string, branch string) (string, error)
 	ListChangeTemplates(context.Context, string, forge.Repository) ([]*forge.ChangeTemplate, error)
@@ -213,7 +212,10 @@ type BatchRequest struct {
 
 // SubmitBatch submits a batch of branches to a remote repository,
 // creating or updating change requests as needed.
-func (h *Handler) SubmitBatch(ctx context.Context, req *BatchRequest) error {
+func (h *Handler) SubmitBatch(
+	ctx context.Context,
+	req *BatchRequest,
+) (retErr error) {
 	opts := cmp.Or(req.Options, &Options{})
 	mergeConfiguredOptions(opts)
 
@@ -236,8 +238,24 @@ func (h *Handler) SubmitBatch(ctx context.Context, req *BatchRequest) error {
 		return err
 	}
 
-	stackUpdates := new(submitStackUpdates)
-	var branchesToComment []string
+	stackUpdates := submitStackUpdates{requestedBranches: slices.Clone(req.Branches)}
+	var submittedBranches, completedBranches []string
+	// A later branch failure must not strand earlier published changes without
+	// their stack representations. Synchronize every completed submission on
+	// every exit from the loop.
+	defer func() {
+		retErr = errors.Join(
+			retErr,
+			h.updateStackRepresentations(
+				ctx,
+				opts,
+				&stackUpdates,
+				submittedBranches,
+				completedBranches,
+			),
+		)
+	}()
+
 	for _, branch := range req.Branches {
 		// Shallow copy the options because submitBranch may modify them.
 		opts := *opts
@@ -245,35 +263,20 @@ func (h *Handler) SubmitBatch(ctx context.Context, req *BatchRequest) error {
 			ctx,
 			graph,
 			branch,
-			&submitOptions{Options: &opts, stackUpdates: stackUpdates},
+			&submitOptions{Options: &opts, stackUpdates: &stackUpdates},
 		)
+		if status.Submitted {
+			submittedBranches = append(submittedBranches, branch)
+		}
 		if err != nil {
 			return fmt.Errorf("submit branch %s: %w", branch, err)
 		}
 		if status.Submitted {
-			branchesToComment = append(branchesToComment, branch)
+			completedBranches = append(completedBranches, branch)
 		}
 	}
 
-	if len(branchesToComment) == 0 || opts.DryRun {
-		return nil // nothing to do
-	}
-
-	stackErr := h.updateStacks(ctx, branchesToComment, stackUpdates)
-	navCommentErr := updateNavigationComments(
-		ctx,
-		h.Store, h.Service, h.Log,
-		opts.NavComment,
-		opts.NavCommentSync,
-		opts.NavCommentDownstack,
-		opts.NavCommentMarker,
-		opts.NavCommentTrunkLink,
-		opts.NavCommentTrunkLinkText,
-		branchesToComment,
-		h.upstreamRepository,
-		h.pushRepositoryID,
-	)
-	return errors.Join(stackErr, navCommentErr)
+	return nil
 }
 
 // Request is a request to submit a single branch to a remote repository.
@@ -294,7 +297,7 @@ type Request struct {
 
 // Submit submits a single branch to a remote repository,
 // creating or updating a change request as needed.
-func (h *Handler) Submit(ctx context.Context, req *Request) error {
+func (h *Handler) Submit(ctx context.Context, req *Request) (retErr error) {
 	opts := cmp.Or(req.Options, &Options{})
 	mergeConfiguredOptions(opts)
 	graph := req.BranchGraph
@@ -309,7 +312,21 @@ func (h *Handler) Submit(ctx context.Context, req *Request) error {
 		return err
 	}
 
-	stackUpdates := new(submitStackUpdates)
+	stackUpdates := submitStackUpdates{requestedBranches: []string{req.Branch}}
+	var submittedBranches, completedBranches []string
+	defer func() {
+		retErr = errors.Join(
+			retErr,
+			h.updateStackRepresentations(
+				ctx,
+				opts,
+				&stackUpdates,
+				submittedBranches,
+				completedBranches,
+			),
+		)
+	}()
+
 	status, err := h.submitBranch(
 		ctx,
 		graph,
@@ -318,33 +335,174 @@ func (h *Handler) Submit(ctx context.Context, req *Request) error {
 			Options:      opts,
 			Title:        req.Title,
 			Body:         req.Body,
-			stackUpdates: stackUpdates,
+			stackUpdates: &stackUpdates,
 		},
 	)
+	if status.Submitted {
+		submittedBranches = append(submittedBranches, req.Branch)
+	}
 	if err != nil {
 		return fmt.Errorf("submit branch %s: %w", req.Branch, err)
 	}
+	if status.Submitted {
+		completedBranches = append(completedBranches, req.Branch)
+	}
+	return nil
+}
 
-	if !status.Submitted || opts.DryRun {
-		// Nothing was submitted, so nothing to do.
+// updateStackRepresentations synchronizes the forge-native stack and
+// navigation comments from one view of the branch graph after submission.
+// The independent forge updates run concurrently. Native-stack operation
+// failures are warnings, while failures that prevent navigation comments are
+// returned to the submit operation.
+func (h *Handler) updateStackRepresentations(
+	ctx context.Context,
+	opts *Options,
+	stackUpdates *submitStackUpdates,
+	submittedBranches []string,
+	completedBranches []string,
+) error {
+	if len(submittedBranches) == 0 || opts.DryRun {
 		return nil
 	}
 
-	stackErr := h.updateStacks(ctx, []string{req.Branch}, stackUpdates)
-	navCommentErr := updateNavigationComments(
-		ctx,
-		h.Store, h.Service, h.Log,
-		opts.NavComment,
-		opts.NavCommentSync,
-		opts.NavCommentDownstack,
-		opts.NavCommentMarker,
-		opts.NavCommentTrunkLink,
-		opts.NavCommentTrunkLinkText,
-		[]string{req.Branch},
-		h.upstreamRepository,
-		h.pushRepositoryID,
+	navCommentsEnabled := opts.NavComment != NavCommentNever
+	var (
+		remoteRepo forge.Repository
+		stackRepo  forge.StackRepository
+		graph      *spice.BranchGraph
 	)
-	return errors.Join(stackErr, navCommentErr)
+	if err := func() error {
+		var err error
+		remoteRepo, err = h.upstreamRepository(ctx)
+		if err != nil {
+			return fmt.Errorf("get remote repository: %w", err)
+		}
+
+		stackRepo, _ = remoteRepo.(forge.StackRepository)
+		if stackRepo == nil && !navCommentsEnabled {
+			return nil
+		}
+
+		graph, err = h.Service.BranchGraph(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("build branch graph: %w", err)
+		}
+		return nil
+	}(); err != nil {
+		if navCommentsEnabled || len(stackUpdates.deferredBases) > 0 {
+			return err
+		}
+		h.Log.Warn("Could not update stacks", "error", err)
+		return nil
+	}
+	if graph == nil {
+		return nil // neither representation is enabled
+	}
+
+	// Submission may have created change metadata that was absent from the graph
+	// used by the submit loop. This post-submit graph is the authoritative input
+	// for both remote representations. A partially submitted requested component
+	// cannot be treated as a complete desired stack: apply its successful base
+	// edits through the ordinary forge path and plan only independent complete
+	// components.
+	completed := make(map[string]struct{}, len(completedBranches))
+	for _, branch := range completedBranches {
+		completed[branch] = struct{}{}
+	}
+	incompleteBottoms := make(map[string]struct{})
+	for _, branch := range stackUpdates.requestedBranches {
+		if _, ok := completed[branch]; !ok {
+			incompleteBottoms[graph.Bottom(branch)] = struct{}{}
+		}
+	}
+	completeBranches := make([]string, 0, len(completedBranches))
+	for _, branch := range completedBranches {
+		if _, incomplete := incompleteBottoms[graph.Bottom(branch)]; !incomplete {
+			completeBranches = append(completeBranches, branch)
+		}
+	}
+
+	var fallbackBases []deferredBaseUpdate
+	for _, update := range stackUpdates.deferredBases {
+		if _, incomplete := incompleteBottoms[graph.Bottom(update.branch)]; incomplete {
+			fallbackBases = append(fallbackBases, update)
+		}
+	}
+
+	// Navigation comment creation mutates change metadata. Project and plan the
+	// native-stack request first so concurrent finalization owns only immutable
+	// values from the shared graph snapshot.
+	var stackChanges []forge.StackChange
+	if stackRepo != nil {
+		stackChanges = nativeStackChanges(graph, remoteRepo.Forge().ID(), completeBranches)
+	}
+	var stackPlan forge.StackUpdatePlan
+	if len(stackChanges) > 0 {
+		var err error
+		stackPlan, err = stackRepo.PlanStackUpdate(ctx, stackChanges)
+		switch {
+		case errors.Is(err, forge.ErrUnsupported):
+			for _, update := range stackUpdates.deferredBases {
+				if _, incomplete := incompleteBottoms[graph.Bottom(update.branch)]; !incomplete {
+					fallbackBases = append(fallbackBases, update)
+				}
+			}
+		case err != nil:
+			h.Log.Warn("Could not plan stack update", "error", err)
+		}
+	}
+
+	var wg sync.WaitGroup
+	if stackPlan != nil {
+		wg.Go(func() {
+			if err := stackPlan.Execute(ctx); err != nil {
+				h.Log.Warn("Could not update stacks", "error", err)
+			}
+		})
+	}
+
+	var fallbackErr error
+	if len(fallbackBases) > 0 {
+		wg.Go(func() {
+			var errs []error
+			for _, update := range fallbackBases {
+				if err := update.repository.EditChange(ctx, update.change, forge.EditChangeOptions{
+					Base: update.base,
+				}); err != nil {
+					errs = append(errs, fmt.Errorf("update %v base: %w", update.change, err))
+				}
+			}
+			fallbackErr = errors.Join(errs...)
+		})
+	}
+
+	var navCommentErr error
+	if navCommentsEnabled {
+		wg.Go(func() {
+			navCommentErr = updateNavigationComments(
+				ctx,
+				navigationCommentUpdate{
+					store:            h.Store,
+					graph:            graph,
+					log:              h.Log,
+					remoteRepository: remoteRepo,
+
+					when:          opts.NavComment,
+					sync:          opts.NavCommentSync,
+					downstack:     opts.NavCommentDownstack,
+					marker:        opts.NavCommentMarker,
+					trunkLink:     opts.NavCommentTrunkLink,
+					trunkLinkText: opts.NavCommentTrunkLinkText,
+
+					submittedBranches: submittedBranches,
+					pushRepositoryID:  h.pushRepositoryID,
+				},
+			)
+		})
+	}
+	wg.Wait()
+	return errors.Join(navCommentErr, fallbackErr)
 }
 
 type submitStatus struct {
@@ -361,6 +519,21 @@ type submitOptions struct {
 
 	Title, Body  string
 	stackUpdates *submitStackUpdates
+}
+
+// submitStackUpdates carries provider base edits from the submit loop to the
+// post-submit stack transaction. Existing changes keep their old provider base
+// until the native provider plan has had a chance to unstack them safely.
+type submitStackUpdates struct {
+	requestedBranches []string
+	deferredBases     []deferredBaseUpdate
+}
+
+type deferredBaseUpdate struct {
+	branch     string
+	repository forge.Repository
+	change     forge.ChangeID
+	base       string
 }
 
 func (h *Handler) submitBranch(
@@ -619,9 +792,10 @@ func (h *Handler) submitBranch(
 				branch.Base,
 				h.Store.Trunk(),
 			) {
-				log.Warnf("Branch %[1]s is not restacked."+
-					" Run '%[2]s branch restack --branch=%[1]s'"+
-					" to fix this.",
+				log.Warnf(
+					"Branch %[1]s is not restacked."+
+						" Run '%[2]s branch restack --branch=%[1]s'"+
+						" to fix this.",
 					branchToSubmit, cli.Name(),
 				)
 			} else {
@@ -943,15 +1117,16 @@ func (h *Handler) submitBranch(
 				return status, fmt.Errorf("edit CR %v: %w", pull.ID, err)
 			}
 
-			// A native stack provider may need to dissolve existing membership
-			// before changing the pull request base. Defer that mutation to its
-			// planned transition; unsupported planning applies the same ordinary
-			// EditChange after submission.
+			// Native stack providers may need to dissolve an existing stack before
+			// changing a pull request base. Defer that base mutation to their
+			// planned transaction; unsupported planning falls back to this same
+			// ordinary EditChange operation after the submit loop.
 			if pull.BaseName != upstreamBase {
 				if _, ok := remoteRepo.(forge.StackRepository); ok && opts.stackUpdates != nil {
 					opts.stackUpdates.deferredBases = append(
 						opts.stackUpdates.deferredBases,
 						deferredBaseUpdate{
+							branch:     branchToSubmit,
 							repository: remoteRepo,
 							change:     pull.ID,
 							base:       upstreamBase,
@@ -993,7 +1168,8 @@ func (h *Handler) resolveUpstreamBranch(
 			return "", fmt.Errorf(
 				"refusing to push branch %q to trunk %q; "+
 					"run '%s branch untrack %s' and track the branch again",
-				branch, storedUpstream, cli.Name(), branch)
+				branch, storedUpstream, cli.Name(), branch,
+			)
 		}
 
 		return storedUpstream, nil
@@ -1015,7 +1191,8 @@ func (h *Handler) resolveUpstreamBranch(
 			return "", fmt.Errorf(
 				"refusing to push branch %q to trunk %q; "+
 					"run 'git branch --unset-upstream %s'",
-				branch, b, branch)
+				branch, b, branch,
+			)
 		}
 
 		h.Log.Infof("%v: Using upstream name '%v'", branch, b)
@@ -1070,7 +1247,8 @@ func (h *Handler) prepareBranch(
 				WithDescription(
 					fmt.Sprintf("Branch %s has no changes compared to its base (%s). "+
 						"Submitting it will create an empty change request. "+
-						"This is usually not what you want to do.", branchToSubmit, baseBranch)).
+						"This is usually not what you want to do.", branchToSubmit, baseBranch),
+				).
 				WithValue(&submitNoChanges)
 			if err := ui.Run(h.View, field); err != nil {
 				return nil, fmt.Errorf("run prompt: %w", err)
@@ -1163,7 +1341,8 @@ func (h *Handler) prepareBranch(
 				WithTitle("Recover previously filled information?").
 				WithDescription(
 					"We found previously filled information for this branch.\n" +
-						"Would you like to recover and edit it?")
+						"Would you like to recover and edit it?",
+				)
 			if err := ui.Run(h.View, f); err != nil {
 				return nil, fmt.Errorf("prompt for recovery: %w", err)
 			}

--- a/internal/handler/submit/handler_test.go
+++ b/internal/handler/submit/handler_test.go
@@ -3,6 +3,7 @@ package submit
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -18,6 +19,7 @@ import (
 	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/spicetest"
 	"go.abhg.dev/gs/internal/spice/state"
+	"go.abhg.dev/gs/internal/spice/state/statetest"
 	"go.abhg.dev/gs/internal/ui"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -184,6 +186,105 @@ func TestHandler_SubmitBatch_rejectsStaleBaseBeforeSubmitting(t *testing.T) {
 	assert.Contains(t, logBuffer.String(), "Branch has stale base")
 	assert.Contains(t, logBuffer.String(), "branch=feat2")
 	assert.Contains(t, logBuffer.String(), "base=feat1")
+}
+
+func TestHandler_SubmitBatch_updatesStackRepresentationsAfterPartialFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	log := silogtest.New(t)
+	store := statetest.NewMemoryStore(t, "main", "origin", log)
+	branches := []spice.LoadBranchItem{
+		{
+			Name:           "bottom",
+			Base:           "main",
+			Head:           "bottom-head",
+			UpstreamBranch: "bottom",
+			Change:         submitFakeChange("pr-1"),
+		},
+		{
+			Name: "top",
+			Base: "bottom",
+			Head: "top-head",
+		},
+	}
+	graph := spicetest.NewBranchGraph(t, spicetest.BranchGraphConfig{
+		Trunk:    "main",
+		Branches: branches,
+	})
+
+	remoteForge := forgetest.NewMockForge(ctrl)
+	remoteForge.EXPECT().ID().Return("test").AnyTimes()
+	remoteForge.EXPECT().
+		MarshalChangeMetadata(gomock.Any()).
+		Return(json.RawMessage(`{}`), nil)
+
+	remoteRepo := forgetest.NewMockRepository(ctrl)
+	remoteRepo.EXPECT().Forge().Return(remoteForge).AnyTimes()
+	remoteRepo.EXPECT().
+		FindChangeByID(gomock.Any(), submitFakeChangeID("pr-1")).
+		Return(&forge.FindChangeItem{
+			ID:       submitFakeChangeID("pr-1"),
+			URL:      "https://example.com/pr-1",
+			State:    forge.ChangeOpen,
+			Subject:  "Bottom",
+			HeadHash: git.Hash("bottom-head"),
+			BaseName: "main",
+		}, nil)
+	remoteRepo.EXPECT().
+		PostChangeComment(gomock.Any(), submitFakeChangeID("pr-1"), gomock.Any()).
+		Return(submitFakeCommentID("comment-1"), nil)
+	stackRepo := &submitStackRepository{Repository: remoteRepo}
+
+	service := NewMockService(ctrl)
+	service.EXPECT().BranchGraph(gomock.Any(), nil).Return(graph, nil)
+
+	transientErr := errors.New("transient submit failure")
+	handler := &Handler{
+		Log:  log,
+		View: ui.NewFileView(&bytes.Buffer{}),
+		Repository: &submitTestGitRepository{
+			peelToCommit: func(_ context.Context, ref string) (git.Hash, error) {
+				switch ref {
+				case "bottom":
+					return git.Hash("bottom-head"), nil
+				case "top":
+					return "", transientErr
+				default:
+					t.Fatalf("unexpected ref: %q", ref)
+					return "", nil
+				}
+			},
+		},
+		Worktree: &submitTestGitWorktree{},
+		Store:    store,
+		Service:  service,
+		Browser:  &browser.Noop{},
+		FindRemote: func(context.Context) (state.Remote, error) {
+			return state.Remote{Upstream: "origin", Push: "origin"}, nil
+		},
+		ResolveRepository: func(
+			context.Context,
+			string,
+		) (forge.Forge, forge.RepositoryID, error) {
+			return remoteForge, stubRepositoryID("alice/repo"), nil
+		},
+		OpenRepository: func(
+			context.Context,
+			forge.Forge,
+			forge.RepositoryID,
+		) (forge.Repository, error) {
+			return stackRepo, nil
+		},
+	}
+
+	err := handler.SubmitBatch(t.Context(), &BatchRequest{
+		Branches:     []string{"bottom", "top"},
+		Options:      &Options{Force: true, Publish: true},
+		BatchOptions: &BatchOptions{},
+		BranchGraph:  graph,
+	})
+
+	require.ErrorIs(t, err, transientErr)
+	assert.Empty(t, stackRepo.plans)
 }
 
 func TestHandler_submitBranch_editBase(t *testing.T) {
@@ -721,6 +822,10 @@ func (m *submitFakeChangeMetadata) SetNavigationCommentID(forge.ChangeCommentID)
 type submitFakeChangeID string
 
 func (id submitFakeChangeID) String() string { return string(id) }
+
+type submitFakeCommentID string
+
+func (id submitFakeCommentID) String() string { return string(id) }
 
 func submitFakeChange(id string) forge.ChangeMetadata {
 	return &submitFakeChangeMetadata{id: submitFakeChangeID(id)}

--- a/internal/handler/submit/mocks_test.go
+++ b/internal/handler/submit/mocks_test.go
@@ -120,45 +120,6 @@ func (c *MockServiceListChangeTemplatesCall) DoAndReturn(f func(context.Context,
 	return c
 }
 
-// LoadBranches mocks base method.
-func (m *MockService) LoadBranches(arg0 context.Context) ([]spice.LoadBranchItem, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoadBranches", arg0)
-	ret0, _ := ret[0].([]spice.LoadBranchItem)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// LoadBranches indicates an expected call of LoadBranches.
-func (mr *MockServiceMockRecorder) LoadBranches(arg0 any) *MockServiceLoadBranchesCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadBranches", reflect.TypeOf((*MockService)(nil).LoadBranches), arg0)
-	return &MockServiceLoadBranchesCall{Call: call}
-}
-
-// MockServiceLoadBranchesCall wrap *gomock.Call
-type MockServiceLoadBranchesCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockServiceLoadBranchesCall) Return(arg0 []spice.LoadBranchItem, arg1 error) *MockServiceLoadBranchesCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockServiceLoadBranchesCall) Do(f func(context.Context) ([]spice.LoadBranchItem, error)) *MockServiceLoadBranchesCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockServiceLoadBranchesCall) DoAndReturn(f func(context.Context) ([]spice.LoadBranchItem, error)) *MockServiceLoadBranchesCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // UnusedBranchName mocks base method.
 func (m *MockService) UnusedBranchName(ctx context.Context, remote, branch string) (string, error) {
 	m.ctrl.T.Helper()

--- a/internal/handler/submit/nav_comment.go
+++ b/internal/handler/submit/nav_comment.go
@@ -16,6 +16,7 @@ import (
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/forge/stacknav"
 	"go.abhg.dev/gs/internal/silog"
+	"go.abhg.dev/gs/internal/spice"
 	"go.abhg.dev/gs/internal/spice/state"
 )
 
@@ -69,6 +70,31 @@ func (f NavCommentWhen) String() string {
 	}
 }
 
+// navigationCommentUpdate captures the complete post-submit view used to
+// render and persist navigation comments. The submit finalizer copies the
+// navigation choices and loads the branch graph and repository before launch,
+// so this concurrent operation does not retain the broader mutable submit
+// options.
+type navigationCommentUpdate struct {
+	store            Store
+	graph            *spice.BranchGraph
+	log              *silog.Logger
+	remoteRepository forge.Repository
+
+	when          NavCommentWhen
+	sync          NavCommentSync
+	downstack     NavCommentDownstack
+	marker        string
+	trunkLink     NavCommentTrunkLink
+	trunkLinkText string
+
+	submittedBranches []string
+
+	// The push repository is resolved only when trunk comparison links are
+	// enabled and the forge supports them.
+	pushRepositoryID func(context.Context) (forge.RepositoryID, error)
+}
+
 // For each branch in the list of submitted branches,
 // we'll add or update a comment in the form:
 //
@@ -85,30 +111,20 @@ func (f NavCommentWhen) String() string {
 // we'll need to also update the store to record the comment ID for later.
 func updateNavigationComments(
 	ctx context.Context,
-	store Store,
-	svc Service,
-	log *silog.Logger,
-	navComment NavCommentWhen,
-	navCommentSync NavCommentSync,
-	navCommentDownstack NavCommentDownstack,
-	navCommentMarker string,
-	navCommentTrunkLink NavCommentTrunkLink,
-	navCommentTrunkLinkText string,
-	submittedBranches []string,
-	getRemoteRepo func(context.Context) (forge.Repository, error),
-	getPushRepositoryID func(context.Context) (forge.RepositoryID, error),
+	update navigationCommentUpdate,
 ) error {
+	store := update.store
+	graph := update.graph
+	log := update.log
+	remoteRepo := update.remoteRepository
+	submittedBranches := update.submittedBranches
+
 	if len(submittedBranches) == 0 {
 		return nil
 	}
 
-	if navComment == NavCommentNever {
+	if update.when == NavCommentNever {
 		return nil // nothing to do
-	}
-
-	remoteRepo, err := getRemoteRepo(ctx)
-	if err != nil {
-		return fmt.Errorf("get remote repository: %w", err)
 	}
 
 	// Build a reference formatter for forges that customize navigation.
@@ -131,29 +147,24 @@ func updateNavigationComments(
 	// each comment gets a link comparing the branch against trunk.
 	// Forges that don't implement WithComparisonURL simply omit the link.
 	var comparisonRepo forge.WithComparisonURL
-	if navCommentTrunkLink != NavCommentTrunkLinkOff {
+	if update.trunkLink != NavCommentTrunkLinkOff {
 		if r, ok := remoteRepo.(forge.WithComparisonURL); ok {
 			comparisonRepo = r
 		}
 	}
 	var headRepository forge.RepositoryID
-	if comparisonRepo != nil && getPushRepositoryID != nil {
-		headRepository, err = getPushRepositoryID(ctx)
+	if comparisonRepo != nil && update.pushRepositoryID != nil {
+		var err error
+		headRepository, err = update.pushRepositoryID(ctx)
 		if err != nil {
 			return fmt.Errorf("get push repository: %w", err)
 		}
 	}
-	trunkLinkText := navCommentTrunkLinkText
+	trunkLinkText := update.trunkLinkText
 	if trunkLinkText == "" {
 		trunkLinkText = _defaultTrunkComparisonLinkText
 	}
-	trunk := store.Trunk()
-
-	// Look up branch graph once, and share between all syncs.
-	trackedBranches, err := svc.LoadBranches(ctx)
-	if err != nil {
-		return fmt.Errorf("list tracked branches: %w", err)
-	}
+	trunk := graph.Trunk()
 
 	type branchInfo struct {
 		Branch         string
@@ -168,7 +179,7 @@ func updateNavigationComments(
 	idxByBranch := make(map[string]int) // branch -> index in nodes
 
 	// First pass: add nodes but don't connect.
-	for _, b := range trackedBranches {
+	for b := range graph.All() {
 		if b.Change == nil {
 			continue
 		}
@@ -190,7 +201,7 @@ func updateNavigationComments(
 	//
 	// - Add merged downstacks as separate nodes (if enabled).
 	// - Connect Aboves if this is a base to another node.
-	for _, b := range trackedBranches {
+	for b := range graph.All() {
 		nodeIdx, ok := idxByBranch[b.Name]
 		if !ok {
 			continue
@@ -204,7 +215,7 @@ func updateNavigationComments(
 		//
 		// Skip merged downstack branches if navCommentDownstack is Open.
 		lastDownstackIdx := -1
-		if navCommentDownstack == NavCommentDownstackAll {
+		if update.downstack == NavCommentDownstackAll {
 			for _, crJSON := range b.MergedDownstack {
 				downstackCR, err := remoteRepo.Forge().UnmarshalChangeID(crJSON)
 				if err != nil {
@@ -252,7 +263,7 @@ func updateNavigationComments(
 	// Third pass:
 	// Compute list of branches to sync based on the navCommentSync.
 	var branchesToSync []int
-	switch navCommentSync {
+	switch update.sync {
 	case NavCommentSyncBranch:
 		// Only submitted branches get commented on.
 		for _, branch := range submittedBranches {
@@ -414,7 +425,7 @@ func updateNavigationComments(
 	// Open CRs occupy the first len(infos) nodes, so a node whose base
 	// falls in that range is stacked on another open CR.
 	trunkLinks := trunkComparison{
-		mode:           navCommentTrunkLink,
+		mode:           update.trunkLink,
 		comparisonRepo: comparisonRepo,
 		trunk:          trunk,
 		linkText:       trunkLinkText,
@@ -427,7 +438,7 @@ func updateNavigationComments(
 		// If we're only posting on multiple,
 		// we'll need to check if the branch is part of a stack
 		// that has at least one other branch.
-		if navComment == NavCommentOnMultiple {
+		if update.when == NavCommentOnMultiple {
 			if len(nodes[idx].Aboves) == 0 && nodes[idx].Base == -1 {
 				continue
 			}
@@ -436,7 +447,13 @@ func updateNavigationComments(
 		info := infos[idx]
 		head := cmp.Or(info.UpstreamBranch, info.Branch)
 		trunkLink := trunkLinks.link(nodes[idx], head)
-		commentBody := generateStackNavigationComment(nodes, idx, navCommentMarker, remoteRepo.Forge(), trunkLink)
+		commentBody := generateStackNavigationComment(
+			nodes,
+			idx,
+			update.marker,
+			remoteRepo.Forge(),
+			trunkLink,
+		)
 		if info.Meta.NavigationCommentID() == nil {
 			postc <- &postComment{
 				Branch: info.Branch,

--- a/internal/handler/submit/nav_comment_test.go
+++ b/internal/handler/submit/nav_comment_test.go
@@ -18,6 +18,7 @@ import (
 	"go.abhg.dev/gs/internal/forge/shamhub"
 	"go.abhg.dev/gs/internal/silog/silogtest"
 	"go.abhg.dev/gs/internal/spice"
+	"go.abhg.dev/gs/internal/spice/spicetest"
 	"go.abhg.dev/gs/internal/spice/state"
 	"go.abhg.dev/gs/internal/spice/state/statetest"
 	gomock "go.uber.org/mock/gomock"
@@ -351,40 +352,36 @@ func TestUpdateNavigationComments(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			store := statetest.NewMemoryStore(t, "main", "origin", log)
 
-			mockService := NewMockService(ctrl)
-			mockService.EXPECT().
-				LoadBranches(gomock.Any()).
-				DoAndReturn(func(context.Context) ([]spice.LoadBranchItem, error) {
-					items := make([]spice.LoadBranchItem, len(tt.trackedBranches))
-					for i, b := range tt.trackedBranches {
-						item := spice.LoadBranchItem{
-							Name:           b.Name,
-							Base:           cmp.Or(b.Base, "main"),
-							Head:           "abcd1234",
-							BaseHash:       "efgh5678",
-							UpstreamBranch: b.Name,
-						}
+			items := make([]spice.LoadBranchItem, len(tt.trackedBranches))
+			for i, b := range tt.trackedBranches {
+				item := spice.LoadBranchItem{
+					Name:           b.Name,
+					Base:           cmp.Or(b.Base, "main"),
+					Head:           "abcd1234",
+					BaseHash:       "efgh5678",
+					UpstreamBranch: b.Name,
+				}
 
-						if b.ChangeID > 0 {
-							item.Change = &shamhub.ChangeMetadata{
-								Number: b.ChangeID,
-							}
-						}
-
-						// Add merged downstack entries if any
-						for _, mergedID := range b.MergedDownstack {
-							mergedMeta := &shamhub.ChangeMetadata{Number: mergedID}
-							mergedJSON, err := json.Marshal(mergedMeta)
-							require.NoError(t, err)
-							item.MergedDownstack = append(item.MergedDownstack, mergedJSON)
-						}
-
-						items[i] = item
+				if b.ChangeID > 0 {
+					item.Change = &shamhub.ChangeMetadata{
+						Number: b.ChangeID,
 					}
+				}
 
-					return items, nil
-				}).
-				AnyTimes()
+				// Add merged downstack entries if any
+				for _, mergedID := range b.MergedDownstack {
+					mergedMeta := &shamhub.ChangeMetadata{Number: mergedID}
+					mergedJSON, err := json.Marshal(mergedMeta)
+					require.NoError(t, err)
+					item.MergedDownstack = append(item.MergedDownstack, mergedJSON)
+				}
+
+				items[i] = item
+			}
+			graph := spicetest.NewBranchGraph(t, spicetest.BranchGraphConfig{
+				Trunk:    "main",
+				Branches: items,
+			})
 
 			mockForge := forgetest.NewMockForge(ctrl)
 			mockForge.EXPECT().ID().Return("shamhub").AnyTimes()
@@ -445,20 +442,16 @@ func TestUpdateNavigationComments(t *testing.T) {
 
 			err := updateNavigationComments(
 				t.Context(),
-				store,
-				mockService,
-				log,
-				tt.when,
-				tt.sync,
-				tt.downstack,
-				"",
-				NavCommentTrunkLinkOff, // trunk comparison link
-				"",                     // trunk comparison link text
-				tt.submit,
-				func(context.Context) (forge.Repository, error) {
-					return mockRemoteRepo, nil
+				navigationCommentUpdate{
+					store:             store,
+					graph:             graph,
+					log:               log,
+					remoteRepository:  mockRemoteRepo,
+					when:              tt.when,
+					sync:              tt.sync,
+					downstack:         tt.downstack,
+					submittedBranches: tt.submit,
 				},
-				nil, // push repository
 			)
 			require.NoError(t, err)
 
@@ -516,10 +509,9 @@ func TestUpdateNavigationComments_deletedExternally(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		mockService := NewMockService(ctrl)
-		mockService.EXPECT().
-			LoadBranches(gomock.Any()).
-			Return([]spice.LoadBranchItem{
+		graph := spicetest.NewBranchGraph(t, spicetest.BranchGraphConfig{
+			Trunk: "main",
+			Branches: []spice.LoadBranchItem{
 				{
 					Name:           "feat1",
 					Base:           "main",
@@ -528,7 +520,8 @@ func TestUpdateNavigationComments_deletedExternally(t *testing.T) {
 					UpstreamBranch: "feat1",
 					Change:         existingMeta,
 				},
-			}, nil)
+			},
+		})
 
 		mockForge := forgetest.NewMockForge(ctrl)
 		mockForge.EXPECT().ID().Return("shamhub").AnyTimes()
@@ -561,19 +554,16 @@ func TestUpdateNavigationComments_deletedExternally(t *testing.T) {
 
 		err = updateNavigationComments(
 			t.Context(),
-			store,
-			mockService, log,
-			NavCommentAlways,
-			NavCommentSyncBranch,
-			NavCommentDownstackAll,
-			"",
-			NavCommentTrunkLinkOff, // trunk comparison link
-			"",                     // trunk comparison link text
-			[]string{"feat1"},
-			func(context.Context) (forge.Repository, error) {
-				return mockRemoteRepo, nil
+			navigationCommentUpdate{
+				store:             store,
+				graph:             graph,
+				log:               log,
+				remoteRepository:  mockRemoteRepo,
+				when:              NavCommentAlways,
+				sync:              NavCommentSyncBranch,
+				downstack:         NavCommentDownstackAll,
+				submittedBranches: []string{"feat1"},
 			},
-			nil, // push repository
 		)
 		require.NoError(t, err)
 	})
@@ -610,10 +600,9 @@ func TestUpdateNavigationComments_deletedExternally(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		mockService := NewMockService(ctrl)
-		mockService.EXPECT().
-			LoadBranches(gomock.Any()).
-			Return([]spice.LoadBranchItem{
+		graph := spicetest.NewBranchGraph(t, spicetest.BranchGraphConfig{
+			Trunk: "main",
+			Branches: []spice.LoadBranchItem{
 				{
 					Name:           "feat1",
 					Base:           "main",
@@ -638,7 +627,8 @@ func TestUpdateNavigationComments_deletedExternally(t *testing.T) {
 					UpstreamBranch: "feat3",
 					Change:         existingMetas[2],
 				},
-			}, nil)
+			},
+		})
 
 		mockForge := forgetest.NewMockForge(ctrl)
 		mockForge.EXPECT().ID().Return("shamhub").AnyTimes()
@@ -678,20 +668,16 @@ func TestUpdateNavigationComments_deletedExternally(t *testing.T) {
 
 		err = updateNavigationComments(
 			t.Context(),
-			store,
-			mockService,
-			log,
-			NavCommentAlways,
-			NavCommentSyncDownstack,
-			NavCommentDownstackAll,
-			"",
-			NavCommentTrunkLinkOff, // trunk comparison link
-			"",                     // trunk comparison link text
-			[]string{"feat3"},
-			func(context.Context) (forge.Repository, error) {
-				return mockRemoteRepo, nil
+			navigationCommentUpdate{
+				store:             store,
+				graph:             graph,
+				log:               log,
+				remoteRepository:  mockRemoteRepo,
+				when:              NavCommentAlways,
+				sync:              NavCommentSyncDownstack,
+				downstack:         NavCommentDownstackAll,
+				submittedBranches: []string{"feat3"},
 			},
-			nil, // push repository
 		)
 		require.NoError(t, err)
 	})
@@ -750,11 +736,10 @@ func TestUpdateNavigationComments_trunkComparisonLink(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		store := statetest.NewMemoryStore(t, "main", "origin", log)
 
-		mockService := NewMockService(ctrl)
-		mockService.EXPECT().
-			LoadBranches(gomock.Any()).
-			Return(newBranches(), nil).
-			AnyTimes()
+		graph := spicetest.NewBranchGraph(t, spicetest.BranchGraphConfig{
+			Trunk:    "main",
+			Branches: newBranches(),
+		})
 
 		mockForge := forgetest.NewMockForge(ctrl)
 		mockForge.EXPECT().ID().Return("shamhub").AnyTimes()
@@ -789,20 +774,18 @@ func TestUpdateNavigationComments_trunkComparisonLink(t *testing.T) {
 
 		err := updateNavigationComments(
 			t.Context(),
-			store,
-			mockService,
-			log,
-			NavCommentAlways,
-			NavCommentSyncDownstack,
-			NavCommentDownstackAll,
-			"",
-			mode, // trunk comparison link mode
-			"",   // default text
-			[]string{"feat3"},
-			func(context.Context) (forge.Repository, error) {
-				return getRepo(mockRepo), nil
+			navigationCommentUpdate{
+				store:             store,
+				graph:             graph,
+				log:               log,
+				remoteRepository:  getRepo(mockRepo),
+				when:              NavCommentAlways,
+				sync:              NavCommentSyncDownstack,
+				downstack:         NavCommentDownstackAll,
+				trunkLink:         mode,
+				submittedBranches: []string{"feat3"},
+				pushRepositoryID:  getPushRepositoryID,
 			},
-			getPushRepositoryID,
 		)
 		require.NoError(t, err)
 		return bodies

--- a/internal/handler/submit/stacks.go
+++ b/internal/handler/submit/stacks.go
@@ -1,80 +1,9 @@
 package submit
 
 import (
-	"context"
-	"errors"
-	"fmt"
-
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/spice"
 )
-
-// updateStacks plans and executes the forge-native representation of the
-// tracked stack trees affected by a successful submit. Unsupported planning
-// applies the provider base edits deferred by the submit loop.
-func (h *Handler) updateStacks(
-	ctx context.Context,
-	submitted []string,
-	stackUpdates *submitStackUpdates,
-) error {
-	repo, err := h.upstreamRepository(ctx)
-	if err != nil {
-		return fmt.Errorf("get remote repository: %w", err)
-	}
-
-	stackRepo, ok := repo.(forge.StackRepository)
-	if !ok {
-		return nil
-	}
-
-	// Submission can create change metadata after the command builds its first
-	// branch graph.
-	// Reload it so newly published changes participate in the update.
-	graph, err := h.Service.BranchGraph(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("build branch graph: %w", err)
-	}
-
-	changes := nativeStackChanges(graph, repo.Forge().ID(), submitted)
-	if len(changes) == 0 {
-		return nil
-	}
-
-	plan, err := stackRepo.PlanStackUpdate(ctx, changes)
-	if errors.Is(err, forge.ErrUnsupported) {
-		return stackUpdates.applyDeferredBases(ctx)
-	}
-	if err != nil {
-		h.Log.Warn("Could not plan stack update", "error", err)
-		return nil
-	}
-	if err := plan.Execute(ctx); err != nil {
-		h.Log.Warn("Could not update stacks", "error", err)
-	}
-	return nil
-}
-
-type submitStackUpdates struct {
-	deferredBases []deferredBaseUpdate
-}
-
-type deferredBaseUpdate struct {
-	repository forge.Repository
-	change     forge.ChangeID
-	base       string
-}
-
-func (u *submitStackUpdates) applyDeferredBases(ctx context.Context) error {
-	var errs []error
-	for _, update := range u.deferredBases {
-		if err := update.repository.EditChange(ctx, update.change, forge.EditChangeOptions{
-			Base: update.base,
-		}); err != nil {
-			errs = append(errs, fmt.Errorf("update %v base: %w", update.change, err))
-		}
-	}
-	return errors.Join(errs...)
-}
 
 // nativeStackChanges projects every published change in a tree containing a
 // submitted branch into the forge's native-stack representation.

--- a/internal/handler/submit/stacks_test.go
+++ b/internal/handler/submit/stacks_test.go
@@ -29,15 +29,16 @@ func TestNativeStackChanges(t *testing.T) {
 		},
 	})
 
+	got := nativeStackChanges(graph, "test", []string{"top"})
 	assert.ElementsMatch(t, []forge.StackChange{
 		{Change: submitFakeChangeID("pr-1"), BaseBranch: "main"},
 		{Change: submitFakeChangeID("pr-2"), BaseChange: submitFakeChangeID("pr-1"), BaseBranch: "bottom"},
 		{Change: submitFakeChangeID("pr-3"), BaseChange: submitFakeChangeID("pr-2"), BaseBranch: "middle"},
 		{Change: submitFakeChangeID("pr-4"), BaseChange: submitFakeChangeID("pr-2"), BaseBranch: "middle"},
-	}, nativeStackChanges(graph, "test", []string{"top"}))
+	}, got)
 }
 
-func TestHandler_updateStacks_unsupported(t *testing.T) {
+func TestHandler_updateStackRepresentations_unsupported(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	remoteForge := forgetest.NewMockForge(ctrl)
 	remoteRepo := forgetest.NewMockRepository(ctrl)
@@ -63,14 +64,16 @@ func TestHandler_updateStacks_unsupported(t *testing.T) {
 		return remoteRepo, nil
 	}
 
-	require.NoError(t, handler.updateStacks(
+	require.NoError(t, handler.updateStackRepresentations(
 		t.Context(),
+		&Options{NavComment: NavCommentNever},
+		&submitStackUpdates{requestedBranches: []string{"feature"}},
 		[]string{"feature"},
-		new(submitStackUpdates),
+		[]string{"feature"},
 	))
 }
 
-func TestHandler_updateStacks_errors(t *testing.T) {
+func TestHandler_updateStackRepresentations_nativeStackErrors(t *testing.T) {
 	tests := []struct {
 		name    string
 		planErr error
@@ -88,7 +91,7 @@ func TestHandler_updateStacks_errors(t *testing.T) {
 			remoteForge.EXPECT().ID().Return("test").AnyTimes()
 
 			remoteRepo := forgetest.NewMockRepository(ctrl)
-			remoteRepo.EXPECT().Forge().Return(remoteForge)
+			remoteRepo.EXPECT().Forge().Return(remoteForge).AnyTimes()
 			stackRepo := &submitStackRepository{
 				Repository: remoteRepo,
 				planErr:    tt.planErr,
@@ -125,11 +128,14 @@ func TestHandler_updateStacks_errors(t *testing.T) {
 				return stackRepo, nil
 			}
 
-			require.NoError(t, handler.updateStacks(
+			require.NoError(t, handler.updateStackRepresentations(
 				t.Context(),
+				&Options{NavComment: NavCommentNever},
+				&submitStackUpdates{requestedBranches: []string{"feature"}},
 				[]string{"feature"},
-				new(submitStackUpdates),
+				[]string{"feature"},
 			))
+			require.Len(t, stackRepo.plans, 1)
 
 			if tt.wantLog {
 				assert.Contains(t, logs.String(), "Could not update stacks")
@@ -141,12 +147,12 @@ func TestHandler_updateStacks_errors(t *testing.T) {
 	}
 }
 
-func TestHandler_updateStacks_fallsBackAfterUnsupportedPlan(t *testing.T) {
+func TestHandler_updateStackRepresentations_fallsBackAfterUnsupportedPlan(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	remoteForge := forgetest.NewMockForge(ctrl)
 	remoteForge.EXPECT().ID().Return("test").AnyTimes()
 	remoteRepo := forgetest.NewMockRepository(ctrl)
-	remoteRepo.EXPECT().Forge().Return(remoteForge)
+	remoteRepo.EXPECT().Forge().Return(remoteForge).AnyTimes()
 	change := submitFakeChangeID("pr-1")
 	remoteRepo.EXPECT().EditChange(gomock.Any(), change, forge.EditChangeOptions{
 		Base: "main",
@@ -164,6 +170,51 @@ func TestHandler_updateStacks_fallsBackAfterUnsupportedPlan(t *testing.T) {
 	})
 	service := NewMockService(ctrl)
 	service.EXPECT().BranchGraph(gomock.Any(), nil).Return(graph, nil)
+	handler := newStackFinalizationTestHandler(remoteForge, stackRepo, service)
+
+	err := handler.updateStackRepresentations(
+		t.Context(),
+		&Options{NavComment: NavCommentNever},
+		&submitStackUpdates{
+			requestedBranches: []string{"feature"},
+			deferredBases: []deferredBaseUpdate{
+				{branch: "feature", repository: remoteRepo, change: change, base: "main"},
+			},
+		},
+		[]string{"feature"},
+		[]string{"feature"},
+	)
+	require.NoError(t, err)
+}
+
+type submitStackRepository struct {
+	forge.Repository
+
+	plans   [][]forge.StackChange
+	planErr error
+	runErr  error
+}
+
+func (r *submitStackRepository) PlanStackUpdate(
+	_ context.Context,
+	changes []forge.StackChange,
+) (forge.StackUpdatePlan, error) {
+	r.plans = append(r.plans, changes)
+	if r.planErr != nil {
+		return nil, r.planErr
+	}
+	return submitStackUpdatePlan{err: r.runErr}, nil
+}
+
+type submitStackUpdatePlan struct{ err error }
+
+func (p submitStackUpdatePlan) Execute(context.Context) error { return p.err }
+
+func newStackFinalizationTestHandler(
+	remoteForge forge.Forge,
+	remoteRepo forge.Repository,
+	service Service,
+) *Handler {
 	handler := new(Handler)
 	handler.Log = silog.Nop()
 	handler.Service = service
@@ -181,38 +232,10 @@ func TestHandler_updateStacks_fallsBackAfterUnsupportedPlan(t *testing.T) {
 		forge.Forge,
 		forge.RepositoryID,
 	) (forge.Repository, error) {
-		return stackRepo, nil
+		return remoteRepo, nil
 	}
-
-	require.NoError(t, handler.updateStacks(
-		t.Context(),
-		[]string{"feature"},
-		&submitStackUpdates{deferredBases: []deferredBaseUpdate{
-			{repository: remoteRepo, change: change, base: "main"},
-		}},
-	))
+	return handler
 }
-
-type submitStackRepository struct {
-	forge.Repository
-
-	planErr error
-	runErr  error
-}
-
-func (r *submitStackRepository) PlanStackUpdate(
-	_ context.Context,
-	_ []forge.StackChange,
-) (forge.StackUpdatePlan, error) {
-	if r.planErr != nil {
-		return nil, r.planErr
-	}
-	return submitStackUpdatePlan{err: r.runErr}, nil
-}
-
-type submitStackUpdatePlan struct{ err error }
-
-func (p submitStackUpdatePlan) Execute(context.Context) error { return p.err }
 
 func (*submitStackRepository) PlanMergeRanges(
 	context.Context,

--- a/testdata/script/stack_submit_partial_failure.txt
+++ b/testdata/script/stack_submit_partial_failure.txt
@@ -1,0 +1,60 @@
+# A partially successful stack submit still updates navigation comments,
+# but does not reconcile an incomplete native stack component.
+
+as 'Test <test@example.com>'
+at '2026-08-11T15:00:00Z'
+
+cd repo
+git init
+git config spice.forge.shamhub.stacks on
+git commit --allow-empty -m 'Initial commit'
+
+shamhub-setup
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+git add bottom.txt
+gs branch create bottom -m 'Add bottom'
+git add top.txt
+gs branch create top -m 'Add top'
+
+# Let the bottom branch publish, then fail the top branch's push.
+mkdir -p .git/hooks
+cp $WORK/extra/pre-push .git/hooks/pre-push
+chmod 755 .git/hooks/pre-push
+
+! gs stack submit --fill
+stderr 'Created #1'
+stderr 'transient pre-push failure'
+
+shamhub dump stacks alice/example
+cmpenvJSON stdout $WORK/golden/stacks.json
+
+shamhub dump comments
+cmp stdout $WORK/golden/comments.txt
+
+-- repo/bottom.txt --
+bottom
+-- repo/top.txt --
+top
+-- extra/pre-push --
+#!/bin/sh
+if test -e .git/hooks/first-push-complete; then
+    echo 'transient pre-push failure' >&2
+    exit 1
+fi
+touch .git/hooks/first-push-complete
+-- golden/stacks.json --
+[]
+-- golden/comments.txt --
+- change: 1
+  body: |
+    This change is part of the following stack:
+
+    - #1 ◀
+
+    <sub>Change managed by [git-spice](https://abhinav.github.io/git-spice/).</sub>
+    <!-- gs:navigation comment -->


### PR DESCRIPTION
A batch submit returned immediately when any branch failed. Earlier change
requests had already been published, but their native stack membership and
navigation comments were skipped until another successful submit.

Defer stack-representation synchronization for completed branches and join its
error with the primary submit failure. Load one post-submit branch graph, derive
the native stack request before navigation metadata can change, and perform the
independent forge updates concurrently. Native stack failures remain
warning-only, while navigation comment failures and the original submit error
stay observable.