### PR TITLE
bitbucket: Support pull request reviews

### DIFF
--- a/internal/forge/bitbucket/forge.go
+++ b/internal/forge/bitbucket/forge.go
@@ -186,7 +186,9 @@ func (f *Forge) OpenRepository(
 	if err != nil {
 		return nil, err
 	}
-	return newRepository(f, f.logger(), gateway), nil
+	return withReviewRepository(
+		ctx, newRepository(f, f.logger(), gateway),
+	)
 }
 
 // bitbucketProduct fixes the product-specific repository behavior

--- a/internal/forge/bitbucket/forge_int_test.go
+++ b/internal/forge/bitbucket/forge_int_test.go
@@ -1,8 +1,10 @@
 package bitbucket
 
 import (
+	"context"
 	"net/http"
 
+	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/gateway/bitbucket/cloud"
 	"go.abhg.dev/gs/internal/silog"
 )
@@ -25,7 +27,7 @@ func NewRepositoryForTest(
 	log *silog.Logger,
 	httpClient *http.Client,
 	token *AuthenticationToken,
-) *Repository {
+) forge.Repository {
 	var ctok *cloud.Token
 	if token != nil {
 		ctok = &cloud.Token{AccessToken: token.AccessToken}
@@ -50,7 +52,7 @@ func NewRepositoryForTest(
 		panic(err)
 	}
 
-	return newRepository(forge, log, &testCloudGateway{
+	repository, err := withReviewRepository(context.Background(), newRepository(forge, log, &testCloudGateway{
 		Gateway:   gw,
 		client:    client,
 		token:     token,
@@ -58,5 +60,9 @@ func NewRepositoryForTest(
 		apiURL:    forge.APIURL(),
 		workspace: workspace,
 		repo:      repo,
-	})
+	}))
+	if err != nil {
+		panic(err)
+	}
+	return repository
 }

--- a/internal/forge/bitbucket/forge_server_test.go
+++ b/internal/forge/bitbucket/forge_server_test.go
@@ -1,6 +1,7 @@
 package bitbucket
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -189,18 +190,27 @@ func TestForge_OpenRepository_requiresURL(t *testing.T) {
 }
 
 func TestForge_OpenRepository_serverUsesRepositoryIDURL(t *testing.T) {
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/rest/api/1.0/application-properties", r.URL.Path)
+		_, err := w.Write([]byte(`{"version":"7.6.9"}`))
+		assert.NoError(t, err)
+	}))
+	defer apiSrv.Close()
+	webSrv := httptest.NewServer(http.NotFoundHandler())
+	defer webSrv.Close()
+
 	f := newForgeForTest(t,
 		Options{
 			Kind: KindDataCenter,
-			URL:  "https://wrong.example.com",
+			URL:  apiSrv.URL,
 		},
-		"https://wrong.example.com/scm/KEY/repo.git")
+		apiSrv.URL+"/scm/KEY/repo.git")
 
 	repo, err := f.OpenRepository(
 		t.Context(),
 		&AuthenticationToken{AccessToken: "tok"},
 		&RepositoryID{
-			url:        "https://bitbucket.example.com",
+			url:        webSrv.URL,
 			kind:       KindDataCenter,
 			projectKey: "KEY",
 			slug:       "repo",
@@ -209,13 +219,92 @@ func TestForge_OpenRepository_serverUsesRepositoryIDURL(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		"https://bitbucket.example.com/projects/KEY/repos/repo/pull-requests/42/overview",
+		webSrv.URL+"/projects/KEY/repos/repo/pull-requests/42/overview",
 		repo.(forge.WithChangeURL).ChangeURL(&PR{Number: 42}))
+}
+
+func TestForge_OpenRepository_reviewCapabilityProbeError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/rest/api/1.0/application-properties", r.URL.Path)
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	f := newForgeForTest(t,
+		Options{Kind: KindDataCenter, URL: srv.URL},
+		srv.URL+"/scm/KEY/repo.git")
+	_, err := f.OpenRepository(
+		t.Context(),
+		&AuthenticationToken{AccessToken: "tok"},
+		&RepositoryID{
+			url:        srv.URL,
+			kind:       KindDataCenter,
+			projectKey: "KEY",
+			slug:       "repo",
+		},
+	)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "review capabilities")
+}
+
+func TestForge_OpenRepository_reviewCapabilities(t *testing.T) {
+	tests := []struct {
+		version      string
+		wantReview   bool
+		wantResolver bool
+	}{
+		{version: "7.6.9"},
+		{version: "7.7.0", wantReview: true},
+		{version: "8.9.0", wantReview: true, wantResolver: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, "/rest/api/1.0/application-properties", r.URL.Path)
+				_, err := fmt.Fprintf(w, `{"version":%q}`, tt.version)
+				assert.NoError(t, err)
+			}))
+			defer srv.Close()
+
+			f := newForgeForTest(t,
+				Options{Kind: KindDataCenter, URL: srv.URL},
+				srv.URL+"/scm/KEY/repo.git")
+			repo, err := f.OpenRepository(
+				t.Context(),
+				&AuthenticationToken{AccessToken: "tok"},
+				&RepositoryID{
+					url:        srv.URL,
+					kind:       KindDataCenter,
+					projectKey: "KEY",
+					slug:       "repo",
+				},
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantReview,
+				implementsReviewRepository(repo))
+			assert.Equal(t, tt.wantResolver,
+				implementsReviewThreadResolver(repo))
+		})
+	}
+}
+
+func implementsReviewRepository(repo forge.Repository) bool {
+	_, ok := repo.(forge.ReviewRepository)
+	return ok
+}
+
+func implementsReviewThreadResolver(repo forge.Repository) bool {
+	_, ok := repo.(forge.ReviewThreadResolver)
+	return ok
 }
 
 func TestForge_OpenRepository_personalRepositoryUsesTildeRESTProjectKey(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
+		case "/rest/api/1.0/application-properties":
+			_, err := w.Write([]byte(`{"version":"7.6.9"}`))
+			assert.NoError(t, err)
 		case "/rest/api/1.0/projects/~jcaptain/repos/warp-core/raw/PULL_REQUEST_TEMPLATE.md":
 			_, err := w.Write([]byte("personal template\n"))
 			assert.NoError(t, err)

--- a/internal/forge/bitbucket/integration_test.go
+++ b/internal/forge/bitbucket/integration_test.go
@@ -86,7 +86,7 @@ func TestIntegration(t *testing.T) {
 			require.NoError(t,
 				bitbucket.MergeChange(
 					t.Context(),
-					repo.(*bitbucket.Repository),
+					repo,
 					change.(*bitbucket.PR),
 				))
 		},
@@ -98,7 +98,7 @@ func TestIntegration(t *testing.T) {
 			require.NoError(t,
 				bitbucket.CloseChange(
 					t.Context(),
-					repo.(*bitbucket.Repository),
+					repo,
 					change.(*bitbucket.PR),
 				))
 		},
@@ -126,7 +126,8 @@ func TestIntegration(t *testing.T) {
 		// because no working test account is available.
 		SetCommentsPageSize: bitbucket.SetListChangeCommentsPageSize,
 		Reviewers:           []string{cfg.Reviewer},
-		Assignees:           []string{},
+		// ReviewThreads:       true,
+		Assignees: []string{},
 		// Bitbucket limitations:
 		SkipLabels:            true, // no PR labels
 		SkipAssignees:         true, // no PR assignees

--- a/internal/forge/bitbucket/repository_int_test.go
+++ b/internal/forge/bitbucket/repository_int_test.go
@@ -10,12 +10,23 @@ import (
 	"go.abhg.dev/gs/internal/git"
 )
 
-func cloudGW(repo *Repository) *testCloudGateway {
-	return repo.gw.(*testCloudGateway)
+func baseRepository(repo forge.Repository) *Repository {
+	switch repo := repo.(type) {
+	case *Repository:
+		return repo
+	case *reviewRepository:
+		return repo.Repository
+	default:
+		panic(fmt.Sprintf("unexpected Bitbucket repository %T", repo))
+	}
+}
+
+func cloudGW(repo forge.Repository) *testCloudGateway {
+	return baseRepository(repo).gw.(*testCloudGateway)
 }
 
 func prActionPath(
-	repo *Repository, prID int64, action string,
+	repo forge.Repository, prID int64, action string,
 ) string {
 	gw := cloudGW(repo)
 	return fmt.Sprintf(
@@ -26,10 +37,11 @@ func prActionPath(
 
 // MergeChange merges a pull request for integration tests.
 func MergeChange(
-	ctx context.Context, repo *Repository, id *PR,
+	ctx context.Context, repo forge.Repository, id *PR,
 ) error {
+	base := baseRepository(repo)
 	if err := approvePR(ctx, repo, id); err != nil {
-		repo.log.Debug(
+		base.log.Debug(
 			"Approval failed (may not be required)",
 			"err", err,
 		)
@@ -39,14 +51,14 @@ func MergeChange(
 	if err := doTestAction(ctx, repo, path); err != nil {
 		return fmt.Errorf("merge PR: %w", err)
 	}
-	repo.log.Debug("Merged pull request", "pr", id.Number)
+	base.log.Debug("Merged pull request", "pr", id.Number)
 	return nil
 }
 
 // SetChangeChecksState sets a synthetic build status for integration tests.
 func SetChangeChecksState(
 	ctx context.Context,
-	repo *Repository,
+	repo forge.Repository,
 	headHash git.Hash,
 	state forge.ChangeCheckState,
 ) error {
@@ -82,7 +94,7 @@ func bitbucketStatusState(state forge.ChangeCheckState) string {
 }
 
 func approvePR(
-	ctx context.Context, repo *Repository, id *PR,
+	ctx context.Context, repo forge.Repository, id *PR,
 ) error {
 	path := prActionPath(repo, id.Number, "approve")
 	if err := doTestAction(ctx, repo, path); err != nil {
@@ -93,13 +105,13 @@ func approvePR(
 
 // CloseChange declines a pull request for integration tests.
 func CloseChange(
-	ctx context.Context, repo *Repository, id *PR,
+	ctx context.Context, repo forge.Repository, id *PR,
 ) error {
 	path := prActionPath(repo, id.Number, "decline")
 	if err := doTestAction(ctx, repo, path); err != nil {
 		return fmt.Errorf("decline PR: %w", err)
 	}
-	repo.log.Debug(
+	baseRepository(repo).log.Debug(
 		"Declined pull request", "pr", id.Number,
 	)
 	return nil
@@ -107,7 +119,7 @@ func CloseChange(
 
 func doTestAction(
 	ctx context.Context,
-	repo *Repository,
+	repo forge.Repository,
 	path string,
 ) error {
 	gw := cloudGW(repo)

--- a/internal/forge/bitbucket/review.go
+++ b/internal/forge/bitbucket/review.go
@@ -1,0 +1,466 @@
+package bitbucket
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"strconv"
+
+	"go.abhg.dev/gs/internal/forge"
+	gw "go.abhg.dev/gs/internal/gateway/bitbucket"
+)
+
+// Bitbucket exposes review conversations through pull request comments rather
+// than a separate thread resource. Each product gateway reconstructs an
+// anchored root and its replies in product order.
+//
+// reviewThreadID preserves the root comment ID and pull request ID.
+// The root comment ID is the parent used when posting replies
+// and the resource accepted by optional resolve and unresolve operations.
+// The pull request ID is retained because every comment endpoint is scoped to
+// a pull request, while later ReviewRepository operations receive only the ID
+// returned by listing or submission.
+// Its String form retains the established "commentID:prID" representation.
+//
+// reviewCommentID separately preserves each individual comment ID
+// and its pull request ID for the pull-request-scoped update endpoint.
+// Keeping this concrete type distinct from PRComment prevents ordinary change
+// comments from crossing the review-comment editing boundary. Data Center's
+// optimistic-locking version travels with this ID without changing its stable
+// String representation.
+//
+// Listing and new-comment submission construct the same synthetic thread
+// coordinates.
+// Reply submission decodes those coordinates, posts a comment whose parent is
+// the root comment, and returns the existing thread ID with the new comment ID.
+// Resolve and unresolve decode that same thread ID and operate on its root.
+// The retained coordinates therefore reconnect list and submit results to the
+// later reply, update, resolve, and unresolve calls that consume them.
+//
+// Data Center 7.7+ creates requested comments as pending drafts and publishes
+// them through its native review endpoint. Before 9.2, it can represent only a
+// single line, so the provider anchors a requested range at its start line.
+// Thread resolution is exposed separately from 8.9 onward.
+type reviewRepository struct {
+	*Repository
+	reviewGW     gw.ReviewGateway
+	capabilities gw.ReviewCapabilities
+}
+
+// resolvableReviewRepository keeps ReviewThreadResolver out of the method set
+// when the selected Data Center version predates thread resolution.
+type resolvableReviewRepository struct {
+	*reviewRepository
+}
+
+var (
+	_ forge.ReviewRepository     = (*reviewRepository)(nil)
+	_ forge.ReviewCommentEditor  = (*reviewRepository)(nil)
+	_ forge.ReviewThreadResolver = (*resolvableReviewRepository)(nil)
+)
+
+// reviewThreadID is a synthetic Bitbucket thread identity.
+type reviewThreadID struct {
+	CommentID int64
+	PRID      int64
+}
+
+var _ forge.ReviewThreadID = reviewThreadID{}
+
+func (id reviewThreadID) String() string {
+	return strconv.FormatInt(id.CommentID, 10) + ":" +
+		strconv.FormatInt(id.PRID, 10)
+}
+
+// reviewCommentID identifies one comment in a Bitbucket review thread.
+type reviewCommentID struct {
+	CommentID int64
+	PRID      int64
+	Version   int
+}
+
+var _ forge.ReviewCommentID = reviewCommentID{}
+
+func (id reviewCommentID) String() string {
+	return strconv.FormatInt(id.CommentID, 10) + ":" +
+		strconv.FormatInt(id.PRID, 10)
+}
+
+// withReviewRepository discovers product capabilities while opening the
+// repository. Probe failures are returned because treating an unknown Data
+// Center version as unsupported would hide a surface the server may provide.
+func withReviewRepository(
+	ctx context.Context,
+	repo *Repository,
+) (forge.Repository, error) {
+	reviewGW, ok := repo.gw.(gw.ReviewGateway)
+	if !ok {
+		return repo, nil
+	}
+	capabilities, err := reviewGW.ReviewCapabilities(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("determine review capabilities: %w", err)
+	}
+	if !capabilities.Supported {
+		return repo, nil
+	}
+	reviewRepo := &reviewRepository{
+		Repository:   repo,
+		reviewGW:     reviewGW,
+		capabilities: capabilities,
+	}
+	if capabilities.ThreadResolution {
+		return &resolvableReviewRepository{reviewRepository: reviewRepo}, nil
+	}
+	return reviewRepo, nil
+}
+
+// ListReviewerStates lists the latest state exposed for each participant.
+func (r *reviewRepository) ListReviewerStates(
+	ctx context.Context,
+	id forge.ChangeID,
+) iter.Seq2[*forge.ReviewerState, error] {
+	prID := mustPR(id).Number
+	return func(yield func(*forge.ReviewerState, error) bool) {
+		for state, err := range r.reviewGW.ListReviewerStates(ctx, prID) {
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+			if !yield(&forge.ReviewerState{
+				Reviewer:    state.Reviewer,
+				Disposition: state.Disposition,
+				CommitHash:  state.CommitHash,
+				SubmittedAt: state.SubmittedAt,
+			}, nil) {
+				return
+			}
+		}
+	}
+}
+
+// ListReviewThreads lists comment-backed threads on a pull request. Resolved
+// is populated only when the selected product version exposes resolution;
+// Bitbucket does not expose a distinct outdated-thread flag.
+func (r *reviewRepository) ListReviewThreads(
+	ctx context.Context,
+	id forge.ChangeID,
+) iter.Seq2[*forge.ReviewThread, error] {
+	prID := mustPR(id).Number
+	return func(yield func(*forge.ReviewThread, error) bool) {
+		for thread, err := range r.reviewGW.ListReviewThreads(ctx, prID) {
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+
+			item := &forge.ReviewThread{
+				ID: reviewThreadID{
+					CommentID: thread.RootCommentID,
+					PRID:      prID,
+				},
+				Path:  thread.Path,
+				Range: thread.Range,
+				Side:  thread.Side,
+			}
+			if r.capabilities.ThreadResolution {
+				resolved := thread.Resolved
+				item.Resolved = &resolved
+			}
+			for _, comment := range thread.Comments {
+				item.Comments = append(item.Comments, forge.ReviewComment{
+					ID: reviewCommentID{
+						CommentID: comment.ID,
+						PRID:      prID,
+						Version:   comment.Version,
+					},
+					Body:      comment.Body,
+					Author:    comment.Author,
+					CreatedAt: comment.CreatedAt,
+				})
+			}
+			if !yield(item, nil) {
+				return
+			}
+		}
+	}
+}
+
+// SubmitReview dispatches to the product's review workflow. Cloud publishes
+// each resource immediately. Data Center creates pending comments before
+// publishing the native review.
+func (r *reviewRepository) SubmitReview(
+	ctx context.Context,
+	id forge.ChangeID,
+	req forge.SubmitReviewRequest,
+) (forge.SubmitReviewResult, error) {
+	mustReviewDisposition(req.Disposition)
+	prID := mustPR(id).Number
+	if r.capabilities.NativeDrafts {
+		return r.submitNativeReview(ctx, prID, req)
+	}
+	return r.submitEmulatedReview(ctx, id, prID, req)
+}
+
+// mustReviewDisposition checks the git-spice-owned enum before any provider
+// mutation, so an internal invariant failure cannot leave a partial review.
+func mustReviewDisposition(disposition forge.ReviewDisposition) {
+	switch disposition {
+	case forge.ReviewDispositionNone,
+		forge.ReviewDispositionApprove,
+		forge.ReviewDispositionRequestChanges:
+		return
+	default:
+		panic(fmt.Sprintf(
+			"bitbucket: invalid review disposition %d", disposition))
+	}
+}
+
+// submitEmulatedReview publishes each Cloud resource through its individual
+// endpoint before setting the disposition. An error may therefore leave earlier
+// operations visible, but SubmitReview does not expose partial results.
+func (r *reviewRepository) submitEmulatedReview(
+	ctx context.Context,
+	id forge.ChangeID,
+	prID int64,
+	req forge.SubmitReviewRequest,
+) (forge.SubmitReviewResult, error) {
+	var result forge.SubmitReviewResult
+	if req.Body != "" {
+		if _, err := r.PostChangeComment(ctx, id, req.Body); err != nil {
+			return forge.SubmitReviewResult{}, fmt.Errorf(
+				"post review body: %w", err)
+		}
+	}
+
+	for _, comment := range req.Comments {
+		posted, err := r.submitReviewComment(
+			ctx, prID, gw.ReviewContext{}, comment)
+		if err != nil {
+			return forge.SubmitReviewResult{}, err
+		}
+		result.Comments = append(result.Comments, posted)
+	}
+
+	if req.Disposition != forge.ReviewDispositionNone {
+		dispositionGW, ok := r.reviewGW.(gw.EmulatedReviewGateway)
+		if !ok {
+			panic(fmt.Sprintf(
+				"bitbucket: %T advertises emulated reviews without implementing EmulatedReviewGateway",
+				r.reviewGW,
+			))
+		}
+		if err := dispositionGW.SetReviewDisposition(
+			ctx, prID, req.Disposition,
+		); err != nil {
+			return forge.SubmitReviewResult{}, fmt.Errorf(
+				"set review disposition: %w", err)
+		}
+	}
+
+	return result, nil
+}
+
+// submitNativeReview resolves every Data Center anchor before mutation, creates
+// the comments as drafts, and then publishes the native review.
+func (r *reviewRepository) submitNativeReview(
+	ctx context.Context,
+	prID int64,
+	req forge.SubmitReviewRequest,
+) (forge.SubmitReviewResult, error) {
+	pendingGW, ok := r.reviewGW.(gw.PendingReviewGateway)
+	if !ok {
+		panic(fmt.Sprintf(
+			"bitbucket: %T advertises native review drafts without implementing PendingReviewGateway",
+			r.reviewGW,
+		))
+	}
+
+	var reviewContext gw.ReviewContext
+	if req.Body != "" || len(req.Comments) > 0 ||
+		req.Disposition != forge.ReviewDispositionNone {
+		var err error
+		reviewContext, err = pendingGW.ReviewContext(ctx, prID)
+		if err != nil {
+			return forge.SubmitReviewResult{}, fmt.Errorf(
+				"prepare review: %w", err)
+		}
+	}
+
+	prepared := make([]gw.CreateReviewCommentRequest, 0, len(req.Comments))
+	for _, comment := range req.Comments {
+		// Data Center versions before 9.2 have no multiline anchor shape.
+		// Preserve the requested start rather than rejecting the whole review.
+		if comment.ReplyTo == nil && !r.capabilities.Multiline {
+			comment.Range = forge.ReviewThreadLine(comment.Range.StartLine)
+		}
+		apiReq := reviewCommentRequest(prID, reviewContext, comment)
+		if apiReq.ParentID == 0 {
+			anchor, err := pendingGW.ReviewAnchor(
+				ctx,
+				prID,
+				reviewContext,
+				apiReq.Path,
+				apiReq.Range,
+				apiReq.Side,
+			)
+			if err != nil {
+				return forge.SubmitReviewResult{}, fmt.Errorf(
+					"prepare review comment: %w", err)
+			}
+			apiReq.ReviewAnchor = anchor
+		}
+		prepared = append(prepared, apiReq)
+	}
+
+	var pending forge.SubmitReviewResult
+	for _, apiReq := range prepared {
+		posted, err := r.createReviewComment(ctx, prID, apiReq)
+		if err != nil {
+			return forge.SubmitReviewResult{}, err
+		}
+		pending.Comments = append(pending.Comments, posted)
+	}
+
+	if req.Body != "" || len(req.Comments) > 0 ||
+		req.Disposition != forge.ReviewDispositionNone {
+		if err := pendingGW.PublishReview(
+			ctx, prID, reviewContext, req.Body, req.Disposition,
+		); err != nil {
+			return forge.SubmitReviewResult{}, err
+		}
+	}
+
+	return pending, nil
+}
+
+// submitReviewComment converts one forge request and creates it immediately.
+// The emulated Cloud path uses this because no pending publication phase exists.
+func (r *reviewRepository) submitReviewComment(
+	ctx context.Context,
+	prID int64,
+	reviewContext gw.ReviewContext,
+	req forge.SubmitReviewCommentRequest,
+) (forge.SubmitReviewCommentResult, error) {
+	return r.createReviewComment(
+		ctx, prID, reviewCommentRequest(prID, reviewContext, req))
+}
+
+// reviewCommentRequest converts git-spice-owned IDs and carries the prepared
+// Data Center review context into the gateway request.
+func reviewCommentRequest(
+	prID int64,
+	reviewContext gw.ReviewContext,
+	req forge.SubmitReviewCommentRequest,
+) gw.CreateReviewCommentRequest {
+	apiReq := gw.CreateReviewCommentRequest{
+		Path:          req.Path,
+		Range:         req.Range,
+		Side:          req.Side,
+		Body:          req.Body,
+		ReviewContext: reviewContext,
+	}
+	if req.ReplyTo != nil {
+		threadID := mustReviewThreadForPullRequest(req.ReplyTo, prID)
+		apiReq.ParentID = threadID.CommentID
+	}
+	return apiReq
+}
+
+// createReviewComment reconstructs the stable synthetic thread identity from
+// either the new root comment or the parent named by a reply.
+func (r *reviewRepository) createReviewComment(
+	ctx context.Context,
+	prID int64,
+	apiReq gw.CreateReviewCommentRequest,
+) (forge.SubmitReviewCommentResult, error) {
+	comment, err := r.reviewGW.CreateReviewComment(ctx, prID, apiReq)
+	if err != nil {
+		return forge.SubmitReviewCommentResult{}, err
+	}
+	threadID := reviewThreadID{CommentID: apiReq.ParentID, PRID: prID}
+	if apiReq.ParentID == 0 {
+		threadID = reviewThreadID{CommentID: comment.ID, PRID: prID}
+	}
+	return forge.SubmitReviewCommentResult{
+		ThreadID: threadID,
+		CommentID: reviewCommentID{
+			CommentID: comment.ID,
+			PRID:      prID,
+			Version:   comment.Version,
+		},
+	}, nil
+}
+
+// mustReviewThreadID converts an ID produced by this provider. A foreign ID is
+// an internal wiring error because SubmitReviewRequest is built by git-spice.
+func mustReviewThreadID(id forge.ReviewThreadID) reviewThreadID {
+	threadID, ok := id.(reviewThreadID)
+	if !ok {
+		panic(fmt.Sprintf("bitbucket: expected review thread ID, got %T", id))
+	}
+	return threadID
+}
+
+// mustReviewThreadForPullRequest additionally preserves the pull-request scope
+// encoded in the synthetic thread ID.
+func mustReviewThreadForPullRequest(
+	id forge.ReviewThreadID,
+	prID int64,
+) reviewThreadID {
+	threadID := mustReviewThreadID(id)
+	if threadID.PRID != prID {
+		panic(fmt.Sprintf(
+			"review thread %s belongs to pull request %d, not %d",
+			threadID, threadID.PRID, prID))
+	}
+	if threadID.CommentID <= 0 {
+		panic(fmt.Sprintf(
+			"review thread %s has an invalid comment ID", threadID))
+	}
+	return threadID
+}
+
+// UpdateReviewComment replaces a review comment body.
+func (r *reviewRepository) UpdateReviewComment(
+	ctx context.Context,
+	id forge.ReviewCommentID,
+	body string,
+) error {
+	comment := mustReviewCommentID(id)
+	return r.gw.UpdateComment(ctx, &gw.ChangeComment{
+		ID:      comment.CommentID,
+		PRID:    comment.PRID,
+		Version: comment.Version,
+	}, body)
+}
+
+// mustReviewCommentID keeps ordinary pull request comments from crossing the
+// review-comment editing boundary.
+func mustReviewCommentID(id forge.ReviewCommentID) reviewCommentID {
+	comment, ok := id.(reviewCommentID)
+	if !ok {
+		panic(fmt.Sprintf("bitbucket: expected review comment ID, got %T", id))
+	}
+	return comment
+}
+
+// ResolveReviewThread resolves a comment-backed thread.
+func (r *resolvableReviewRepository) ResolveReviewThread(
+	ctx context.Context,
+	id forge.ReviewThreadID,
+) error {
+	threadID := mustReviewThreadID(id)
+	return r.reviewGW.ResolveReviewThread(
+		ctx, threadID.PRID, threadID.CommentID)
+}
+
+// UnresolveReviewThread reopens a comment-backed thread.
+func (r *resolvableReviewRepository) UnresolveReviewThread(
+	ctx context.Context,
+	id forge.ReviewThreadID,
+) error {
+	threadID := mustReviewThreadID(id)
+	return r.reviewGW.UnresolveReviewThread(
+		ctx, threadID.PRID, threadID.CommentID)
+}

--- a/internal/forge/bitbucket/review.go
+++ b/internal/forge/bitbucket/review.go
@@ -196,6 +196,14 @@ func (r *reviewRepository) SubmitReview(
 ) (forge.SubmitReviewResult, error) {
 	mustReviewDisposition(req.Disposition)
 	prID := mustPR(id).Number
+	if !r.capabilities.FileLevel {
+		for _, comment := range req.Comments {
+			if comment.ReplyTo == nil && comment.Range.IsZero() {
+				return forge.SubmitReviewResult{}, fmt.Errorf(
+					"submit file-level comment: %w", forge.ErrUnsupported)
+			}
+		}
+	}
 	if r.capabilities.NativeDrafts {
 		return r.submitNativeReview(ctx, prID, req)
 	}
@@ -291,7 +299,8 @@ func (r *reviewRepository) submitNativeReview(
 	for _, comment := range req.Comments {
 		// Data Center versions before 9.2 have no multiline anchor shape.
 		// Preserve the requested start rather than rejecting the whole review.
-		if comment.ReplyTo == nil && !r.capabilities.Multiline {
+		if comment.ReplyTo == nil && !comment.Range.IsZero() &&
+			!r.capabilities.Multiline {
 			comment.Range = forge.ReviewThreadLine(comment.Range.StartLine)
 		}
 		apiReq := reviewCommentRequest(prID, reviewContext, comment)

--- a/internal/forge/bitbucket/review_test.go
+++ b/internal/forge/bitbucket/review_test.go
@@ -1,0 +1,770 @@
+package bitbucket
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/forge"
+	gw "go.abhg.dev/gs/internal/gateway/bitbucket"
+	"go.abhg.dev/gs/internal/silog"
+	"go.uber.org/mock/gomock"
+)
+
+func TestRepository_reviewCapability(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	base := newRepository(new(Forge), silog.Nop(), NewMockGateway(ctrl))
+	assert.NotImplements(t, (*forge.ReviewRepository)(nil), base)
+
+	reviewGW := &stubReviewGateway{
+		Gateway: NewMockGateway(ctrl),
+		capabilities: gw.ReviewCapabilities{
+			Supported: true,
+		},
+	}
+	repo := mustWithReviewRepository(t.Context(), t, newRepository(new(Forge), silog.Nop(), reviewGW))
+	assert.Implements(t, (*forge.ReviewRepository)(nil), repo)
+	assert.Implements(t, (*forge.ReviewCommentEditor)(nil), repo)
+	assert.NotImplements(t, (*forge.ReviewThreadResolver)(nil), repo)
+
+	reviewGW.capabilities.ThreadResolution = true
+	repo = mustWithReviewRepository(t.Context(), t, newRepository(new(Forge), silog.Nop(), reviewGW))
+	assert.Implements(t, (*forge.ReviewThreadResolver)(nil), repo)
+}
+
+func TestReviewRepository_ListReviewThreads(t *testing.T) {
+	resolved := true
+	created := time.Date(2026, time.June, 14, 12, 0, 0, 0, time.UTC)
+	reviewGW := &stubReviewGateway{
+		Gateway: NewMockGateway(gomock.NewController(t)),
+		listReviewThreads: func(context.Context, int64) iter.Seq2[*gw.ReviewThread, error] {
+			return func(yield func(*gw.ReviewThread, error) bool) {
+				yield(&gw.ReviewThread{
+					RootCommentID: 10,
+					Path:          "review.go",
+					Range:         forge.ReviewThreadLine(3),
+					Side:          forge.ReviewThreadSideRight,
+					Resolved:      resolved,
+					Comments: []gw.ReviewComment{
+						{ID: 10, Body: "root", Author: "spock", CreatedAt: created},
+						{ID: 11, Body: "reply", Author: "kirk", CreatedAt: created.Add(time.Minute)},
+					},
+				}, nil)
+			}
+		},
+	}
+	repo := mustWithReviewRepository(t.Context(), t, newRepository(new(Forge), silog.Nop(), reviewGW)).(forge.ReviewRepository)
+
+	var got []*forge.ReviewThread
+	for thread, err := range repo.ListReviewThreads(t.Context(), &PR{Number: 7}) {
+		require.NoError(t, err)
+		got = append(got, thread)
+	}
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "10:7", got[0].ID.String())
+	assert.Equal(t, reviewCommentID{CommentID: 10, PRID: 7}, got[0].Comments[0].ID)
+	assert.Equal(t, reviewCommentID{CommentID: 11, PRID: 7}, got[0].Comments[1].ID)
+	assert.Equal(t, &resolved, got[0].Resolved)
+	assert.Nil(t, got[0].Outdated)
+}
+
+func TestReviewRepository_ListReviewerStates(t *testing.T) {
+	submitted := time.Date(2026, time.June, 14, 12, 0, 0, 0, time.UTC)
+	reviewGW := &stubReviewGateway{
+		Gateway: NewMockGateway(gomock.NewController(t)),
+		listReviewerStates: func(context.Context, int64) iter.Seq2[*gw.ReviewerState, error] {
+			return func(yield func(*gw.ReviewerState, error) bool) {
+				yield(&gw.ReviewerState{
+					Reviewer:    "spock",
+					Disposition: forge.ReviewDispositionApprove,
+					SubmittedAt: submitted,
+				}, nil)
+			}
+		},
+	}
+	repo := mustWithReviewRepository(t.Context(), t, newRepository(new(Forge), silog.Nop(), reviewGW)).(forge.ReviewRepository)
+
+	var got []*forge.ReviewerState
+	for state, err := range repo.ListReviewerStates(t.Context(), &PR{Number: 7}) {
+		require.NoError(t, err)
+		got = append(got, state)
+	}
+
+	assert.Equal(t, []*forge.ReviewerState{{
+		Reviewer:    "spock",
+		Disposition: forge.ReviewDispositionApprove,
+		SubmittedAt: submitted,
+	}}, got)
+}
+
+func TestReviewRepository_SubmitReview_degradesUnsupportedMultiline(t *testing.T) {
+	var actions []string
+	base := &stubReviewGateway{
+		Gateway: NewMockGateway(gomock.NewController(t)),
+		capabilities: gw.ReviewCapabilities{
+			Supported:    true,
+			NativeDrafts: true,
+		},
+		createReviewComment: func(
+			_ context.Context,
+			_ int64,
+			req gw.CreateReviewCommentRequest,
+		) (*gw.ReviewComment, error) {
+			actions = append(actions, "draft")
+			assert.Equal(t, forge.ReviewThreadLine(3), req.Range)
+			return &gw.ReviewComment{ID: 10}, nil
+		},
+	}
+	reviewGW := &stubPendingReviewGateway{
+		stubReviewGateway: base,
+		reviewContext: func(context.Context, int64) (gw.ReviewContext, error) {
+			actions = append(actions, "context")
+			return gw.ReviewContext{}, nil
+		},
+		reviewAnchor: func(
+			_ context.Context,
+			_ int64,
+			_ gw.ReviewContext,
+			_ string,
+			lines forge.ReviewThreadRange,
+			_ forge.ReviewThreadSide,
+		) (gw.ReviewAnchor, error) {
+			actions = append(actions, "anchor")
+			assert.Equal(t, forge.ReviewThreadLine(3), lines)
+			return gw.ReviewAnchor{EndLineType: "ADDED"}, nil
+		},
+		publishReview: func(
+			context.Context,
+			int64,
+			gw.ReviewContext,
+			string,
+			forge.ReviewDisposition,
+		) error {
+			actions = append(actions, "publish")
+			return nil
+		},
+	}
+	repo := mustWithReviewRepository(
+		t.Context(), t, newRepository(new(Forge), silog.Nop(), reviewGW),
+	).(forge.ReviewRepository)
+
+	result, err := repo.SubmitReview(
+		t.Context(), &PR{Number: 7}, forge.SubmitReviewRequest{
+			Comments: []forge.SubmitReviewCommentRequest{{
+				Path:  "review.go",
+				Range: forge.ReviewThreadRange{StartLine: 3, EndLine: 4},
+				Body:  "comment",
+			}},
+		})
+
+	require.NoError(t, err)
+	require.Len(t, result.Comments, 1)
+	assert.Equal(t, []string{"context", "anchor", "draft", "publish"}, actions)
+}
+
+func TestReviewRepository_SubmitReview_invalidDispositionPanicsBeforeMutation(t *testing.T) {
+	var mutations int
+	mockGateway := NewMockGateway(gomock.NewController(t))
+	mockGateway.EXPECT().
+		CreateComment(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(context.Context, int64, string) (*gw.ChangeComment, error) {
+			mutations++
+			return &gw.ChangeComment{}, nil
+		}).
+		AnyTimes()
+	reviewGW := &stubReviewGateway{
+		Gateway: mockGateway,
+		createReviewComment: func(
+			context.Context,
+			int64,
+			gw.CreateReviewCommentRequest,
+		) (*gw.ReviewComment, error) {
+			mutations++
+			return &gw.ReviewComment{ID: 10}, nil
+		},
+		setReviewDisposition: func(
+			context.Context,
+			int64,
+			forge.ReviewDisposition,
+		) error {
+			mutations++
+			return nil
+		},
+	}
+	repo := mustWithReviewRepository(
+		t.Context(), t, newRepository(new(Forge), silog.Nop(), reviewGW),
+	).(forge.ReviewRepository)
+
+	assert.Panics(t, func() {
+		_, _ = repo.SubmitReview(
+			t.Context(), &PR{Number: 7}, forge.SubmitReviewRequest{
+				Body:        "summary",
+				Disposition: forge.ReviewDisposition(99),
+				Comments: []forge.SubmitReviewCommentRequest{{
+					Path:  "review.go",
+					Range: forge.ReviewThreadLine(3),
+					Body:  "comment",
+				}},
+			})
+	})
+	assert.Zero(t, mutations)
+
+	nativeMutations := 0
+	nativeBase := &stubReviewGateway{
+		Gateway: NewMockGateway(gomock.NewController(t)),
+		capabilities: gw.ReviewCapabilities{
+			Supported:    true,
+			NativeDrafts: true,
+			Multiline:    true,
+		},
+		createReviewComment: func(
+			context.Context,
+			int64,
+			gw.CreateReviewCommentRequest,
+		) (*gw.ReviewComment, error) {
+			nativeMutations++
+			return &gw.ReviewComment{ID: 10}, nil
+		},
+		setReviewDisposition: func(
+			context.Context,
+			int64,
+			forge.ReviewDisposition,
+		) error {
+			nativeMutations++
+			return nil
+		},
+	}
+	nativeGW := &stubPendingReviewGateway{
+		stubReviewGateway: nativeBase,
+		reviewContext: func(context.Context, int64) (gw.ReviewContext, error) {
+			nativeMutations++
+			return gw.ReviewContext{}, nil
+		},
+		reviewAnchor: func(
+			context.Context,
+			int64,
+			gw.ReviewContext,
+			string,
+			forge.ReviewThreadRange,
+			forge.ReviewThreadSide,
+		) (gw.ReviewAnchor, error) {
+			nativeMutations++
+			return gw.ReviewAnchor{}, nil
+		},
+		publishReview: func(
+			context.Context,
+			int64,
+			gw.ReviewContext,
+			string,
+			forge.ReviewDisposition,
+		) error {
+			nativeMutations++
+			return nil
+		},
+	}
+	nativeRepo := mustWithReviewRepository(
+		t.Context(), t, newRepository(new(Forge), silog.Nop(), nativeGW),
+	).(forge.ReviewRepository)
+
+	assert.Panics(t, func() {
+		_, _ = nativeRepo.SubmitReview(
+			t.Context(), &PR{Number: 7}, forge.SubmitReviewRequest{
+				Body:        "summary",
+				Disposition: forge.ReviewDisposition(99),
+				Comments: []forge.SubmitReviewCommentRequest{{
+					Path:  "review.go",
+					Range: forge.ReviewThreadLine(3),
+					Body:  "comment",
+				}},
+			})
+	})
+	assert.Zero(t, nativeMutations)
+}
+
+func TestReviewRepository_SubmitReview_commentErrorReturnsEmptyResult(t *testing.T) {
+	wantErr := errors.New("second comment failed")
+	var calls int
+	reviewGW := &stubReviewGateway{
+		Gateway: NewMockGateway(gomock.NewController(t)),
+		createReviewComment: func(
+			_ context.Context,
+			_ int64,
+			req gw.CreateReviewCommentRequest,
+		) (*gw.ReviewComment, error) {
+			calls++
+			if calls == 2 {
+				return nil, wantErr
+			}
+			assert.Equal(t, forge.ReviewThreadSideLeft, req.Side)
+			return &gw.ReviewComment{ID: 10, Body: req.Body}, nil
+		},
+	}
+	repo := mustWithReviewRepository(t.Context(), t, newRepository(new(Forge), silog.Nop(), reviewGW)).(forge.ReviewRepository)
+
+	result, err := repo.SubmitReview(t.Context(), &PR{Number: 7}, forge.SubmitReviewRequest{
+		Comments: []forge.SubmitReviewCommentRequest{
+			{Path: "review.go", Range: forge.ReviewThreadLine(3), Side: forge.ReviewThreadSideLeft, Body: "first"},
+			{Path: "review.go", Range: forge.ReviewThreadLine(4), Body: "second"},
+		},
+	})
+	require.ErrorIs(t, err, wantErr)
+	assert.Empty(t, result.Comments)
+}
+
+func TestReviewRepository_SubmitReview_dispositionErrorReturnsEmptyResult(t *testing.T) {
+	wantErr := errors.New("request changes failed")
+	reviewGW := &stubReviewGateway{
+		Gateway: NewMockGateway(gomock.NewController(t)),
+		createReviewComment: func(
+			_ context.Context,
+			_ int64,
+			req gw.CreateReviewCommentRequest,
+		) (*gw.ReviewComment, error) {
+			return &gw.ReviewComment{ID: 10, Body: req.Body}, nil
+		},
+		setReviewDisposition: func(
+			context.Context,
+			int64,
+			forge.ReviewDisposition,
+		) error {
+			return wantErr
+		},
+	}
+	repo := mustWithReviewRepository(
+		t.Context(), t, newRepository(new(Forge), silog.Nop(), reviewGW),
+	).(forge.ReviewRepository)
+
+	result, err := repo.SubmitReview(
+		t.Context(), &PR{Number: 7}, forge.SubmitReviewRequest{
+			Disposition: forge.ReviewDispositionRequestChanges,
+			Comments: []forge.SubmitReviewCommentRequest{{
+				Path:  "review.go",
+				Range: forge.ReviewThreadLine(3),
+				Body:  "comment",
+			}},
+		})
+	require.ErrorIs(t, err, wantErr)
+	assert.Empty(t, result.Comments)
+}
+
+func TestReviewRepository_SubmitReview_reply(t *testing.T) {
+	reviewGW := &stubReviewGateway{
+		Gateway: NewMockGateway(gomock.NewController(t)),
+		createReviewComment: func(
+			_ context.Context,
+			prID int64,
+			req gw.CreateReviewCommentRequest,
+		) (*gw.ReviewComment, error) {
+			assert.Equal(t, int64(7), prID)
+			assert.Equal(t, int64(10), req.ParentID)
+			return &gw.ReviewComment{ID: 11, Body: req.Body}, nil
+		},
+	}
+	repo := mustWithReviewRepository(t.Context(), t, newRepository(new(Forge), silog.Nop(), reviewGW)).(forge.ReviewRepository)
+	threadID := reviewThreadID{CommentID: 10, PRID: 7}
+
+	result, err := repo.SubmitReview(t.Context(), &PR{Number: 7}, forge.SubmitReviewRequest{
+		Comments: []forge.SubmitReviewCommentRequest{{
+			ReplyTo: threadID,
+			Body:    "reply",
+		}},
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Comments, 1)
+	assert.Equal(t, threadID, result.Comments[0].ThreadID)
+	assert.Equal(t, reviewCommentID{CommentID: 11, PRID: 7}, result.Comments[0].CommentID)
+}
+
+func TestReviewRepository_SubmitReview_bodyAndDisposition(t *testing.T) {
+	mockGateway := NewMockGateway(gomock.NewController(t))
+	mockGateway.EXPECT().CreateComment(gomock.Any(), int64(7), "summary").
+		Return(&gw.ChangeComment{ID: 9, PRID: 7}, nil)
+	var gotDisposition forge.ReviewDisposition
+	reviewGW := &stubReviewGateway{
+		Gateway: mockGateway,
+		setReviewDisposition: func(
+			_ context.Context,
+			_ int64,
+			disposition forge.ReviewDisposition,
+		) error {
+			gotDisposition = disposition
+			return nil
+		},
+	}
+	repo := mustWithReviewRepository(t.Context(), t, newRepository(new(Forge), silog.Nop(), reviewGW)).(forge.ReviewRepository)
+
+	result, err := repo.SubmitReview(t.Context(), &PR{Number: 7}, forge.SubmitReviewRequest{
+		Body:        "summary",
+		Disposition: forge.ReviewDispositionRequestChanges,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, result.Comments)
+	assert.Equal(t, forge.ReviewDispositionRequestChanges, gotDisposition)
+}
+
+func TestReviewRepository_SubmitReview_noneDoesNotSetDisposition(t *testing.T) {
+	mockGateway := NewMockGateway(gomock.NewController(t))
+	mockGateway.EXPECT().CreateComment(gomock.Any(), int64(7), "summary").
+		Return(&gw.ChangeComment{ID: 9, PRID: 7}, nil)
+	reviewGW := &stubReviewGateway{
+		Gateway: mockGateway,
+		createReviewComment: func(
+			_ context.Context,
+			_ int64,
+			req gw.CreateReviewCommentRequest,
+		) (*gw.ReviewComment, error) {
+			return &gw.ReviewComment{ID: 10, Body: req.Body}, nil
+		},
+		setReviewDisposition: func(
+			context.Context,
+			int64,
+			forge.ReviewDisposition,
+		) error {
+			t.Fatal("content-only submission must not set a disposition")
+			return nil
+		},
+	}
+	repo := mustWithReviewRepository(
+		t.Context(), t, newRepository(new(Forge), silog.Nop(), reviewGW),
+	).(forge.ReviewRepository)
+
+	result, err := repo.SubmitReview(
+		t.Context(), &PR{Number: 7}, forge.SubmitReviewRequest{
+			Body: "summary",
+			Comments: []forge.SubmitReviewCommentRequest{{
+				Path:  "review.go",
+				Range: forge.ReviewThreadLine(3),
+				Body:  "comment",
+			}},
+		})
+	require.NoError(t, err)
+	require.Len(t, result.Comments, 1)
+	assert.Equal(t, reviewCommentID{CommentID: 10, PRID: 7}, result.Comments[0].CommentID)
+}
+
+func TestReviewRepository_SubmitReview_nativeDrafts(t *testing.T) {
+	var actions []string
+	base := &stubReviewGateway{
+		Gateway: NewMockGateway(gomock.NewController(t)),
+		capabilities: gw.ReviewCapabilities{
+			Supported:    true,
+			NativeDrafts: true,
+			Multiline:    true,
+		},
+		createReviewComment: func(
+			_ context.Context,
+			_ int64,
+			req gw.CreateReviewCommentRequest,
+		) (*gw.ReviewComment, error) {
+			actions = append(actions, "draft")
+			assert.Equal(t, gw.ReviewContext{
+				BaseHash: "base-sha",
+				HeadHash: "head-sha",
+				Version:  4,
+			}, req.ReviewContext)
+			assert.Equal(t, gw.ReviewAnchor{
+				StartLineType: "ADDED",
+				EndLineType:   "ADDED",
+			}, req.ReviewAnchor)
+			assert.Equal(t,
+				forge.ReviewThreadRange{StartLine: 3, EndLine: 4},
+				req.Range)
+			return &gw.ReviewComment{ID: 10}, nil
+		},
+		setReviewDisposition: func(
+			context.Context,
+			int64,
+			forge.ReviewDisposition,
+		) error {
+			t.Fatal("native review must not update the participant separately")
+			return nil
+		},
+	}
+	reviewGW := &stubPendingReviewGateway{
+		stubReviewGateway: base,
+		reviewContext: func(context.Context, int64) (gw.ReviewContext, error) {
+			actions = append(actions, "context")
+			return gw.ReviewContext{
+				BaseHash: "base-sha",
+				HeadHash: "head-sha",
+				Version:  4,
+			}, nil
+		},
+		reviewAnchor: func(
+			_ context.Context,
+			_ int64,
+			_ gw.ReviewContext,
+			_ string,
+			lines forge.ReviewThreadRange,
+			_ forge.ReviewThreadSide,
+		) (gw.ReviewAnchor, error) {
+			actions = append(actions, "anchor")
+			assert.Equal(t,
+				forge.ReviewThreadRange{StartLine: 3, EndLine: 4},
+				lines)
+			return gw.ReviewAnchor{
+				StartLineType: "ADDED",
+				EndLineType:   "ADDED",
+			}, nil
+		},
+		publishReview: func(
+			_ context.Context,
+			_ int64,
+			_ gw.ReviewContext,
+			body string,
+			disposition forge.ReviewDisposition,
+		) error {
+			actions = append(actions, "publish")
+			assert.Equal(t, "summary", body)
+			assert.Equal(t, forge.ReviewDispositionRequestChanges, disposition)
+			return nil
+		},
+	}
+	repo := mustWithReviewRepository(
+		t.Context(), t, newRepository(new(Forge), silog.Nop(), reviewGW),
+	).(forge.ReviewRepository)
+
+	result, err := repo.SubmitReview(
+		t.Context(), &PR{Number: 7}, forge.SubmitReviewRequest{
+			Body:        "summary",
+			Disposition: forge.ReviewDispositionRequestChanges,
+			Comments: []forge.SubmitReviewCommentRequest{{
+				Path:  "review.go",
+				Range: forge.ReviewThreadRange{StartLine: 3, EndLine: 4},
+				Body:  "comment",
+			}},
+		})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"context", "anchor", "draft", "publish"}, actions)
+	require.Len(t, result.Comments, 1)
+	assert.Equal(t, "10:7", result.Comments[0].ThreadID.String())
+}
+
+func TestReviewRepository_SubmitReview_nativeDispositionOnly(t *testing.T) {
+	var actions []string
+	base := &stubReviewGateway{
+		Gateway: NewMockGateway(gomock.NewController(t)),
+		capabilities: gw.ReviewCapabilities{
+			Supported:    true,
+			NativeDrafts: true,
+			Multiline:    true,
+		},
+		setReviewDisposition: func(
+			context.Context,
+			int64,
+			forge.ReviewDisposition,
+		) error {
+			t.Fatal("native review must not update the participant separately")
+			return nil
+		},
+	}
+	reviewGW := &stubPendingReviewGateway{
+		stubReviewGateway: base,
+		reviewContext: func(context.Context, int64) (gw.ReviewContext, error) {
+			actions = append(actions, "context")
+			return gw.ReviewContext{HeadHash: "head-sha", Version: 4}, nil
+		},
+		publishReview: func(
+			_ context.Context,
+			_ int64,
+			review gw.ReviewContext,
+			body string,
+			disposition forge.ReviewDisposition,
+		) error {
+			actions = append(actions, "publish")
+			assert.Equal(t, gw.ReviewContext{
+				HeadHash: "head-sha",
+				Version:  4,
+			}, review)
+			assert.Empty(t, body)
+			assert.Equal(t, forge.ReviewDispositionApprove, disposition)
+			return nil
+		},
+	}
+	repo := mustWithReviewRepository(
+		t.Context(), t, newRepository(new(Forge), silog.Nop(), reviewGW),
+	).(forge.ReviewRepository)
+
+	result, err := repo.SubmitReview(
+		t.Context(), &PR{Number: 7}, forge.SubmitReviewRequest{
+			Disposition: forge.ReviewDispositionApprove,
+		})
+	require.NoError(t, err)
+	assert.Empty(t, result.Comments)
+	assert.Equal(t, []string{"context", "publish"}, actions)
+}
+
+func TestReviewRepository_UpdateAndResolve(t *testing.T) {
+	mockGateway := NewMockGateway(gomock.NewController(t))
+	mockGateway.EXPECT().UpdateComment(gomock.Any(), &gw.ChangeComment{
+		ID:   11,
+		PRID: 7,
+	}, "edited").Return(nil)
+	var actions []string
+	reviewGW := &stubReviewGateway{
+		Gateway: mockGateway,
+		resolveReviewThread: func(_ context.Context, prID, commentID int64) error {
+			actions = append(actions, "resolve")
+			assert.Equal(t, int64(7), prID)
+			assert.Equal(t, int64(10), commentID)
+			return nil
+		},
+		unresolveReviewThread: func(_ context.Context, prID, commentID int64) error {
+			actions = append(actions, "unresolve")
+			assert.Equal(t, int64(7), prID)
+			assert.Equal(t, int64(10), commentID)
+			return nil
+		},
+	}
+	repo := mustWithReviewRepository(t.Context(), t, newRepository(new(Forge), silog.Nop(), reviewGW))
+
+	require.NoError(t, repo.(forge.ReviewCommentEditor).UpdateReviewComment(
+		t.Context(), reviewCommentID{CommentID: 11, PRID: 7}, "edited"))
+	threadID := reviewThreadID{CommentID: 10, PRID: 7}
+	resolver := repo.(forge.ReviewThreadResolver)
+	require.NoError(t, resolver.ResolveReviewThread(t.Context(), threadID))
+	require.NoError(t, resolver.UnresolveReviewThread(t.Context(), threadID))
+	assert.Equal(t, []string{"resolve", "unresolve"}, actions)
+}
+
+func TestReviewRepository_internalIDsPanic(t *testing.T) {
+	reviewGW := &stubReviewGateway{
+		Gateway: NewMockGateway(gomock.NewController(t)),
+	}
+	repo := mustWithReviewRepository(t.Context(), t, newRepository(new(Forge), silog.Nop(), reviewGW))
+
+	assert.Panics(t, func() {
+		_ = repo.(forge.ReviewCommentEditor).UpdateReviewComment(
+			t.Context(), &PRComment{ID: 11, PRID: 7}, "edited")
+	})
+	assert.Panics(t, func() {
+		_, _ = repo.(forge.ReviewRepository).SubmitReview(
+			t.Context(), &PR{Number: 7}, forge.SubmitReviewRequest{
+				Comments: []forge.SubmitReviewCommentRequest{{
+					ReplyTo: reviewThreadID{CommentID: 10, PRID: 8},
+					Body:    "reply",
+				}},
+			})
+	})
+}
+
+type stubReviewGateway struct {
+	gw.Gateway
+	capabilities          gw.ReviewCapabilities
+	listReviewerStates    func(context.Context, int64) iter.Seq2[*gw.ReviewerState, error]
+	listReviewThreads     func(context.Context, int64) iter.Seq2[*gw.ReviewThread, error]
+	createReviewComment   func(context.Context, int64, gw.CreateReviewCommentRequest) (*gw.ReviewComment, error)
+	setReviewDisposition  func(context.Context, int64, forge.ReviewDisposition) error
+	resolveReviewThread   func(context.Context, int64, int64) error
+	unresolveReviewThread func(context.Context, int64, int64) error
+}
+
+func mustWithReviewRepository(
+	ctx context.Context,
+	t *testing.T,
+	repo *Repository,
+) forge.Repository {
+	t.Helper()
+	wrapped, err := withReviewRepository(ctx, repo)
+	require.NoError(t, err)
+	return wrapped
+}
+
+type stubPendingReviewGateway struct {
+	*stubReviewGateway
+	reviewContext func(context.Context, int64) (gw.ReviewContext, error)
+	reviewAnchor  func(context.Context, int64, gw.ReviewContext, string, forge.ReviewThreadRange, forge.ReviewThreadSide) (gw.ReviewAnchor, error)
+	publishReview func(context.Context, int64, gw.ReviewContext, string, forge.ReviewDisposition) error
+}
+
+func (g *stubPendingReviewGateway) ReviewContext(
+	ctx context.Context,
+	prID int64,
+) (gw.ReviewContext, error) {
+	return g.reviewContext(ctx, prID)
+}
+
+func (g *stubPendingReviewGateway) ReviewAnchor(
+	ctx context.Context,
+	prID int64,
+	review gw.ReviewContext,
+	path string,
+	lines forge.ReviewThreadRange,
+	side forge.ReviewThreadSide,
+) (gw.ReviewAnchor, error) {
+	return g.reviewAnchor(ctx, prID, review, path, lines, side)
+}
+
+func (g *stubPendingReviewGateway) PublishReview(
+	ctx context.Context,
+	prID int64,
+	review gw.ReviewContext,
+	body string,
+	disposition forge.ReviewDisposition,
+) error {
+	return g.publishReview(ctx, prID, review, body, disposition)
+}
+
+func (g *stubReviewGateway) ReviewCapabilities(
+	context.Context,
+) (gw.ReviewCapabilities, error) {
+	if g.capabilities == (gw.ReviewCapabilities{}) {
+		return gw.ReviewCapabilities{
+			Supported:        true,
+			Multiline:        true,
+			ThreadResolution: true,
+		}, nil
+	}
+	return g.capabilities, nil
+}
+
+func (g *stubReviewGateway) ListReviewerStates(
+	ctx context.Context,
+	prID int64,
+) iter.Seq2[*gw.ReviewerState, error] {
+	return g.listReviewerStates(ctx, prID)
+}
+
+func (g *stubReviewGateway) ListReviewThreads(
+	ctx context.Context,
+	prID int64,
+) iter.Seq2[*gw.ReviewThread, error] {
+	return g.listReviewThreads(ctx, prID)
+}
+
+func (g *stubReviewGateway) CreateReviewComment(
+	ctx context.Context,
+	prID int64,
+	req gw.CreateReviewCommentRequest,
+) (*gw.ReviewComment, error) {
+	return g.createReviewComment(ctx, prID, req)
+}
+
+func (g *stubReviewGateway) SetReviewDisposition(
+	ctx context.Context,
+	prID int64,
+	disposition forge.ReviewDisposition,
+) error {
+	return g.setReviewDisposition(ctx, prID, disposition)
+}
+
+func (g *stubReviewGateway) ResolveReviewThread(
+	ctx context.Context,
+	prID int64,
+	commentID int64,
+) error {
+	return g.resolveReviewThread(ctx, prID, commentID)
+}
+
+func (g *stubReviewGateway) UnresolveReviewThread(
+	ctx context.Context,
+	prID int64,
+	commentID int64,
+) error {
+	return g.unresolveReviewThread(ctx, prID, commentID)
+}

--- a/internal/forge/bitbucket/review_test.go
+++ b/internal/forge/bitbucket/review_test.go
@@ -167,6 +167,106 @@ func TestReviewRepository_SubmitReview_degradesUnsupportedMultiline(t *testing.T
 	assert.Equal(t, []string{"context", "anchor", "draft", "publish"}, actions)
 }
 
+func TestReviewRepository_SubmitReview_fileLevel(t *testing.T) {
+	reviewGW := &stubReviewGateway{
+		Gateway: NewMockGateway(gomock.NewController(t)),
+		capabilities: gw.ReviewCapabilities{
+			Supported: true,
+			FileLevel: true,
+		},
+		createReviewComment: func(
+			_ context.Context,
+			_ int64,
+			req gw.CreateReviewCommentRequest,
+		) (*gw.ReviewComment, error) {
+			assert.True(t, req.Range.IsZero())
+			assert.Equal(t, forge.ReviewThreadSide(99), req.Side)
+			return &gw.ReviewComment{ID: 10}, nil
+		},
+	}
+	repo := mustWithReviewRepository(
+		t.Context(), t, newRepository(new(Forge), silog.Nop(), reviewGW),
+	).(forge.ReviewRepository)
+
+	result, err := repo.SubmitReview(
+		t.Context(), &PR{Number: 7}, forge.SubmitReviewRequest{
+			Comments: []forge.SubmitReviewCommentRequest{{
+				Path: "review.go",
+				Side: forge.ReviewThreadSide(99),
+				Body: "whole file",
+			}},
+		})
+	require.NoError(t, err)
+	require.Len(t, result.Comments, 1)
+	assert.Equal(t, "10:7", result.Comments[0].ThreadID.String())
+}
+
+func TestReviewRepository_SubmitReview_nativeFileLevel(t *testing.T) {
+	var actions []string
+	base := &stubReviewGateway{
+		Gateway: NewMockGateway(gomock.NewController(t)),
+		capabilities: gw.ReviewCapabilities{
+			Supported:    true,
+			NativeDrafts: true,
+			FileLevel:    true,
+		},
+		createReviewComment: func(
+			_ context.Context,
+			_ int64,
+			req gw.CreateReviewCommentRequest,
+		) (*gw.ReviewComment, error) {
+			actions = append(actions, "draft")
+			assert.True(t, req.Range.IsZero())
+			assert.Zero(t, req.ReviewAnchor)
+			return &gw.ReviewComment{ID: 10}, nil
+		},
+	}
+	reviewGW := &stubPendingReviewGateway{
+		stubReviewGateway: base,
+		reviewContext: func(context.Context, int64) (gw.ReviewContext, error) {
+			actions = append(actions, "context")
+			return gw.ReviewContext{}, nil
+		},
+		reviewAnchor: func(
+			_ context.Context,
+			_ int64,
+			_ gw.ReviewContext,
+			_ string,
+			lines forge.ReviewThreadRange,
+			side forge.ReviewThreadSide,
+		) (gw.ReviewAnchor, error) {
+			actions = append(actions, "anchor")
+			assert.True(t, lines.IsZero())
+			assert.Equal(t, forge.ReviewThreadSide(99), side)
+			return gw.ReviewAnchor{}, nil
+		},
+		publishReview: func(
+			context.Context,
+			int64,
+			gw.ReviewContext,
+			string,
+			forge.ReviewDisposition,
+		) error {
+			actions = append(actions, "publish")
+			return nil
+		},
+	}
+	repo := mustWithReviewRepository(
+		t.Context(), t, newRepository(new(Forge), silog.Nop(), reviewGW),
+	).(forge.ReviewRepository)
+
+	_, err := repo.SubmitReview(
+		t.Context(), &PR{Number: 7}, forge.SubmitReviewRequest{
+			Comments: []forge.SubmitReviewCommentRequest{{
+				Path: "review.go",
+				Side: forge.ReviewThreadSide(99),
+				Body: "whole file",
+			}},
+		})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"context", "anchor", "draft", "publish"}, actions)
+}
+
 func TestReviewRepository_SubmitReview_invalidDispositionPanicsBeforeMutation(t *testing.T) {
 	var mutations int
 	mockGateway := NewMockGateway(gomock.NewController(t))
@@ -716,6 +816,7 @@ func (g *stubReviewGateway) ReviewCapabilities(
 	if g.capabilities == (gw.ReviewCapabilities{}) {
 		return gw.ReviewCapabilities{
 			Supported:        true,
+			FileLevel:        true,
 			Multiline:        true,
 			ThreadResolution: true,
 		}, nil

--- a/internal/gateway/bitbucket/cloud/api.go
+++ b/internal/gateway/bitbucket/cloud/api.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Bitbucket Cloud REST API references:
@@ -21,16 +22,17 @@ const (
 
 // PullRequest is a Bitbucket pull request.
 type PullRequest struct {
-	ID          int64            `json:"id"`
-	Title       string           `json:"title"`
-	Description string           `json:"description"`
-	State       string           `json:"state"`
-	Draft       bool             `json:"draft"`
-	Source      BranchRef        `json:"source"`
-	Destination BranchRef        `json:"destination"`
-	Reviewers   []User           `json:"reviewers"`
-	Links       PullRequestLinks `json:"links"`
-	MergeCommit *Commit          `json:"merge_commit,omitzero"`
+	ID           int64            `json:"id"`
+	Title        string           `json:"title"`
+	Description  string           `json:"description"`
+	State        string           `json:"state"`
+	Draft        bool             `json:"draft"`
+	Source       BranchRef        `json:"source"`
+	Destination  BranchRef        `json:"destination"`
+	Reviewers    []User           `json:"reviewers"`
+	Participants []Participant    `json:"participants"`
+	Links        PullRequestLinks `json:"links"`
+	MergeCommit  *Commit          `json:"merge_commit,omitzero"`
 
 	// Mergeable reports Bitbucket Cloud's current merge decision.
 	//
@@ -93,12 +95,22 @@ type Comment struct {
 	ID         int64       `json:"id"`
 	Content    Content     `json:"content"`
 	Inline     *Inline     `json:"inline,omitzero"`
+	Parent     *CommentRef `json:"parent,omitzero"`
 	Resolution *Resolution `json:"resolution,omitzero"`
+	User       User        `json:"user"`
+	CreatedOn  time.Time   `json:"created_on"`
 }
 
 // CommentCreateRequest is the request body for creating or updating a comment.
 type CommentCreateRequest struct {
-	Content Content `json:"content"`
+	Content Content     `json:"content"`
+	Inline  *Inline     `json:"inline,omitzero"`
+	Parent  *CommentRef `json:"parent,omitzero"`
+}
+
+// CommentRef identifies another pull request comment.
+type CommentRef struct {
+	ID int64 `json:"id"`
 }
 
 // CommentList is the paginated response for listing comments.
@@ -166,6 +178,15 @@ type Reviewer struct {
 	UUID string `json:"uuid"`
 }
 
+// Participant is a user who has acted on a pull request.
+type Participant struct {
+	User           User       `json:"user"`
+	Role           string     `json:"role"`
+	Approved       bool       `json:"approved"`
+	State          string     `json:"state"`
+	ParticipatedOn *time.Time `json:"participated_on,omitzero"`
+}
+
 // User is a Bitbucket user.
 type User struct {
 	UUID        string `json:"uuid"`
@@ -197,9 +218,11 @@ type Content struct {
 
 // Inline identifies an inline comment location.
 type Inline struct {
-	Path string `json:"path"`
-	From *int   `json:"from,omitzero"`
-	To   *int   `json:"to,omitzero"`
+	Path      string `json:"path"`
+	From      *int   `json:"from,omitzero"`
+	To        *int   `json:"to,omitzero"`
+	StartFrom *int   `json:"start_from,omitzero"`
+	StartTo   *int   `json:"start_to,omitzero"`
 }
 
 // Resolution indicates a comment resolution state.
@@ -375,6 +398,60 @@ func (c *Client) CommentList(
 		return nil, resp, err
 	}
 	return &response, resp, nil
+}
+
+// PullRequestApprove approves a pull request as the authenticated user.
+func (c *Client) PullRequestApprove(
+	ctx context.Context,
+	workspace string,
+	repo string,
+	prID int64,
+) (*Response, error) {
+	return c.post(ctx, fmt.Sprintf(
+		"/repositories/%s/%s/pullrequests/%d/approve",
+		workspace, repo, prID,
+	), nil, nil, nil)
+}
+
+// PullRequestRequestChanges requests changes as the authenticated user.
+func (c *Client) PullRequestRequestChanges(
+	ctx context.Context,
+	workspace string,
+	repo string,
+	prID int64,
+) (*Response, error) {
+	return c.post(ctx, fmt.Sprintf(
+		"/repositories/%s/%s/pullrequests/%d/request-changes",
+		workspace, repo, prID,
+	), nil, nil, nil)
+}
+
+// CommentResolve resolves the thread rooted at commentID.
+func (c *Client) CommentResolve(
+	ctx context.Context,
+	workspace string,
+	repo string,
+	prID int64,
+	commentID int64,
+) (*Response, error) {
+	return c.post(ctx, fmt.Sprintf(
+		"/repositories/%s/%s/pullrequests/%d/comments/%d/resolve",
+		workspace, repo, prID, commentID,
+	), nil, nil, nil)
+}
+
+// CommentUnresolve reopens the thread rooted at commentID.
+func (c *Client) CommentUnresolve(
+	ctx context.Context,
+	workspace string,
+	repo string,
+	prID int64,
+	commentID int64,
+) (*Response, error) {
+	return c.delete(ctx, fmt.Sprintf(
+		"/repositories/%s/%s/pullrequests/%d/comments/%d/resolve",
+		workspace, repo, prID, commentID,
+	), nil)
 }
 
 // WorkspaceMemberList lists workspace members.

--- a/internal/gateway/bitbucket/cloud/review.go
+++ b/internal/gateway/bitbucket/cloud/review.go
@@ -2,6 +2,7 @@ package cloud
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"iter"
 	"strings"
@@ -22,6 +23,7 @@ func (*Gateway) ReviewCapabilities(
 ) (bitbucket.ReviewCapabilities, error) {
 	return bitbucket.ReviewCapabilities{
 		Supported:        true,
+		FileLevel:        true,
 		Multiline:        true,
 		ThreadResolution: true,
 	}, nil
@@ -98,7 +100,11 @@ func (g *Gateway) ListReviewThreads(
 				continue
 			}
 			if comment.Inline != nil {
-				thread := reviewThreadFromComment(comment)
+				thread, err := reviewThreadFromComment(comment)
+				if err != nil {
+					yield(nil, err)
+					return
+				}
 				threadsByComment[comment.ID] = thread
 				threads = append(threads, thread)
 			}
@@ -112,38 +118,65 @@ func (g *Gateway) ListReviewThreads(
 	}
 }
 
-// reviewThreadFromComment maps Cloud's to/start_to postimage coordinates or
-// from/start_from preimage coordinates into one inclusive forge range.
-func reviewThreadFromComment(comment *Comment) *bitbucket.ReviewThread {
+// reviewThreadFromComment maps Cloud's path-only file anchor or side-specific
+// line coordinates into a forge review location.
+func reviewThreadFromComment(comment *Comment) (*bitbucket.ReviewThread, error) {
 	inline := comment.Inline
-	side := forge.ReviewThreadSideRight
-	start, end := inlineLineRange(inline.StartTo, inline.To)
-	if inline.To == nil {
-		side = forge.ReviewThreadSideLeft
-		start, end = inlineLineRange(inline.StartFrom, inline.From)
+	if inline.Path == "" {
+		return nil, fmt.Errorf(
+			"review comment %d has malformed inline anchor: path is empty",
+			comment.ID)
+	}
+	lines, side, err := reviewInlineLocation(inline)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"review comment %d has malformed inline anchor: %w", comment.ID, err)
 	}
 	return &bitbucket.ReviewThread{
 		RootCommentID: comment.ID,
 		Path:          inline.Path,
-		Range: forge.ReviewThreadRange{
-			StartLine: start,
-			EndLine:   end,
-		},
-		Side:     side,
-		Resolved: comment.Resolution != nil,
-		Comments: []bitbucket.ReviewComment{reviewCommentFromAPI(comment)},
-	}
+		Range:         lines,
+		Side:          side,
+		Resolved:      comment.Resolution != nil,
+		Comments:      []bitbucket.ReviewComment{reviewCommentFromAPI(comment)},
+	}, nil
 }
 
-// inlineLineRange treats an omitted start coordinate as a single-line anchor.
-func inlineLineRange(start, end *int) (int, int) {
+// reviewInlineLocation recognizes Cloud's file-level comment shape.
+// The pull request comment API uses a path-only inline anchor for a whole-file
+// comment; any line coordinates select a side-specific line anchor.
+//
+// See https://developer.atlassian.com/cloud/bitbucket/rest/api-group-pullrequests/
+func reviewInlineLocation(
+	inline *Inline,
+) (forge.ReviewThreadRange, forge.ReviewThreadSide, error) {
+	if inline.From == nil && inline.To == nil &&
+		inline.StartFrom == nil && inline.StartTo == nil {
+		return forge.ReviewThreadRange{}, forge.ReviewThreadSideRight, nil
+	}
+
+	side := forge.ReviewThreadSideRight
+	start, end := inline.StartTo, inline.To
 	if end == nil {
-		return 0, 0
+		side = forge.ReviewThreadSideLeft
+		start, end = inline.StartFrom, inline.From
 	}
+	if end == nil {
+		return forge.ReviewThreadRange{}, 0, errors.New(
+			"line start is present without an endpoint")
+	}
+	startLine := *end
 	if start == nil {
-		return *end, *end
+		start = &startLine
 	}
-	return *start, *end
+	if *start <= 0 || *end < *start {
+		return forge.ReviewThreadRange{}, 0, fmt.Errorf(
+			"invalid line range %d-%d", *start, *end)
+	}
+	return forge.ReviewThreadRange{
+		StartLine: *start,
+		EndLine:   *end,
+	}, side, nil
 }
 
 // reviewCommentFromAPI retains the product fields exposed by ReviewComment.
@@ -188,6 +221,9 @@ func mustReviewInline(
 ) *Inline {
 	if path == "" {
 		panic("bitbucket: review comment path is empty")
+	}
+	if lines.IsZero() {
+		return &Inline{Path: path}
 	}
 	if lines.StartLine <= 0 || lines.EndLine < lines.StartLine {
 		panic(fmt.Sprintf("bitbucket: invalid review comment range: %d-%d",

--- a/internal/gateway/bitbucket/cloud/review.go
+++ b/internal/gateway/bitbucket/cloud/review.go
@@ -1,0 +1,262 @@
+package cloud
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"strings"
+
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/gateway/bitbucket"
+)
+
+var (
+	_ bitbucket.ReviewGateway         = (*Gateway)(nil)
+	_ bitbucket.EmulatedReviewGateway = (*Gateway)(nil)
+)
+
+// ReviewCapabilities reports the review features available from Bitbucket
+// Cloud. Unlike Data Center, Cloud does not need a product-version probe.
+func (*Gateway) ReviewCapabilities(
+	context.Context,
+) (bitbucket.ReviewCapabilities, error) {
+	return bitbucket.ReviewCapabilities{
+		Supported:        true,
+		Multiline:        true,
+		ThreadResolution: true,
+	}, nil
+}
+
+// ListReviewerStates lists participants with an effective review disposition.
+// Bitbucket Cloud does not expose the commit reviewed by a participant.
+func (g *Gateway) ListReviewerStates(
+	ctx context.Context,
+	prID int64,
+) iter.Seq2[*bitbucket.ReviewerState, error] {
+	return func(yield func(*bitbucket.ReviewerState, error) bool) {
+		pr, err := g.getPullRequest(ctx, prID)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+
+		for _, participant := range pr.Participants {
+			if participant.ParticipatedOn == nil {
+				continue
+			}
+
+			var disposition forge.ReviewDisposition
+			switch strings.ToLower(participant.State) {
+			case "approved":
+				disposition = forge.ReviewDispositionApprove
+			case "changes_requested":
+				disposition = forge.ReviewDispositionRequestChanges
+			default:
+				if !participant.Approved {
+					continue
+				}
+				disposition = forge.ReviewDispositionApprove
+			}
+
+			if !yield(&bitbucket.ReviewerState{
+				Reviewer:    extractUsername(&participant.User),
+				Disposition: disposition,
+				SubmittedAt: *participant.ParticipatedOn,
+			}, nil) {
+				return
+			}
+		}
+	}
+}
+
+// ListReviewThreads reconstructs comment-backed review threads.
+// The comments endpoint returns roots and replies oldest first, so a reply can
+// be attached to the previously observed root without another API request.
+func (g *Gateway) ListReviewThreads(
+	ctx context.Context,
+	prID int64,
+) iter.Seq2[*bitbucket.ReviewThread, error] {
+	return func(yield func(*bitbucket.ReviewThread, error) bool) {
+		var threads []*bitbucket.ReviewThread
+		threadsByComment := make(map[int64]*bitbucket.ReviewThread)
+		for comment, err := range g.listPullRequestComments(ctx, prID) {
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+
+			// Replies repeat the root's inline coordinates in Bitbucket payloads.
+			// Parent must therefore take precedence over Inline classification.
+			if comment.Parent != nil {
+				thread := threadsByComment[comment.Parent.ID]
+				if thread == nil {
+					continue
+				}
+				thread.Comments = append(
+					thread.Comments, reviewCommentFromAPI(comment))
+				threadsByComment[comment.ID] = thread
+				continue
+			}
+			if comment.Inline != nil {
+				thread := reviewThreadFromComment(comment)
+				threadsByComment[comment.ID] = thread
+				threads = append(threads, thread)
+			}
+		}
+
+		for _, thread := range threads {
+			if !yield(thread, nil) {
+				return
+			}
+		}
+	}
+}
+
+// reviewThreadFromComment maps Cloud's to/start_to postimage coordinates or
+// from/start_from preimage coordinates into one inclusive forge range.
+func reviewThreadFromComment(comment *Comment) *bitbucket.ReviewThread {
+	inline := comment.Inline
+	side := forge.ReviewThreadSideRight
+	start, end := inlineLineRange(inline.StartTo, inline.To)
+	if inline.To == nil {
+		side = forge.ReviewThreadSideLeft
+		start, end = inlineLineRange(inline.StartFrom, inline.From)
+	}
+	return &bitbucket.ReviewThread{
+		RootCommentID: comment.ID,
+		Path:          inline.Path,
+		Range: forge.ReviewThreadRange{
+			StartLine: start,
+			EndLine:   end,
+		},
+		Side:     side,
+		Resolved: comment.Resolution != nil,
+		Comments: []bitbucket.ReviewComment{reviewCommentFromAPI(comment)},
+	}
+}
+
+// inlineLineRange treats an omitted start coordinate as a single-line anchor.
+func inlineLineRange(start, end *int) (int, int) {
+	if end == nil {
+		return 0, 0
+	}
+	if start == nil {
+		return *end, *end
+	}
+	return *start, *end
+}
+
+// reviewCommentFromAPI retains the product fields exposed by ReviewComment.
+func reviewCommentFromAPI(comment *Comment) bitbucket.ReviewComment {
+	return bitbucket.ReviewComment{
+		ID:        comment.ID,
+		Body:      comment.Content.Raw,
+		Author:    extractUsername(&comment.User),
+		CreatedAt: comment.CreatedOn,
+	}
+}
+
+// CreateReviewComment creates an inline comment or replies to a root comment.
+func (g *Gateway) CreateReviewComment(
+	ctx context.Context,
+	prID int64,
+	req bitbucket.CreateReviewCommentRequest,
+) (*bitbucket.ReviewComment, error) {
+	apiReq := &CommentCreateRequest{Content: Content{Raw: req.Body}}
+	if req.ParentID != 0 {
+		apiReq.Parent = &CommentRef{ID: req.ParentID}
+	} else {
+		apiReq.Inline = mustReviewInline(req.Path, req.Range, req.Side)
+	}
+
+	comment, _, err := g.client.CommentCreate(
+		ctx, g.workspace, g.repo, prID, apiReq,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create review comment: %w", err)
+	}
+	result := reviewCommentFromAPI(comment)
+	return &result, nil
+}
+
+// mustReviewInline converts a git-spice-owned location into Cloud's side-
+// specific inline fields. Invalid coordinates are internal invariant failures.
+func mustReviewInline(
+	path string,
+	lines forge.ReviewThreadRange,
+	side forge.ReviewThreadSide,
+) *Inline {
+	if path == "" {
+		panic("bitbucket: review comment path is empty")
+	}
+	if lines.StartLine <= 0 || lines.EndLine < lines.StartLine {
+		panic(fmt.Sprintf("bitbucket: invalid review comment range: %d-%d",
+			lines.StartLine, lines.EndLine))
+	}
+
+	inline := &Inline{Path: path}
+	switch side {
+	case forge.ReviewThreadSideRight:
+		inline.To = &lines.EndLine
+		if lines.StartLine != lines.EndLine {
+			inline.StartTo = &lines.StartLine
+		}
+	case forge.ReviewThreadSideLeft:
+		inline.From = &lines.EndLine
+		if lines.StartLine != lines.EndLine {
+			inline.StartFrom = &lines.StartLine
+		}
+	default:
+		panic(fmt.Sprintf("bitbucket: invalid review comment side: %s", side))
+	}
+	return inline
+}
+
+// SetReviewDisposition applies a native Bitbucket Cloud review disposition.
+func (g *Gateway) SetReviewDisposition(
+	ctx context.Context,
+	prID int64,
+	disposition forge.ReviewDisposition,
+) error {
+	var err error
+	switch disposition {
+	case forge.ReviewDispositionApprove:
+		_, err = g.client.PullRequestApprove(ctx, g.workspace, g.repo, prID)
+	case forge.ReviewDispositionRequestChanges:
+		_, err = g.client.PullRequestRequestChanges(ctx, g.workspace, g.repo, prID)
+	default:
+		panic(fmt.Sprintf("bitbucket: invalid review disposition %d", disposition))
+	}
+	if err != nil {
+		return fmt.Errorf("set review disposition: %w", err)
+	}
+	return nil
+}
+
+// ResolveReviewThread resolves the thread rooted at commentID.
+func (g *Gateway) ResolveReviewThread(
+	ctx context.Context,
+	prID int64,
+	commentID int64,
+) error {
+	if _, err := g.client.CommentResolve(
+		ctx, g.workspace, g.repo, prID, commentID,
+	); err != nil {
+		return fmt.Errorf("resolve review thread: %w", err)
+	}
+	return nil
+}
+
+// UnresolveReviewThread reopens the thread rooted at commentID.
+func (g *Gateway) UnresolveReviewThread(
+	ctx context.Context,
+	prID int64,
+	commentID int64,
+) error {
+	if _, err := g.client.CommentUnresolve(
+		ctx, g.workspace, g.repo, prID, commentID,
+	); err != nil {
+		return fmt.Errorf("unresolve review thread: %w", err)
+	}
+	return nil
+}

--- a/internal/gateway/bitbucket/cloud/review_test.go
+++ b/internal/gateway/bitbucket/cloud/review_test.go
@@ -1,0 +1,197 @@
+package cloud
+
+import (
+	json "encoding/json/v2"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/gateway/bitbucket"
+)
+
+func TestGateway_CreateReviewComment(t *testing.T) {
+	tests := []struct {
+		name string
+		req  bitbucket.CreateReviewCommentRequest
+		want CommentCreateRequest
+	}{
+		{
+			name: "RightRange",
+			req: bitbucket.CreateReviewCommentRequest{
+				Path:  "review.go",
+				Range: forge.ReviewThreadRange{StartLine: 3, EndLine: 5},
+				Side:  forge.ReviewThreadSideRight,
+				Body:  "right range",
+			},
+			want: CommentCreateRequest{
+				Content: Content{Raw: "right range"},
+				Inline:  &Inline{Path: "review.go", StartTo: new(3), To: new(5)},
+			},
+		},
+		{
+			name: "LeftLine",
+			req: bitbucket.CreateReviewCommentRequest{
+				Path:  "review.go",
+				Range: forge.ReviewThreadLine(4),
+				Side:  forge.ReviewThreadSideLeft,
+				Body:  "left line",
+			},
+			want: CommentCreateRequest{
+				Content: Content{Raw: "left line"},
+				Inline:  &Inline{Path: "review.go", From: new(4)},
+			},
+		},
+		{
+			name: "Reply",
+			req: bitbucket.CreateReviewCommentRequest{
+				ParentID: 10,
+				Body:     "reply",
+			},
+			want: CommentCreateRequest{
+				Content: Content{Raw: "reply"},
+				Parent:  &CommentRef{ID: 10},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t,
+					"/repositories/workspace/repo/pullrequests/1/comments",
+					r.URL.Path)
+
+				var got CommentCreateRequest
+				require.NoError(t, json.UnmarshalRead(r.Body, &got))
+				assert.Equal(t, tt.want, got)
+				require.NoError(t, json.MarshalWrite(w, Comment{
+					ID:      42,
+					Content: got.Content,
+					User:    User{Nickname: "spock"},
+				}))
+			}))
+			defer srv.Close()
+
+			comment, err := newTestGateway(t, srv.URL).
+				CreateReviewComment(t.Context(), 1, tt.req)
+			require.NoError(t, err)
+			assert.Equal(t, &bitbucket.ReviewComment{
+				ID:     42,
+				Body:   tt.req.Body,
+				Author: "spock",
+			}, comment)
+		})
+	}
+}
+
+func TestGateway_ListReviewThreads(t *testing.T) {
+	created := time.Date(2026, time.June, 14, 12, 0, 0, 0, time.UTC)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		require.NoError(t, json.MarshalWrite(w, CommentList{Values: []Comment{
+			{ID: 1, Content: Content{Raw: "global"}},
+			{
+				ID:         10,
+				Content:    Content{Raw: "root"},
+				Inline:     &Inline{Path: "review.go", StartFrom: new(3), From: new(5)},
+				Resolution: &Resolution{Type: "resolved"},
+				User:       User{Nickname: "spock"},
+				CreatedOn:  created,
+			},
+			{
+				ID:        11,
+				Content:   Content{Raw: "reply"},
+				Inline:    &Inline{Path: "review.go", StartFrom: new(3), From: new(5)},
+				Parent:    &CommentRef{ID: 10},
+				User:      User{Nickname: "kirk"},
+				CreatedOn: created.Add(time.Minute),
+			},
+		}}))
+	}))
+	defer srv.Close()
+
+	var got []*bitbucket.ReviewThread
+	for thread, err := range newTestGateway(t, srv.URL).
+		ListReviewThreads(t.Context(), 7) {
+		require.NoError(t, err)
+		got = append(got, thread)
+	}
+
+	require.Len(t, got, 1)
+	assert.Equal(t, &bitbucket.ReviewThread{
+		RootCommentID: 10,
+		Path:          "review.go",
+		Range:         forge.ReviewThreadRange{StartLine: 3, EndLine: 5},
+		Side:          forge.ReviewThreadSideLeft,
+		Resolved:      true,
+		Comments: []bitbucket.ReviewComment{
+			{ID: 10, Body: "root", Author: "spock", CreatedAt: created},
+			{ID: 11, Body: "reply", Author: "kirk", CreatedAt: created.Add(time.Minute)},
+		},
+	}, got[0])
+}
+
+func TestGateway_ListReviewerStates(t *testing.T) {
+	participated := time.Date(2026, time.June, 14, 12, 0, 0, 0, time.UTC)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		require.NoError(t, json.MarshalWrite(w, PullRequest{
+			ID: 7,
+			Participants: []Participant{
+				{User: User{Nickname: "spock"}, State: "approved", ParticipatedOn: &participated},
+				{User: User{Nickname: "kirk"}, State: "changes_requested", ParticipatedOn: &participated},
+				{User: User{Nickname: "uhura"}, ParticipatedOn: &participated},
+				{User: User{Nickname: "bones"}},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	var got []*bitbucket.ReviewerState
+	for state, err := range newTestGateway(t, srv.URL).
+		ListReviewerStates(t.Context(), 7) {
+		require.NoError(t, err)
+		got = append(got, state)
+	}
+
+	assert.Equal(t, []*bitbucket.ReviewerState{
+		{Reviewer: "spock", Disposition: forge.ReviewDispositionApprove, SubmittedAt: participated},
+		{Reviewer: "kirk", Disposition: forge.ReviewDispositionRequestChanges, SubmittedAt: participated},
+	}, got)
+}
+
+func TestGateway_ReviewActions(t *testing.T) {
+	var got []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = append(got, r.Method+" "+r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	gw := newTestGateway(t, srv.URL)
+	require.NoError(t, gw.SetReviewDisposition(
+		t.Context(), 7, forge.ReviewDispositionApprove))
+	require.NoError(t, gw.SetReviewDisposition(
+		t.Context(), 7, forge.ReviewDispositionRequestChanges))
+	require.NoError(t, gw.ResolveReviewThread(t.Context(), 7, 10))
+	require.NoError(t, gw.UnresolveReviewThread(t.Context(), 7, 10))
+
+	assert.Equal(t, []string{
+		"POST /repositories/workspace/repo/pullrequests/7/approve",
+		"POST /repositories/workspace/repo/pullrequests/7/request-changes",
+		"POST /repositories/workspace/repo/pullrequests/7/comments/10/resolve",
+		"DELETE /repositories/workspace/repo/pullrequests/7/comments/10/resolve",
+	}, got)
+}
+
+func TestGateway_SetReviewDisposition_none(t *testing.T) {
+	assert.Panics(t, func() {
+		_ = newTestGateway(t, "http://example.com").SetReviewDisposition(
+			t.Context(), 7, forge.ReviewDispositionNone)
+	})
+}

--- a/internal/gateway/bitbucket/cloud/review_test.go
+++ b/internal/gateway/bitbucket/cloud/review_test.go
@@ -46,6 +46,18 @@ func TestGateway_CreateReviewComment(t *testing.T) {
 			},
 		},
 		{
+			name: "FileLevel",
+			req: bitbucket.CreateReviewCommentRequest{
+				Path: "review.go",
+				Side: forge.ReviewThreadSide(99),
+				Body: "whole file",
+			},
+			want: CommentCreateRequest{
+				Content: Content{Raw: "whole file"},
+				Inline:  &Inline{Path: "review.go"},
+			},
+		},
+		{
 			name: "Reply",
 			req: bitbucket.CreateReviewCommentRequest{
 				ParentID: 10,
@@ -87,6 +99,46 @@ func TestGateway_CreateReviewComment(t *testing.T) {
 			}, comment)
 		})
 	}
+}
+
+func TestGateway_ListReviewThreads_fileLevel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.MarshalWrite(w, CommentList{Values: []Comment{{
+			ID:      10,
+			Content: Content{Raw: "whole file"},
+			Inline:  &Inline{Path: "review.go"},
+		}}}))
+	}))
+	defer srv.Close()
+
+	var got []*bitbucket.ReviewThread
+	for thread, err := range newTestGateway(t, srv.URL).
+		ListReviewThreads(t.Context(), 7) {
+		require.NoError(t, err)
+		got = append(got, thread)
+	}
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "review.go", got[0].Path)
+	assert.True(t, got[0].Range.IsZero())
+}
+
+func TestGateway_ListReviewThreads_rejectsMalformedInline(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.MarshalWrite(w, CommentList{Values: []Comment{{
+			ID:      10,
+			Content: Content{Raw: "missing endpoint"},
+			Inline:  &Inline{Path: "review.go", StartTo: new(3)},
+		}}}))
+	}))
+	defer srv.Close()
+
+	var gotErr error
+	for _, err := range newTestGateway(t, srv.URL).
+		ListReviewThreads(t.Context(), 7) {
+		gotErr = err
+	}
+	require.ErrorContains(t, gotErr, "malformed inline anchor")
 }
 
 func TestGateway_ListReviewThreads(t *testing.T) {

--- a/internal/gateway/bitbucket/gateway.go
+++ b/internal/gateway/bitbucket/gateway.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"iter"
+	"time"
 
 	"go.abhg.dev/gs/internal/forge"
 	"go.abhg.dev/gs/internal/git"
@@ -129,6 +130,176 @@ type ResolvableComment struct {
 	// Only Bitbucket Data Center reports pending comments;
 	// it is always false on Bitbucket Cloud.
 	Pending bool
+}
+
+// ReviewerState is the latest effective review state of a pull request
+// participant.
+type ReviewerState struct {
+	// Reviewer is the participant's Bitbucket username.
+	Reviewer string
+
+	// Disposition is the participant's current review outcome.
+	Disposition forge.ReviewDisposition
+
+	// CommitHash is the revision reviewed by the participant.
+	CommitHash git.Hash
+
+	// SubmittedAt is when the participant established this state.
+	SubmittedAt time.Time
+}
+
+// ReviewThread is a comment-backed discussion attached to a pull request diff.
+// RootCommentID identifies the top-level inline comment that owns the replies.
+type ReviewThread struct {
+	// RootCommentID is the top-level anchored comment that owns the thread.
+	RootCommentID int64
+
+	// Path is the repository-relative file path attached to the root.
+	Path string
+
+	// Range is the inclusive range represented by the product anchor.
+	Range forge.ReviewThreadRange
+
+	// Side is the preimage or postimage file selected by the anchor.
+	Side forge.ReviewThreadSide
+
+	// Resolved is meaningful only when ReviewCapabilities.ThreadResolution is
+	// true for the gateway.
+	Resolved bool
+
+	// Comments contains the root followed by its replies in product order.
+	Comments []ReviewComment
+}
+
+// ReviewComment is one comment in a comment-backed review thread.
+type ReviewComment struct {
+	// ID is the product comment ID.
+	ID int64
+
+	// Version is the optimistic-locking version used by Data Center edits.
+	// It is zero for Bitbucket Cloud.
+	Version int
+
+	// Body is the raw comment text.
+	Body string
+
+	// Author is the comment author's Bitbucket username.
+	Author string
+
+	// CreatedAt is the product-reported creation time.
+	CreatedAt time.Time
+}
+
+// CreateReviewCommentRequest describes an inline comment or thread reply.
+// ParentID is zero for a new inline comment. When it is non-zero, the location
+// fields are ignored and the comment replies to that root comment.
+type CreateReviewCommentRequest struct {
+	// ParentID is the root comment ID for a reply, or zero for a new thread.
+	ParentID int64
+
+	// Path, Range, and Side locate a new thread and are ignored for replies.
+	Path  string
+	Range forge.ReviewThreadRange
+	Side  forge.ReviewThreadSide
+
+	// Body is the comment text.
+	Body string
+
+	// ReviewContext and ReviewAnchor carry Data Center's native draft anchor
+	// inputs. Cloud ignores them.
+	ReviewContext ReviewContext
+	ReviewAnchor  ReviewAnchor
+}
+
+// ReviewCapabilities reports the review features available from a gateway.
+// Bitbucket Cloud reports static capabilities. Bitbucket Data Center derives
+// them from the running product version.
+type ReviewCapabilities struct {
+	// Supported reports whether the product can satisfy ReviewRepository.
+	Supported bool
+
+	// NativeDrafts reports whether review contents remain pending until
+	// PublishReview.
+	NativeDrafts bool
+
+	// Multiline reports whether root anchors can span an inclusive range.
+	Multiline bool
+
+	// ThreadResolution reports whether the product exposes resolution state and
+	// permits ResolveReviewThread and UnresolveReviewThread.
+	ThreadResolution bool
+}
+
+// ReviewContext identifies the Data Center pull request revision on which a
+// pending review is built. Cloud review submissions do not use it.
+type ReviewContext struct {
+	// BaseHash and HeadHash are the exact sinceId/untilId revision pair used by
+	// Data Center diff lookup and comment anchors.
+	BaseHash git.Hash
+	HeadHash git.Hash
+
+	// Version is the Data Center pull request optimistic-locking version used
+	// when publishing the native review.
+	Version int
+}
+
+// ReviewAnchor carries Data Center's diff-segment classifications for the
+// inclusive review range. Cloud review submissions do not use it.
+type ReviewAnchor struct {
+	// StartLineType and EndLineType are Data Center diff segment values:
+	// ADDED, REMOVED, or CONTEXT.
+	StartLineType string
+	EndLineType   string
+}
+
+// ReviewGateway is implemented by Bitbucket products that expose review
+// conversations through pull request comments.
+type ReviewGateway interface {
+	Gateway
+
+	ReviewCapabilities(context.Context) (ReviewCapabilities, error)
+	ListReviewerStates(context.Context, int64) iter.Seq2[*ReviewerState, error]
+	ListReviewThreads(context.Context, int64) iter.Seq2[*ReviewThread, error]
+	CreateReviewComment(
+		context.Context,
+		int64,
+		CreateReviewCommentRequest,
+	) (*ReviewComment, error)
+	ResolveReviewThread(context.Context, int64, int64) error
+	UnresolveReviewThread(context.Context, int64, int64) error
+}
+
+// EmulatedReviewGateway applies dispositions outside a pending review workflow.
+// Bitbucket Cloud implements this because its review resources publish
+// immediately rather than through one native completion endpoint.
+type EmulatedReviewGateway interface {
+	ReviewGateway
+
+	SetReviewDisposition(context.Context, int64, forge.ReviewDisposition) error
+}
+
+// PendingReviewGateway publishes comments, summary, and disposition as one
+// native review. Bitbucket Data Center implements this interface from version
+// 7.7 onward.
+type PendingReviewGateway interface {
+	ReviewGateway
+
+	ReviewContext(context.Context, int64) (ReviewContext, error)
+	ReviewAnchor(
+		context.Context,
+		int64,
+		ReviewContext,
+		string,
+		forge.ReviewThreadRange,
+		forge.ReviewThreadSide,
+	) (ReviewAnchor, error)
+	PublishReview(
+		context.Context,
+		int64,
+		ReviewContext,
+		string,
+		forge.ReviewDisposition,
+	) error
 }
 
 // FindChangesOptions filters pull requests

--- a/internal/gateway/bitbucket/gateway.go
+++ b/internal/gateway/bitbucket/gateway.go
@@ -158,9 +158,11 @@ type ReviewThread struct {
 	Path string
 
 	// Range is the inclusive range represented by the product anchor.
+	// A zero range identifies the whole file.
 	Range forge.ReviewThreadRange
 
 	// Side is the preimage or postimage file selected by the anchor.
+	// It is ignored when Range is zero.
 	Side forge.ReviewThreadSide
 
 	// Resolved is meaningful only when ReviewCapabilities.ThreadResolution is
@@ -198,6 +200,7 @@ type CreateReviewCommentRequest struct {
 	ParentID int64
 
 	// Path, Range, and Side locate a new thread and are ignored for replies.
+	// A zero Range identifies the whole file and ignores Side.
 	Path  string
 	Range forge.ReviewThreadRange
 	Side  forge.ReviewThreadSide
@@ -221,6 +224,9 @@ type ReviewCapabilities struct {
 	// NativeDrafts reports whether review contents remain pending until
 	// PublishReview.
 	NativeDrafts bool
+
+	// FileLevel reports whether root comments can be attached to a whole file.
+	FileLevel bool
 
 	// Multiline reports whether root anchors can span an inclusive range.
 	Multiline bool

--- a/internal/gateway/bitbucket/server/api.go
+++ b/internal/gateway/bitbucket/server/api.go
@@ -662,9 +662,10 @@ type CommentAnchor struct {
 	LineType        string           `json:"lineType"`
 	MultilineMarker *MultilineMarker `json:"multilineMarker"`
 
-	// Path is returned as a structured object, normalized by RestPath.
-	Path   RestPath `json:"path"`
-	ToHash string   `json:"toHash"`
+	// Path and SrcPath are returned as structured objects, normalized by RestPath.
+	Path    RestPath `json:"path"`
+	SrcPath RestPath `json:"srcPath"`
+	ToHash  string   `json:"toHash"`
 }
 
 // RestPath is the structured path returned in a comment anchor.
@@ -720,18 +721,19 @@ type ReviewCommentCreateRequest struct {
 type CommentAnchorCreate struct {
 	// DiffType, FromHash, and ToHash identify the exact revision range.
 	DiffType string `json:"diffType"`
-	FileType string `json:"fileType"`
+	FileType string `json:"fileType,omitzero"`
 	FromHash string `json:"fromHash"`
 
 	// LineType and MultilineMarker are resolved from the structured diff before
 	// the pending comment mutation.
-	Line            int              `json:"line"`
-	LineType        string           `json:"lineType"`
+	Line            int              `json:"line,omitzero"`
+	LineType        string           `json:"lineType,omitzero"`
 	MultilineMarker *MultilineMarker `json:"multilineMarker,omitzero"`
 
-	// Data Center accepts a plain repository-relative path on create.
-	Path   string `json:"path"`
-	ToHash string `json:"toHash"`
+	// Data Center accepts plain repository-relative paths on create.
+	Path    string `json:"path"`
+	SrcPath string `json:"srcPath,omitzero"`
+	ToHash  string `json:"toHash"`
 }
 
 // commentText is the request body shared by comment create and update.

--- a/internal/gateway/bitbucket/server/api.go
+++ b/internal/gateway/bitbucket/server/api.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	json "encoding/json/v2"
 	"errors"
 	"fmt"
 	"iter"
@@ -54,7 +55,14 @@ type Author struct {
 
 // Reviewer is a reviewer entry on a pull request.
 type Reviewer struct {
+	// User identifies the participant.
 	User User `json:"user"`
+
+	// Status is UNAPPROVED, NEEDS_WORK, or APPROVED.
+	Status string `json:"status"`
+
+	// LastReviewedCommit is empty until the reviewer acts on a revision.
+	LastReviewedCommit string `json:"lastReviewedCommit"`
 }
 
 // User is a Bitbucket Data Center user. Name is the username used to address
@@ -342,6 +350,84 @@ func (c *Client) PullRequestCanMerge(
 	return &response, resp, nil
 }
 
+// Diff is the structured diff returned for one pull request path.
+type Diff struct {
+	// Hunks contains the line segments used for review-anchor classification.
+	Hunks []DiffHunk `json:"hunks"`
+
+	// Truncated reports that the server omitted part of the diff.
+	Truncated bool `json:"truncated"`
+}
+
+// DiffHunk groups contiguous diff segments.
+type DiffHunk struct {
+	// Segments groups lines by their ADDED, REMOVED, or CONTEXT type.
+	Segments []DiffSegment `json:"segments"`
+
+	// Truncated reports that the server omitted part of this hunk.
+	Truncated bool `json:"truncated"`
+}
+
+// DiffSegment classifies its lines as ADDED, REMOVED, or CONTEXT.
+type DiffSegment struct {
+	// Type is ADDED, REMOVED, or CONTEXT.
+	Type string `json:"type"`
+
+	// Lines carries side-specific source and destination coordinates.
+	Lines []DiffLine `json:"lines"`
+
+	// Truncated reports that the server omitted part of this segment.
+	Truncated bool `json:"truncated"`
+}
+
+// DiffLine reports the source and destination coordinates for one line.
+type DiffLine struct {
+	// Source is the preimage coordinate; it is zero for an added line.
+	Source int `json:"source"`
+
+	// Destination is the postimage coordinate; it is zero for a removed line.
+	Destination int `json:"destination"`
+
+	// Truncated reports that the server omitted line content.
+	Truncated bool `json:"truncated"`
+}
+
+// PullRequestDiff fetches the structured diff for path at the exact revision
+// pair used by a review anchor.
+func (c *Client) PullRequestDiff(
+	ctx context.Context,
+	projectKey string,
+	slug string,
+	prID int64,
+	path string,
+	fromHash string,
+	toHash string,
+) (*Diff, *Response, error) {
+	query := url.Values{
+		"diffType":     []string{"RANGE"},
+		"sinceId":      []string{fromHash},
+		"untilId":      []string{toHash},
+		"withComments": []string{"false"},
+	}
+	var response Diff
+	resp, err := c.get(
+		ctx,
+		fmt.Sprintf(
+			"/projects/%s/repos/%s/pull-requests/%d/diff/%s",
+			url.PathEscape(projectKey),
+			url.PathEscape(slug),
+			prID,
+			escapePath(path),
+		),
+		query,
+		&response,
+	)
+	if err != nil {
+		return nil, resp, err
+	}
+	return &response, resp, nil
+}
+
 // CurrentUser identifies the authenticated user. Data Center has no "/user"
 // endpoint, so the identity comes from the X-AUSERNAME response header.
 type CurrentUser struct {
@@ -534,8 +620,15 @@ type Comment struct {
 	// Version is the optimistic-locking version, required on update and delete.
 	Version int `json:"version"`
 
-	Text   string `json:"text"`
-	Author User   `json:"author"`
+	Text        string `json:"text"`
+	Author      User   `json:"author"`
+	CreatedDate int64  `json:"createdDate"`
+
+	// Parent is set on a reply. Anchor is set on an inline root. Comments holds
+	// nested replies when the root comes from the comment-listing endpoint.
+	Parent   *CommentRef    `json:"parent"`
+	Anchor   *CommentAnchor `json:"anchor"`
+	Comments []Comment      `json:"comments"`
 
 	// Severity is "NORMAL" or "BLOCKER" (a task; Data Center folds tasks
 	// into comments as blocker-severity comments).
@@ -548,6 +641,97 @@ type Comment struct {
 	// ThreadResolved reports whether the thread was resolved via the "Resolve"
 	// action, independent of task state.
 	ThreadResolved bool `json:"threadResolved"`
+}
+
+// CommentRef identifies a parent comment when creating or decoding a reply.
+type CommentRef struct {
+	// ID is the referenced parent comment ID.
+	ID int64 `json:"id"`
+}
+
+// CommentAnchor locates a pull request comment on one side of a diff.
+type CommentAnchor struct {
+	// DiffType and revision hashes identify the exact diff used by the anchor.
+	DiffType string `json:"diffType"`
+	FileType string `json:"fileType"`
+	FromHash string `json:"fromHash"`
+
+	// Line and LineType identify the range endpoint; MultilineMarker identifies
+	// its start when the anchor spans multiple lines.
+	Line            int              `json:"line"`
+	LineType        string           `json:"lineType"`
+	MultilineMarker *MultilineMarker `json:"multilineMarker"`
+
+	// Path is returned as a structured object, normalized by RestPath.
+	Path   RestPath `json:"path"`
+	ToHash string   `json:"toHash"`
+}
+
+// RestPath is the structured path returned in a comment anchor.
+type RestPath struct {
+	// Components is the complete repository-relative path when provided.
+	Components []string `json:"components"`
+
+	// Name and Parent are the split form used by some Data Center versions.
+	Name   string `json:"name"`
+	Parent string `json:"parent"`
+}
+
+// UnmarshalJSON accepts both path encodings returned by supported Data Center
+// versions: a plain slash-separated string or the newer structured object.
+func (p *RestPath) UnmarshalJSON(data []byte) error {
+	var text string
+	if err := json.Unmarshal(data, &text); err == nil {
+		p.Components = strings.Split(text, "/")
+		return nil
+	}
+
+	type plainRestPath RestPath
+	var decoded plainRestPath
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*p = RestPath(decoded)
+	return nil
+}
+
+// MultilineMarker identifies the first line of a multiline comment anchor.
+type MultilineMarker struct {
+	// StartLine is the first line in the inclusive range.
+	StartLine int `json:"startLine"`
+
+	// StartLineType is ADDED, REMOVED, or CONTEXT at StartLine.
+	StartLineType string `json:"startLineType"`
+}
+
+// ReviewCommentCreateRequest creates a pending inline comment or reply.
+type ReviewCommentCreateRequest struct {
+	// Text and State create an unpublished PENDING comment.
+	Text  string `json:"text"`
+	State string `json:"state"`
+
+	// Parent creates a reply; Anchor creates a new inline thread. They are
+	// mutually exclusive.
+	Parent *CommentRef          `json:"parent,omitzero"`
+	Anchor *CommentAnchorCreate `json:"anchor,omitzero"`
+}
+
+// CommentAnchorCreate is the string-path representation accepted on create.
+type CommentAnchorCreate struct {
+	// DiffType, FromHash, and ToHash identify the exact revision range.
+	DiffType string `json:"diffType"`
+	FileType string `json:"fileType"`
+	FromHash string `json:"fromHash"`
+
+	// LineType and MultilineMarker are resolved from the structured diff before
+	// the pending comment mutation.
+	Line            int              `json:"line"`
+	LineType        string           `json:"lineType"`
+	MultilineMarker *MultilineMarker `json:"multilineMarker,omitzero"`
+
+	// Data Center accepts a plain repository-relative path on create.
+	Path   string `json:"path"`
+	ToHash string `json:"toHash"`
 }
 
 // commentText is the request body shared by comment create and update.
@@ -582,6 +766,157 @@ func (c *Client) CommentCreate(
 		return nil, resp, err
 	}
 	return &response, resp, nil
+}
+
+// ReviewCommentCreate adds a pending review comment or reply.
+func (c *Client) ReviewCommentCreate(
+	ctx context.Context,
+	projectKey string,
+	slug string,
+	prID int64,
+	req ReviewCommentCreateRequest,
+) (*Comment, *Response, error) {
+	var response Comment
+	resp, err := c.post(
+		ctx,
+		fmt.Sprintf(
+			"/projects/%s/repos/%s/pull-requests/%d/comments",
+			url.PathEscape(projectKey),
+			url.PathEscape(slug),
+			prID,
+		),
+		nil,
+		req,
+		&response,
+	)
+	if err != nil {
+		return nil, resp, err
+	}
+	return &response, resp, nil
+}
+
+// CommentGet fetches one pull request comment with its current version.
+func (c *Client) CommentGet(
+	ctx context.Context,
+	projectKey string,
+	slug string,
+	prID int64,
+	commentID int64,
+) (*Comment, *Response, error) {
+	var response Comment
+	resp, err := c.get(
+		ctx,
+		fmt.Sprintf(
+			"/projects/%s/repos/%s/pull-requests/%d/comments/%d",
+			url.PathEscape(projectKey),
+			url.PathEscape(slug),
+			prID,
+			commentID,
+		),
+		nil,
+		&response,
+	)
+	if err != nil {
+		return nil, resp, err
+	}
+	return &response, resp, nil
+}
+
+// CommentList iterates pull request comments, including inline anchors and
+// nested replies.
+func (c *Client) CommentList(
+	ctx context.Context,
+	projectKey string,
+	slug string,
+	prID int64,
+) iter.Seq2[Comment, error] {
+	return c.getPaged[Comment](
+		ctx,
+		fmt.Sprintf(
+			"/projects/%s/repos/%s/pull-requests/%d/comments",
+			url.PathEscape(projectKey),
+			url.PathEscape(slug),
+			prID,
+		),
+		nil,
+	)
+}
+
+// CommentReviewUpdateRequest updates comment text or thread resolution under
+// the comment's optimistic-locking version.
+type CommentReviewUpdateRequest struct {
+	// Text is preserved while changing resolution, or replaced while editing.
+	Text string `json:"text"`
+
+	// Version is the live optimistic-locking version fetched from Data Center.
+	Version int `json:"version"`
+
+	// ThreadResolved is nil for text-only updates.
+	ThreadResolved *bool `json:"threadResolved,omitzero"`
+}
+
+// CommentReviewUpdate updates review-comment fields.
+func (c *Client) CommentReviewUpdate(
+	ctx context.Context,
+	projectKey string,
+	slug string,
+	prID int64,
+	commentID int64,
+	req CommentReviewUpdateRequest,
+) (*Comment, *Response, error) {
+	var response Comment
+	resp, err := c.put(
+		ctx,
+		fmt.Sprintf(
+			"/projects/%s/repos/%s/pull-requests/%d/comments/%d",
+			url.PathEscape(projectKey),
+			url.PathEscape(slug),
+			prID,
+			commentID,
+		),
+		nil,
+		req,
+		&response,
+	)
+	if err != nil {
+		return nil, resp, err
+	}
+	return &response, resp, nil
+}
+
+// PullRequestFinishReviewRequest publishes the current user's pending review.
+type PullRequestFinishReviewRequest struct {
+	// CommentText is the optional top-level review summary.
+	CommentText string `json:"commentText,omitzero"`
+
+	// ParticipantStatus is approved or needs_work when the review includes a
+	// disposition. These completion-endpoint values differ from the uppercase
+	// participant resource statuses. Empty leaves the disposition unchanged.
+	ParticipantStatus string `json:"participantStatus,omitzero"`
+}
+
+// PullRequestFinishReview atomically publishes pending comments, an optional
+// summary, and an optional participant disposition.
+func (c *Client) PullRequestFinishReview(
+	ctx context.Context,
+	projectKey string,
+	slug string,
+	prID int64,
+	version int,
+	req PullRequestFinishReviewRequest,
+) (*Response, error) {
+	return c.put(
+		ctx,
+		fmt.Sprintf(
+			"/projects/%s/repos/%s/pull-requests/%d/review",
+			url.PathEscape(projectKey),
+			url.PathEscape(slug),
+			prID,
+		),
+		url.Values{"version": []string{strconv.Itoa(version)}},
+		req,
+		nil,
+	)
 }
 
 // CommentUpdate edits the text of a pull request comment. A stale version

--- a/internal/gateway/bitbucket/server/review.go
+++ b/internal/gateway/bitbucket/server/review.go
@@ -1,0 +1,475 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/gateway/bitbucket"
+	"go.abhg.dev/gs/internal/git"
+	"golang.org/x/mod/semver"
+)
+
+// Review feature boundaries come from these Atlassian references:
+//   - 7.7 native review workflow and completion endpoint:
+//     https://docs.atlassian.com/bitbucket-server/rest/7.7.1/bitbucket-rest.html
+//   - 8.9 resolvable comment threads:
+//     https://confluence.atlassian.com/bitbucketserver089/enhancements-to-your-code-review-workflow-1236435900.html
+//   - 9.2 multiline comments:
+//     https://confluence.atlassian.com/display/BitbucketServer/Bitbucket%2BData%2BCenter%2B9.2%2Brelease%2Bnotes
+const (
+	_reviewMinVersion     = "7.7.0"
+	_reviewMinBuildNumber = 7007000
+	_resolutionMinVersion = "8.9.0"
+	_resolutionMinBuild   = 8009000
+	_multilineMinVersion  = "9.2.0"
+	_multilineMinBuild    = 9002000
+)
+
+var (
+	_ bitbucket.ReviewGateway        = (*Gateway)(nil)
+	_ bitbucket.PendingReviewGateway = (*Gateway)(nil)
+)
+
+// ReviewCapabilities derives the Data Center review surface from the running
+// product version. The API additions are versioned independently, so exposing
+// ReviewRepository and ReviewThreadResolver are separate decisions.
+func (g *Gateway) ReviewCapabilities(
+	ctx context.Context,
+) (bitbucket.ReviewCapabilities, error) {
+	props, err := g.client.ApplicationProperties(ctx)
+	if err != nil {
+		return bitbucket.ReviewCapabilities{}, fmt.Errorf(
+			"read Bitbucket Data Center version: %w", err)
+	}
+
+	version, build, err := applicationVersion(props)
+	if err != nil {
+		return bitbucket.ReviewCapabilities{}, err
+	}
+	capabilities := bitbucket.ReviewCapabilities{
+		Supported: versionAtLeast(
+			version, build, _reviewMinVersion, _reviewMinBuildNumber),
+	}
+	capabilities.NativeDrafts = capabilities.Supported
+	capabilities.ThreadResolution = versionAtLeast(
+		version, build, _resolutionMinVersion, _resolutionMinBuild)
+	capabilities.Multiline = versionAtLeast(
+		version, build, _multilineMinVersion, _multilineMinBuild)
+	return capabilities, nil
+}
+
+// applicationVersion normalizes the semantic version when available and falls
+// back to Atlassian's numeric build encoding for customized version strings.
+func applicationVersion(
+	props *ApplicationProperties,
+) (version string, build int, _ error) {
+	if semver.IsValid("v" + props.Version) {
+		return "v" + props.Version, 0, nil
+	}
+
+	build, err := strconv.Atoi(props.BuildNumber)
+	if err == nil && build > 0 {
+		return "", build, nil
+	}
+	return "", 0, fmt.Errorf(
+		"unrecognized Bitbucket Data Center version %q (build %q)",
+		props.Version, props.BuildNumber)
+}
+
+// versionAtLeast compares whichever representation applicationVersion found.
+func versionAtLeast(
+	version string,
+	build int,
+	minimumVersion string,
+	minimumBuild int,
+) bool {
+	if version != "" {
+		return semver.Compare(version, "v"+minimumVersion) >= 0
+	}
+	return build >= minimumBuild
+}
+
+// ReviewContext captures the pull request revisions and optimistic-locking
+// version before any pending review comment is created.
+func (g *Gateway) ReviewContext(
+	ctx context.Context,
+	prID int64,
+) (bitbucket.ReviewContext, error) {
+	pr, _, err := g.client.PullRequestGet(
+		ctx, g.repoID.restProjectKey(), g.repoID.slug, prID)
+	if err != nil {
+		return bitbucket.ReviewContext{}, fmt.Errorf("get pull request: %w", err)
+	}
+	if pr.ToRef.LatestCommit == "" || pr.FromRef.LatestCommit == "" {
+		return bitbucket.ReviewContext{}, fmt.Errorf(
+			"pull request %d did not report both review revisions", prID)
+	}
+	return bitbucket.ReviewContext{
+		BaseHash: git.Hash(pr.ToRef.LatestCommit),
+		HeadHash: git.Hash(pr.FromRef.LatestCommit),
+		Version:  pr.Version,
+	}, nil
+}
+
+// ReviewAnchor resolves Data Center's required line classifications from the
+// structured diff before any pending review comment is created.
+func (g *Gateway) ReviewAnchor(
+	ctx context.Context,
+	prID int64,
+	review bitbucket.ReviewContext,
+	path string,
+	lines forge.ReviewThreadRange,
+	side forge.ReviewThreadSide,
+) (bitbucket.ReviewAnchor, error) {
+	diff, _, err := g.client.PullRequestDiff(
+		ctx,
+		g.repoID.restProjectKey(),
+		g.repoID.slug,
+		prID,
+		path,
+		string(review.BaseHash),
+		string(review.HeadHash),
+	)
+	if err != nil {
+		return bitbucket.ReviewAnchor{}, fmt.Errorf(
+			"get pull request diff for %q: %w", path, err)
+	}
+
+	var anchor bitbucket.ReviewAnchor
+	for _, hunk := range diff.Hunks {
+		for _, segment := range hunk.Segments {
+			for _, line := range segment.Lines {
+				coordinate, eligible := reviewLineCoordinate(side, segment.Type, line)
+				if !eligible {
+					continue
+				}
+				if coordinate == lines.StartLine {
+					anchor.StartLineType = segment.Type
+				}
+				if coordinate == lines.EndLine {
+					anchor.EndLineType = segment.Type
+				}
+			}
+		}
+	}
+	if anchor.StartLineType == "" || anchor.EndLineType == "" {
+		return bitbucket.ReviewAnchor{}, fmt.Errorf(
+			"review range %d-%d on the %s side of %q is not present in the pull request diff",
+			lines.StartLine, lines.EndLine, side, path,
+		)
+	}
+	return anchor, nil
+}
+
+// reviewLineCoordinate selects the coordinate and segment classifications that
+// exist on the requested file side. Removed lines have no destination
+// coordinate; added lines have no source coordinate.
+func reviewLineCoordinate(
+	side forge.ReviewThreadSide,
+	lineType string,
+	line DiffLine,
+) (coordinate int, eligible bool) {
+	switch side {
+	case forge.ReviewThreadSideRight:
+		if lineType != "ADDED" && lineType != "CONTEXT" {
+			return 0, false
+		}
+		return line.Destination, true
+	case forge.ReviewThreadSideLeft:
+		if lineType != "REMOVED" && lineType != "CONTEXT" {
+			return 0, false
+		}
+		return line.Source, true
+	default:
+		panic(fmt.Sprintf("bitbucket: invalid review thread side %d", side))
+	}
+}
+
+// ListReviewerStates lists effective review dispositions for concrete revisions.
+// Data Center does not expose the review submission timestamp on participants.
+func (g *Gateway) ListReviewerStates(
+	ctx context.Context,
+	prID int64,
+) iter.Seq2[*bitbucket.ReviewerState, error] {
+	return func(yield func(*bitbucket.ReviewerState, error) bool) {
+		pr, _, err := g.client.PullRequestGet(
+			ctx, g.repoID.restProjectKey(), g.repoID.slug, prID)
+		if err != nil {
+			yield(nil, fmt.Errorf("get pull request: %w", err))
+			return
+		}
+
+		for _, reviewer := range pr.Reviewers {
+			if reviewer.LastReviewedCommit == "" {
+				continue
+			}
+			var disposition forge.ReviewDisposition
+			switch reviewer.Status {
+			case "APPROVED":
+				disposition = forge.ReviewDispositionApprove
+			case "NEEDS_WORK":
+				disposition = forge.ReviewDispositionRequestChanges
+			default:
+				continue
+			}
+			if !yield(&bitbucket.ReviewerState{
+				Reviewer:    reviewer.User.Name,
+				Disposition: disposition,
+				CommitHash:  git.Hash(reviewer.LastReviewedCommit),
+			}, nil) {
+				return
+			}
+		}
+	}
+}
+
+// ListReviewThreads reconstructs comment-backed threads from the pull request
+// comment listing. General comments and separately listed replies are omitted;
+// replies nested under each anchored root are flattened in server order.
+func (g *Gateway) ListReviewThreads(
+	ctx context.Context,
+	prID int64,
+) iter.Seq2[*bitbucket.ReviewThread, error] {
+	return func(yield func(*bitbucket.ReviewThread, error) bool) {
+		for comment, err := range g.client.CommentList(
+			ctx, g.repoID.restProjectKey(), g.repoID.slug, prID,
+		) {
+			if err != nil {
+				yield(nil, fmt.Errorf("list pull request comments: %w", err))
+				return
+			}
+			if comment.Parent != nil || comment.Anchor == nil {
+				continue
+			}
+			thread, err := reviewThreadFromServerComment(&comment)
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+			if !yield(thread, nil) {
+				return
+			}
+		}
+	}
+}
+
+// reviewThreadFromServerComment maps Data Center's fileType independently from
+// lineType: fileType owns the forge side, while segment types describe the
+// endpoints of the inclusive range.
+func reviewThreadFromServerComment(
+	comment *Comment,
+) (*bitbucket.ReviewThread, error) {
+	anchor := comment.Anchor
+	start := anchor.Line
+	if anchor.MultilineMarker != nil {
+		start = anchor.MultilineMarker.StartLine
+	}
+	var side forge.ReviewThreadSide
+	switch anchor.FileType {
+	case "TO":
+		side = forge.ReviewThreadSideRight
+	case "FROM":
+		side = forge.ReviewThreadSideLeft
+	default:
+		return nil, fmt.Errorf(
+			"review comment %d has unrecognized file side %q",
+			comment.ID, anchor.FileType)
+	}
+	thread := &bitbucket.ReviewThread{
+		RootCommentID: comment.ID,
+		Path:          reviewPath(anchor.Path),
+		Range: forge.ReviewThreadRange{
+			StartLine: start,
+			EndLine:   anchor.Line,
+		},
+		Side:     side,
+		Resolved: comment.ThreadResolved,
+	}
+	appendServerReviewComment(&thread.Comments, comment)
+	return thread, nil
+}
+
+// appendServerReviewComment flattens Data Center's nested reply tree into the
+// chronological root-first representation required by ReviewRepository.
+func appendServerReviewComment(dst *[]bitbucket.ReviewComment, comment *Comment) {
+	*dst = append(*dst, bitbucket.ReviewComment{
+		ID:        comment.ID,
+		Version:   comment.Version,
+		Body:      comment.Text,
+		Author:    comment.Author.Name,
+		CreatedAt: reviewCommentTime(comment.CreatedDate),
+	})
+	for i := range comment.Comments {
+		appendServerReviewComment(dst, &comment.Comments[i])
+	}
+}
+
+// reviewCommentTime preserves a missing product timestamp as Go's zero time.
+func reviewCommentTime(milliseconds int64) time.Time {
+	if milliseconds == 0 {
+		return time.Time{}
+	}
+	return time.UnixMilli(milliseconds)
+}
+
+// reviewPath normalizes both Data Center path object shapes decoded by RestPath.
+func reviewPath(path RestPath) string {
+	if len(path.Components) > 0 {
+		return strings.Join(path.Components, "/")
+	}
+	if path.Parent != "" {
+		return path.Parent + "/" + path.Name
+	}
+	return path.Name
+}
+
+// CreateReviewComment creates an unpublished pending comment. Root comments
+// carry the exact base/head revision pair used to produce their diff anchor;
+// replies carry only the parent comment ID.
+func (g *Gateway) CreateReviewComment(
+	ctx context.Context,
+	prID int64,
+	req bitbucket.CreateReviewCommentRequest,
+) (*bitbucket.ReviewComment, error) {
+	apiReq := ReviewCommentCreateRequest{
+		Text:  req.Body,
+		State: "PENDING",
+	}
+	if req.ParentID != 0 {
+		apiReq.Parent = &CommentRef{ID: req.ParentID}
+	} else {
+		apiReq.Anchor = reviewCommentAnchor(req)
+	}
+
+	comment, _, err := g.client.ReviewCommentCreate(
+		ctx, g.repoID.restProjectKey(), g.repoID.slug, prID, apiReq)
+	if err != nil {
+		return nil, fmt.Errorf("create pending review comment: %w", err)
+	}
+	return &bitbucket.ReviewComment{
+		ID:        comment.ID,
+		Version:   comment.Version,
+		Body:      comment.Text,
+		Author:    comment.Author.Name,
+		CreatedAt: reviewCommentTime(comment.CreatedDate),
+	}, nil
+}
+
+// reviewCommentAnchor combines the preflighted diff classifications with the
+// native file side and exact revision pair. It performs no remote lookup and is
+// called only after all anchors in the review have been prepared.
+func reviewCommentAnchor(
+	req bitbucket.CreateReviewCommentRequest,
+) *CommentAnchorCreate {
+	if req.ReviewAnchor.EndLineType == "" ||
+		(req.Range.StartLine != req.Range.EndLine &&
+			req.ReviewAnchor.StartLineType == "") {
+		panic("bitbucket: review comment anchor was not classified")
+	}
+	anchor := &CommentAnchorCreate{
+		DiffType: "RANGE",
+		FromHash: string(req.ReviewContext.BaseHash),
+		Line:     req.Range.EndLine,
+		LineType: req.ReviewAnchor.EndLineType,
+		Path:     req.Path,
+		ToHash:   string(req.ReviewContext.HeadHash),
+	}
+	switch req.Side {
+	case forge.ReviewThreadSideRight:
+		anchor.FileType = "TO"
+	case forge.ReviewThreadSideLeft:
+		anchor.FileType = "FROM"
+	default:
+		panic(fmt.Sprintf("bitbucket: invalid review thread side %d", req.Side))
+	}
+	if req.Range.StartLine != req.Range.EndLine {
+		anchor.MultilineMarker = &MultilineMarker{
+			StartLine:     req.Range.StartLine,
+			StartLineType: req.ReviewAnchor.StartLineType,
+		}
+	}
+	return anchor
+}
+
+// PublishReview finishes the native review, making all pending comments, the
+// optional summary, and the optional disposition visible atomically. The pull
+// request version supplies optimistic concurrency, and the completion endpoint
+// owns participant status, so publication needs no separate participant lookup
+// or update.
+func (g *Gateway) PublishReview(
+	ctx context.Context,
+	prID int64,
+	review bitbucket.ReviewContext,
+	body string,
+	disposition forge.ReviewDisposition,
+) error {
+	var participantStatus string
+	switch disposition {
+	case forge.ReviewDispositionNone:
+	case forge.ReviewDispositionApprove:
+		participantStatus = "approved"
+	case forge.ReviewDispositionRequestChanges:
+		participantStatus = "needs_work"
+	default:
+		panic(fmt.Sprintf("bitbucket: invalid review disposition %d", disposition))
+	}
+	_, err := g.client.PullRequestFinishReview(
+		ctx, g.repoID.restProjectKey(), g.repoID.slug, prID, review.Version,
+		PullRequestFinishReviewRequest{
+			CommentText:       body,
+			ParticipantStatus: participantStatus,
+		})
+	if err != nil {
+		return fmt.Errorf("publish review: %w", err)
+	}
+	return nil
+}
+
+// ResolveReviewThread resolves the thread rooted at commentID.
+func (g *Gateway) ResolveReviewThread(
+	ctx context.Context,
+	prID int64,
+	commentID int64,
+) error {
+	return g.setReviewThreadResolved(ctx, prID, commentID, true)
+}
+
+// UnresolveReviewThread reopens the thread rooted at commentID.
+func (g *Gateway) UnresolveReviewThread(
+	ctx context.Context,
+	prID int64,
+	commentID int64,
+) error {
+	return g.setReviewThreadResolved(ctx, prID, commentID, false)
+}
+
+// setReviewThreadResolved fetches the live comment first because Data Center
+// owns the optimistic-locking version used by the resolution update.
+func (g *Gateway) setReviewThreadResolved(
+	ctx context.Context,
+	prID int64,
+	commentID int64,
+	resolved bool,
+) error {
+	comment, _, err := g.client.CommentGet(
+		ctx, g.repoID.restProjectKey(), g.repoID.slug, prID, commentID)
+	if err != nil {
+		return fmt.Errorf("get review thread: %w", err)
+	}
+	_, _, err = g.client.CommentReviewUpdate(
+		ctx, g.repoID.restProjectKey(), g.repoID.slug, prID, commentID,
+		CommentReviewUpdateRequest{
+			Text:           comment.Text,
+			Version:        comment.Version,
+			ThreadResolved: &resolved,
+		})
+	if err != nil {
+		return fmt.Errorf("update review thread resolution: %w", err)
+	}
+	return nil
+}

--- a/internal/gateway/bitbucket/server/review.go
+++ b/internal/gateway/bitbucket/server/review.go
@@ -56,6 +56,7 @@ func (g *Gateway) ReviewCapabilities(
 			version, build, _reviewMinVersion, _reviewMinBuildNumber),
 	}
 	capabilities.NativeDrafts = capabilities.Supported
+	capabilities.FileLevel = capabilities.Supported
 	capabilities.ThreadResolution = versionAtLeast(
 		version, build, _resolutionMinVersion, _resolutionMinBuild)
 	capabilities.Multiline = versionAtLeast(
@@ -126,6 +127,9 @@ func (g *Gateway) ReviewAnchor(
 	lines forge.ReviewThreadRange,
 	side forge.ReviewThreadSide,
 ) (bitbucket.ReviewAnchor, error) {
+	if lines.IsZero() {
+		return bitbucket.ReviewAnchor{}, nil
+	}
 	diff, _, err := g.client.PullRequestDiff(
 		ctx,
 		g.repoID.restProjectKey(),
@@ -265,8 +269,27 @@ func reviewThreadFromServerComment(
 	comment *Comment,
 ) (*bitbucket.ReviewThread, error) {
 	anchor := comment.Anchor
+	if isGeneralFileAnchor(anchor) {
+		thread := &bitbucket.ReviewThread{
+			RootCommentID: comment.ID,
+			Path:          reviewPath(anchor.Path),
+			Resolved:      comment.ThreadResolved,
+		}
+		appendServerReviewComment(&thread.Comments, comment)
+		return thread, nil
+	}
+	if anchor.Line <= 0 || anchor.LineType == "" {
+		return nil, fmt.Errorf(
+			"review comment %d has malformed line anchor", comment.ID)
+	}
 	start := anchor.Line
 	if anchor.MultilineMarker != nil {
+		if anchor.MultilineMarker.StartLine <= 0 ||
+			anchor.MultilineMarker.StartLine > anchor.Line ||
+			anchor.MultilineMarker.StartLineType == "" {
+			return nil, fmt.Errorf(
+				"review comment %d has malformed multiline anchor", comment.ID)
+		}
 		start = anchor.MultilineMarker.StartLine
 	}
 	var side forge.ReviewThreadSide
@@ -292,6 +315,24 @@ func reviewThreadFromServerComment(
 	}
 	appendServerReviewComment(&thread.Comments, comment)
 	return thread, nil
+}
+
+// isGeneralFileAnchor recognizes Data Center's general file-comment shape.
+// The API uses a RANGE anchor with both revisions, path, and srcPath, but no
+// fileType or line fields. Requiring that complete shape keeps missing line data
+// from being interpreted as a file-level thread.
+//
+// See https://developer.atlassian.com/server/bitbucket/rest/v904/api-group-pull-requests/
+func isGeneralFileAnchor(anchor *CommentAnchor) bool {
+	return anchor.DiffType == "RANGE" &&
+		anchor.FileType == "" &&
+		anchor.FromHash != "" &&
+		anchor.Line == 0 &&
+		anchor.LineType == "" &&
+		anchor.MultilineMarker == nil &&
+		reviewPath(anchor.Path) != "" &&
+		reviewPath(anchor.SrcPath) != "" &&
+		anchor.ToHash != ""
 }
 
 // appendServerReviewComment flattens Data Center's nested reply tree into the
@@ -366,19 +407,23 @@ func (g *Gateway) CreateReviewComment(
 func reviewCommentAnchor(
 	req bitbucket.CreateReviewCommentRequest,
 ) *CommentAnchorCreate {
+	anchor := &CommentAnchorCreate{
+		DiffType: "RANGE",
+		FromHash: string(req.ReviewContext.BaseHash),
+		Path:     req.Path,
+		ToHash:   string(req.ReviewContext.HeadHash),
+	}
+	if req.Range.IsZero() {
+		anchor.SrcPath = req.Path
+		return anchor
+	}
 	if req.ReviewAnchor.EndLineType == "" ||
 		(req.Range.StartLine != req.Range.EndLine &&
 			req.ReviewAnchor.StartLineType == "") {
 		panic("bitbucket: review comment anchor was not classified")
 	}
-	anchor := &CommentAnchorCreate{
-		DiffType: "RANGE",
-		FromHash: string(req.ReviewContext.BaseHash),
-		Line:     req.Range.EndLine,
-		LineType: req.ReviewAnchor.EndLineType,
-		Path:     req.Path,
-		ToHash:   string(req.ReviewContext.HeadHash),
-	}
+	anchor.Line = req.Range.EndLine
+	anchor.LineType = req.ReviewAnchor.EndLineType
 	switch req.Side {
 	case forge.ReviewThreadSideRight:
 		anchor.FileType = "TO"

--- a/internal/gateway/bitbucket/server/review_test.go
+++ b/internal/gateway/bitbucket/server/review_test.go
@@ -1,0 +1,432 @@
+package server
+
+import (
+	json "encoding/json/v2"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/forge"
+	"go.abhg.dev/gs/internal/gateway/bitbucket"
+	"go.abhg.dev/gs/internal/git"
+)
+
+func TestGateway_ReviewCapabilities(t *testing.T) {
+	tests := []struct {
+		name  string
+		props map[string]any
+		want  bitbucket.ReviewCapabilities
+	}{
+		{
+			name:  "BeforeReviewWorkflow",
+			props: map[string]any{"version": "7.6.9"},
+			want:  bitbucket.ReviewCapabilities{},
+		},
+		{
+			name:  "ReviewWorkflow",
+			props: map[string]any{"version": "7.7.0"},
+			want: bitbucket.ReviewCapabilities{
+				Supported:    true,
+				NativeDrafts: true,
+			},
+		},
+		{
+			name:  "ThreadResolution",
+			props: map[string]any{"version": "8.9.0"},
+			want: bitbucket.ReviewCapabilities{
+				Supported:        true,
+				NativeDrafts:     true,
+				ThreadResolution: true,
+			},
+		},
+		{
+			name:  "BeforeMultiline",
+			props: map[string]any{"version": "9.1.9"},
+			want: bitbucket.ReviewCapabilities{
+				Supported:        true,
+				NativeDrafts:     true,
+				ThreadResolution: true,
+			},
+		},
+		{
+			name:  "Multiline",
+			props: map[string]any{"version": "9.2.0"},
+			want: bitbucket.ReviewCapabilities{
+				Supported:        true,
+				NativeDrafts:     true,
+				Multiline:        true,
+				ThreadResolution: true,
+			},
+		},
+		{
+			name:  "BuildNumberFallback",
+			props: map[string]any{"version": "custom", "buildNumber": "9002000"},
+			want: bitbucket.ReviewCapabilities{
+				Supported:        true,
+				NativeDrafts:     true,
+				Multiline:        true,
+				ThreadResolution: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, "/rest/api/1.0/application-properties", r.URL.Path)
+				gatewayWriteJSON(t, w, http.StatusOK, tt.props)
+			}))
+			defer srv.Close()
+
+			got, err := newOpsTestServerGateway(t, srv).ReviewCapabilities(t.Context())
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGateway_CreateReviewComment_multilineAnchor(t *testing.T) {
+	var got map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, prItemPath(7)+"/comments", r.URL.Path)
+		require.NoError(t, json.UnmarshalRead(r.Body, &got))
+		gatewayWriteJSON(t, w, http.StatusCreated, map[string]any{
+			"id": 101, "text": "explain this", "createdDate": 1234,
+		})
+	}))
+	defer srv.Close()
+
+	comment, err := newOpsTestServerGateway(t, srv).CreateReviewComment(
+		t.Context(), 7, bitbucket.CreateReviewCommentRequest{
+			Path:  "internal/review.go",
+			Range: forge.ReviewThreadRange{StartLine: 12, EndLine: 14},
+			Side:  forge.ReviewThreadSideLeft,
+			Body:  "explain this",
+			ReviewContext: bitbucket.ReviewContext{
+				BaseHash: git.Hash("base-sha"),
+				HeadHash: git.Hash("head-sha"),
+			},
+			ReviewAnchor: bitbucket.ReviewAnchor{
+				StartLineType: "CONTEXT",
+				EndLineType:   "REMOVED",
+			},
+		})
+	require.NoError(t, err)
+	assert.Equal(t, int64(101), comment.ID)
+	assert.Equal(t, map[string]any{
+		"text":  "explain this",
+		"state": "PENDING",
+		"anchor": map[string]any{
+			"diffType": "RANGE",
+			"fileType": "FROM",
+			"fromHash": "base-sha",
+			"line":     float64(14),
+			"lineType": "REMOVED",
+			"multilineMarker": map[string]any{
+				"startLine":     float64(12),
+				"startLineType": "CONTEXT",
+			},
+			"path":   "internal/review.go",
+			"toHash": "head-sha",
+		},
+	}, got)
+}
+
+func TestGateway_ReviewAnchor(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, prItemPath(7)+"/diff/internal/review.go", r.URL.Path)
+		assert.Equal(t, "RANGE", r.URL.Query().Get("diffType"))
+		assert.Equal(t, "base-sha", r.URL.Query().Get("sinceId"))
+		assert.Equal(t, "head-sha", r.URL.Query().Get("untilId"))
+		assert.Equal(t, "false", r.URL.Query().Get("withComments"))
+		gatewayWriteJSON(t, w, http.StatusOK, map[string]any{
+			"hunks": []any{map[string]any{
+				"segments": []any{
+					map[string]any{
+						"type":  "CONTEXT",
+						"lines": []any{map[string]any{"source": 10, "destination": 12}},
+					},
+					map[string]any{
+						"type":  "ADDED",
+						"lines": []any{map[string]any{"destination": 14}},
+					},
+				},
+			}},
+		})
+	}))
+	defer srv.Close()
+
+	anchor, err := newOpsTestServerGateway(t, srv).ReviewAnchor(
+		t.Context(),
+		7,
+		bitbucket.ReviewContext{BaseHash: "base-sha", HeadHash: "head-sha"},
+		"internal/review.go",
+		forge.ReviewThreadRange{StartLine: 12, EndLine: 14},
+		forge.ReviewThreadSideRight,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, bitbucket.ReviewAnchor{
+		StartLineType: "CONTEXT",
+		EndLineType:   "ADDED",
+	}, anchor)
+}
+
+func TestGateway_CreateReviewComment_singleLineAnchor(t *testing.T) {
+	var got map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.UnmarshalRead(r.Body, &got))
+		gatewayWriteJSON(t, w, http.StatusCreated, map[string]any{"id": 101})
+	}))
+	defer srv.Close()
+
+	_, err := newOpsTestServerGateway(t, srv).CreateReviewComment(
+		t.Context(), 7, bitbucket.CreateReviewCommentRequest{
+			Path:  "review.go",
+			Range: forge.ReviewThreadLine(8),
+			Side:  forge.ReviewThreadSideRight,
+			Body:  "single line",
+			ReviewContext: bitbucket.ReviewContext{
+				BaseHash: "base-sha",
+				HeadHash: "head-sha",
+			},
+			ReviewAnchor: bitbucket.ReviewAnchor{
+				StartLineType: "CONTEXT",
+				EndLineType:   "CONTEXT",
+			},
+		})
+	require.NoError(t, err)
+	anchor := got["anchor"].(map[string]any)
+	assert.Equal(t, "TO", anchor["fileType"])
+	assert.Equal(t, "CONTEXT", anchor["lineType"])
+	assert.NotContains(t, anchor, "multilineMarker")
+}
+
+func TestGateway_CreateReviewComment_reply(t *testing.T) {
+	var got map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.UnmarshalRead(r.Body, &got))
+		gatewayWriteJSON(t, w, http.StatusCreated, map[string]any{
+			"id": 102, "text": "reply",
+		})
+	}))
+	defer srv.Close()
+
+	_, err := newOpsTestServerGateway(t, srv).CreateReviewComment(
+		t.Context(), 7, bitbucket.CreateReviewCommentRequest{
+			ParentID: 101,
+			Body:     "reply",
+		})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{
+		"text":   "reply",
+		"state":  "PENDING",
+		"parent": map[string]any{"id": float64(101)},
+	}, got)
+}
+
+func TestGateway_ReviewContextAndPublish(t *testing.T) {
+	var gotBody map[string]any
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		switch calls {
+		case 1:
+			require.Equal(t, http.MethodGet, r.Method)
+			require.Equal(t, prItemPath(7), r.URL.Path)
+			gatewayWriteJSON(t, w, http.StatusOK, map[string]any{
+				"id": 7, "version": 4,
+				"fromRef": map[string]any{"latestCommit": "head-sha"},
+				"toRef":   map[string]any{"latestCommit": "base-sha"},
+			})
+		case 2:
+			require.Equal(t, http.MethodPut, r.Method)
+			require.Equal(t, prItemPath(7)+"/review", r.URL.Path)
+			assert.Equal(t, "4", r.URL.Query().Get("version"))
+			require.NoError(t, json.UnmarshalRead(r.Body, &gotBody))
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected request %d: %s %s", calls, r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	gw := newOpsTestServerGateway(t, srv)
+	review, err := gw.ReviewContext(t.Context(), 7)
+	require.NoError(t, err)
+	assert.Equal(t, bitbucket.ReviewContext{
+		BaseHash: git.Hash("base-sha"),
+		HeadHash: git.Hash("head-sha"),
+		Version:  4,
+	}, review)
+	require.NoError(t, gw.PublishReview(
+		t.Context(), 7, review, "summary",
+		forge.ReviewDispositionRequestChanges,
+	))
+	assert.Equal(t, map[string]any{
+		"commentText":       "summary",
+		"participantStatus": "needs_work",
+	}, gotBody)
+}
+
+func TestGateway_PublishReview_dispositionOnly(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPut, r.Method)
+		require.Equal(t, prItemPath(7)+"/review", r.URL.Path)
+		assert.Equal(t, "4", r.URL.Query().Get("version"))
+		require.NoError(t, json.UnmarshalRead(r.Body, &gotBody))
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	require.NoError(t, newOpsTestServerGateway(t, srv).PublishReview(
+		t.Context(), 7, bitbucket.ReviewContext{Version: 4}, "",
+		forge.ReviewDispositionApprove,
+	))
+	assert.Equal(t, map[string]any{"participantStatus": "approved"}, gotBody)
+}
+
+func TestGateway_PublishReview_none(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPut, r.Method)
+		require.Equal(t, prItemPath(7)+"/review", r.URL.Path)
+		assert.Equal(t, "4", r.URL.Query().Get("version"))
+		require.NoError(t, json.UnmarshalRead(r.Body, &gotBody))
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	require.NoError(t, newOpsTestServerGateway(t, srv).PublishReview(
+		t.Context(), 7, bitbucket.ReviewContext{Version: 4}, "summary",
+		forge.ReviewDispositionNone,
+	))
+	assert.Equal(t, map[string]any{"commentText": "summary"}, gotBody)
+}
+
+func TestGateway_ListReviewerStates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, prItemPath(7), r.URL.Path)
+		gatewayWriteJSON(t, w, http.StatusOK, map[string]any{
+			"reviewers": []any{
+				map[string]any{
+					"user":   map[string]any{"name": "spock"},
+					"status": "APPROVED", "lastReviewedCommit": "abc123",
+				},
+				map[string]any{
+					"user":   map[string]any{"name": "kirk"},
+					"status": "NEEDS_WORK", "lastReviewedCommit": "def456",
+				},
+				map[string]any{
+					"user":   map[string]any{"name": "uhura"},
+					"status": "UNAPPROVED", "lastReviewedCommit": "789abc",
+				},
+				map[string]any{
+					"user":   map[string]any{"name": "sulu"},
+					"status": "UNAPPROVED",
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	var got []*bitbucket.ReviewerState
+	for state, err := range newOpsTestServerGateway(t, srv).ListReviewerStates(t.Context(), 7) {
+		require.NoError(t, err)
+		got = append(got, state)
+	}
+	assert.Equal(t, []*bitbucket.ReviewerState{
+		{Reviewer: "spock", Disposition: forge.ReviewDispositionApprove, CommitHash: git.Hash("abc123")},
+		{Reviewer: "kirk", Disposition: forge.ReviewDispositionRequestChanges, CommitHash: git.Hash("def456")},
+	}, got)
+}
+
+func TestGateway_ListReviewThreads(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, prItemPath(7)+"/comments", r.URL.Path)
+		gatewayWriteJSON(t, w, http.StatusOK, map[string]any{
+			"isLastPage": true,
+			"values": []any{
+				map[string]any{"id": 1, "text": "general"},
+				map[string]any{
+					"id": 101, "text": "root", "createdDate": int64(1000),
+					"author":         map[string]any{"name": "spock"},
+					"threadResolved": true,
+					"anchor": map[string]any{
+						"fileType": "TO", "line": 14, "lineType": "ADDED",
+						"multilineMarker": map[string]any{"startLine": 12, "startLineType": "CONTEXT"},
+						"path":            map[string]any{"components": []string{"internal", "review.go"}},
+					},
+					"comments": []any{map[string]any{
+						"id": 102, "text": "reply", "createdDate": int64(2000),
+						"author": map[string]any{"name": "kirk"},
+					}},
+				},
+				map[string]any{
+					"id": 102, "text": "reply",
+					"parent": map[string]any{"id": 101},
+					"anchor": map[string]any{
+						"fileType": "TO", "line": 14, "lineType": "ADDED",
+						"path": map[string]any{"components": []string{"internal", "review.go"}},
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	var got []*bitbucket.ReviewThread
+	for thread, err := range newOpsTestServerGateway(t, srv).ListReviewThreads(t.Context(), 7) {
+		require.NoError(t, err)
+		got = append(got, thread)
+	}
+	require.Len(t, got, 1)
+	assert.Equal(t, int64(101), got[0].RootCommentID)
+	assert.Equal(t, "internal/review.go", got[0].Path)
+	assert.Equal(t, forge.ReviewThreadRange{StartLine: 12, EndLine: 14}, got[0].Range)
+	assert.Equal(t, forge.ReviewThreadSideRight, got[0].Side)
+	assert.True(t, got[0].Resolved)
+	require.Len(t, got[0].Comments, 2)
+	assert.Equal(t, int64(101), got[0].Comments[0].ID)
+	assert.Equal(t, "root", got[0].Comments[0].Body)
+	assert.Equal(t, "spock", got[0].Comments[0].Author)
+	assert.Equal(t, int64(102), got[0].Comments[1].ID)
+	assert.Equal(t, "reply", got[0].Comments[1].Body)
+	assert.Equal(t, "kirk", got[0].Comments[1].Author)
+}
+
+func TestGateway_ResolveReviewThread(t *testing.T) {
+	var gotBody map[string]any
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		switch calls {
+		case 1:
+			require.Equal(t, http.MethodGet, r.Method)
+			require.Equal(t, prItemPath(7)+"/comments/101", r.URL.Path)
+			gatewayWriteJSON(t, w, http.StatusOK, map[string]any{
+				"id": 101, "version": 3, "text": "root",
+			})
+		case 2:
+			require.Equal(t, http.MethodPut, r.Method)
+			require.Equal(t, prItemPath(7)+"/comments/101", r.URL.Path)
+			require.NoError(t, json.UnmarshalRead(r.Body, &gotBody))
+			gatewayWriteJSON(t, w, http.StatusOK, map[string]any{})
+		default:
+			t.Fatalf("unexpected request %d: %s %s", calls, r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	require.NoError(t, newOpsTestServerGateway(t, srv).ResolveReviewThread(
+		t.Context(), 7, 101))
+	assert.Equal(t, map[string]any{
+		"text":           "root",
+		"version":        float64(3),
+		"threadResolved": true,
+	}, gotBody)
+}

--- a/internal/gateway/bitbucket/server/review_test.go
+++ b/internal/gateway/bitbucket/server/review_test.go
@@ -30,6 +30,7 @@ func TestGateway_ReviewCapabilities(t *testing.T) {
 			want: bitbucket.ReviewCapabilities{
 				Supported:    true,
 				NativeDrafts: true,
+				FileLevel:    true,
 			},
 		},
 		{
@@ -38,6 +39,7 @@ func TestGateway_ReviewCapabilities(t *testing.T) {
 			want: bitbucket.ReviewCapabilities{
 				Supported:        true,
 				NativeDrafts:     true,
+				FileLevel:        true,
 				ThreadResolution: true,
 			},
 		},
@@ -47,6 +49,7 @@ func TestGateway_ReviewCapabilities(t *testing.T) {
 			want: bitbucket.ReviewCapabilities{
 				Supported:        true,
 				NativeDrafts:     true,
+				FileLevel:        true,
 				ThreadResolution: true,
 			},
 		},
@@ -56,6 +59,7 @@ func TestGateway_ReviewCapabilities(t *testing.T) {
 			want: bitbucket.ReviewCapabilities{
 				Supported:        true,
 				NativeDrafts:     true,
+				FileLevel:        true,
 				Multiline:        true,
 				ThreadResolution: true,
 			},
@@ -66,6 +70,7 @@ func TestGateway_ReviewCapabilities(t *testing.T) {
 			want: bitbucket.ReviewCapabilities{
 				Supported:        true,
 				NativeDrafts:     true,
+				FileLevel:        true,
 				Multiline:        true,
 				ThreadResolution: true,
 			},
@@ -85,6 +90,53 @@ func TestGateway_ReviewCapabilities(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestGateway_CreateReviewComment_fileLevel(t *testing.T) {
+	var got map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.UnmarshalRead(r.Body, &got))
+		gatewayWriteJSON(t, w, http.StatusCreated, map[string]any{"id": 101})
+	}))
+	defer srv.Close()
+
+	_, err := newOpsTestServerGateway(t, srv).CreateReviewComment(
+		t.Context(), 7, bitbucket.CreateReviewCommentRequest{
+			Path: "internal/review.go",
+			Side: forge.ReviewThreadSide(99),
+			Body: "whole file",
+			ReviewContext: bitbucket.ReviewContext{
+				BaseHash: "base-sha",
+				HeadHash: "head-sha",
+			},
+		})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{
+		"text":  "whole file",
+		"state": "PENDING",
+		"anchor": map[string]any{
+			"diffType": "RANGE",
+			"fromHash": "base-sha",
+			"path":     "internal/review.go",
+			"srcPath":  "internal/review.go",
+			"toHash":   "head-sha",
+		},
+	}, got)
+}
+
+func TestGateway_ReviewAnchor_fileLevel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		t.Fatalf("file-level anchor must not inspect the diff: %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	anchor, err := newOpsTestServerGateway(t, srv).ReviewAnchor(
+		t.Context(), 7,
+		bitbucket.ReviewContext{BaseHash: "base-sha", HeadHash: "head-sha"},
+		"internal/review.go", forge.ReviewThreadRange{}, forge.ReviewThreadSide(99),
+	)
+	require.NoError(t, err)
+	assert.Zero(t, anchor)
 }
 
 func TestGateway_CreateReviewComment_multilineAnchor(t *testing.T) {
@@ -397,6 +449,63 @@ func TestGateway_ListReviewThreads(t *testing.T) {
 	assert.Equal(t, int64(102), got[0].Comments[1].ID)
 	assert.Equal(t, "reply", got[0].Comments[1].Body)
 	assert.Equal(t, "kirk", got[0].Comments[1].Author)
+}
+
+func TestGateway_ListReviewThreads_fileLevel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		gatewayWriteJSON(t, w, http.StatusOK, map[string]any{
+			"values": []any{map[string]any{
+				"id": 10, "text": "whole file",
+				"anchor": map[string]any{
+					"diffType": "RANGE",
+					"fromHash": "base-sha",
+					"path":     "internal/review.go",
+					"srcPath":  "internal/review.go",
+					"toHash":   "head-sha",
+				},
+			}},
+			"isLastPage": true,
+		})
+	}))
+	defer srv.Close()
+
+	var got []*bitbucket.ReviewThread
+	for thread, err := range newOpsTestServerGateway(t, srv).
+		ListReviewThreads(t.Context(), 7) {
+		require.NoError(t, err)
+		got = append(got, thread)
+	}
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "internal/review.go", got[0].Path)
+	assert.True(t, got[0].Range.IsZero())
+}
+
+func TestGateway_ListReviewThreads_rejectsMalformedLineAnchor(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		gatewayWriteJSON(t, w, http.StatusOK, map[string]any{
+			"values": []any{map[string]any{
+				"id": 10, "text": "missing line",
+				"anchor": map[string]any{
+					"diffType": "RANGE",
+					"fileType": "TO",
+					"fromHash": "base-sha",
+					"path":     "internal/review.go",
+					"srcPath":  "internal/review.go",
+					"toHash":   "head-sha",
+				},
+			}},
+			"isLastPage": true,
+		})
+	}))
+	defer srv.Close()
+
+	var gotErr error
+	for _, err := range newOpsTestServerGateway(t, srv).
+		ListReviewThreads(t.Context(), 7) {
+		gotErr = err
+	}
+	require.ErrorContains(t, gotErr, "malformed line anchor")
 }
 
 func TestGateway_ResolveReviewThread(t *testing.T) {


### PR DESCRIPTION
Bitbucket Cloud and Data Center expose review conversations through pull
request comments rather than a uniform thread API.
Adapt comment-backed discussions to ReviewRepository while preserving the
publication and anchor semantics of each product.

Discover Data Center capabilities from the running product version.
From 7.7, create comments as pending drafts and finish comments, summary, and
disposition through one versioned native review request.
Expose thread resolution from 8.9 and multiline anchors from 9.2.
On earlier supported versions, classify single-line anchors from the exact
base/head diff and reject multiline reviews before mutation.
Propagate version-probe failures so repository opening cannot silently hide
supported review behavior.

Integration tests are disabled because we don't have a way
of recording these fixtures without paying for BitBucket.

Co-Authored-By: Edmund Kohlwey <ed@irl.llc>