### PR TITLE
jsonmut: Compose replayable transformations

### DIFF
--- a/internal/jsonmut/jsonmut.go
+++ b/internal/jsonmut/jsonmut.go
@@ -1,0 +1,580 @@
+// Package jsonmut defines composable, typed transformations over JSON objects.
+// A [Program] transforms one document and returns a typed result,
+// while a [Statement] is a program whose result is not meaningful.
+// Applying either leaves the input document unchanged,
+// so callers may replay the same transformation against a newer document.
+//
+// Use [Block] when statements are independent but must run in order:
+//
+//	program := jsonmut.Block(
+//		jsonmut.Set("/status", jsontext.Value(`"ready"`)),
+//		jsonmut.Insert("/items/42", itemJSON),
+//	)
+//
+// Use [Program.Then] when a later transformation depends on an earlier result:
+//
+//	program := jsonmut.Increment("/lastID").Then(
+//		func(id int64) jsonmut.Program[int64] {
+//			path := jsontext.Pointer("/items").AppendToken(strconv.FormatInt(id, 10))
+//			return jsonmut.Insert(path, itemJSON).Returning(id)
+//		},
+//	)
+//
+// Because a program may be replayed,
+// continuations passed to [Program.Then] must depend only on their argument
+// and immutable captured inputs.
+//
+// # Limitations
+//
+// Paths address object members only;
+// they cannot traverse or rewrite array elements.
+package jsonmut
+
+import (
+	"bytes"
+	"encoding/json/jsontext"
+	json "encoding/json/v2"
+	"errors"
+	"fmt"
+	"iter"
+	"math"
+	"slices"
+	"strconv"
+
+	"go.abhg.dev/gs/internal/must"
+)
+
+var (
+	// ErrExist indicates that a statement expected a JSON member to be absent.
+	ErrExist = errors.New("JSON value already exists")
+
+	// ErrNotExist indicates that a statement expected a JSON member to exist.
+	ErrNotExist = errors.New("JSON value does not exist")
+)
+
+// Program is a replayable JSON transformation that returns a value of type T.
+// The zero value is not a valid program.
+type Program[T any] struct {
+	apply func(jsontext.Value) (jsontext.Value, T, error)
+}
+
+// Statement is a [Program] whose result is not meaningful.
+type Statement = Program[struct{}]
+
+// Apply runs program against document without modifying document.
+// It returns no updated document or result when the program fails.
+func Apply[T any](
+	document jsontext.Value,
+	program Program[T],
+) (jsontext.Value, T, error) {
+	var zero T
+	if !document.IsValid() {
+		return nil, zero, errors.New("invalid JSON document")
+	}
+	must.Bef(program.apply != nil, "cannot apply a zero Program")
+	return program.apply(document.Clone())
+}
+
+// Then runs the program returned by next against the updated document.
+//
+// Reapplying the returned program calls next again,
+// possibly with a different value.
+// next must not mutate value and must depend only on value
+// and immutable captured inputs.
+func (p Program[A]) Then[B any](
+	next func(A) Program[B],
+) Program[B] {
+	must.Bef(p.apply != nil, "cannot compose a zero Program")
+	must.Bef(next != nil, "Program.Then requires a continuation")
+	return Program[B]{
+		apply: func(document jsontext.Value) (jsontext.Value, B, error) {
+			var zero B
+			document, value, err := p.apply(document)
+			if err != nil {
+				return nil, zero, err
+			}
+
+			program := next(value)
+			must.Bef(
+				program.apply != nil,
+				"Program.Then continuation returned a zero Program",
+			)
+			return program.apply(document)
+		},
+	}
+}
+
+// Returning runs p and replaces its result with value.
+// value must remain immutable while the returned program may be applied.
+func (p Program[A]) Returning[B any](value B) Program[B] {
+	must.Bef(p.apply != nil, "cannot compose a zero Program")
+	return Program[B]{
+		apply: func(document jsontext.Value) (jsontext.Value, B, error) {
+			document, _, err := p.apply(document)
+			if err != nil {
+				var zero B
+				return nil, zero, err
+			}
+			return document, value, nil
+		},
+	}
+}
+
+// Block returns a statement that runs statements in order.
+func Block(statements ...Statement) Statement {
+	for i, statement := range statements {
+		must.Bef(statement.apply != nil, "statement %d is a zero Statement", i)
+	}
+	statements = slices.Clone(statements)
+	return Statement{
+		apply: func(document jsontext.Value) (jsontext.Value, struct{}, error) {
+			for _, statement := range statements {
+				var err error
+				document, _, err = statement.apply(document)
+				if err != nil {
+					return nil, struct{}{}, err
+				}
+			}
+			return document, struct{}{}, nil
+		},
+	}
+}
+
+// Lookup returns the JSON value at path without changing the document.
+// It returns an empty value when path does not exist.
+func Lookup(path jsontext.Pointer) Program[jsontext.Value] {
+	must.Bef(path.IsValid(), "invalid JSON pointer %q", path)
+	return Program[jsontext.Value]{
+		apply: func(document jsontext.Value) (
+			jsontext.Value,
+			jsontext.Value,
+			error,
+		) {
+			value, ok, err := lookup(document, path)
+			if err != nil {
+				return nil, nil, err
+			}
+			if !ok {
+				return document, nil, nil
+			}
+			return document, value, nil
+		},
+	}
+}
+
+// Decode returns the value at path decoded as T.
+// It returns the zero value of T when path does not exist.
+// Decode a pointer type to distinguish an absent value from a present,
+// non-null zero value; absence and JSON null both decode to nil.
+func Decode[T any](path jsontext.Pointer) Program[T] {
+	return Lookup(path).Then(func(value jsontext.Value) Program[T] {
+		var decoded T
+		if len(value) == 0 {
+			return returnValue(decoded)
+		}
+		if err := json.Unmarshal(value, &decoded); err != nil {
+			return Fail[T](fmt.Errorf("decode %q: %w", path, err))
+		}
+		return returnValue(decoded)
+	})
+}
+
+// Set returns a statement that adds or replaces the value at path.
+// Parent objects addressed by path must exist.
+func Set(path jsontext.Pointer, value jsontext.Value) Statement {
+	return newSetStatement(path, value, setUpsert)
+}
+
+// SetIfAbsent returns a statement that adds value only when path is absent.
+// Parent objects addressed by path must exist.
+func SetIfAbsent(path jsontext.Pointer, value jsontext.Value) Statement {
+	return newSetStatement(path, value, setIfAbsent)
+}
+
+// Insert returns a statement that adds value at path.
+// It returns [ErrExist] when path already exists.
+// Parent objects addressed by path must exist.
+func Insert(path jsontext.Pointer, value jsontext.Value) Statement {
+	return newSetStatement(path, value, setInsert)
+}
+
+// Replace returns a statement that replaces the value at path.
+// It returns [ErrNotExist] when path does not exist.
+func Replace(path jsontext.Pointer, value jsontext.Value) Statement {
+	return newSetStatement(path, value, setReplace)
+}
+
+type setMode uint8
+
+const (
+	setUpsert setMode = iota
+	setIfAbsent
+	setInsert
+	setReplace
+)
+
+func newSetStatement(
+	path jsontext.Pointer,
+	value jsontext.Value,
+	mode setMode,
+) Statement {
+	must.Bef(path.IsValid(), "invalid JSON pointer %q", path)
+	must.Bef(value.IsValid(), "invalid JSON mutation value")
+	value = value.Clone()
+	return Statement{
+		apply: func(document jsontext.Value) (jsontext.Value, struct{}, error) {
+			updated, err := applySet(document, path, value, mode)
+			return updated, struct{}{}, err
+		},
+	}
+}
+
+func applySet(
+	document jsontext.Value,
+	pointer jsontext.Pointer,
+	replacement jsontext.Value,
+	mode setMode,
+) (jsontext.Value, error) {
+	operation := "set"
+	switch mode {
+	case setIfAbsent:
+		operation = "set if absent"
+	case setInsert:
+		operation = "insert"
+	case setReplace:
+		operation = "replace"
+	}
+
+	next, stop := iter.Pull(pointer.Tokens())
+	defer stop()
+
+	updated, _, err := rewriteAtPath(
+		document,
+		next,
+		replacement,
+		mode,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("%s %q: %w", operation, pointer, err)
+	}
+	return updated, nil
+}
+
+// rewriteAtPath consumes next to select and rewrite a value in document.
+// It returns changed false only when setIfAbsent finds an existing target.
+//
+// The traversal retains one frame for each ancestor object.
+// Each frame holds the encoded object prefix and a decoder positioned after
+// the selected child, allowing the function to rebuild ancestors inside out.
+func rewriteAtPath(
+	document jsontext.Value,
+	next func() (string, bool),
+	replacement jsontext.Value,
+	mode setMode,
+) (updated jsontext.Value, changed bool, _ error) {
+	member, ok := next()
+	if !ok {
+		switch mode {
+		case setInsert:
+			return nil, false, ErrExist
+		case setIfAbsent:
+			return document, false, nil
+		default:
+			return replacement.Clone(), true, nil
+		}
+	}
+
+	original := document
+	var ancestors []*objectRewriteFrame
+
+	// Traverse only the ancestor members. Looking ahead one token distinguishes
+	// an ancestor from the final target without resolving the target itself.
+	// Each retained frame has copied the prefix before its selected child and
+	// leaves its decoder positioned at the suffix needed during unwinding.
+	for {
+		nextMember, ok := next()
+		if !ok {
+			break
+		}
+
+		frame, err := newObjectRewriteFrame(document)
+		if err != nil {
+			return nil, false, err
+		}
+		found, err := frame.advanceTo(member)
+		if err != nil {
+			return nil, false, err
+		}
+
+		if !found {
+			return nil, false, ErrNotExist
+		}
+
+		child, err := frame.decoder.ReadValue()
+		if err != nil {
+			return nil, false, fmt.Errorf("read member %q: %w", member, err)
+		}
+		ancestors = append(ancestors, frame)
+		document = child
+		member = nextMember
+	}
+
+	// Resolve the final target only after traversal has established its parent.
+	frame, err := newObjectRewriteFrame(document)
+	if err != nil {
+		return nil, false, err
+	}
+	found, err := frame.advanceTo(member)
+	if err != nil {
+		return nil, false, err
+	}
+	if !found {
+		if mode == setReplace {
+			return nil, false, ErrNotExist
+		}
+		if err := frame.encoder.WriteToken(jsontext.String(member)); err != nil {
+			return nil, false, fmt.Errorf("write member %q: %w", member, err)
+		}
+		if err := frame.encoder.WriteValue(replacement); err != nil {
+			return nil, false, fmt.Errorf("write member %q: %w", member, err)
+		}
+	} else {
+		switch mode {
+		case setInsert:
+			return nil, false, ErrExist
+		case setIfAbsent:
+			return original, false, nil
+		}
+		if err := frame.decoder.SkipValue(); err != nil {
+			return nil, false, fmt.Errorf("skip member %q: %w", member, err)
+		}
+		if err := frame.encoder.WriteValue(replacement); err != nil {
+			return nil, false, fmt.Errorf("write member %q: %w", member, err)
+		}
+	}
+	updated, err = frame.finish()
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Rebuild ancestors from the target outward. Writing the transformed child
+	// resumes each parent frame before finish copies its untouched suffix.
+	for _, frame := range slices.Backward(ancestors) {
+		if err := frame.encoder.WriteValue(updated); err != nil {
+			return nil, false, fmt.Errorf("write child object: %w", err)
+		}
+		var err error
+		updated, err = frame.finish()
+		if err != nil {
+			return nil, false, err
+		}
+	}
+	return updated, true, nil
+}
+
+// objectRewriteFrame retains an object traversal paused at one selected member.
+// output contains the opening delimiter and every member before the selection.
+type objectRewriteFrame struct {
+	decoder *jsontext.Decoder
+	output  *bytes.Buffer
+	encoder *jsontext.Encoder
+}
+
+func newObjectRewriteFrame(document jsontext.Value) (*objectRewriteFrame, error) {
+	if document.Kind() != '{' {
+		return nil, fmt.Errorf(
+			"expected JSON object, got %v",
+			document.Kind(),
+		)
+	}
+
+	output := new(bytes.Buffer)
+	frame := &objectRewriteFrame{
+		decoder: jsontext.NewDecoder(bytes.NewReader(document)),
+		output:  output,
+		encoder: jsontext.NewEncoder(output),
+	}
+	begin, err := frame.decoder.ReadToken()
+	if err != nil {
+		return nil, fmt.Errorf("read object opening: %w", err)
+	}
+	if err := frame.encoder.WriteToken(begin); err != nil {
+		return nil, fmt.Errorf("write object opening: %w", err)
+	}
+	return frame, nil
+}
+
+// advanceTo copies complete object members until member is found.
+// When it succeeds, it has copied the member name but leaves its value unread.
+func (f *objectRewriteFrame) advanceTo(member string) (bool, error) {
+	for f.decoder.PeekKind() != '}' {
+		name, err := f.decoder.ReadToken()
+		if err != nil {
+			return false, fmt.Errorf("read member name: %w", err)
+		}
+		if err := f.encoder.WriteToken(name); err != nil {
+			return false, fmt.Errorf("write member name: %w", err)
+		}
+		if name.String() == member {
+			return true, nil
+		}
+
+		// Read and write each unrelated value before the decoder advances
+		// and invalidates the raw JSON returned by ReadValue.
+		value, err := f.decoder.ReadValue()
+		if err != nil {
+			return false, fmt.Errorf("read member %q: %w", name.String(), err)
+		}
+		if err := f.encoder.WriteValue(value); err != nil {
+			return false, fmt.Errorf("write member %q: %w", name.String(), err)
+		}
+	}
+	return false, nil
+}
+
+// finish copies the members after the selected value and closes the object.
+func (f *objectRewriteFrame) finish() (jsontext.Value, error) {
+	for f.decoder.PeekKind() != '}' {
+		name, err := f.decoder.ReadToken()
+		if err != nil {
+			return nil, fmt.Errorf("read member name: %w", err)
+		}
+		if err := f.encoder.WriteToken(name); err != nil {
+			return nil, fmt.Errorf("write member name: %w", err)
+		}
+
+		value, err := f.decoder.ReadValue()
+		if err != nil {
+			return nil, fmt.Errorf("read member %q: %w", name.String(), err)
+		}
+		if err := f.encoder.WriteValue(value); err != nil {
+			return nil, fmt.Errorf("write member %q: %w", name.String(), err)
+		}
+	}
+
+	end, err := f.decoder.ReadToken()
+	if err != nil {
+		return nil, fmt.Errorf("read object closing: %w", err)
+	}
+	if err := f.encoder.WriteToken(end); err != nil {
+		return nil, fmt.Errorf("write object closing: %w", err)
+	}
+	return bytes.TrimSuffix(f.output.Bytes(), []byte("\n")), nil
+}
+
+// Increment returns a program that increments the integer at path.
+// An absent value starts at zero.
+func Increment(path jsontext.Pointer) Program[int64] {
+	return Decode[int64](path).Then(func(value int64) Program[int64] {
+		if value == math.MaxInt64 {
+			return Fail[int64](errors.New("integer overflow"))
+		}
+		value++
+		return Set(
+			path,
+			jsontext.Value(strconv.FormatInt(value, 10)),
+		).Returning(value)
+	})
+}
+
+// InsertAutoIncrement returns a program that increments the integer at
+// counter and inserts value into object under the resulting decimal value.
+// An absent counter starts at zero, and an absent object starts empty.
+// The parent objects addressed by both pointers must exist.
+func InsertAutoIncrement(
+	counter, object jsontext.Pointer,
+	value jsontext.Value,
+) Program[int64] {
+	must.Bef(counter.IsValid(), "invalid JSON pointer %q", counter)
+	must.Bef(counter != "", "auto-increment counter must not be the document root")
+	must.Bef(object.IsValid(), "invalid JSON pointer %q", object)
+	must.Bef(object != "", "auto-increment object must not be the document root")
+	must.Bef(value.IsValid(), "invalid JSON mutation value")
+	value = value.Clone()
+
+	return Increment(counter).Then(func(id int64) Program[int64] {
+		member := object.AppendToken(strconv.FormatInt(id, 10))
+		return Block(
+			SetIfAbsent(object, jsontext.Value(`{}`)),
+			Insert(member, value),
+		).Returning(id)
+	})
+}
+
+// Fail returns a program that always returns err.
+func Fail[T any](err error) Program[T] {
+	must.Bef(err != nil, "jsonmut.Fail requires an error")
+	return Program[T]{
+		apply: func(jsontext.Value) (jsontext.Value, T, error) {
+			var zero T
+			return nil, zero, err
+		},
+	}
+}
+
+func returnValue[T any](value T) Program[T] {
+	return Program[T]{
+		apply: func(document jsontext.Value) (jsontext.Value, T, error) {
+			return document, value, nil
+		},
+	}
+}
+
+func lookup(
+	document jsontext.Value,
+	pointer jsontext.Pointer,
+) (jsontext.Value, bool, error) {
+	next, stop := iter.Pull(pointer.Tokens())
+	defer stop()
+
+	member, ok := next()
+	if !ok {
+		return document, true, nil
+	}
+	value, ok, err := lookupObjectMember(document, member, next)
+	if err != nil {
+		return nil, false, fmt.Errorf("follow %q: %w", pointer, err)
+	}
+	return value, ok, nil
+}
+
+func lookupObjectMember(
+	document jsontext.Value,
+	member string,
+	next func() (string, bool),
+) (jsontext.Value, bool, error) {
+	if document.Kind() != '{' {
+		return nil, false, fmt.Errorf(
+			"expected JSON object, got %v",
+			document.Kind(),
+		)
+	}
+
+	decoder := jsontext.NewDecoder(bytes.NewReader(document))
+	if _, err := decoder.ReadToken(); err != nil {
+		return nil, false, err
+	}
+	for decoder.PeekKind() != '}' {
+		name, err := decoder.ReadToken()
+		if err != nil {
+			return nil, false, err
+		}
+		if name.String() != member {
+			if err := decoder.SkipValue(); err != nil {
+				return nil, false, err
+			}
+			continue
+		}
+
+		value, err := decoder.ReadValue()
+		if err != nil {
+			return nil, false, err
+		}
+		childMember, ok := next()
+		if !ok {
+			return value, true, nil
+		}
+		return lookupObjectMember(value, childMember, next)
+	}
+	return nil, false, nil
+}

