### PR TITLE
repo sync: Detach merged branch worktrees

### DIFF
--- a/.changes/unreleased/Added-20260830-124334.yaml
+++ b/.changes/unreleased/Added-20260830-124334.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'repo sync: Other worktrees may be detached before deleting their merged branches by enabling `spice.repoSync.detachWorktrees`.'
+time: 2026-08-30T12:43:34.419724-07:00

--- a/config_test.go
+++ b/config_test.go
@@ -331,6 +331,50 @@ func TestRepoSyncRestackConfig(t *testing.T) {
 	}
 }
 
+func TestRepoSyncDetachWorktreesConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		config string
+		want   bool
+	}{
+		{name: "Default"},
+		{
+			name: "Config",
+			config: joinLines(
+				`[spice "repoSync"]`,
+				`  detachWorktrees = true`,
+			),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spicecfg := loadTestSpiceConfig(t, tt.config)
+
+			var cmd mainCmd
+			logger := silogtest.New(t)
+			var (
+				forges   forge.Registry
+				sigStack sigstack.Stack
+			)
+			parser, err := kong.New(
+				&cmd,
+				kong.Resolvers(spicecfg),
+				kong.Bind(logger, &forges, &sigStack),
+				kong.BindTo(t.Context(), (*context.Context)(nil)),
+				kong.BindTo(spicecfg, (*experiment.Enabler)(nil)),
+				kong.Vars{"defaultPrompt": "false"},
+			)
+			require.NoError(t, err)
+
+			_, err = parser.Parse([]string{"repo", "sync"})
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, cmd.Repo.Sync.DetachWorktrees)
+		})
+	}
+}
+
 func TestBranchDeleteRestackFlag(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -166,7 +166,7 @@ of deleted branches, leaving higher branches in place.
 
 * `--restack` ([:material-wrench:{ .middle title="spice.repoSync.restack" }](/cli/config.md#spicereposyncrestack)): How to restack branches above deleted branches. One of 'none', 'aboves', and 'upstack'.
 
-**Configuration**: [spice.repoSync.closedChanges](/cli/config.md#spicereposyncclosedchanges), [spice.repoSync.restack](/cli/config.md#spicereposyncrestack)
+**Configuration**: [spice.repoSync.closedChanges](/cli/config.md#spicereposyncclosedchanges), [spice.repoSync.detachWorktrees](/cli/config.md#spicereposyncdetachworktrees), [spice.repoSync.restack](/cli/config.md#spicereposyncrestack)
 
 ### git-spice repo restack {#gs-repo-restack}
 

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -1098,6 +1098,19 @@ $$gs repo sync$$ will skip closed CRs entirely
 and log an informational message about the closed CR being ignored.
 The branch will remain on the system.
 
+### spice.repoSync.detachWorktrees
+
+<!-- gs:version unreleased -->
+
+Whether $$gs repo sync$$ detaches other worktrees
+before deleting their merged branches.
+
+The default is `false`.
+When set to `true`,
+git-spice leaves each affected worktree at its current commit
+with staged, unstaged, and untracked changes intact,
+then deletes the merged branch.
+
 ### spice.submit.web
 
 <!-- gs:version v0.8.0 -->

--- a/internal/handler/sync/deletion.go
+++ b/internal/handler/sync/deletion.go
@@ -103,7 +103,11 @@ func (h *Handler) restackDeletedBranchUpstack(
 	return nil
 }
 
-func (h *Handler) deleteBranches(ctx context.Context, branchesToDelete []branchDeletion) ([]string, error) {
+func (h *Handler) deleteBranches(
+	ctx context.Context,
+	branchesToDelete []branchDeletion,
+	detachWorktrees bool,
+) ([]string, error) {
 	if len(branchesToDelete) == 0 {
 		return nil, nil
 	}
@@ -125,9 +129,36 @@ func (h *Handler) deleteBranches(ctx context.Context, branchesToDelete []branchD
 		}
 
 		if branchInfo.Worktree != "" && branchInfo.Worktree != h.Worktree.RootDir() {
-			h.Log.Warnf("%v: checked out in another worktree (%v), skipping deletion.", branchInfo.Name, branchInfo.Worktree)
-			h.Log.Warnf("Run '%[1]s branch delete' or run '%[1]s repo sync' again from that worktree to delete it.", cli.Name())
-			continue
+			if !detachWorktrees {
+				h.Log.Warnf("%v: checked out in another worktree (%v), skipping deletion.", branchInfo.Name, branchInfo.Worktree)
+				h.Log.Warnf("Run '%[1]s branch delete' or run '%[1]s repo sync' again from that worktree to delete it.", cli.Name())
+				continue
+			}
+
+			detachedHead, err := func() (git.Hash, error) {
+				worktree, err := h.Repository.OpenWorktree(ctx, branchInfo.Worktree)
+				if err != nil {
+					return "", fmt.Errorf("open worktree: %w", err)
+				}
+				if err := worktree.DetachHead(ctx, ""); err != nil {
+					return "", fmt.Errorf("detach HEAD: %w", err)
+				}
+
+				detachedHead, err := worktree.Head(ctx)
+				if err != nil {
+					return "", fmt.Errorf("read detached HEAD: %w", err)
+				}
+				return detachedHead, nil
+			}()
+			if err != nil {
+				h.Log.Warn("Unable to detach worktree; skipping branch deletion",
+					"branch", branchInfo.Name,
+					"worktree", branchInfo.Worktree,
+					"error", err)
+				continue
+			}
+			h.Log.Infof("%v: detached worktree %v at %v.",
+				branchInfo.Name, branchInfo.Worktree, detachedHead)
 		}
 
 		deleteBranchNames = append(deleteBranchNames, branchInfo.Name)

--- a/internal/handler/sync/deletion_test.go
+++ b/internal/handler/sync/deletion_test.go
@@ -1,0 +1,219 @@
+package sync
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"go.abhg.dev/gs/internal/git"
+	"go.abhg.dev/gs/internal/git/gittest"
+	branchdel "go.abhg.dev/gs/internal/handler/delete"
+	"go.abhg.dev/gs/internal/silog"
+	"go.abhg.dev/gs/internal/text"
+	"go.abhg.dev/gs/internal/ui"
+)
+
+func TestHandler_deleteBranches_detachWorktreeFailure(t *testing.T) {
+	t.Run("Open", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		mockRepo := NewMockGitRepository(ctrl)
+		mockRepo.EXPECT().
+			LocalBranches(gomock.Any(), &git.LocalBranchesOptions{
+				Patterns: []string{"blocked", "deletable"},
+			}).
+			Return(branchIter(
+				git.LocalBranch{Name: "blocked", Worktree: "/missing"},
+				git.LocalBranch{Name: "deletable"},
+			))
+		mockRepo.EXPECT().
+			OpenWorktree(gomock.Any(), "/missing").
+			Return(nil, errors.New("not found"))
+
+		mockWorktree := NewMockGitWorktree(ctrl)
+		mockWorktree.EXPECT().
+			RootDir().
+			Return("/repo")
+
+		mockDelete := NewMockDeleteHandler(ctrl)
+		mockDelete.EXPECT().
+			DeleteBranches(gomock.Any(), &branchdel.Request{
+				Branches: []string{"deletable"},
+				Force:    true,
+			}).
+			Return(nil)
+
+		var logBuffer bytes.Buffer
+		got, err := (&Handler{
+			Log:        silog.New(&logBuffer, nil),
+			View:       ui.NewFileView(t.Output()),
+			Repository: mockRepo,
+			Worktree:   mockWorktree,
+			Store:      NewMockStore(ctrl),
+			Service:    NewMockService(ctrl),
+			Delete:     mockDelete,
+			Restack:    NewMockRestackHandler(ctrl),
+			Autostash:  NewMockAutostashHandler(ctrl),
+			Remote:     "origin",
+		}).deleteBranches(t.Context(), []branchDeletion{
+			{BranchName: "blocked"},
+			{BranchName: "deletable"},
+		}, true)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"deletable"}, got)
+		assert.Contains(t, logBuffer.String(),
+			"Unable to detach worktree; skipping branch deletion")
+		assert.Contains(t, logBuffer.String(),
+			"branch=blocked worktree=/missing error=open worktree: not found")
+	})
+
+	t.Run("Detach", func(t *testing.T) {
+		fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+			as 'Test <test@example.com>'
+			at '2026-08-30T18:30:00Z'
+
+			mkdir repo
+			cd repo
+			git init
+			git commit --allow-empty -m 'Initial commit'
+			git worktree add ../blocked -b blocked
+		`)))
+		require.NoError(t, err)
+		t.Cleanup(fixture.Cleanup)
+
+		blockedPath := filepath.Join(fixture.Dir(), "blocked")
+		blockedWorktree, err := git.OpenWorktree(t.Context(), blockedPath, git.OpenOptions{
+			Log: silog.New(t.Output(), nil),
+		})
+		require.NoError(t, err)
+		require.NoError(t, os.Rename(blockedPath, blockedPath+"-moved"))
+
+		ctrl := gomock.NewController(t)
+		mockRepo := NewMockGitRepository(ctrl)
+		mockRepo.EXPECT().
+			LocalBranches(gomock.Any(), &git.LocalBranchesOptions{
+				Patterns: []string{"blocked", "deletable"},
+			}).
+			Return(branchIter(
+				git.LocalBranch{Name: "blocked", Worktree: blockedPath},
+				git.LocalBranch{Name: "deletable"},
+			))
+		mockRepo.EXPECT().
+			OpenWorktree(gomock.Any(), blockedPath).
+			Return(blockedWorktree, nil)
+
+		mockWorktree := NewMockGitWorktree(ctrl)
+		mockWorktree.EXPECT().
+			RootDir().
+			Return(filepath.Join(fixture.Dir(), "repo"))
+
+		mockDelete := NewMockDeleteHandler(ctrl)
+		mockDelete.EXPECT().
+			DeleteBranches(gomock.Any(), &branchdel.Request{
+				Branches: []string{"deletable"},
+				Force:    true,
+			}).
+			Return(nil)
+
+		var logBuffer bytes.Buffer
+		got, err := (&Handler{
+			Log:        silog.New(&logBuffer, nil),
+			View:       ui.NewFileView(t.Output()),
+			Repository: mockRepo,
+			Worktree:   mockWorktree,
+			Store:      NewMockStore(ctrl),
+			Service:    NewMockService(ctrl),
+			Delete:     mockDelete,
+			Restack:    NewMockRestackHandler(ctrl),
+			Autostash:  NewMockAutostashHandler(ctrl),
+			Remote:     "origin",
+		}).deleteBranches(t.Context(), []branchDeletion{
+			{BranchName: "blocked"},
+			{BranchName: "deletable"},
+		}, true)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"deletable"}, got)
+		assert.Contains(t, logBuffer.String(),
+			"Unable to detach worktree; skipping branch deletion")
+		assert.Contains(t, logBuffer.String(),
+			"branch=blocked worktree="+blockedPath)
+	})
+}
+
+func TestHandler_deleteBranches_logsDetachedHead(t *testing.T) {
+	fixture, err := gittest.LoadFixtureScript([]byte(text.Dedent(`
+		as 'Test <test@example.com>'
+		at '2026-08-30T18:30:00Z'
+
+		mkdir repo
+		cd repo
+		git init
+		git commit --allow-empty -m 'Initial commit'
+		git worktree add ../feature -b feature
+	`)))
+	require.NoError(t, err)
+	t.Cleanup(fixture.Cleanup)
+
+	featurePath := filepath.Join(fixture.Dir(), "feature")
+	featureWorktree, err := git.OpenWorktree(t.Context(), featurePath, git.OpenOptions{
+		Log: silog.New(t.Output(), nil),
+	})
+	require.NoError(t, err)
+	wantHead, err := featureWorktree.Head(t.Context())
+	require.NoError(t, err)
+
+	ctrl := gomock.NewController(t)
+	mockRepo := NewMockGitRepository(ctrl)
+	mockRepo.EXPECT().
+		LocalBranches(gomock.Any(), &git.LocalBranchesOptions{
+			Patterns: []string{"feature"},
+		}).
+		Return(singleBranchIter(git.LocalBranch{
+			Name:     "feature",
+			Hash:     "stale-branch-snapshot",
+			Worktree: featurePath,
+		}))
+	mockRepo.EXPECT().
+		OpenWorktree(gomock.Any(), featurePath).
+		Return(featureWorktree, nil)
+
+	mockWorktree := NewMockGitWorktree(ctrl)
+	mockWorktree.EXPECT().
+		RootDir().
+		Return(filepath.Join(fixture.Dir(), "repo"))
+
+	mockDelete := NewMockDeleteHandler(ctrl)
+	mockDelete.EXPECT().
+		DeleteBranches(gomock.Any(), &branchdel.Request{
+			Branches: []string{"feature"},
+			Force:    true,
+		}).
+		Return(nil)
+
+	var logBuffer bytes.Buffer
+	got, err := (&Handler{
+		Log:        silog.New(&logBuffer, nil),
+		View:       ui.NewFileView(t.Output()),
+		Repository: mockRepo,
+		Worktree:   mockWorktree,
+		Store:      NewMockStore(ctrl),
+		Service:    NewMockService(ctrl),
+		Delete:     mockDelete,
+		Restack:    NewMockRestackHandler(ctrl),
+		Autostash:  NewMockAutostashHandler(ctrl),
+		Remote:     "origin",
+	}).deleteBranches(t.Context(), []branchDeletion{{
+		BranchName: "feature",
+	}}, true)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"feature"}, got)
+	assert.Contains(t, logBuffer.String(),
+		"feature: detached worktree "+featurePath+" at "+wantHead.String()+".")
+	assert.NotContains(t, logBuffer.String(), "stale-branch-snapshot")
+}

--- a/internal/handler/sync/handler.go
+++ b/internal/handler/sync/handler.go
@@ -174,6 +174,10 @@ type TrunkOptions struct {
 
 	Restack       spice.RestackMode `default:"none" config:"repoSync.restack" enum:"none,aboves,upstack" help:"How to restack branches above deleted branches. One of 'none', 'aboves', and 'upstack'."`
 	ClosedChanges ClosedChanges     `default:"ask" config:"repoSync.closedChanges" enum:"ask,ignore" help:"How to handle closed change requests. One of 'ask' and 'ignore'." hidden:""`
+
+	// DetachWorktrees allows SyncTrunk to detach another worktree
+	// before deleting its merged branch.
+	DetachWorktrees bool `default:"false" config:"repoSync.detachWorktrees" help:"Detach other worktrees before deleting their merged branches." hidden:""`
 }
 
 // SyncTrunk syncs the trunk branch with the remote repository,
@@ -443,7 +447,7 @@ func (h *Handler) SyncTrunk(ctx context.Context, opts *TrunkOptions) (retErr err
 	}
 	autostashRescueBranch = branchAfterDelete
 
-	deletedBranchNames, err := h.deleteBranches(ctx, branchesToDelete)
+	deletedBranchNames, err := h.deleteBranches(ctx, branchesToDelete, opts.DetachWorktrees)
 	if err != nil {
 		return err
 	}

--- a/testdata/help/repo_sync.txt
+++ b/testdata/help/repo_sync.txt
@@ -26,3 +26,6 @@ Global Flags:
 Configuration (🔧):
   spice.repoSync.closedChanges    How to handle closed change requests. One of
                                   'ask' and 'ignore'.
+  spice.repoSync.detachWorktrees
+                                  Detach other worktrees before deleting their
+                                  merged branches.

--- a/testdata/script/repo_sync_detach_worktrees.txt
+++ b/testdata/script/repo_sync_detach_worktrees.txt
@@ -1,0 +1,70 @@
+# 'repo sync' detaches another worktree before deleting its merged branch
+# when repoSync.detachWorktrees is enabled.
+
+as 'Test <test@example.com>'
+at '2026-08-30T18:30:00Z'
+
+# setup
+mkdir repo
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# set up a remote
+shamhub-setup
+shamhub new origin alice/example.git
+git push origin main
+
+# set up user
+shamhub register alice
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# create and submit a feature branch
+git add feat.txt
+gs bc -m 'Add feature' feature
+gs bs --fill
+
+# Keep staged, unstaged, and untracked changes in another worktree.
+git switch main
+git worktree add ../feature-wt feature
+cd ../feature-wt
+cp $WORK/extra/feat-staged.txt feat.txt
+git add feat.txt
+cp $WORK/extra/feat-unstaged.txt feat.txt
+cp $WORK/extra/untracked.txt untracked.txt
+
+# Merge the branch, then sync with automatic worktree detachment enabled.
+cd ../repo
+shamhub merge alice/example 1
+git checkout main
+git config spice.repoSync.detachWorktrees true
+gs repo sync
+stderr 'INF feature: #1 was merged'
+stderr 'INF feature: detached worktree .+/feature-wt at [a-f0-9]+\.'
+stderr 'INF feature: deleted \(was [a-f0-9]+\)'
+
+# The branch is gone, while its former worktree remains at the same commit
+# with all local changes intact.
+! git show-ref --verify refs/heads/feature
+cd ../feature-wt
+! git symbolic-ref --quiet HEAD
+git log --oneline -1
+cmp stdout $WORK/golden/head.txt
+git status --porcelain
+cmp stdout $WORK/golden/status.txt
+
+-- repo/feat.txt --
+committed feature
+-- extra/feat-staged.txt --
+staged feature
+-- extra/feat-unstaged.txt --
+unstaged feature
+-- extra/untracked.txt --
+untracked feature
+-- golden/head.txt --
+e3682ab Add feature
+-- golden/status.txt --
+MM feat.txt
+?? untracked.txt


### PR DESCRIPTION
`spice.repoSync.detachWorktrees` lets `repo sync` detach another
worktree at its current commit before deleting its merged branch.
Staged, unstaged, and untracked changes remain in the detached worktree.

The setting defaults to false and preserves the existing warning-and-skip
behavior.
If the worktree cannot be opened, detached, or inspected after detaching,
`repo sync` warns once and leaves the branch intact.
Independent deletion candidates continue to be processed.

Fixes #1424