### PR TITLE
storage: Move values transactionally

### DIFF
--- a/internal/spice/branch_mutation.go
+++ b/internal/spice/branch_mutation.go
@@ -2,7 +2,6 @@ package spice
 
 import (
 	"context"
-	"encoding/json/jsontext"
 	"errors"
 	"fmt"
 
@@ -74,8 +73,7 @@ func (s *Service) ForgetBranch(ctx context.Context, name string) error {
 // This handles both, renaming the branch in the repository,
 // and updating the internal state to reflect the new name.
 func (s *Service) RenameBranch(ctx context.Context, oldName, newName string) error {
-	oldBranch, err := s.LookupBranch(ctx, oldName)
-	if err != nil {
+	if _, err := s.LookupBranch(ctx, oldName); err != nil {
 		return fmt.Errorf("lookup %v: %w", oldName, err)
 	}
 
@@ -90,33 +88,9 @@ func (s *Service) RenameBranch(ctx context.Context, oldName, newName string) err
 		return fmt.Errorf("list branches above %v: %w", oldName, err)
 	}
 
-	var (
-		changeForge    string
-		changeMetadata jsontext.Value
-	)
-	if md := oldBranch.Change; md != nil {
-		if codec, ok := s.forges.Lookup(md.ForgeID()); ok {
-			changeForge = codec.ID()
-			changeMetadata, err = codec.MarshalChangeMetadata(md)
-			if err != nil {
-				return fmt.Errorf("marshal change metadata: %w", err)
-			}
-		}
-	}
-
 	tx := s.store.BeginBranchTx()
-
-	// Create the new branch with the same base
-	// and other state as the old branch.
-	if err := tx.Upsert(ctx, state.UpsertRequest{
-		Name:           newName,
-		Base:           oldBranch.Base,
-		BaseHash:       oldBranch.BaseHash,
-		ChangeForge:    changeForge,
-		ChangeMetadata: changeMetadata,
-		UpstreamBranch: &oldBranch.UpstreamBranch,
-	}); err != nil {
-		return fmt.Errorf("create branch with name %v: %w", newName, err)
+	if err := tx.Rename(ctx, oldName, newName); err != nil {
+		return fmt.Errorf("rename tracked branch: %w", err)
 	}
 
 	// Point the branches above the old branch to the new branch.
@@ -128,11 +102,6 @@ func (s *Service) RenameBranch(ctx context.Context, oldName, newName string) err
 			return fmt.Errorf("update branch %v to point to %v: %w", above, newName, err)
 		}
 		s.log.Debug("Updating upstack branch to new name", "upstack", above)
-	}
-
-	// Delete the old branch.
-	if err := tx.Delete(ctx, oldName); err != nil {
-		return fmt.Errorf("delete branch %v: %w", oldName, err)
 	}
 
 	// If we get here, the change will be committed successfully.

--- a/internal/spice/state/branch.go
+++ b/internal/spice/state/branch.go
@@ -178,19 +178,21 @@ func (s *Store) listBranches(ctx context.Context) iter.Seq2[string, error] {
 type BranchTx struct {
 	store *Store
 
-	states map[string]*branchState // cached states with changes
-	sets   map[string]struct{}     // branches to set
-	dels   map[string]struct{}     // branches to delete
+	states  map[string]*branchState // cached states with changes
+	sets    map[string]struct{}     // branches to set
+	dels    map[string]struct{}     // branches to delete
+	renames map[string]string       // old branch name to new branch name
 }
 
 // BeginBranchTx starts a new transaction for updating the branch graph.
 // Changes are not persisted until Commit is called.
 func (s *Store) BeginBranchTx() *BranchTx {
 	return &BranchTx{
-		store:  s,
-		states: make(map[string]*branchState),
-		sets:   make(map[string]struct{}),
-		dels:   make(map[string]struct{}),
+		store:   s,
+		states:  make(map[string]*branchState),
+		sets:    make(map[string]struct{}),
+		dels:    make(map[string]struct{}),
+		renames: make(map[string]string),
 	}
 }
 
@@ -351,12 +353,51 @@ func (tx *BranchTx) Delete(ctx context.Context, name string) error {
 	return nil
 }
 
+// Rename changes a tracked branch name while preserving its stored state.
+func (tx *BranchTx) Rename(
+	ctx context.Context,
+	oldName, newName string,
+) error {
+	if oldName == "" || newName == "" {
+		return errors.New("old and new branch names are required")
+	}
+	if oldName == tx.store.trunk || newName == tx.store.trunk {
+		return ErrTrunk
+	}
+
+	oldState, err := tx.state(ctx, oldName)
+	if err != nil {
+		return err
+	}
+	if _, err := tx.state(ctx, newName); err == nil {
+		return fmt.Errorf("branch %v is already tracked", newName)
+	} else if !errors.Is(err, ErrNotExist) {
+		return err
+	}
+
+	newState := *oldState
+	tx.states[newName] = &newState
+	delete(tx.states, oldName)
+	tx.dels[oldName] = struct{}{}
+
+	if _, modified := tx.sets[oldName]; modified {
+		// The persisted source does not include earlier transaction changes.
+		// Write the changed state under its new name instead of moving it.
+		tx.sets[newName] = struct{}{}
+	} else {
+		tx.renames[oldName] = newName
+	}
+	delete(tx.sets, oldName)
+	return nil
+}
+
 // Commit persists all planned changes to the store.
 // If there are no changes, this is a no-op.
 func (tx *BranchTx) Commit(ctx context.Context, msg string) error {
 	req := updateBranchesRequest{
 		Sets:    make([]setBranchStateRequest, 0, len(tx.sets)),
 		Deletes: slices.Collect(maps.Keys(tx.dels)),
+		Renames: maps.Clone(tx.renames),
 		Message: msg,
 	}
 
@@ -376,6 +417,7 @@ func (tx *BranchTx) Commit(ctx context.Context, msg string) error {
 	clear(tx.sets)
 	clear(tx.dels)
 	clear(tx.states)
+	clear(tx.renames)
 	return nil
 }
 
@@ -402,9 +444,24 @@ func (tx *BranchTx) listBranches(ctx context.Context) iter.Seq2[string, error] {
 		// seen prevents underlying branches from being listed twice.
 		seen := make(map[string]struct{})
 
+		// A renamed branch is visible under its destination name even when
+		// its persisted state can move without being rewritten.
+		for _, branch := range tx.renames {
+			if _, deleted := tx.dels[branch]; deleted {
+				continue
+			}
+			if !yield(branch, nil) {
+				return
+			}
+			seen[branch] = struct{}{}
+		}
+
 		// Entries in tx.sets take precedence unless they are deleted.
 		for branch := range tx.sets {
 			if _, ok := tx.dels[branch]; ok {
+				continue
+			}
+			if _, ok := seen[branch]; ok {
 				continue
 			}
 
@@ -495,17 +552,18 @@ type setBranchStateRequest struct {
 }
 
 // updateBranchesRequest is a request to update the state of multiple branches.
-// The request can set the state of branches, delete branches, or both.
+// The request can set, delete, or rename branches in one transaction.
 // A message is recorded with the update.
 type updateBranchesRequest struct {
 	Sets    []setBranchStateRequest
 	Deletes []string
+	Renames map[string]string
 	Message string // required
 }
 
 // updateBranches atomically updates the state of multiple branches in the store.
 func (s *Store) updateBranches(ctx context.Context, req updateBranchesRequest) error {
-	if len(req.Sets) == 0 && len(req.Deletes) == 0 {
+	if len(req.Sets) == 0 && len(req.Deletes) == 0 && len(req.Renames) == 0 {
 		return nil
 	}
 
@@ -521,13 +579,24 @@ func (s *Store) updateBranches(ctx context.Context, req updateBranchesRequest) e
 		}
 	}
 
-	dels := make([]string, len(req.Deletes))
-	for idx, del := range req.Deletes {
-		dels[idx] = branchKey(del)
+	var dels []string
+	for _, del := range req.Deletes {
+		if _, renamed := req.Renames[del]; !renamed {
+			dels = append(dels, branchKey(del))
+		}
+	}
+
+	var moves []storage.MoveRequest
+	for _, oldName := range slices.Sorted(maps.Keys(req.Renames)) {
+		moves = append(moves, storage.MoveRequest{
+			From: branchKey(oldName),
+			To:   branchKey(req.Renames[oldName]),
+		})
 	}
 
 	updReq := storage.UpdateRequest{
 		Sets:    sets,
+		Moves:   moves,
 		Deletes: dels,
 		Message: req.Message,
 	}

--- a/internal/spice/state/storage/backend.go
+++ b/internal/spice/state/storage/backend.go
@@ -50,9 +50,13 @@ type Snapshot interface {
 }
 
 // UpdateRequest performs a batch of writes in one transaction.
+// Moves are applied before sets, and deletes are applied last.
 type UpdateRequest struct {
 	// Sets lists the keys to add or replace.
 	Sets []SetRequest
+
+	// Moves lists keys whose values move within the same transaction.
+	Moves []MoveRequest
 
 	// Deletes lists the keys to delete.
 	Deletes []string
@@ -68,6 +72,13 @@ type SetRequest struct {
 
 	// Value is serialized to JSON.
 	Value any
+}
+
+// MoveRequest transfers the optional value at From to To.
+// If From does not exist, To is deleted.
+type MoveRequest struct {
+	From string // required
+	To   string // required
 }
 
 // ErrNotExist indicates that an expected key does not exist.

--- a/internal/spice/state/storage/backend_test.go
+++ b/internal/spice/state/storage/backend_test.go
@@ -95,6 +95,38 @@ func testStorageBackend(t *testing.T, backend Backend) {
 		assert.ErrorIs(t, err, ErrConflict)
 	})
 
+	t.Run("Move", func(t *testing.T) {
+		defer func() {
+			assert.NoError(t, db.Clear(ctx, "clear"))
+		}()
+
+		require.NoError(t, db.Set(ctx, "old", "value", "set old"))
+		require.NoError(t, db.Update(ctx, UpdateRequest{
+			Moves:   []MoveRequest{{From: "old", To: "new"}},
+			Message: "move value",
+		}))
+
+		var got string
+		assert.ErrorIs(t, db.Get(ctx, "old", &got), ErrNotExist)
+		require.NoError(t, db.Get(ctx, "new", &got))
+		assert.Equal(t, "value", got)
+	})
+
+	t.Run("Move/Absent", func(t *testing.T) {
+		defer func() {
+			assert.NoError(t, db.Clear(ctx, "clear"))
+		}()
+
+		require.NoError(t, db.Set(ctx, "new", "stale", "set stale value"))
+		require.NoError(t, db.Update(ctx, UpdateRequest{
+			Moves:   []MoveRequest{{From: "old", To: "new"}},
+			Message: "move absent value",
+		}))
+
+		var got string
+		assert.ErrorIs(t, db.Get(ctx, "new", &got), ErrNotExist)
+	})
+
 	t.Run("SetNested", func(t *testing.T) {
 		defer func() {
 			assert.NoError(t, db.Clear(ctx, "clear"))

--- a/internal/spice/state/storage/git.go
+++ b/internal/spice/state/storage/git.go
@@ -267,8 +267,26 @@ func (g *GitBackend) update(
 	setBlobs []git.Hash,
 	prevCommit, prevTree git.Hash,
 ) error {
-	writesByPath := make(map[string]git.Hash, len(req.Sets))
-	deletes := make(map[string]struct{}, len(req.Deletes))
+	writesByPath := make(map[string]git.Hash, len(req.Sets)+len(req.Moves))
+	deletes := make(map[string]struct{}, len(req.Deletes)+len(req.Moves))
+	for _, move := range req.Moves {
+		var blob git.Hash
+		if prevTree != "" {
+			var err error
+			blob, err = g.repo.HashAt(ctx, prevTree.String(), move.From)
+			if err != nil && !errors.Is(err, git.ErrNotExist) {
+				return fmt.Errorf("read moved value %q: %w", move.From, err)
+			}
+		}
+		if blob == "" {
+			deletes[move.To] = struct{}{}
+		} else {
+			writesByPath[move.To] = blob
+			delete(deletes, move.To)
+		}
+		delete(writesByPath, move.From)
+		deletes[move.From] = struct{}{}
+	}
 	for i, set := range req.Sets {
 		writesByPath[set.Key] = setBlobs[i]
 		delete(deletes, set.Key)

--- a/internal/spice/state/storage/git_test.go
+++ b/internal/spice/state/storage/git_test.go
@@ -84,6 +84,46 @@ func TestGitBackendUpdateNoChanges_concurrentUpdate(t *testing.T) {
 	assert.Equal(t, 1, racingRepo.calls)
 }
 
+func TestGitBackendMove_replaysConcurrentUpdate(t *testing.T) {
+	ctx := t.Context()
+	repo, _, err := git.Init(ctx, t.TempDir(), git.InitOptions{
+		Log: silogtest.New(t),
+	})
+	require.NoError(t, err)
+
+	newBackend := func(repo GitRepository) *GitBackend {
+		return NewGitBackend(GitConfig{
+			Repo:        repo,
+			Ref:         "refs/data",
+			AuthorName:  "Test Author",
+			AuthorEmail: "test@example.com",
+			Log:         silogtest.New(t),
+		})
+	}
+	concurrent := NewDB(newBackend(repo))
+	require.NoError(t, concurrent.Set(ctx, "old", "before", "set old"))
+
+	racingRepo := &updateTreeHookRepository{
+		GitRepository: repo,
+		BeforeUpdate: func(ctx context.Context, call int) error {
+			if call != 1 {
+				return nil
+			}
+			return concurrent.Set(ctx, "old", "after", "update old")
+		},
+	}
+	db := NewDB(newBackend(racingRepo))
+	require.NoError(t, db.Update(ctx, UpdateRequest{
+		Moves:   []MoveRequest{{From: "old", To: "new"}},
+		Message: "move value",
+	}))
+
+	var got string
+	assert.ErrorIs(t, db.Get(ctx, "old", &got), ErrNotExist)
+	require.NoError(t, db.Get(ctx, "new", &got))
+	assert.Equal(t, "after", got)
+}
+
 func TestGitBackend_ConcurrentOperations(t *testing.T) {
 	var seed [32]byte
 	if seedstr := os.Getenv("GIT_BACKEND_CONCURRENT_SEED"); seedstr != "" {

--- a/internal/spice/state/storage/map.go
+++ b/internal/spice/state/storage/map.go
@@ -69,6 +69,14 @@ func (m MapBackend) Update(
 		values[i] = value
 	}
 
+	for _, move := range req.Moves {
+		if value, ok := m[move.From]; ok {
+			m[move.To] = bytes.Clone(value)
+		} else {
+			delete(m, move.To)
+		}
+		delete(m, move.From)
+	}
 	for i, set := range req.Sets {
 		m[set.Key] = values[i]
 	}


### PR DESCRIPTION
Tracked branch rename reconstructs a stored branch under its new key before
deleting the old key. That obscures whether storage can relocate an existing
value atomically and requires the caller to reproduce the stored record.

Let one update move an optional source before applying sets and deletes.
Use that operation for an unmodified tracked branch record; an earlier change
in the same transaction is written under the new name instead. An absent
source removes a stale destination, and Git retries resolve the source from
the winning revision.