### PR TITLE
review: Configure the draft default

### DIFF
--- a/doc/includes/cli-reference.md
+++ b/doc/includes/cli-reference.md
@@ -1495,8 +1495,10 @@ If no message is given with -m, an editor is opened.
 **Flags**
 
 * `-m`, `--message=MSG`: Comment body. Opens editor if not provided.
-* `--[no-]draft`: Save the comment as a local draft instead of posting it.
+* `--[no-]draft` ([:material-wrench:{ .middle title="spice.reviewComment.draft" }](/cli/config.md#spicereviewcommentdraft)): Whether to save the comment as a local draft or post it.
 * `-b`, `--branch=BRANCH`: Branch to comment on. Defaults to the current branch.
+
+**Configuration**: [spice.reviewComment.draft](/cli/config.md#spicereviewcommentdraft)
 
 ### git-spice review reply {#gs-review-reply}
 
@@ -1521,8 +1523,10 @@ If no message is given with -m, an editor is opened.
 **Flags**
 
 * `-m`, `--message=MSG`: Reply body. Opens editor if not provided.
-* `--[no-]draft`: Save the reply as a local draft instead of posting it.
+* `--[no-]draft` ([:material-wrench:{ .middle title="spice.reviewComment.draft" }](/cli/config.md#spicereviewcommentdraft)): Whether to save the reply as a local draft or post it.
 * `-b`, `--branch=BRANCH`: Branch containing the thread. Defaults to the current branch.
+
+**Configuration**: [spice.reviewComment.draft](/cli/config.md#spicereviewcommentdraft)
 
 ### git-spice review publish {#gs-review-publish}
 

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -730,6 +730,18 @@ If set to false, you can opt in to opening the editor with the `--edit` flag.
 - `true` (default)
 - `false`
 
+### spice.reviewComment.draft
+
+<!-- gs:version unreleased -->
+
+Whether $$gs review comment$$ and $$gs review reply$$ save comments as local
+drafts or post them immediately by default.
+
+**Accepted values:**
+
+- `true` (default): save comments and replies as local drafts
+- `false`: post comments and replies immediately
+
 ### spice.submit.draft
 
 <!-- gs:version v0.16.0 -->

--- a/review_comment.go
+++ b/review_comment.go
@@ -12,7 +12,7 @@ import (
 type reviewCommentCmd struct {
 	Anchor  review.Anchor `arg:"" name:"file[:line[-end]]" help:"Comment anchor: file.go, file.go:42, or file.go:42-50."`
 	Message string        `short:"m" placeholder:"MSG" help:"Comment body. Opens editor if not provided."`
-	Draft   bool          `negatable:"" default:"true" help:"Save the comment as a local draft instead of posting it."`
+	Draft   bool          `negatable:"" default:"true" config:"reviewComment.draft" help:"Whether to save the comment as a local draft or post it."`
 	Branch  string        `short:"b" placeholder:"BRANCH" predictor:"trackedBranches" help:"Branch to comment on. Defaults to the current branch."`
 }
 

--- a/review_reply.go
+++ b/review_reply.go
@@ -12,7 +12,7 @@ import (
 type reviewReplyCmd struct {
 	ThreadID string `arg:"" help:"Thread ID to reply to."`
 	Message  string `short:"m" placeholder:"MSG" help:"Reply body. Opens editor if not provided."`
-	Draft    bool   `negatable:"" default:"true" help:"Save the reply as a local draft instead of posting it."`
+	Draft    bool   `negatable:"" default:"true" config:"reviewComment.draft" help:"Whether to save the reply as a local draft or post it."`
 	Branch   string `short:"b" placeholder:"BRANCH" predictor:"trackedBranches" help:"Branch containing the thread. Defaults to the current branch."`
 }
 

--- a/testdata/help/review_comment.txt
+++ b/testdata/help/review_comment.txt
@@ -19,8 +19,8 @@ Arguments:
 
 Flags:
   -m, --message=MSG      Comment body. Opens editor if not provided.
-      --[no-]draft       Save the comment as a local draft instead of posting
-                         it.
+      --[no-]draft       Whether to save the comment as a local draft or post
+                         it. (🔧 spice.reviewComment.draft)
   -b, --branch=BRANCH    Branch to comment on. Defaults to the current branch.
 
 Global Flags:

--- a/testdata/help/review_reply.txt
+++ b/testdata/help/review_reply.txt
@@ -14,7 +14,8 @@ Arguments:
 
 Flags:
   -m, --message=MSG      Reply body. Opens editor if not provided.
-      --[no-]draft       Save the reply as a local draft instead of posting it.
+      --[no-]draft       Whether to save the reply as a local draft or post it.
+                         (🔧 spice.reviewComment.draft)
   -b, --branch=BRANCH    Branch containing the thread. Defaults to the current
                          branch.
 

--- a/testdata/script/review_draft_config.txt
+++ b/testdata/script/review_draft_config.txt
@@ -1,0 +1,52 @@
+# Configure whether review comments are drafted by default.
+
+as 'Test <test@example.com>'
+at '2024-04-05T16:40:32Z'
+
+# setup
+cd repo
+git init
+git commit --allow-empty -m 'Initial commit'
+gs repo init
+
+# set up a fake GitHub remote
+shamhub-setup
+shamhub new origin alice/example.git
+shamhub register alice
+git push origin main
+
+env SHAMHUB_USERNAME=alice
+gs auth login
+
+# create a branch with a file and submit it
+git add main.go
+gs bc -m 'Add main' feature1
+gs branch submit --fill
+stderr 'Created #'
+
+# disabling the draft default posts comments and replies immediately
+git config spice.reviewComment.draft false
+gs review comment main.go:3 -m 'Posted by configuration.'
+stderr 'Posted comment'
+gs review reply thread-2 -m 'Posted reply by configuration.'
+stderr 'Posted comment'
+
+# --draft overrides the configuration
+gs review comment main.go:3 -m 'Explicit draft.' --draft
+stderr 'Drafted comment 1'
+gs review reply thread-2 -m 'Explicit draft reply.' --draft
+stderr 'Drafted reply 2'
+
+# --no-draft overrides the default configuration
+git config spice.reviewComment.draft true
+gs review comment main.go:3 -m 'Default draft.'
+stderr 'Drafted comment 3'
+gs review comment main.go:3 -m 'Explicit post.' --no-draft
+stderr 'Posted comment'
+
+-- repo/main.go --
+package main
+
+func main() {
+	println("hello")
+}


### PR DESCRIPTION
Review comments and replies default to local drafts
when neither draft flag is set.
Some workflows prefer immediate publication as their normal path.

Let `spice.reviewComment.draft` select that default for both commands.
Explicit `--draft` and `--no-draft` override the configured behavior
for one invocation.