### PR TITLE
storage: Add conflict-safe JSON updates

### DIFF
--- a/internal/spice/state/continue.go
+++ b/internal/spice/state/continue.go
@@ -2,23 +2,21 @@ package state
 
 import (
 	"context"
+	"encoding/json/jsontext"
+	json "encoding/json/v2"
 	"errors"
 	"fmt"
+	"slices"
+
+	"go.abhg.dev/gs/internal/jsonmut"
+	"go.abhg.dev/gs/internal/spice/state/storage"
 )
 
 const _rebaseContinueJSON = "rebase-continue"
 
-type rebaseContinueState struct {
-	Continuations []rebaseContinuation `json:"continuations"`
-}
+const _continuationsPointer = jsontext.Pointer("/continuations")
 
-type rebaseContinuation struct {
-	// Command is the git-spice command that will be run.
-	Command []string `json:"command"`
-
-	// Branch on which the command must be run.
-	Branch string `json:"branch"`
-}
+const _emptyRebaseContinueJSON = `{"continuations":null}`
 
 // Continuation includes the information needed to resume a
 // rebase operation that was interrupted.
@@ -31,25 +29,47 @@ type Continuation struct {
 	Branch string
 }
 
+type rebaseContinuation struct {
+	// Command is the git-spice command that will be run.
+	Command []string `json:"command"`
+
+	// Branch on which the command must be run.
+	Branch string `json:"branch"`
+}
+
 // AppendContinuations records one or more commands to run
 // when an interrupted rebase operation is resumed.
 // If there are existing continuations, this will append to the list.