--- a/internal/jsonmut/jsonmut_property_test.go
+++ b/internal/jsonmut/jsonmut_property_test.go
@@ -1,0 +1,337 @@
+package jsonmut_test
+
+import (
+	"encoding/json/jsontext"
+	json "encoding/json/v2"
+	"errors"
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/jsonmut"
+	"pgregory.net/rapid"
+)
+
+const maxGeneratedJSONDepth = 10
+
+// TestLookup_matchesReference compares lookup behavior
+// with an independent decoded-object model.
+func TestLookup_matchesReference(t *testing.T) {
+	rapid.Check(t, testLookupMatchesReference)
+}
+
+// FuzzLookup_matchesReference exposes the lookup property to Go fuzzing.
+func FuzzLookup_matchesReference(f *testing.F) {
+	f.Fuzz(rapid.MakeFuzz(testLookupMatchesReference))
+}
+
+func testLookupMatchesReference(t *rapid.T) {
+	document := jsonObjectGenerator(maxGeneratedJSONDepth).Draw(t, "document")
+	path := drawJSONPath(t, document)
+	documentJSON := marshalJSON(t, document)
+	original := documentJSON.Clone()
+
+	updated, got, err := jsonmut.Apply(
+		documentJSON,
+		jsonmut.Lookup(jsonPointer(path)),
+	)
+	want, found, wantErr := referenceLookup(document, path)
+	if wantErr != referenceWrongType {
+		require.NoError(t, err)
+		if found {
+			assert.JSONEq(t, marshalJSON(t, want).String(), got.String())
+		} else {
+			assert.Empty(t, got)
+		}
+		assert.JSONEq(t, original.String(), updated.String())
+	} else {
+		require.Error(t, err)
+		assert.Nil(t, updated)
+	}
+	assert.Equal(t, original, documentJSON, "Apply must not mutate its input")
+}
+
+// TestMutation_matchesReference compares every mutation mode
+// with an independent decoded-object model.
+func TestMutation_matchesReference(t *testing.T) {
+	rapid.Check(t, testMutationMatchesReference)
+}
+
+// FuzzMutation_matchesReference exposes the mutation property to Go fuzzing.
+func FuzzMutation_matchesReference(f *testing.F) {
+	f.Fuzz(rapid.MakeFuzz(testMutationMatchesReference))
+}
+
+func testMutationMatchesReference(t *rapid.T) {
+	document := jsonObjectGenerator(maxGeneratedJSONDepth).Draw(t, "document")
+	path := drawJSONPath(t, document)
+	replacement := jsonValueGenerator(maxGeneratedJSONDepth).
+		Draw(t, "replacement")
+	mode := rapid.SampledFrom([]referenceMutation{
+		referenceSet,
+		referenceSetIfAbsent,
+		referenceInsert,
+		referenceReplace,
+	}).Draw(t, "mode")
+
+	documentJSON := marshalJSON(t, document)
+	original := documentJSON.Clone()
+	updated, _, err := jsonmut.Apply(
+		documentJSON,
+		mode.statement(jsonPointer(path), marshalJSON(t, replacement)),
+	)
+	want, wantErr := referenceMutate(document, path, replacement, mode)
+
+	switch wantErr {
+	case referenceNoError:
+		require.NoError(t, err)
+		require.True(t, updated.IsValid(), "mutation must produce valid JSON")
+		assert.JSONEq(t, marshalJSON(t, want).String(), updated.String())
+	case referenceAlreadyExists:
+		assert.ErrorIs(t, err, jsonmut.ErrExist)
+		assert.Nil(t, updated)
+	case referenceDoesNotExist:
+		assert.ErrorIs(t, err, jsonmut.ErrNotExist)
+		assert.Nil(t, updated)
+	case referenceWrongType:
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, jsonmut.ErrExist))
+		assert.False(t, errors.Is(err, jsonmut.ErrNotExist))
+		assert.Nil(t, updated)
+	default:
+		t.Fatalf("unknown reference error: %v", wantErr)
+	}
+	assert.Equal(t, original, documentJSON, "Apply must not mutate its input")
+}
+
+// referenceMutation selects equivalent operations
+// in jsonmut and the decoded reference model.
+//
+// The reference model mutates decoded Go values rather than raw JSON.
+// This gives the streaming implementation an independent semantic oracle
+// without making whitespace or object-member order part of the contract.
+type referenceMutation uint8
+
+const (
+	referenceSet referenceMutation = iota
+	referenceSetIfAbsent
+	referenceInsert
+	referenceReplace
+)
+
+func (m referenceMutation) statement(
+	path jsontext.Pointer,
+	value jsontext.Value,
+) jsonmut.Statement {
+	switch m {
+	case referenceSet:
+		return jsonmut.Set(path, value)
+	case referenceSetIfAbsent:
+		return jsonmut.SetIfAbsent(path, value)
+	case referenceInsert:
+		return jsonmut.Insert(path, value)
+	case referenceReplace:
+		return jsonmut.Replace(path, value)
+	default:
+		panic("unknown reference mutation")
+	}
+}
+
+// referenceError records observable failure classes
+// without sharing jsonmut's error values with the reference model.
+type referenceError uint8
+
+const (
+	referenceNoError referenceError = iota
+	referenceAlreadyExists
+	referenceDoesNotExist
+	referenceWrongType
+)
+
+// referenceLookup follows path through decoded JSON objects.
+// A missing member is a successful lookup with no value;
+// traversing through a non-object is an invalid operation instead.
+func referenceLookup(
+	value any,
+	path []string,
+) (_ any, found bool, _ referenceError) {
+	for _, member := range path {
+		object, ok := value.(map[string]any)
+		if !ok {
+			return nil, false, referenceWrongType
+		}
+		value, ok = object[member]
+		if !ok {
+			return nil, false, referenceNoError
+		}
+	}
+	return value, true, referenceNoError
+}
+
+// referenceMutate applies mode to decoded JSON values in place.
+// Production instead returns transformed raw JSON,
+// so agreement exercises behavior without sharing implementation.
+func referenceMutate(
+	document any,
+	path []string,
+	replacement any,
+	mode referenceMutation,
+) (any, referenceError) {
+	if len(path) == 0 {
+		switch mode {
+		case referenceInsert:
+			return nil, referenceAlreadyExists
+		case referenceSetIfAbsent:
+			return document, referenceNoError
+		default:
+			return replacement, referenceNoError
+		}
+	}
+
+	object, ok := document.(map[string]any)
+	if !ok {
+		return nil, referenceWrongType
+	}
+	member := path[0]
+	current, exists := object[member]
+	if len(path) == 1 {
+		switch {
+		case mode == referenceInsert && exists:
+			return nil, referenceAlreadyExists
+		case mode == referenceReplace && !exists:
+			return nil, referenceDoesNotExist
+		case mode == referenceSetIfAbsent && exists:
+			return document, referenceNoError
+		default:
+			object[member] = replacement
+			return document, referenceNoError
+		}
+	}
+	if !exists {
+		return nil, referenceDoesNotExist
+	}
+
+	current, err := referenceMutate(current, path[1:], replacement, mode)
+	if err != referenceNoError {
+		return nil, err
+	}
+	object[member] = current
+	return document, referenceNoError
+}
+
+// jsonLocation associates a path with the value found there.
+// Locations include the root and values of every JSON kind.
+type jsonLocation struct {
+	Path  []string
+	Value any
+}
+
+// drawJSONPath chooses among paths known to exist,
+// paths known to be missing, and arbitrary paths.
+func drawJSONPath(t *rapid.T, document map[string]any) []string {
+	locations := collectJSONLocations(document, nil)
+	switch rapid.IntRange(0, 2).Draw(t, "pathKind") {
+	case 0:
+		// Existing paths exercise successful traversal to roots,
+		// objects, arrays, and scalar values.
+		location := rapid.SampledFrom(locations).Draw(t, "existingPath")
+		return slices.Clone(location.Path)
+	case 1:
+		// Build from an existing object to guarantee a missing member.
+		// An optional descendant turns that member into a missing parent.
+		var objects []jsonLocation
+		for _, location := range locations {
+			if _, ok := location.Value.(map[string]any); ok {
+				objects = append(objects, location)
+			}
+		}
+		parent := rapid.SampledFrom(objects).Draw(t, "parentPath")
+		object := parent.Value.(map[string]any)
+		member := jsonMemberGenerator().
+			Filter(func(member string) bool {
+				_, exists := object[member]
+				return !exists
+			}).
+			Draw(t, "missingMember")
+		path := append(slices.Clone(parent.Path), member)
+		if rapid.Bool().Draw(t, "missingParent") {
+			path = append(path, jsonMemberGenerator().Draw(t, "descendant"))
+		}
+		return path
+	default:
+		// Independent paths cover chance intersections and attempts
+		// to traverse through non-object values.
+		return rapid.SliceOfN(
+			jsonMemberGenerator(),
+			0,
+			maxGeneratedJSONDepth+2,
+		).
+			Draw(t, "arbitraryPath")
+	}
+}
+
+// collectJSONLocations records the root and every descendant value.
+func collectJSONLocations(value any, path []string) []jsonLocation {
+	locations := []jsonLocation{{Path: slices.Clone(path), Value: value}}
+	object, ok := value.(map[string]any)
+	if !ok {
+		return locations
+	}
+	// Stable ordering makes a Rapid choice reproducible while shrinking
+	// even though Go map iteration order is not stable.
+	for _, member := range slices.Sorted(maps.Keys(object)) {
+		childPath := append(slices.Clone(path), member)
+		locations = append(
+			locations,
+			collectJSONLocations(object[member], childPath)...,
+		)
+	}
+	return locations
+}
+
+// jsonObjectGenerator generates an object with values nested up to depth.
+func jsonObjectGenerator(depth int) *rapid.Generator[map[string]any] {
+	return rapid.MapOfN(jsonMemberGenerator(), jsonValueGenerator(depth), 0, 4)
+}
+
+// jsonValueGenerator generates values nested up to depth.
+func jsonValueGenerator(depth int) *rapid.Generator[any] {
+	options := []*rapid.Generator[any]{
+		rapid.Just[any](nil),
+		rapid.Bool().AsAny(),
+		rapid.Int64Range(-10_000, 10_000).AsAny(),
+		rapid.StringN(0, 8, 32).AsAny(),
+	}
+	// Bounded recursion adds nested objects and arrays
+	// without allowing generated documents to grow without limit.
+	if depth > 0 {
+		options = append(
+			options,
+			jsonObjectGenerator(depth-1).AsAny(),
+			rapid.SliceOfN(jsonValueGenerator(depth-1), 0, 4).AsAny(),
+		)
+	}
+	return rapid.OneOf(options...)
+}
+
+func jsonMemberGenerator() *rapid.Generator[string] {
+	// Concentrate generated names on JSON Pointer escapes,
+	// JSON string escapes, whitespace, Unicode, and ordinary characters.
+	return rapid.StringOfN(rapid.RuneFrom([]rune("ab09/~\" \n\u2603")), 0, 6, 24)
+}
+
+func jsonPointer(path []string) jsontext.Pointer {
+	var pointer jsontext.Pointer
+	for _, member := range path {
+		pointer = pointer.AppendToken(member)
+	}
+	return pointer
+}
+
+func marshalJSON(t rapid.TB, value any) jsontext.Value {
+	encoded, err := json.Marshal(value)
+	require.NoError(t, err)
+	return jsontext.Value(encoded)
+}

