### PR TITLE
docs: Cover Azure DevOps workflows

### DIFF
--- a/auth_login.go
+++ b/auth_login.go
@@ -22,11 +22,11 @@ func (*authLoginCmd) Help() string {
 		A prompt will allow selecting between available authentication methods.
 		Available methods include:
 
-		- OAuth: Web-based authentication flow
-		- GitHub App (GitHub only): Authenticate using a GitHub App installation
-		- Git Credential Manager: Reuse credentials already stored for Git
-		- Personal Access Token: Directly provide a personal access token
-		- CLI: Use the GitHub or GitLab CLI tool for authentication (if installed)
+		 - OAuth: Web-based authentication flow
+		 - GitHub App (GitHub only): Authenticate using a GitHub App installation
+		 - Git Credential Manager: Reuse credentials already stored for Git
+		 - Personal Access Token: Directly provide a personal access token
+		 - CLI: Use the GitHub, GitLab, or Azure CLI tool for authentication (if installed)
 
 		The differences between them are explained in the prompt.
 

--- a/doc/hooks/replace.py
+++ b/doc/hooks/replace.py
@@ -14,18 +14,21 @@ REPLACEMENTS = {
     '<!-- gs:bitbucket-server -->': ':simple-bitbucket: Bitbucket Data Center',
     '<!-- gs:gitea -->': ':simple-gitea: Gitea',
     '<!-- gs:forgejo -->': ':simple-forgejo: Forgejo',
+    '<!-- gs:azuredevops -->': ':material-microsoft-azure-devops: Azure DevOps',
     '<!-- gs:icon:github -->': ':simple-github:',
     '<!-- gs:icon:gitlab -->': ':simple-gitlab:',
     '<!-- gs:icon:bitbucket -->': ':simple-bitbucket:',
     '<!-- gs:icon:bitbucket-server -->': ':simple-bitbucket:',
     '<!-- gs:icon:gitea -->': ':simple-gitea:',
     '<!-- gs:icon:forgejo -->': ':simple-forgejo:',
+    '<!-- gs:icon:azuredevops -->': ':material-microsoft-azure-devops:',
     '<!-- gs:badge:github ': '<!-- gs:badge simple-github GitHub ',
     '<!-- gs:badge:gitlab ': '<!-- gs:badge simple-gitlab GitLab ',
     '<!-- gs:badge:bitbucket ': '<!-- gs:badge simple-bitbucket Bitbucket ',
     '<!-- gs:badge:bitbucket-server ': '<!-- gs:badge simple-bitbucket Bitbucket Data Center ',
     '<!-- gs:badge:gitea ': '<!-- gs:badge simple-gitea Gitea ',
     '<!-- gs:badge:forgejo ': '<!-- gs:badge simple-forgejo Forgejo ',
+    '<!-- gs:badge:azuredevops ': '<!-- gs:badge material-microsoft-azure-devops Azure DevOps ',
 }
 
 

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -57,11 +57,11 @@ Log in to a service
 A prompt will allow selecting between available authentication methods.
 Available methods include:
 
-- OAuth: Web-based authentication flow
-- GitHub App (GitHub only): Authenticate using a GitHub App installation
-- Git Credential Manager: Reuse credentials already stored for Git
-- Personal Access Token: Directly provide a personal access token
-- CLI: Use the GitHub or GitLab CLI tool for authentication (if installed)
+ - OAuth: Web-based authentication flow
+ - GitHub App (GitHub only): Authenticate using a GitHub App installation
+ - Git Credential Manager: Reuse credentials already stored for Git
+ - Personal Access Token: Directly provide a personal access token
+ - CLI: Use the GitHub, GitLab, or Azure CLI tool for authentication (if installed)
 
 The differences between them are explained in the prompt.
 

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -311,7 +311,8 @@ the repository path.
 ```
 
 Accepted values are registered forge IDs,
-including `github`, `gitlab`, `bitbucket`, `gitea`, and `forgejo`.
+including `github`, `gitlab`, `bitbucket`, `gitea`, `forgejo`,
+and `azuredevops`.
 
 With `bitbucket`, the instance URL is derived from the remote URL
 when $$spice.forge.bitbucket.url$$ is not set,

--- a/doc/src/cli/json.md
+++ b/doc/src/cli/json.md
@@ -85,7 +85,8 @@ These objects take the following form:
       // (e.g. with 'gs branch submit').
       change?: {
         // Human-readable identifier for the Change Request.
-        // This is the PR number for GitHub, Bitbucket, Gitea, or Forgejo
+        // This is the PR number for GitHub, Bitbucket, Gitea, Forgejo,
+        // or Azure DevOps
         // (e.g. "#123"),
         // and the MR IID for GitLab (e.g. "!123").
         id: string,

--- a/doc/src/guide/concepts.md
+++ b/doc/src/guide/concepts.md
@@ -118,9 +118,10 @@ text "Sibling" with s at F.n
 
 **Change Request**
 :   Change Request refers to a single merge-able unit of work
-    submitted to GitHub, GitLab, Bitbucket, Gitea, or Forgejo.
+    submitted to GitHub, GitLab, Bitbucket, Gitea, Forgejo, or Azure DevOps.
     Each Change Request corresponds to a branch.
-    On GitHub, Bitbucket, Gitea, and Forgejo, these are called Pull Requests,
+    On GitHub, Bitbucket, Gitea, Forgejo, and Azure DevOps,
+    these are called Pull Requests,
     and on GitLab, they are called Merge Requests.
     Since git-spice supports these platforms,
     the term Change Request is used to refer to all of them.

--- a/doc/src/guide/cr.md
+++ b/doc/src/guide/cr.md
@@ -17,6 +17,7 @@ description: >-
     - <!-- gs:bitbucket --> (<!-- gs:version v0.25.0 -->)
     - <!-- gs:gitea --> (<!-- gs:version v0.30.0 -->)
     - <!-- gs:forgejo --> (<!-- gs:version v0.30.0 -->)
+    - <!-- gs:azuredevops --> (<!-- gs:version unreleased -->)
 
     If you're using a different service,
     you can still use git-spice,
@@ -32,7 +33,8 @@ description: >-
 !!! info
 
     git-spice uses the term *Change Request* to refer to submitted branches.
-    These correspond to Pull Requests on GitHub, Bitbucket, Gitea, and Forgejo,
+    These correspond to Pull Requests on GitHub, Bitbucket, Gitea, Forgejo,
+    and Azure DevOps,
     and to Merge Requests on GitLab.
 
 When your local changes are ready,

--- a/doc/src/guide/merge.md
+++ b/doc/src/guide/merge.md
@@ -369,3 +369,4 @@ Depending on the forge, the following additional variables may be set:
 | `GIT_SPICE_BITBUCKET_PR_ID` | <!-- gs:badge:bitbucket --> |
 | `GIT_SPICE_FORGEJO_PR_NUMBER` | <!-- gs:badge:forgejo --> |
 | `GIT_SPICE_GITEA_PR_NUMBER` | <!-- gs:badge:gitea --> |
+| `GIT_SPICE_AZUREDEVOPS_PR_NUMBER` | <!-- gs:badge:azuredevops --> |

--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -16,7 +16,7 @@ git-spice is a tool for stacking Git branches.
 It lets you manage and navigate stacks of branches,
 conveniently modify and rebase them, and create
 <!-- gs:github --> <!-- gs:bitbucket --> <!-- gs:gitea -->
-<!-- gs:forgejo --> *Pull Requests* or
+<!-- gs:forgejo --> <!-- gs:azuredevops --> *Pull Requests* or
 <!-- gs:gitlab --> *Merge Requests* from them.
 
 It works with Git instead of trying to replace Git.
@@ -99,7 +99,7 @@ $ gs repo sync
 -   [:octicons-git-pull-request-16:{ .lg .middle } __Submit change requests__](guide/cr.md)
     <!-- gs:icon:github --> <!-- gs:icon:gitlab -->
     <!-- gs:icon:bitbucket --> <!-- gs:icon:gitea -->
-    <!-- gs:icon:forgejo -->
+    <!-- gs:icon:forgejo --> <!-- gs:icon:azuredevops -->
 
     ---
 
@@ -145,7 +145,8 @@ $ gs repo sync
 
     git-spice operates entirely locally.
     It talks directly to Git, and when you ask for it,
-    to GitHub/GitLab/Bitbucket/Gitea/Forgejo hosts such as Codeberg.
+    to GitHub, GitLab, Bitbucket, Gitea, Forgejo (including Codeberg),
+    and Azure DevOps.
     All state is stored locally in your Git repository.
     A network connection is not required, except when pushing or pulling.
 

--- a/doc/src/resources/faq.md
+++ b/doc/src/resources/faq.md
@@ -89,7 +89,8 @@ With tooling like this, there are two options:
 each commit is an atomic unit of work, or each branch is.
 While the former might be more in line with Git's original philosophy,
 the latter is more practical for most teams
-with GitHub, GitLab, Bitbucket, Gitea, or Forgejo-based workflows.
+with GitHub, GitLab, Bitbucket, Gitea, Forgejo,
+or Azure DevOps-based workflows.
 
 With a PR per commit, when a PR gets review feedback,
 you must amend that commit with fixes and force-push.
@@ -125,7 +126,7 @@ and leave them as-is.
 As of writing this, git-spice supports
 GitHub, GitLab, Bitbucket Cloud,
 self-hosted Bitbucket Data Center / Server, Gitea,
-and Forgejo, including Codeberg.
+Forgejo, including Codeberg, and Azure DevOps.
 It is specifically designed to support other forges;
 most of the code is forge-agnostic,
 with forge-specific code is isolated to their own directories inside
@@ -145,7 +146,10 @@ In fact,
   without meaningful changes to the rest of the codebase
 - Gitea support was added by following the same forge boundary;
 - Forgejo support was added by following the same forge boundary,
-  with Codeberg as the default hosted instance
+  with Codeberg as the default hosted instance;
+- Azure DevOps support was added in
+  [#1422](https://github.com/abhinav/git-spice/pull/1422)
+  through the same forge boundary.
 
 Therefore we're confident that adding support for other forges is feasible.
 

--- a/doc/src/setup/auth.md
+++ b/doc/src/setup/auth.md
@@ -1,8 +1,8 @@
 ---
 icon: material/lock
 description: >-
-  Authenticate with GitHub/GitLab/Bitbucket/Gitea/Forgejo
-  to push and pull changes.
+  Authenticate with GitHub, GitLab, Bitbucket, Gitea, Forgejo,
+  or Azure DevOps to push and pull changes.
 ---
 
 # Authentication
@@ -14,13 +14,14 @@ you will need to authenticate with the respective service.
 
 This page covers methods to authenticate git-spice
 with GitHub, GitLab, Bitbucket Cloud,
-Bitbucket Data Center / Server, Gitea, and Forgejo.
+Bitbucket Data Center / Server, Gitea, Forgejo, and Azure DevOps.
 Note that GitLab support requires at least version <!-- gs:version v0.9.0 -->.
 Bitbucket Cloud support requires at least version <!-- gs:version v0.25.0 -->.
 Bitbucket Data Center / Server support requires at least version <!-- gs:version v0.31.0 -->.
 Gitea support requires at least version <!-- gs:version v0.30.0 -->.
 Forgejo support requires at least version <!-- gs:version v0.30.0 -->,
 and defaults to Codeberg.
+Azure DevOps support requires at least version <!-- gs:version unreleased -->.
 
 ## Logging in
 
@@ -45,7 +46,7 @@ Take the following steps to authenticate with a service:
 
     Skip prompt (2) by running $$gs auth login$$
     inside a Git repository cloned from
-    GitHub, GitLab, Bitbucket, Gitea, or Forgejo.
+    GitHub, GitLab, Bitbucket, Gitea, Forgejo, or Azure DevOps.
     For self-hosted Bitbucket,
     configure the instance first as described in
     [Bitbucket Data Center / Server](#bitbucket-data-center-server).
@@ -61,13 +62,15 @@ Each supported service supports different authentication methods.
   <!-- gs:badge:github --> <!-- gs:badge:gitlab -->
   <!-- gs:badge:bitbucket --> <!-- gs:badge:bitbucket-server -->
   <!-- gs:badge:gitea -->
-  <!-- gs:badge:forgejo -->
-- [Service CLI](#service-cli): <!-- gs:badge:github --> <!-- gs:badge:gitlab -->
+  <!-- gs:badge:forgejo --> <!-- gs:badge:azuredevops -->
+- [Service CLI](#service-cli):
+  <!-- gs:badge:github --> <!-- gs:badge:gitlab -->
+  <!-- gs:badge:azuredevops -->
 - [Environment variable](#environment-variable):
   <!-- gs:badge:github --> <!-- gs:badge:gitlab -->
   <!-- gs:badge:bitbucket --> <!-- gs:badge:bitbucket-server -->
   <!-- gs:badge:gitea -->
-  <!-- gs:badge:forgejo -->
+  <!-- gs:badge:forgejo --> <!-- gs:badge:azuredevops -->
 
 Read on for more details on each method,
 or skip on to [Pick an authentication method](#picking-an-authentication-method).
@@ -199,7 +202,7 @@ After that, git-spice will use the stored OAuth token automatically.
 **Supported by**
 <!-- gs:badge:github --> <!-- gs:badge:gitlab -->
 <!-- gs:badge:bitbucket --> <!-- gs:badge:bitbucket-server -->
-<!-- gs:badge:gitea --> <!-- gs:badge:forgejo -->
+<!-- gs:badge:gitea --> <!-- gs:badge:forgejo --> <!-- gs:badge:azuredevops -->
 
 To use a Personal Access Token with git-spice,
 you will generate a Personal Access Token on the website
@@ -270,6 +273,18 @@ Select an authentication method: {red}Personal Access Token{reset}
         - pick a descriptive name for the token
         - pick an expiration date if needed
         - select the `api` scope
+
+=== "<!-- gs:azuredevops -->"
+
+    To use a Personal Access Token with Azure DevOps:
+
+    1. Go to
+       `https://dev.azure.com/{organization}/_usersSettings/tokens`,
+       replacing `{organization}` with your organization name.
+    2. Select *New Token*.
+    3. Enter a descriptive name and choose an expiration date.
+    4. Grant the **Code (Read & Write)** scope.
+    5. Select *Create* and copy the generated token.
 
 === "<!-- gs:bitbucket -->"
 
@@ -346,9 +361,10 @@ After you have a token, enter it into the prompt.
 
 ### Service CLI
 
-**Supported by** <!-- gs:badge:github --> <!-- gs:badge:gitlab -->
+**Supported by**
+<!-- gs:badge:github --> <!-- gs:badge:gitlab --> <!-- gs:badge:azuredevops -->
 
-If you have the GitHub or GitLab CLIs installed and authenticated,
+If you have the GitHub, GitLab, or Azure CLI installed and authenticated,
 you can get authentication tokens for git-spice from them.
 
 === "<!-- gs:github -->"
@@ -369,6 +385,16 @@ you can get authentication tokens for git-spice from them.
         {green}${reset} glab auth login
         ```
 
+=== "<!-- gs:azuredevops -->"
+
+    1. Install the
+       [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli).
+    2. Authenticate it:
+
+        ```freeze language="terminal"
+        {green}${reset} az login
+        ```
+
 Once you pick this authentication option, no additional steps are required.
 git-spice will request a token from the CLI as needed.
 
@@ -377,7 +403,7 @@ git-spice will request a token from the CLI as needed.
 **Supported by**
 <!-- gs:badge:github --> <!-- gs:badge:gitlab -->
 <!-- gs:badge:bitbucket --> <!-- gs:badge:bitbucket-server -->
-<!-- gs:badge:gitea --> <!-- gs:badge:forgejo -->
+<!-- gs:badge:gitea --> <!-- gs:badge:forgejo --> <!-- gs:badge:azuredevops -->
 
 You can provide the authentication token as an environment variable.
 This is not recommended as a primary authentication method,
@@ -414,6 +440,11 @@ but it can be useful in CI/CD environments.
 === "<!-- gs:forgejo -->"
 
     Set the `FORGEJO_TOKEN` environment variable to your API token.
+
+=== "<!-- gs:azuredevops -->"
+
+    Set the `AZURE_DEVOPS_PAT` environment variable
+    to your Personal Access Token.
 
 If you have the environment variable set,
 this takes precedence over all other authentication methods.
@@ -489,6 +520,17 @@ The $$gs auth login$$ operation will always fail if you use this method.
     [Personal Access Token](#personal-access-token) is the primary
     authentication method for Forgejo and Codeberg.
     It requires manual token management but works without additional tools.
+
+=== "<!-- gs:azuredevops -->"
+
+    [Service CLI](#service-cli) is the recommended method
+    if the Azure CLI is already installed.
+    git-spice refreshes the Azure DevOps access token from the Azure CLI
+    before opening a repository.
+
+    [Personal Access Token](#personal-access-token)
+    works without additional tools,
+    but requires manual token management.
 
 [Environment variable](#environment-variable) is the least convenient
 and the least secure method. End users should typically never pick this.

--- a/doc/src/start/submit.md
+++ b/doc/src/start/submit.md
@@ -13,7 +13,7 @@ next_page: ../guide/index.md
 This page will walk you through creating and updating
 *GitHub Pull Requests*, *GitLab Merge Requests*,
 *Bitbucket Pull Requests*, *Gitea Pull Requests*,
-or *Forgejo Pull Requests*
+*Forgejo Pull Requests*, or *Azure DevOps Pull Requests*
 with git-spice.
 git-spice refers to these as *Change Requests* (CRs).
 
@@ -32,7 +32,8 @@ git-spice refers to these as *Change Requests* (CRs).
       text "feat2"
       ```
 
-- [x] Set up a GitHub, GitLab, Bitbucket, Gitea, or Forgejo repository.
+- [x] Set up a GitHub, GitLab, Bitbucket, Gitea, Forgejo,
+      or Azure DevOps repository.
 
     ??? info "Optional: Create an experimental repository"
 
@@ -40,8 +41,7 @@ git-spice refers to these as *Change Requests* (CRs).
         you may want to create a new repository
         to experiment with instead of using a real project.
 
-        To do this, if you have the GitHub or GitLab CLI installed,
-        run the following inside your experimental repository:
+        Use the instructions for the service you want to try:
 
         === "<!-- gs:github -->"
 
@@ -74,6 +74,12 @@ git-spice refers to these as *Change Requests* (CRs).
 
             To create a repository on Codeberg,
             go to <https://codeberg.org/repo/create>
+            and follow the instructions there.
+
+        === "<!-- gs:azuredevops -->"
+
+            To create a repository on Azure DevOps,
+            go to the repository creation page for your Azure DevOps project
             and follow the instructions there.
 
     !!! note "Forked repositories"

--- a/testdata/help/auth_login.txt
+++ b/testdata/help/auth_login.txt
@@ -5,11 +5,12 @@ Log in to a service
 A prompt will allow selecting between available authentication methods.
 Available methods include:
 
-- OAuth: Web-based authentication flow - GitHub App (GitHub only): Authenticate
-using a GitHub App installation - Git Credential Manager: Reuse credentials
-already stored for Git - Personal Access Token: Directly provide a personal
-access token - CLI: Use the GitHub or GitLab CLI tool for authentication (if
-installed)
+  - OAuth: Web-based authentication flow
+  - GitHub App (GitHub only): Authenticate using a GitHub App installation
+  - Git Credential Manager: Reuse credentials already stored for Git
+  - Personal Access Token: Directly provide a personal access token
+  - CLI: Use the GitHub, GitLab, or Azure CLI tool for authentication (if
+    installed)
 
 The differences between them are explained in the prompt.
 


### PR DESCRIPTION
Azure DevOps is supported by the forge implementation but remains absent
from the website's supported-service lists and authentication guidance.

Add Azure DevOps to the relevant workflow and capability documentation,
including PAT, Azure CLI, environment-variable, and merge-hook details.
Keep the generated authentication help aligned with those options.