+// Concurrent appends and takes are applied atomically.
 func (s *Store) AppendContinuations(ctx context.Context, msg string, conts ...Continuation) error {
 	if msg == "" {
 		msg = "set rebase continuation"
 	}
 
-	state, err := s.getRebaseContinueState(ctx)
-	if err != nil {
-		return fmt.Errorf("get rebase continue state: %w", err)
+	additions := make([]rebaseContinuation, len(conts))
+	for i, cont := range conts {
+		additions[i] = rebaseContinuation{
+			Command: slices.Clone(cont.Command),
+			Branch:  cont.Branch,
+		}
 	}
 
-	for _, cont := range conts {
-		state.Continuations = append(state.Continuations, rebaseContinuation(cont))
-	}
-
-	if err := s.setRebaseContinueState(ctx, state, msg); err != nil {
-		return fmt.Errorf("set rebase continue state: %w", err)
+	// The continuation receives freshly decoded state on every CAS attempt.
+	// Keep captured additions immutable so a conflict can replay the program.
+	program := jsonmut.Decode[[]rebaseContinuation](_continuationsPointer).
+		Then(func(current []rebaseContinuation) jsonmut.Statement {
+			updated, err := json.Marshal(slices.Concat(current, additions))
+			if err != nil {
+				return jsonmut.Fail[struct{}](fmt.Errorf("marshal continuations: %w", err))
+			}
+			return jsonmut.Set(_continuationsPointer, updated)
+		})
+	if err := storage.UpdateJSON(ctx, s.db, storage.JSONMutationRequest{
+		Key:       _rebaseContinueJSON,
+		IfMissing: jsontext.Value(_emptyRebaseContinueJSON),
+		Message:   msg,
+	}, program); err != nil {
+		return fmt.Errorf("append rebase continuations: %w", err)
 	}
 
 	return nil
@@ -59,47 +79,40 @@ func (s *Store) AppendContinuations(ctx context.Context, msg string, conts ...Co
 // and returns them.
 //
 // If there are no continuations, it returns an empty slice.
+// Concurrent appends and takes are applied atomically.
 func (s *Store) TakeContinuations(ctx context.Context, msg string) ([]Continuation, error) {
 	if msg == "" {
 		msg = "take all rebase continuations"
 	}
 
-	state, err := s.getRebaseContinueState(ctx)
+	// Clearing the value and returning its previous contents must happen in the
+	// same CAS attempt. A replay therefore observes the winning revision instead
+	// of returning continuations already taken by another caller.
+	program := jsonmut.Decode[[]rebaseContinuation](_continuationsPointer).
+		Then(func(current []rebaseContinuation) jsonmut.Program[[]rebaseContinuation] {
+			return jsonmut.Set(
+				_continuationsPointer,
+				jsontext.Value("null"),
+			).Returning(current)
+		})
+	stored, err := storage.MutateJSON(ctx, s.db, storage.JSONMutationRequest{
+		Key:     _rebaseContinueJSON,
+		Message: msg,
+	}, program)
 	if err != nil {
-		return nil, fmt.Errorf("get rebase continue state: %w", err)
+		if errors.Is(err, storage.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("take rebase continuations: %w", err)
 	}
 
-	if len(state.Continuations) == 0 {
+	if len(stored) == 0 {
 		return nil, nil
 	}
 
-	conts := make([]Continuation, len(state.Continuations))
-	for i, cont := range state.Continuations {
+	conts := make([]Continuation, len(stored))
+	for i, cont := range stored {
 		conts[i] = Continuation(cont)
 	}
-
-	state.Continuations = nil
-	if err := s.setRebaseContinueState(ctx, state, msg); err != nil {
-		return nil, fmt.Errorf("set rebase continue state: %w", err)
-	}
-
 	return conts, nil
-}
-
-func (s *Store) getRebaseContinueState(ctx context.Context) (*rebaseContinueState, error) {
-	var state rebaseContinueState
-	if err := s.db.Get(ctx, _rebaseContinueJSON, &state); err != nil {
-		if errors.Is(err, ErrNotExist) {
-			return &rebaseContinueState{}, nil
-		}
-		return nil, fmt.Errorf("get rebase continue state: %w", err)
-	}
-	return &state, nil
-}
-
-func (s *Store) setRebaseContinueState(ctx context.Context, state *rebaseContinueState, msg string) error {
-	if msg == "" {
-		msg = "set rebase continue state"
-	}
-	return s.db.Set(ctx, _rebaseContinueJSON, state, msg)
 }

--- a/internal/spice/state/continue_test.go
+++ b/internal/spice/state/continue_test.go
@@ -1,0 +1,253 @@
+package state_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/spice/state"
+	"go.abhg.dev/gs/internal/spice/state/storage"
+)
+
+func TestStoreAppendContinuations_concurrent(t *testing.T) {
+	backend := newReadBarrierBackend(
+		storage.SyncBackend(make(storage.MapBackend)),
+	)
+	store, err := state.InitStore(t.Context(), state.InitStoreRequest{
+		DB:    storage.NewDB(backend),
+		Trunk: "main",
+	})
+	require.NoError(t, err)
+
+	first := state.Continuation{
+		Command: []string{"branch", "restack"},
+		Branch:  "first",
+	}
+	second := state.Continuation{
+		Command: []string{"branch", "restack"},
+		Branch:  "second",
+	}
+
+	backend.barrierReads("rebase-continue", 2)
+	errs := make(chan error, 2)
+	go func() {
+		errs <- store.AppendContinuations(t.Context(), "append first", first)
+	}()
+	go func() {
+		errs <- store.AppendContinuations(t.Context(), "append second", second)
+	}()
+	require.NoError(t, <-errs)
+	require.NoError(t, <-errs)
+
+	got, err := store.TakeContinuations(t.Context(), "inspect continuations")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []state.Continuation{first, second}, got)
+}
+
+func TestStoreTakeContinuations_concurrent(t *testing.T) {
+	backend := newReadBarrierBackend(
+		storage.SyncBackend(make(storage.MapBackend)),
+	)
+	store, err := state.InitStore(t.Context(), state.InitStoreRequest{
+		DB:    storage.NewDB(backend),
+		Trunk: "main",
+	})
+	require.NoError(t, err)
+
+	want := state.Continuation{
+		Command: []string{"branch", "restack"},
+		Branch:  "feature",
+	}
+	require.NoError(t, store.AppendContinuations(
+		t.Context(),
+		"seed continuation",
+		want,
+	))
+
+	backend.barrierReads("rebase-continue", 2)
+	takes := make(chan []state.Continuation, 2)
+	errs := make(chan error, 2)
+	for range 2 {
+		go func() {
+			got, err := store.TakeContinuations(t.Context(), "take continuations")
+			takes <- got
+			errs <- err
+		}()
+	}
+
+	var got []state.Continuation
+	for range 2 {
+		got = append(got, <-takes...)
+		require.NoError(t, <-errs)
+	}
+	assert.Equal(t, []state.Continuation{want}, got)
+}
+
+func TestStoreTakeContinuations_missing(t *testing.T) {
+	backend := storage.SyncBackend(make(storage.MapBackend))
+	store, err := state.InitStore(t.Context(), state.InitStoreRequest{
+		DB:    storage.NewDB(backend),
+		Trunk: "main",
+	})
+	require.NoError(t, err)
+
+	got, err := store.TakeContinuations(t.Context(), "take continuations")
+	require.NoError(t, err)
+	assert.Empty(t, got)
+
+	var document any
+	assert.ErrorIs(
+		t,
+		backend.Get(t.Context(), "rebase-continue", &document),
+		storage.ErrNotExist,
+	)
+}
+
+func TestStoreContinuations_concurrentAppendAndTake(t *testing.T) {
+	backend := newReadBarrierBackend(
+		storage.SyncBackend(make(storage.MapBackend)),
+	)
+	store, err := state.InitStore(t.Context(), state.InitStoreRequest{
+		DB:    storage.NewDB(backend),
+		Trunk: "main",
+	})
+	require.NoError(t, err)
+
+	first := state.Continuation{
+		Command: []string{"branch", "restack"},
+		Branch:  "first",
+	}
+	second := state.Continuation{
+		Command: []string{"branch", "restack"},
+		Branch:  "second",
+	}
+	require.NoError(t, store.AppendContinuations(
+		t.Context(),
+		"seed continuation",
+		first,
+	))
+
+	backend.barrierReads("rebase-continue", 2)
+	appendErr := make(chan error, 1)
+	go func() {
+		appendErr <- store.AppendContinuations(
+			t.Context(),
+			"append continuation",
+			second,
+		)
+	}()
+	takenResult := make(chan []state.Continuation, 1)
+	takeErr := make(chan error, 1)
+	go func() {
+		got, err := store.TakeContinuations(t.Context(), "take continuations")
+		takenResult <- got
+		takeErr <- err
+	}()
+
+	require.NoError(t, <-appendErr)
+	require.NoError(t, <-takeErr)
+	taken := <-takenResult
+	remaining, err := store.TakeContinuations(
+		t.Context(),
+		"inspect remaining continuations",
+	)
+	require.NoError(t, err)
+	assert.ElementsMatch(
+		t,
+		[]state.Continuation{first, second},
+		append(taken, remaining...),
+	)
+}
+
+// readBarrierBackend holds a configured number of completed reads until every
+// reader has observed the backend. It wraps both direct reads and snapshot reads
+// so the tests exercise the public state operations before and after their CAS
+// migration.
+type readBarrierBackend struct {
+	storage.Backend
+
+	mu        sync.Mutex
+	key       string
+	remaining int
+	ready     chan struct{}
+}
+
+func newReadBarrierBackend(backend storage.Backend) *readBarrierBackend {
+	return &readBarrierBackend{Backend: backend}
+}
+
+func (b *readBarrierBackend) barrierReads(key string, count int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.key = key
+	b.remaining = count
+	b.ready = make(chan struct{})
+}
+
+func (b *readBarrierBackend) Get(
+	ctx context.Context,
+	key string,
+	dst any,
+) error {
+	err := b.Backend.Get(ctx, key, dst)
+	b.afterRead(key)
+	return err
+}
+
+func (b *readBarrierBackend) Snapshot(ctx context.Context) (storage.Snapshot, error) {
+	snapshot, err := b.Backend.Snapshot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &readBarrierSnapshot{
+		Snapshot:  snapshot,
+		afterRead: b.afterRead,
+	}, nil
+}
+
+func (b *readBarrierBackend) CompareAndSwap(
+	ctx context.Context,
+	snapshot storage.Snapshot,
+	req storage.UpdateRequest,
+) error {
+	barrierSnapshot, ok := snapshot.(*readBarrierSnapshot)
+	if !ok {
+		return storage.ErrInvalidSnapshot
+	}
+	return b.Backend.CompareAndSwap(ctx, barrierSnapshot.Snapshot, req)
+}
+
+func (b *readBarrierBackend) afterRead(key string) {
+	b.mu.Lock()
+	if key != b.key || b.remaining == 0 {
+		b.mu.Unlock()
+		return
+	}
+
+	b.remaining--
+	ready := b.ready
+	if b.remaining == 0 {
+		close(ready)
+	}
+	b.mu.Unlock()
+
+	<-ready
+}
+
+type readBarrierSnapshot struct {
+	storage.Snapshot
+	afterRead func(string)
+}
+
+func (s *readBarrierSnapshot) Get(
+	ctx context.Context,
+	key string,
+	dst any,
+) error {
+	err := s.Snapshot.Get(ctx, key, dst)
+	s.afterRead(key)
+	return err
+}

--- a/internal/spice/state/mocks_test.go
+++ b/internal/spice/state/mocks_test.go
@@ -79,6 +79,44 @@ func (c *MockDBClearCall) DoAndReturn(f func(context.Context, string) error) *Mo
 	return c
 }
 
+// CompareAndSwap mocks base method.
+func (m *MockDB) CompareAndSwap(ctx context.Context, snapshot storage.Snapshot, req storage.UpdateRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CompareAndSwap", ctx, snapshot, req)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CompareAndSwap indicates an expected call of CompareAndSwap.
+func (mr *MockDBMockRecorder) CompareAndSwap(ctx, snapshot, req any) *MockDBCompareAndSwapCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompareAndSwap", reflect.TypeOf((*MockDB)(nil).CompareAndSwap), ctx, snapshot, req)
+	return &MockDBCompareAndSwapCall{Call: call}
+}
+
+// MockDBCompareAndSwapCall wrap *gomock.Call
+type MockDBCompareAndSwapCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockDBCompareAndSwapCall) Return(arg0 error) *MockDBCompareAndSwapCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockDBCompareAndSwapCall) Do(f func(context.Context, storage.Snapshot, storage.UpdateRequest) error) *MockDBCompareAndSwapCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockDBCompareAndSwapCall) DoAndReturn(f func(context.Context, storage.Snapshot, storage.UpdateRequest) error) *MockDBCompareAndSwapCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Delete mocks base method.
 func (m *MockDB) Delete(ctx context.Context, k, msg string) error {
 	m.ctrl.T.Helper()
@@ -118,17 +156,17 @@ func (c *MockDBDeleteCall) DoAndReturn(f func(context.Context, string, string) e
 }
 
 // Get mocks base method.
-func (m *MockDB) Get(ctx context.Context, k string, v any) error {
+func (m *MockDB) Get(ctx context.Context, key string, dst any) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", ctx, k, v)
+	ret := m.ctrl.Call(m, "Get", ctx, key, dst)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockDBMockRecorder) Get(ctx, k, v any) *MockDBGetCall {
+func (mr *MockDBMockRecorder) Get(ctx, key, dst any) *MockDBGetCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockDB)(nil).Get), ctx, k, v)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockDB)(nil).Get), ctx, key, dst)
 	return &MockDBGetCall{Call: call}
 }
 