--- a/internal/jsonmut/jsonmut_test.go
+++ b/internal/jsonmut/jsonmut_test.go
@@ -1,0 +1,384 @@
+package jsonmut_test
+
+import (
+	"encoding/json/jsontext"
+	"errors"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/jsonmut"
+)
+
+func TestApply_invalidDocument(t *testing.T) {
+	t.Parallel()
+
+	updated, value, err := jsonmut.Apply(
+		jsontext.Value(`{`),
+		jsonmut.Lookup("/answer"),
+	)
+	require.Error(t, err)
+	assert.Nil(t, updated)
+	assert.Empty(t, value)
+}
+
+func TestBlock(t *testing.T) {
+	t.Parallel()
+
+	document := jsontext.Value(`{
+		"first": "before",
+		"second": "before"
+	}`)
+	updated, _, err := jsonmut.Apply(
+		document,
+		jsonmut.Block(
+			jsonmut.Replace("/first", jsontext.Value(`"after"`)),
+			jsonmut.Set("/third", jsontext.Value(`3`)),
+		),
+	)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"first": "after",
+		"second": "before",
+		"third": 3
+	}`, updated.String())
+}
+
+func TestBlock_StopsAtError(t *testing.T) {
+	t.Parallel()
+
+	document := jsontext.Value(`{"first":"before"}`)
+	original := document.Clone()
+	updated, _, err := jsonmut.Apply(
+		document,
+		jsonmut.Block(
+			jsonmut.Set("/added", jsontext.Value(`true`)),
+			jsonmut.Replace("/missing", jsontext.Value(`null`)),
+		),
+	)
+	assert.ErrorIs(t, err, jsonmut.ErrNotExist)
+	assert.Nil(t, updated)
+	assert.Equal(t, original, document)
+}
+
+func TestProgram_Then(t *testing.T) {
+	t.Parallel()
+
+	updated, result, err := jsonmut.Apply(
+		jsontext.Value(`{"source":41}`),
+		jsonmut.Decode[int64]("/source").Then(
+			func(value int64) jsonmut.Program[int64] {
+				value++
+				return jsonmut.Set(
+					"/destination",
+					jsontext.Value(strconv.FormatInt(value, 10)),
+				).Returning(value)
+			},
+		),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), result)
+	assert.JSONEq(t, `{"source":41,"destination":42}`, updated.String())
+}
+
+func TestProgram_Then_stopsAfterError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("great sadness")
+	var continued bool
+	updated, result, err := jsonmut.Apply(
+		jsontext.Value(`{}`),
+		jsonmut.Fail[int](wantErr).Then(
+			func(int) jsonmut.Program[string] {
+				continued = true
+				return jsonmut.Fail[string](errors.New("continuation called"))
+			},
+		),
+	)
+	assert.ErrorIs(t, err, wantErr)
+	assert.Nil(t, updated)
+	assert.Empty(t, result)
+	assert.False(t, continued)
+}
+
+func TestProgram_Returning_preservesError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("great sadness")
+	updated, result, err := jsonmut.Apply(
+		jsontext.Value(`{}`),
+		jsonmut.Fail[int](wantErr).Returning("unexpected result"),
+	)
+	assert.ErrorIs(t, err, wantErr)
+	assert.Nil(t, updated)
+	assert.Empty(t, result)
+}
+
+func TestLookup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Present", func(t *testing.T) {
+		updated, value, err := jsonmut.Apply(
+			jsontext.Value(`{"answer":42}`),
+			jsonmut.Lookup("/answer"),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, jsontext.Value(`42`), value)
+		assert.JSONEq(t, `{"answer":42}`, updated.String())
+	})
+
+	t.Run("Missing", func(t *testing.T) {
+		_, value, err := jsonmut.Apply(
+			jsontext.Value(`{}`),
+			jsonmut.Lookup("/answer"),
+		)
+		require.NoError(t, err)
+		assert.Len(t, value, 0)
+	})
+}
+
+func TestLookup_arrayElement(t *testing.T) {
+	t.Parallel()
+
+	updated, value, err := jsonmut.Apply(
+		jsontext.Value(`{"items":[{"name":"first"}]}`),
+		jsonmut.Lookup("/items/0/name"),
+	)
+	require.Error(t, err)
+	assert.Nil(t, updated)
+	assert.Empty(t, value)
+}
+
+func TestDecode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Present", func(t *testing.T) {
+		_, value, err := jsonmut.Apply(
+			jsontext.Value(`{"answer":42}`),
+			jsonmut.Decode[int64]("/answer"),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, int64(42), value)
+	})
+
+	t.Run("Missing", func(t *testing.T) {
+		_, value, err := jsonmut.Apply(
+			jsontext.Value(`{}`),
+			jsonmut.Decode[int64]("/answer"),
+		)
+		require.NoError(t, err)
+		assert.Zero(t, value)
+	})
+
+	t.Run("MissingPointer", func(t *testing.T) {
+		_, value, err := jsonmut.Apply(
+			jsontext.Value(`{}`),
+			jsonmut.Decode[*int64]("/answer"),
+		)
+		require.NoError(t, err)
+		assert.Nil(t, value)
+	})
+
+	t.Run("PresentPointer", func(t *testing.T) {
+		_, value, err := jsonmut.Apply(
+			jsontext.Value(`{"answer":0}`),
+			jsonmut.Decode[*int64]("/answer"),
+		)
+		require.NoError(t, err)
+		if assert.NotNil(t, value) {
+			assert.Zero(t, *value)
+		}
+	})
+
+	t.Run("WrongType", func(t *testing.T) {
+		_, _, err := jsonmut.Apply(
+			jsontext.Value(`{"answer":"forty-two"}`),
+			jsonmut.Decode[int64]("/answer"),
+		)
+		assert.Error(t, err)
+	})
+}
+
+func TestSet_replayDoesNotAliasReplacement(t *testing.T) {
+	t.Parallel()
+
+	replacement := jsontext.Value(`{"value":"before"}`)
+	program := jsonmut.Set("", replacement)
+
+	copy(replacement, jsontext.Value(`{"value":"mutate"}`))
+	first, _, err := jsonmut.Apply(jsontext.Value(`{}`), program)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"value":"before"}`, first.String())
+
+	copy(first, jsontext.Value(`{"value":"second"}`))
+	second, _, err := jsonmut.Apply(jsontext.Value(`{}`), program)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"value":"before"}`, second.String())
+}
+
+func TestSet_arrayElement(t *testing.T) {
+	t.Parallel()
+
+	updated, _, err := jsonmut.Apply(
+		jsontext.Value(`{"items":[{"name":"first"}]}`),
+		jsonmut.Set("/items/0/name", jsontext.Value(`"updated"`)),
+	)
+	require.Error(t, err)
+	assert.Nil(t, updated)
+}
+
+func TestIncrement_overflow(t *testing.T) {
+	t.Parallel()
+
+	document := jsontext.Value(`{"counter":9223372036854775807}`)
+	original := document.Clone()
+	updated, result, err := jsonmut.Apply(
+		document,
+		jsonmut.Increment("/counter"),
+	)
+	require.Error(t, err)
+	assert.Nil(t, updated)
+	assert.Zero(t, result)
+	assert.Equal(t, original, document)
+}
+
+func TestInsertAutoIncrement(t *testing.T) {
+	t.Parallel()
+
+	document := jsontext.Value(`{
+		"unrelated": {"preserved": true},
+		"lastID": 41,
+		"drafts": {"9": {"body": "existing"}}
+	}`)
+	original := document.Clone()
+
+	updated, id, err := jsonmut.Apply(
+		document,
+		jsonmut.InsertAutoIncrement(
+			"/lastID",
+			"/drafts",
+			jsontext.Value(`{"body":"new"}`),
+		),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), id)
+	assert.JSONEq(t, `{
+		"unrelated": {"preserved": true},
+		"lastID": 42,
+		"drafts": {
+			"9": {"body": "existing"},
+			"42": {"body": "new"}
+		}
+	}`, updated.String())
+	assert.Equal(t, original, document, "Apply must not mutate its input")
+}
+
+func TestInsertAutoIncrement_InitializesMissingMembers(t *testing.T) {
+	t.Parallel()
+
+	updated, id, err := jsonmut.Apply(
+		jsontext.Value(`{}`),
+		jsonmut.InsertAutoIncrement(
+			"/lastID",
+			"/drafts",
+			jsontext.Value(`{"body":"first"}`),
+		),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), id)
+	assert.JSONEq(t, `{
+		"lastID": 1,
+		"drafts": {"1": {"body": "first"}}
+	}`, updated.String())
+}
+
+func TestInsertAutoIncrement_existingNextMember(t *testing.T) {
+	t.Parallel()
+
+	document := jsontext.Value(`{
+		"lastID": 41,
+		"drafts": {"42": {"body": "existing"}}
+	}`)
+	original := document.Clone()
+	updated, id, err := jsonmut.Apply(
+		document,
+		jsonmut.InsertAutoIncrement(
+			"/lastID",
+			"/drafts",
+			jsontext.Value(`{"body":"new"}`),
+		),
+	)
+	assert.ErrorIs(t, err, jsonmut.ErrExist)
+	assert.Nil(t, updated)
+	assert.Zero(t, id)
+	assert.Equal(t, original, document)
+}
+
+func TestReplace(t *testing.T) {
+	t.Parallel()
+
+	updated, _, err := jsonmut.Apply(
+		jsontext.Value(`{
+			"drafts": {"7": {"body": "before", "file": "main.go"}}
+		}`),
+		jsonmut.Replace(
+			jsontext.Pointer("/drafts").
+				AppendToken("7").
+				AppendToken("body"),
+			jsontext.Value(`"after"`),
+		),
+	)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"drafts": {"7": {"body": "after", "file": "main.go"}}
+	}`, updated.String())
+}
+
+func TestReplace_Missing(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := jsonmut.Apply(
+		jsontext.Value(`{"drafts": {}}`),
+		jsonmut.Replace(
+			"/drafts/7/body",
+			jsontext.Value(`"after"`),
+		),
+	)
+	assert.ErrorIs(t, err, jsonmut.ErrNotExist)
+}
+
+func TestSet_missingParent(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := jsonmut.Apply(
+		jsontext.Value(`{}`),
+		jsonmut.Set(
+			"/drafts/7/body",
+			jsontext.Value(`"after"`),
+		),
+	)
+	assert.ErrorIs(t, err, jsonmut.ErrNotExist)
+}
+
+func TestInsert_Existing(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := jsonmut.Apply(
+		jsontext.Value(`{"answer":42}`),
+		jsonmut.Insert("/answer", jsontext.Value(`43`)),
+	)
+	assert.ErrorIs(t, err, jsonmut.ErrExist)
+}
+
+func TestFail(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("great sadness")
+	updated, _, err := jsonmut.Apply(
+		jsontext.Value(`{}`),
+		jsonmut.Fail[int64](wantErr),
+	)
+	assert.ErrorIs(t, err, wantErr)
+	assert.Nil(t, updated)
+}


### PR DESCRIPTION
Optimistic callers may apply the same transformation more than once as
concurrent writes replace the source document.

Provide immutable statements and typed programs for reading and rewriting
object members. Programs can sequence independent mutations or derive later
operations and results from earlier values without a mutable result registry.
Stream object rewrites so unrelated JSON does not require full decoding.