@@ -228,6 +266,45 @@ func (c *MockDBSetCall) Do(f func(context.Context, string, any, string) error) *
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockDBSetCall) DoAndReturn(f func(context.Context, string, any, string) error) *MockDBSetCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// Snapshot mocks base method.
+func (m *MockDB) Snapshot(ctx context.Context) (storage.Snapshot, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Snapshot", ctx)
+	ret0, _ := ret[0].(storage.Snapshot)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Snapshot indicates an expected call of Snapshot.
+func (mr *MockDBMockRecorder) Snapshot(ctx any) *MockDBSnapshotCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Snapshot", reflect.TypeOf((*MockDB)(nil).Snapshot), ctx)
+	return &MockDBSnapshotCall{Call: call}
+}
+
+// MockDBSnapshotCall wrap *gomock.Call
+type MockDBSnapshotCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockDBSnapshotCall) Return(arg0 storage.Snapshot, arg1 error) *MockDBSnapshotCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockDBSnapshotCall) Do(f func(context.Context) (storage.Snapshot, error)) *MockDBSnapshotCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockDBSnapshotCall) DoAndReturn(f func(context.Context) (storage.Snapshot, error)) *MockDBSnapshotCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/spice/state/storage/backend.go
+++ b/internal/spice/state/storage/backend.go
@@ -1,6 +1,6 @@
 // Package storage provides a key-value storage abstraction
 // where values are JSON-serializable structs.
-// It is used by git-spice to store metadata in a git repository.
+// It is used by git-spice to store metadata in a Git repository.
 // It requires all write operations to have a message.
 package storage
 
@@ -9,68 +9,103 @@ import (
 	"errors"
 )
 
-// UpdateRequest performs a batch of write operations
-// in one transaction.
+// Backend defines the primitive operations for the key-value store.
+type Backend interface {
+	// Get retrieves a value from the store and decodes it into dst.
+	// If the key does not exist, Get returns [ErrNotExist].
+	Get(ctx context.Context, key string, dst any) error
+
+	// Snapshot returns a read-only view of the current store revision.
+	Snapshot(ctx context.Context) (Snapshot, error)
+
+	// CompareAndSwap applies req only if snapshot is still current.
+	// It returns [ErrConflict] if another writer changed the store first.
+	CompareAndSwap(
+		ctx context.Context,
+		snapshot Snapshot,
+		req UpdateRequest,
+	) error
+
+	// Update applies req to the current store revision.
+	Update(ctx context.Context, req UpdateRequest) error
+
+	// Clear removes every key from the store.
+	Clear(ctx context.Context, msg string) error
+
+	// Keys lists the keys in dir with the directory prefix removed.
+	// An empty dir lists every key.
+	Keys(ctx context.Context, dir string) ([]string, error)
+}
+
+// Snapshot is a read-only view of one store revision.
+// Its reads remain pinned if the live store changes.
+type Snapshot interface {
+	// Get retrieves a value from the snapshot and decodes it into dst.
+	// If the key does not exist, Get returns [ErrNotExist].
+	Get(ctx context.Context, key string, dst any) error
+
+	// Keys lists the keys in dir with the directory prefix removed.
+	// An empty dir lists every key.
+	Keys(ctx context.Context, dir string) ([]string, error)
+}
+
+// UpdateRequest performs a batch of writes in one transaction.
 type UpdateRequest struct {
+	// Sets lists the keys to add or replace.
 	Sets []SetRequest
 
 	// Deletes lists the keys to delete.
 	Deletes []string
 
-	// Message to attach to the batch oepration.
+	// Message is attached to the batch operation.
 	Message string
 }
 
-// SetRequest is a single operation to add or update a key.
+// SetRequest is one key-value write.
 type SetRequest struct {
-	// Key to write to.
+	// Key is the key to write.
 	Key string
 
-	// Value to serialize to JSON.
+	// Value is serialized to JSON.
 	Value any
 }
 
-// ErrNotExist indicates that a key that was expected to exist does not exist.
+// ErrNotExist indicates that an expected key does not exist.
 var ErrNotExist = errors.New("does not exist in store")
 
-// Backend defines the primitive operations for the key-value store.
-type Backend interface {
-	// Get retrieves a value from the store
-	// and decodes it into dst.
-	//
-	// If the key does not exist, Get returns ErrNotExist.
-	Get(ctx context.Context, key string, dst any) error
+// ErrConflict indicates that a compare-and-swap snapshot is stale.
+var ErrConflict = errors.New("store changed since snapshot")
 
-	Update(ctx context.Context, req UpdateRequest) error
-	Clear(ctx context.Context, msg string) error
+// ErrInvalidSnapshot indicates that a snapshot belongs to another backend.
+var ErrInvalidSnapshot = errors.New("invalid store snapshot")
 
-	// Keys lists the keys in the store in the given directory,
-	// with the directory prefix removed.
-	//
-	// The directory is defined as '/'-separated components in the key.
-	// If dir is empty, all keys are listed.
-	Keys(ctx context.Context, dir string) ([]string, error)
-}
-
-// DB is a high-level wrapper around a Backend.
-// It provides a more convenient API for interacting with the store.
+// DB is a high-level wrapper around a [Backend].
 type DB struct{ Backend }
 
-// NewDB creates a new DB using the given Backend.
+// NewDB creates a DB using b.
 func NewDB(b Backend) *DB {
 	return &DB{Backend: b}
 }
 
-// Set adds or updates a single key in the store.
-func (db *DB) Set(ctx context.Context, key string, value any, msg string) error {
+// Set adds or updates one key.
+func (db *DB) Set(
+	ctx context.Context,
+	key string,
+	value any,
+	msg string,
+) error {
 	return db.Update(ctx, UpdateRequest{
 		Sets:    []SetRequest{{Key: key, Value: value}},
 		Message: msg,
 	})
 }
 
-// Delete removes a key from the store.
-func (db *DB) Delete(ctx context.Context, key string, msg string) error {
+// Delete removes one key.
+func (db *DB) Delete(
+	ctx context.Context,
+	key string,
+	msg string,
+) error {
 	return db.Update(ctx, UpdateRequest{
 		Deletes: []string{key},
 		Message: msg,

--- a/internal/spice/state/storage/backend_test.go
+++ b/internal/spice/state/storage/backend_test.go
@@ -63,6 +63,38 @@ func testStorageBackend(t *testing.T, backend Backend) {
 		assert.Equal(t, "baz", got)
 	})
 
+	t.Run("CompareAndSwap", func(t *testing.T) {
+		defer func() {
+			assert.NoError(t, db.Clear(ctx, "clear"))
+		}()
+
+		require.NoError(t, db.Set(ctx, "value", "old", "set value"))
+		snapshot, err := db.Snapshot(ctx)
+		require.NoError(t, err)
+		require.NoError(t, db.CompareAndSwap(
+			ctx,
+			snapshot,
+			UpdateRequest{
+				Sets:    []SetRequest{{Key: "value", Value: "new"}},
+				Message: "replace value",
+			},
+		))
+
+		var got string
+		require.NoError(t, db.Get(ctx, "value", &got))
+		assert.Equal(t, "new", got)
+
+		err = db.CompareAndSwap(
+			ctx,
+			snapshot,
+			UpdateRequest{
+				Sets:    []SetRequest{{Key: "value", Value: "stale"}},
+				Message: "stale update",
+			},
+		)
+		assert.ErrorIs(t, err, ErrConflict)
+	})
+
 	t.Run("SetNested", func(t *testing.T) {
 		defer func() {
 			assert.NoError(t, db.Clear(ctx, "clear"))

--- a/internal/spice/state/storage/git.go
+++ b/internal/spice/state/storage/git.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"io"
 	"iter"
+	"maps"
+	"slices"
 	"sync"
 
 	"go.abhg.dev/gs/internal/git"
@@ -78,15 +80,21 @@ func NewGitBackend(cfg GitConfig) *GitBackend {
 func (g *GitBackend) Keys(ctx context.Context, dir string) ([]string, error) {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
+	return g.keys(ctx, g.ref, dir)
+}
 
+func (g *GitBackend) keys(
+	ctx context.Context,
+	treeish, dir string,
+) ([]string, error) {
 	var (
 		treeHash git.Hash
 		err      error
 	)
 	if dir == "" {
-		treeHash, err = g.repo.PeelToTree(ctx, g.ref)
+		treeHash, err = g.repo.PeelToTree(ctx, treeish)
 	} else {
-		treeHash, err = g.repo.HashAt(ctx, g.ref, dir)
+		treeHash, err = g.repo.HashAt(ctx, treeish, dir)
 	}
 	if err != nil {
 		if errors.Is(err, git.ErrNotExist) {
@@ -116,21 +124,30 @@ func (g *GitBackend) Get(ctx context.Context, key string, v any) error {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 
-	blobHash, err := g.repo.HashAt(ctx, g.ref, key)
+	return g.read(ctx, g.ref, key, v)
+}
+
+// Snapshot returns a read-only view of the current Git-backed store revision.
+func (g *GitBackend) Snapshot(ctx context.Context) (Snapshot, error) {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+
+	commit, err := g.repo.PeelToCommit(ctx, g.ref)
 	if err != nil {
-		return ErrNotExist
+		if errors.Is(err, git.ErrNotExist) {
+			return &gitSnapshot{backend: g}, nil
+		}
+		return nil, fmt.Errorf("get store commit: %w", err)
 	}
-
-	var buf bytes.Buffer
-	if err := g.repo.ReadObject(ctx, git.BlobType, blobHash, &buf); err != nil {
-		return fmt.Errorf("read object: %w", err)
+	tree, err := g.repo.PeelToTree(ctx, commit.String())
+	if err != nil {
+		return nil, fmt.Errorf("get tree for %v: %w", commit, err)
 	}
-
-	if err := json.UnmarshalRead(&buf, v); err != nil {
-		return fmt.Errorf("decode JSON: %w", err)
-	}
-
-	return nil
+	return &gitSnapshot{
+		backend: g,
+		commit:  commit,
+		tree:    tree,
+	}, nil
 }
 
 // Clear removes all keys from the store.
@@ -173,30 +190,44 @@ func (g *GitBackend) Clear(ctx context.Context, msg string) error {
 	return nil
 }
 
-// Update applies a batch of changes to the store.
+// CompareAndSwap applies req if snapshot still identifies the backing ref.
+func (g *GitBackend) CompareAndSwap(
+	ctx context.Context,
+	snapshot Snapshot,
+	req UpdateRequest,
+) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	snap, ok := snapshot.(*gitSnapshot)
+	if !ok || snap.backend != g {
+		return ErrInvalidSnapshot
+	}
+	current, err := g.repo.PeelToCommit(ctx, g.ref)
+	if err != nil {
+		if !errors.Is(err, git.ErrNotExist) {
+			return fmt.Errorf("get store commit: %w", err)
+		}
+		current = ""
+	}
+	if current != snap.commit {
+		return ErrConflict
+	}
+	setBlobs, err := g.writeSets(ctx, req.Sets)
+	if err != nil {
+		return err
+	}
+	return g.update(ctx, req, setBlobs, snap.commit, snap.tree)
+}
+
+// Update applies req to the current Git-backed store revision.
 func (g *GitBackend) Update(ctx context.Context, req UpdateRequest) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
-	setBlobs := make([]git.Hash, len(req.Sets))
-	for i, set := range req.Sets {
-		must.NotBeBlankf(set.Key, "key must not be blank")
-
-		var buf bytes.Buffer
-		enc := jsontext.NewEncoder(
-			&buf,
-			jsontext.WithIndent("  "),
-		)
-		if err := json.MarshalEncode(enc, set.Value); err != nil {
-			return fmt.Errorf("encode JSON: %w", err)
-		}
-
-		blobHash, err := g.repo.WriteObject(ctx, git.BlobType, &buf)
-		if err != nil {
-			return fmt.Errorf("write object: %w", err)
-		}
-
-		setBlobs[i] = blobHash
+	setBlobs, err := g.writeSets(ctx, req.Sets)
+	if err != nil {
+		return err
 	}
 
 	var updateErr error
@@ -204,6 +235,9 @@ func (g *GitBackend) Update(ctx context.Context, req UpdateRequest) error {
 		var prevTree git.Hash
 		prevCommit, err := g.repo.PeelToCommit(ctx, g.ref)
 		if err != nil {
+			if !errors.Is(err, git.ErrNotExist) {
+				return fmt.Errorf("get store commit: %w", err)
+			}
 			prevCommit = ""
 			prevTree = ""
 		} else {
@@ -213,55 +247,152 @@ func (g *GitBackend) Update(ctx context.Context, req UpdateRequest) error {
 			}
 		}
 
-		writes := make([]git.BlobInfo, len(req.Sets))
-		for i, req := range req.Sets {
-			writes[i] = git.BlobInfo{
-				Mode: git.RegularMode,
-				Path: req.Key,
-				Hash: setBlobs[i],
-			}
-		}
-
-		newTree, err := g.repo.UpdateTree(ctx, git.UpdateTreeRequest{
-			Tree:    prevTree,
-			Writes:  writes,
-			Deletes: req.Deletes,
-		})
-		if err != nil {
-			return fmt.Errorf("update tree: %w", err)
-		}
-
-		// The tree didn't change, so we don't need to commit.
-		if prevTree == newTree {
+		err = g.update(ctx, req, setBlobs, prevCommit, prevTree)
+		if err == nil {
 			return nil
 		}
-
-		commitReq := git.CommitTreeRequest{
-			Tree:      newTree,
-			Message:   req.Message,
-			Author:    &g.sig,
-			Committer: &g.sig,
+		if !errors.Is(err, ErrConflict) {
+			return err
 		}
-		if prevCommit != "" {
-			commitReq.Parents = []git.Hash{prevCommit}
-		}
-		newCommit, err := g.repo.CommitTree(ctx, commitReq)
-		if err != nil {
-			return fmt.Errorf("commit: %w", err)
-		}
-
-		if err := g.repo.SetRef(ctx, git.SetRefRequest{
-			Ref:     g.ref,
-			Hash:    newCommit,
-			OldHash: prevCommit,
-		}); err != nil {
-			updateErr = err
-			g.log.Warn("could not update ref: retrying", "error", err)
-			continue
-		}
-
-		return nil
+		updateErr = err
+		g.log.Warn("could not update ref: retrying", "error", err)
 	}
 
 	return fmt.Errorf("set ref: %w", updateErr)
+}
+
+func (g *GitBackend) update(
+	ctx context.Context,
+	req UpdateRequest,
+	setBlobs []git.Hash,
+	prevCommit, prevTree git.Hash,
+) error {
+	writesByPath := make(map[string]git.Hash, len(req.Sets))
+	deletes := make(map[string]struct{}, len(req.Deletes))
+	for i, set := range req.Sets {
+		writesByPath[set.Key] = setBlobs[i]
+		delete(deletes, set.Key)
+	}
+	for _, key := range req.Deletes {
+		delete(writesByPath, key)
+		deletes[key] = struct{}{}
+	}
+
+	writes := make([]git.BlobInfo, 0, len(writesByPath))
+	for _, path := range slices.Sorted(maps.Keys(writesByPath)) {
+		writes = append(writes, git.BlobInfo{
+			Mode: git.RegularMode,
+			Path: path,
+			Hash: writesByPath[path],
+		})
+	}
+	newTree, err := g.repo.UpdateTree(ctx, git.UpdateTreeRequest{
+		Tree:    prevTree,
+		Writes:  writes,
+		Deletes: slices.Sorted(maps.Keys(deletes)),
+	})
+	if err != nil {
+		return fmt.Errorf("update tree: %w", err)
+	}
+	if prevTree == newTree {
+		return nil
+	}
+
+	commitReq := git.CommitTreeRequest{
+		Tree:      newTree,
+		Message:   req.Message,
+		Author:    &g.sig,
+		Committer: &g.sig,
+	}
+	if prevCommit != "" {
+		commitReq.Parents = []git.Hash{prevCommit}
+	}
+	newCommit, err := g.repo.CommitTree(ctx, commitReq)
+	if err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+	if err := g.repo.SetRef(ctx, git.SetRefRequest{
+		Ref:     g.ref,
+		Hash:    newCommit,
+		OldHash: prevCommit,
+	}); err != nil {
+		return ErrConflict
+	}
+	return nil
+}
+
+func (g *GitBackend) read(
+	ctx context.Context,
+	commitish string,
+	key string,
+	dst any,
+) error {
+	blobHash, err := g.repo.HashAt(ctx, commitish, key)
+	if err != nil {
+		return ErrNotExist
+	}
+
+	var buf bytes.Buffer
+	if err := g.repo.ReadObject(ctx, git.BlobType, blobHash, &buf); err != nil {
+		return fmt.Errorf("read object: %w", err)
+	}
+	if err := json.UnmarshalRead(&buf, dst); err != nil {
+		return fmt.Errorf("decode JSON: %w", err)
+	}
+	return nil
+}
+
+func (g *GitBackend) writeSets(
+	ctx context.Context,
+	sets []SetRequest,
+) ([]git.Hash, error) {
+	blobs := make([]git.Hash, len(sets))
+	for i, set := range sets {
+		must.NotBeBlankf(set.Key, "key must not be blank")
+
+		var buf bytes.Buffer
+		enc := jsontext.NewEncoder(
+			&buf,
+			jsontext.WithIndent("  "),
+		)
+		if err := json.MarshalEncode(enc, set.Value); err != nil {
+			return nil, fmt.Errorf("encode JSON: %w", err)
+		}
+
+		blob, err := g.repo.WriteObject(ctx, git.BlobType, &buf)
+		if err != nil {
+			return nil, fmt.Errorf("write object: %w", err)
+		}
+		blobs[i] = blob
+	}
+	return blobs, nil
+}
+
+type gitSnapshot struct {
+	backend *GitBackend
+	commit  git.Hash
+	tree    git.Hash
+}
+
+var _ Snapshot = (*gitSnapshot)(nil)
+
+func (s *gitSnapshot) Get(
+	ctx context.Context,
+	key string,
+	dst any,
+) error {
+	if s.commit == "" {
+		return ErrNotExist
+	}
+	return s.backend.read(ctx, s.commit.String(), key, dst)
+}
+
+func (s *gitSnapshot) Keys(
+	ctx context.Context,
+	dir string,
+) ([]string, error) {
+	if s.commit == "" {
+		return nil, nil
+	}
+	return s.backend.keys(ctx, s.commit.String(), dir)
 }

--- a/internal/spice/state/storage/git_test.go
+++ b/internal/spice/state/storage/git_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	cryptorand "crypto/rand"
 	"encoding/hex"
 	"errors"
@@ -45,6 +46,42 @@ func TestGitBackendUpdateNoChanges(t *testing.T) {
 
 	assert.Equal(t, start, end,
 		"there should be no changes in the repository")
+}
+
+func TestGitBackendUpdateNoChanges_concurrentUpdate(t *testing.T) {
+	ctx := t.Context()
+	repo, _, err := git.Init(ctx, t.TempDir(), git.InitOptions{
+		Log: silogtest.New(t),
+	})
+	require.NoError(t, err)
+
+	newBackend := func(repo GitRepository) *GitBackend {
+		return NewGitBackend(GitConfig{
+			Repo:        repo,
+			Ref:         "refs/data",
+			AuthorName:  "Test Author",
+			AuthorEmail: "test@example.com",
+			Log:         silogtest.New(t),
+		})
+	}
+	concurrent := NewDB(newBackend(repo))
+	require.NoError(t, concurrent.Set(ctx, "foo", "bar", "initial set"))
+
+	racingRepo := &updateTreeHookRepository{
+		GitRepository: repo,
+		BeforeUpdate: func(ctx context.Context, call int) error {
+			return concurrent.Set(
+				ctx,
+				fmt.Sprintf("concurrent/%d", call),
+				call,
+				"concurrent update",
+			)
+		},
+	}
+	db := NewDB(newBackend(racingRepo))
+
+	require.NoError(t, db.Set(ctx, "foo", "bar", "keep desired value"))
+	assert.Equal(t, 1, racingRepo.calls)
 }
 
 func TestGitBackend_ConcurrentOperations(t *testing.T) {
@@ -252,4 +289,21 @@ func TestGitBackend_SpecialCharacterKeys(t *testing.T) {
 				"Keys list should contain %q", expectedKey)
 		}
 	})
+}
+
+type updateTreeHookRepository struct {
+	GitRepository
+	BeforeUpdate func(context.Context, int) error
+	calls        int
+}
+
+func (r *updateTreeHookRepository) UpdateTree(
+	ctx context.Context,
+	req git.UpdateTreeRequest,
+) (git.Hash, error) {
+	r.calls++
+	if err := r.BeforeUpdate(ctx, r.calls); err != nil {
+		return "", err
+	}
+	return r.GitRepository.UpdateTree(ctx, req)
 }

--- a/internal/spice/state/storage/json.go
+++ b/internal/spice/state/storage/json.go
@@ -1,0 +1,88 @@
+package storage
+
+import (
+	"context"
+	"encoding/json/jsontext"
+	"errors"
+	"fmt"
+
+	"go.abhg.dev/gs/internal/jsonmut"
+)
+
+// JSONMutationRequest identifies the stored JSON value to mutate.
+type JSONMutationRequest struct {
+	Key string // required
+
+	// Requires lists keys that must exist in the committed revision.
+	Requires []string
+
+	// IfMissing supplies the document when Key does not exist.
+	// If empty, a missing Key returns [ErrNotExist].
+	IfMissing jsontext.Value
+
+	// Message is attached to the committed storage update.
+	Message string // required
+}
+
+// MutateJSON applies program to one JSON value and retries storage conflicts.
+// The returned result belongs to the storage revision that committed.
+func MutateJSON[T any](
+	ctx context.Context,
+	backend Backend,
+	req JSONMutationRequest,
+	program jsonmut.Program[T],
+) (T, error) {
+	var zero T
+	for {
+		if err := ctx.Err(); err != nil {
+			return zero, err
+		}
+
+		snapshot, err := backend.Snapshot(ctx)
+		if err != nil {
+			return zero, fmt.Errorf("snapshot store: %w", err)
+		}
+		for _, required := range req.Requires {
+			var value jsontext.Value
+			if err := snapshot.Get(ctx, required, &value); err != nil {
+				return zero, fmt.Errorf("require %q: %w", required, err)
+			}
+		}
+		var document jsontext.Value
+		if err := snapshot.Get(ctx, req.Key, &document); err != nil {
+			if !errors.Is(err, ErrNotExist) {
+				return zero, fmt.Errorf("read %q: %w", req.Key, err)
+			}
+			if len(req.IfMissing) == 0 {
+				return zero, ErrNotExist
+			}
+			document = req.IfMissing.Clone()
+		}
+
+		updated, result, err := jsonmut.Apply(document, program)
+		if err != nil {
+			return zero, fmt.Errorf("mutate %q: %w", req.Key, err)
+		}
+		err = backend.CompareAndSwap(ctx, snapshot, UpdateRequest{
+			Sets:    []SetRequest{{Key: req.Key, Value: updated}},
+			Message: req.Message,
+		})
+		if err == nil {
+			return result, nil
+		}
+		if !errors.Is(err, ErrConflict) {
+			return zero, fmt.Errorf("commit %q: %w", req.Key, err)
+		}
+	}
+}
+
+// UpdateJSON applies statement to one JSON value and retries storage conflicts.
+func UpdateJSON(
+	ctx context.Context,
+	backend Backend,
+	req JSONMutationRequest,
+	statement jsonmut.Statement,
+) error {
+	_, err := MutateJSON(ctx, backend, req, statement)
+	return err
+}

--- a/internal/spice/state/storage/json_test.go
+++ b/internal/spice/state/storage/json_test.go
@@ -1,0 +1,143 @@
+package storage
+
+import (
+	"context"
+	"encoding/json/jsontext"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/gs/internal/jsonmut"
+)
+
+func TestMutateJSON_replaysConflict(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	backend := &conflictOnceBackend{
+		Backend: SyncBackend(make(MapBackend)),
+		BeforeConflict: func(ctx context.Context, backend Backend) error {
+			return backend.Update(ctx, UpdateRequest{
+				Sets: []SetRequest{{
+					Key: "comments/feature",
+					Value: jsontext.Value(`{
+						"lastID": 1,
+						"drafts": {"1": {"body": "concurrent"}}
+					}`),
+				}},
+				Message: "concurrent insertion",
+			})
+		},
+	}
+
+	id, err := MutateJSON(
+		ctx,
+		backend,
+		JSONMutationRequest{
+			Key:       "comments/feature",
+			IfMissing: jsontext.Value(`{}`),
+			Message:   "insert draft",
+		},
+		jsonmut.InsertAutoIncrement(
+			"/lastID",
+			"/drafts",
+			jsontext.Value(`{"body":"requested"}`),
+		),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), id)
+
+	var document jsontext.Value
+	require.NoError(t, backend.Get(ctx, "comments/feature", &document))
+	assert.JSONEq(t, `{
+		"lastID": 2,
+		"drafts": {
+			"1": {"body": "concurrent"},
+			"2": {"body": "requested"}
+		}
+	}`, document.String())
+}
+
+func TestMutateJSON_rechecksRequirementsAfterConflict(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	underlying := SyncBackend(make(MapBackend))
+	require.NoError(t, underlying.Update(ctx, UpdateRequest{
+		Sets:    []SetRequest{{Key: "branches/feature", Value: struct{}{}}},
+		Message: "track branch",
+	}))
+	backend := &conflictOnceBackend{
+		Backend: underlying,
+		BeforeConflict: func(ctx context.Context, backend Backend) error {
+			return backend.Update(ctx, UpdateRequest{
+				Deletes: []string{"branches/feature"},
+				Message: "untrack branch",
+			})
+		},
+	}
+
+	_, err := MutateJSON(
+		ctx,
+		backend,
+		JSONMutationRequest{
+			Key:       "comments/feature",
+			Requires:  []string{"branches/feature"},
+			IfMissing: jsontext.Value(`{}`),
+			Message:   "insert draft",
+		},
+		jsonmut.InsertAutoIncrement(
+			"/lastID",
+			"/drafts",
+			jsontext.Value(`{"body":"requested"}`),
+		),
+	)
+	assert.ErrorIs(t, err, ErrNotExist)
+
+	var document jsontext.Value
+	assert.ErrorIs(
+		t,
+		backend.Get(ctx, "comments/feature", &document),
+		ErrNotExist,
+	)
+}
+
+func TestMutateJSON_missingWithoutDefault(t *testing.T) {
+	t.Parallel()
+
+	backend := SyncBackend(make(MapBackend))
+	_, err := MutateJSON(
+		t.Context(),
+		backend,
+		JSONMutationRequest{
+			Key:     "missing",
+			Message: "mutate missing value",
+		},
+		jsonmut.Set("/value", jsontext.Value("1")),
+	)
+	assert.ErrorIs(t, err, ErrNotExist)
+
+	var document jsontext.Value
+	assert.ErrorIs(t, backend.Get(t.Context(), "missing", &document), ErrNotExist)
+}
+
+type conflictOnceBackend struct {
+	Backend
+	BeforeConflict func(context.Context, Backend) error
+	conflicted     bool
+}
+
+func (b *conflictOnceBackend) CompareAndSwap(
+	ctx context.Context,
+	snapshot Snapshot,
+	req UpdateRequest,
+) error {
+	if !b.conflicted {
+		b.conflicted = true
+		if err := b.BeforeConflict(ctx, b.Backend); err != nil {
+			return err
+		}
+		return ErrConflict
+	}
+	return b.Backend.CompareAndSwap(ctx, snapshot, req)
+}

--- a/internal/spice/state/storage/map.go
+++ b/internal/spice/state/storage/map.go
@@ -1,45 +1,80 @@
 package storage
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	json "encoding/json/v2"
 	"fmt"
 	"sort"
 	"strings"
 )
 
-// MapBackend is an in-memory implementation of [Backend] backed by a map.
+// MapBackend is an in-memory [Backend] backed by a map.
 //
-// This is NOT thread safe. Use [SyncBackend] to make it so.
+// It is not thread-safe. Use [SyncBackend] when sharing it.
 type MapBackend map[string][]byte
 
 var _ Backend = MapBackend(nil)
 
 // Get retrieves a value from the store.
-func (m MapBackend) Get(_ context.Context, key string, dst any) error {
-	v, ok := m[key]
-	if !ok {
-		return ErrNotExist
-	}
+func (m MapBackend) Get(
+	_ context.Context,
+	key string,
+	dst any,
+) error {
+	return getFromMap(m, key, dst)
+}
 
-	return json.Unmarshal(v, dst)
+// Snapshot returns a read-only copy of the current map contents.
+func (m MapBackend) Snapshot(context.Context) (Snapshot, error) {
+	data := make(MapBackend, len(m))
+	for key, value := range m {
+		data[key] = bytes.Clone(value)
+	}
+	return &mapSnapshot{
+		data:        data,
+		fingerprint: m.fingerprint(),
+	}, nil
+}
+
+// CompareAndSwap applies req if snapshot still describes the current map.
+func (m MapBackend) CompareAndSwap(
+	ctx context.Context,
+	snapshot Snapshot,
+	req UpdateRequest,
+) error {
+	snap, ok := snapshot.(*mapSnapshot)
+	if !ok {
+		return ErrInvalidSnapshot
+	}
+	if m.fingerprint() != snap.fingerprint {
+		return ErrConflict
+	}
+	return m.Update(ctx, req)
 }
 
 // Update applies a batch of changes to the store.
-// MapBackend ignores the message associated with the update.
-func (m MapBackend) Update(_ context.Context, req UpdateRequest) error {
+// MapBackend ignores the update message.
+func (m MapBackend) Update(
+	_ context.Context,
+	req UpdateRequest,
+) error {
+	values := make([][]byte, len(req.Sets))
 	for i, set := range req.Sets {
-		v, err := json.Marshal(set.Value)
+		value, err := json.Marshal(set.Value)
 		if err != nil {
 			return fmt.Errorf("marshal [%d]: %w", i, err)
 		}
-		m[set.Key] = v
+		values[i] = value
 	}
 
+	for i, set := range req.Sets {
+		m[set.Key] = values[i]
+	}
 	for _, key := range req.Deletes {
 		delete(m, key)
 	}
-
 	return nil
 }
 
@@ -50,17 +85,78 @@ func (m MapBackend) Clear(context.Context, string) error {
 }
 
 // Keys returns a list of keys in the store.
-func (m MapBackend) Keys(_ context.Context, dir string) ([]string, error) {
+func (m MapBackend) Keys(
+	_ context.Context,
+	dir string,
+) ([]string, error) {
+	return keysFromMap(m, dir), nil
+}
+
+func getFromMap(m MapBackend, key string, dst any) error {
+	value, ok := m[key]
+	if !ok {
+		return ErrNotExist
+	}
+	return json.Unmarshal(value, dst)
+}
+
+func keysFromMap(m MapBackend, dir string) []string {
 	if dir != "" && !strings.HasSuffix(dir, "/") {
 		dir += "/"
 	}
 
 	keys := make([]string, 0, len(m))
-	for k := range m {
-		if rest, ok := strings.CutPrefix(k, dir); ok {
+	for key := range m {
+		if rest, ok := strings.CutPrefix(key, dir); ok {
 			keys = append(keys, rest)
 		}
 	}
 	sort.Strings(keys)
-	return keys, nil
+	return keys
+}
+
+func (m MapBackend) fingerprint() [sha256.Size]byte {
+	items := make([]mapFingerprintItem, 0, len(m))
+	for key, value := range m {
+		items = append(items, mapFingerprintItem{
+			Key:   key,
+			Value: value,
+		})
+	}
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Key < items[j].Key
+	})
+
+	data, err := json.Marshal(items)
+	if err != nil {
+		panic(fmt.Sprintf("marshal map fingerprint: %v", err))
+	}
+	return sha256.Sum256(data)
+}
+
+type mapSnapshot struct {
+	data        MapBackend
+	fingerprint [sha256.Size]byte
+}
+
+var _ Snapshot = (*mapSnapshot)(nil)
+
+func (s *mapSnapshot) Get(
+	_ context.Context,
+	key string,
+	dst any,
+) error {
+	return getFromMap(s.data, key, dst)
+}
+
+func (s *mapSnapshot) Keys(
+	_ context.Context,
+	dir string,
+) ([]string, error) {
+	return keysFromMap(s.data, dir), nil
+}
+
+type mapFingerprintItem struct {
+	Key   string `json:"key"`
+	Value []byte `json:"value"`
 }

--- a/internal/spice/state/storage/sync.go
+++ b/internal/spice/state/storage/sync.go
@@ -34,11 +34,29 @@ func (s *syncBackend) Get(ctx context.Context, key string, dst any) error {
 	return s.b.Get(ctx, key, dst)
 }
 
+func (s *syncBackend) Snapshot(ctx context.Context) (Snapshot, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.b.Snapshot(ctx)
+}
+
 func (s *syncBackend) Keys(ctx context.Context, dir string) ([]string, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	return s.b.Keys(ctx, dir)
+}
+
+func (s *syncBackend) CompareAndSwap(
+	ctx context.Context,
+	snapshot Snapshot,
+	req UpdateRequest,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.b.CompareAndSwap(ctx, snapshot, req)
 }
 
 func (s *syncBackend) Update(ctx context.Context, req UpdateRequest) error {

--- a/internal/spice/state/store.go
+++ b/internal/spice/state/store.go
@@ -12,13 +12,10 @@ import (
 
 // DB provides a key-value store that holds JSON values.
 type DB interface {
-	Get(ctx context.Context, k string, v any) error
-	Keys(ctx context.Context, dir string) ([]string, error)
+	storage.Backend
 
 	Set(ctx context.Context, k string, v any, msg string) error
 	Delete(ctx context.Context, k, msg string) error
-	Update(ctx context.Context, req storage.UpdateRequest) error
-	Clear(ctx context.Context, msg string) error
 }
 
 var _ DB = (*storage.DB)(nil)


### PR DESCRIPTION
A caller that reads, transforms, and writes one document can overwrite a
concurrent update derived from a newer store revision.
Rebase continuation updates had that shape: concurrent appends could lose
work, and concurrent takes could return the same continuation more than once.

Expose pinned snapshots and compare-and-swap commits across each backend.
Apply replayable `jsonmut` programs to one snapshot and retry conflicts
against current state.
Move continuation appends and takes onto this path so each queue operation is
linearizable.

Required keys are checked in the same revision.
A take from a missing queue remains a no-op, and ordinary updates retain their
existing retry and idempotent no-op behavior.